### PR TITLE
apply various formatters

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,24 +10,25 @@ package(
 
 py_package(
     name = "enzyme_jax_data",
+    # Only include these Python packages.
+    packages = [
+        "@//enzyme_jax:enzyme_call.so",
+        "@llvm-project//clang:builtin_headers_gen",
+    ],
+    prefix = "enzyme_jax/",
     deps = [
         "//enzyme_jax:enzyme_call.so",
         "@llvm-project//clang:builtin_headers_gen",
     ],
-    # Only include these Python packages.
-    packages = ["@//enzyme_jax:enzyme_call.so", "@llvm-project//clang:builtin_headers_gen"],
-    prefix = "enzyme_jax/"
 )
 
 py_wheel(
     name = "enzyme_jax",
+    author = "Enzyme Authors",
+    author_email = "wmoses@mit.edu, zinenko@google.com",
     # Package data. We're building "example_minimal_package-0.0.1-py3-none-any.whl"
     distribution = "enzyme_jax",
-    author="Enzyme Authors",
-    license='LLVM',
-    author_email="wmoses@mit.edu, zinenko@google.com",
-    python_tag = "py3",
-    version = "0.0.5",
+    license = "LLVM",
     platform = select({
         "@bazel_tools//src/conditions:windows_x64": "win_amd64",
         "@bazel_tools//src/conditions:darwin_arm64": "macosx_11_0_arm64",
@@ -36,5 +37,10 @@ py_wheel(
         "@bazel_tools//src/conditions:linux_x86_64": "manylinux2014_x86_64",
         "@bazel_tools//src/conditions:linux_ppc64le": "manylinux2014_ppc64le",
     }),
-    deps = ["//enzyme_jax:enzyme_jax_internal", ":enzyme_jax_data"]
+    python_tag = "py3",
+    version = "0.0.5",
+    deps = [
+        ":enzyme_jax_data",
+        "//enzyme_jax:enzyme_jax_internal",
+    ],
 )

--- a/enzyme_jax/BUILD
+++ b/enzyme_jax/BUILD
@@ -11,7 +11,7 @@ cc_library(
     srcs = ["clang_compile.cc"],
     hdrs = ["clang_compile.h"],
     deps = [
-        "@pybind11",
+        "@enzyme//:EnzymeStatic",
         "@llvm-project//clang:ast",
         "@llvm-project//clang:basic",
         "@llvm-project//clang:driver",
@@ -19,18 +19,21 @@ cc_library(
         "@llvm-project//clang:frontend_tool",
         "@llvm-project//clang:lex",
         "@llvm-project//clang:serialization",
-        "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:IRReader",
         "@llvm-project//llvm:OrcJIT",
-        "@enzyme//:EnzymeStatic"
+        "@llvm-project//llvm:Support",
+        "@pybind11",
     ],
 )
 
 py_library(
     name = "enzyme_jax_internal",
-    srcs = ["primitives.py", "__init__.py"],
-    visibility = ["//visibility:public"]
+    srcs = [
+        "__init__.py",
+        "primitives.py",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 pybind_library(
@@ -95,12 +98,12 @@ pybind_library(
 pybind_extension(
     name = "enzyme_call",
     srcs = ["enzyme_call.cc"],
+    visibility = ["//visibility:public"],
     deps = [
-        "@llvm-project//llvm:Support",
-        "@llvm-project//llvm:OrcJIT",
         ":clang_compile",
         ":compile_with_xla",
-        "@com_google_absl//absl/status"
+        "@com_google_absl//absl/status",
+        "@llvm-project//llvm:OrcJIT",
+        "@llvm-project//llvm:Support",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/enzyme_jax/clang_compile.h
+++ b/enzyme_jax/clang_compile.h
@@ -10,9 +10,14 @@
 #define ENZYME_JAX_CLANG_COMPILE_H
 
 #include <Python.h>
+
 #include <string>
+
 #include "llvm/IR/Module.h"
 
-std::unique_ptr<llvm::Module> GetLLVMFromJob(std::string filename, std::string filecontents, bool cpp, llvm::ArrayRef<std::string> pyargv, llvm::LLVMContext*ctx=nullptr, std::unique_ptr<llvm::Module> linkMod=nullptr);
+std::unique_ptr<llvm::Module> GetLLVMFromJob(
+    std::string filename, std::string filecontents, bool cpp,
+    llvm::ArrayRef<std::string> pyargv, llvm::LLVMContext* ctx = nullptr,
+    std::unique_ptr<llvm::Module> linkMod = nullptr);
 
 #endif  // ENZYME_JAX_CLANG_COMPILE_H


### PR DESCRIPTION
- pyink for python
- clang-format for C++
- buildifier for bazel

This makes the code consistent and adhere to common style. I haven't found any indication as to which style to use.