### PR TITLE
Update docs for Bazel requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install enzyme-jax
 
 ## Building from source
 
-Requirements: `bazel-5.3.0`, `clang++`, `python`, `python-virtualenv`,
+Requirements: `bazel-5.4.0`, `clang++`, `python`, `python-virtualenv`,
 `python3-dev`.
 
 Build our extension with:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install enzyme-jax
 
 ## Building from source
 
-Requirements: `bazel-5.4.0`, `clang++`, `python`, `python-virtualenv`,
+Requirements: `bazel-6.2.1`, `clang++`, `python`, `python-virtualenv`,
 `python3-dev`.
 
 Build our extension with:


### PR DESCRIPTION
When building the project, the following error appeared:

```
Error in fail: Current Bazel version is 5.3.0; expected at least 5.4.0
```

Update the documentation to indicate the correct version.