### PR TITLE
use absltest for tests

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -42,6 +42,7 @@ py_wheel(
     deps = ["//src/enzyme_ad/jax:enzyme_jax_internal", ":enzyme_jax_data"],
     strip_path_prefixes = ["src/"],
     requires = [
+        "absl_py >= 2.0.0",
         "jax >= 0.4.21",
         "jaxlib >= 0.4.21",
     ],

--- a/test/bench_vs_xla.py
+++ b/test/bench_vs_xla.py
@@ -1,6 +1,8 @@
 import jax
 import jax.numpy as jnp
 from enzyme_ad.jax import enzyme_jax_ir
+from absl.testing import absltest
+import timeit
 
 
 @enzyme_jax_ir()
@@ -23,46 +25,6 @@ def add_two_plain(x: jax.Array, z, y) -> jax.Array:
     return x + y
 
 
-in0, in1, in2 = (
-    jnp.array([1.0, 2.0, 3.0]),
-    jnp.array([10.0, 20.0, 30.0]),
-    jnp.array([100.0, 200.0, 300.0]),
-)
-# TODO: this currently throws NYI as it is not yet connected to JIT and runtime.
-# But it should print LLVM IR in the process.
-
-ao = add_one(in0, in1)
-aop = add_one_plain(in0, in1)
-assert (jnp.abs(ao - aop) < 1e-6).all()
-print("Primal success")
-
-at = add_two(in0, in1, in2)
-atp = add_two_plain(in0, in1, in2)
-
-assert (jnp.abs(at - atp) < 1e-6).all()
-print("Primal Deadarg success")
-
-import timeit
-
-print(
-    timeit.Timer(
-        "add_one(in0, in1)", globals={"add_one": add_one, "in0": in0, "in1": in1}
-    ).timeit()
-)
-print(
-    timeit.Timer(
-        "add_one_plain(in0, in1)",
-        globals={"add_one_plain": add_one_plain, "in0": in0, "in1": in1},
-    ).timeit()
-)
-
-din0, din1, din2 = (
-    jnp.array([0.1, 0.2, 0.3]),
-    jnp.array([50.0, 70.0, 110.0]),
-    jnp.array([1300.0, 1700.0, 1900.0]),
-)
-
-
 @jax.jit
 def fwd(in0, in1, din0, din1):
     return jax.jvp(add_one, (in0, in1), (din0, din1))
@@ -73,16 +35,6 @@ def fwd_plain(in0, in1, din0, din1):
     return jax.jvp(add_one_plain, (in0, in1), (din0, din1))
 
 
-primals, tangents = fwd(in0, in1, din0, din1)
-primals_p, tangents_p = fwd_plain(in0, in1, din0, din1)
-
-assert (jnp.abs(primals - primals_p) < 1e-6).all()
-for t, t_p in zip(tangents, tangents_p):
-    assert (jnp.abs(t - t_p) < 1e-6).all()
-
-print("Tangent success")
-
-
 @jax.jit
 def fwd2(in0, in1, in2, din0, din1, din2):
     return jax.jvp(add_two, (in0, in1, in2), (din0, din1, din2))
@@ -91,38 +43,6 @@ def fwd2(in0, in1, in2, din0, din1, din2):
 @jax.jit
 def fwd2_plain(in0, in1, in2, din0, din1, din2):
     return jax.jvp(add_two_plain, (in0, in1, in2), (din0, din1, din2))
-
-
-primals, tangents = fwd2(in0, in1, in2, din0, din1, din2)
-primals_p, tangents_p = fwd2_plain(in0, in1, in2, din0, din1, din2)
-
-print(primals, primals_p)
-assert (jnp.abs(primals - primals_p) < 1e-6).all()
-for i, (t, t_p) in enumerate(zip(tangents, tangents_p)):
-    print(i, t, t_p)
-    assert (jnp.abs(t - t_p) < 1e-6).all()
-
-print("Tangent deadarg success")
-
-
-print(
-    timeit.Timer(
-        "fwd(in0, in1, din0, din1)",
-        globals={"fwd": fwd, "in0": in0, "in1": in1, "din0": din0, "din1": din1},
-    ).timeit()
-)
-print(
-    timeit.Timer(
-        "fwd_plain(in0, in1, din0, din1)",
-        globals={
-            "fwd_plain": fwd_plain,
-            "in0": in0,
-            "in1": in1,
-            "din0": din0,
-            "din1": din1,
-        },
-    ).timeit()
-)
 
 
 @jax.jit
@@ -139,22 +59,6 @@ def rev_plain(in0, in1, dout):
     return primals, grads
 
 
-dout = jnp.array([500.0, 700.0, 110.0])
-
-primals, grads = rev(in0, in1, dout)
-# TODO enzyme will in place 0 the gradient inputs, which may not be expected
-print(dout)
-dout = jnp.array([500.0, 700.0, 110.0])
-primals_p, grads_p = rev_plain(in0, in1, dout)
-
-assert (jnp.abs(primals - primals_p) < 1e-6).all()
-for g, g_p in zip(grads, grads_p):
-    print(i, g, g_p)
-    assert (jnp.abs(g - g_p) < 1e-6).all()
-
-print("Gradient success")
-
-
 @jax.jit
 def rev2(in0, in1, in2, dout):
     primals, f_vjp = jax.vjp(add_two, in0, in1, in2)
@@ -169,35 +73,134 @@ def rev2_plain(in0, in1, in2, dout):
     return primals, grads
 
 
-dout = jnp.array([500.0, 700.0, 110.0])
-primals, grads = rev2(in0, in1, in2, dout)
-# TODO enzyme will in place 0 the gradient inputs, which may not be expected
-print(dout)
-dout = jnp.array([500.0, 700.0, 110.0])
-primals_p, grads_p = rev2_plain(in0, in1, in2, dout)
+class AddOneTwo(absltest.TestCase):
+    def setUp(self):
+        self.in0 = jnp.array([1.0, 2.0, 3.0])
+        self.in1 = jnp.array([10.0, 20.0, 30.0])
+        self.in2 = jnp.array([100.0, 200.0, 300.0])
+        self.din0 = jnp.array([0.1, 0.2, 0.3])
+        self.din1 = jnp.array([50.0, 70.0, 110.0])
+        self.din2 = jnp.array([1300.0, 1700.0, 1900.0])
 
-assert (jnp.abs(primals - primals_p) < 1e-6).all()
-for g, g_p in zip(grads, grads_p):
-    print(i, g, g_p)
-    assert (jnp.abs(g - g_p) < 1e-6).all()
+    def test_add_one_primal(self):
+        ao = add_one(self.in0, self.in1)
+        aop = add_one_plain(self.in0, self.in1)
+        self.assertTrue((jnp.abs(ao - aop) < 1e-6).all())
 
-print("Gradient deadarg success")
+        # Benchmark.
+        print(
+            timeit.Timer(
+                "add_one(in0, in1)",
+                globals={"add_one": add_one, "in0": self.in0, "in1": self.in1},
+            ).timeit()
+        )
+        print(
+            timeit.Timer(
+                "add_one_plain(in0, in1)",
+                globals={
+                    "add_one_plain": add_one_plain,
+                    "in0": self.in0,
+                    "in1": self.in1,
+                },
+            ).timeit()
+        )
 
-print(
-    timeit.Timer(
-        "rev(in0, in1, dout)",
-        globals={"rev": rev, "in0": in0, "in1": in1, "dout": dout},
-    ).timeit()
-)
-print(
-    timeit.Timer(
-        "rev_plain(in0, in1, dout)",
-        globals={"rev_plain": rev_plain, "in0": in0, "in1": in1, "dout": dout},
-    ).timeit()
-)
+    def test_add_two_deadarg(self):
+        at = add_two(self.in0, self.in1, self.in2)
+        atp = add_two_plain(self.in0, self.in1, self.in2)
+        self.assertTrue((jnp.abs(at - atp) < 1e-6).all())
 
-x = jnp.array(range(50), dtype=jnp.float32)
-dx = jnp.array([i * i for i in range(50)], dtype=jnp.float32)
+    def test_add_one_forward(self):
+        primals, tangents = fwd(self.in0, self.in1, self.din0, self.din1)
+        primals_p, tangents_p = fwd_plain(self.in0, self.in1, self.din0, self.din1)
+
+        self.assertTrue((jnp.abs(primals - primals_p) < 1e-6).all())
+        for t, t_p in zip(tangents, tangents_p):
+            self.assertTrue((jnp.abs(t - t_p) < 1e-6).all())
+
+        print(
+            timeit.Timer(
+                "fwd(in0, in1, din0, din1)",
+                globals={
+                    "fwd": fwd,
+                    "in0": self.in0,
+                    "in1": self.in1,
+                    "din0": self.din0,
+                    "din1": self.din1,
+                },
+            ).timeit()
+        )
+        print(
+            timeit.Timer(
+                "fwd_plain(in0, in1, din0, din1)",
+                globals={
+                    "fwd_plain": fwd_plain,
+                    "in0": self.in0,
+                    "in1": self.in1,
+                    "din0": self.din0,
+                    "din1": self.din1,
+                },
+            ).timeit()
+        )
+
+    def test_add_two_deadarg_forward(self):
+        primals, tangents = fwd2(
+            self.in0, self.in1, self.in2, self.din0, self.din1, self.din2
+        )
+        primals_p, tangents_p = fwd2_plain(
+            self.in0, self.in1, self.in2, self.din0, self.din1, self.din2
+        )
+
+        print(primals, primals_p)
+        self.assertTrue((jnp.abs(primals - primals_p) < 1e-6).all())
+        for i, (t, t_p) in enumerate(zip(tangents, tangents_p)):
+            print(i, t, t_p)
+            self.assertTrue((jnp.abs(t - t_p) < 1e-6).all())
+
+    def test_add_one_reverse(self):
+        dout = jnp.array([500.0, 700.0, 110.0])
+
+        primals, grads = rev(self.in0, self.in1, dout)
+        # TODO enzyme will in place 0 the gradient inputs, which may not be expected
+        print(dout)
+        dout = jnp.array([500.0, 700.0, 110.0])
+        primals_p, grads_p = rev_plain(self.in0, self.in1, dout)
+
+        self.assertTrue((jnp.abs(primals - primals_p) < 1e-6).all())
+        for i, (g, g_p) in enumerate(zip(grads, grads_p)):
+            print(i, g, g_p)
+            self.assertTrue((jnp.abs(g - g_p) < 1e-6).all())
+
+        print(
+            timeit.Timer(
+                "rev(in0, in1, dout)",
+                globals={"rev": rev, "in0": self.in0, "in1": self.in1, "dout": dout},
+            ).timeit()
+        )
+        print(
+            timeit.Timer(
+                "rev_plain(in0, in1, dout)",
+                globals={
+                    "rev_plain": rev_plain,
+                    "in0": self.in0,
+                    "in1": self.in1,
+                    "dout": dout,
+                },
+            ).timeit()
+        )
+
+    def test_add_two_deadarg_reverse(self):
+        dout = jnp.array([500.0, 700.0, 110.0])
+        primals, grads = rev2(self.in0, self.in1, self.in2, dout)
+        # TODO enzyme will in place 0 the gradient inputs, which may not be expected
+        print(dout)
+        dout = jnp.array([500.0, 700.0, 110.0])
+        primals_p, grads_p = rev2_plain(self.in0, self.in1, self.in2, dout)
+
+        self.assertTrue((jnp.abs(primals - primals_p) < 1e-6).all())
+        for i, (g, g_p) in enumerate(zip(grads, grads_p)):
+            print(i, g, g_p)
+            self.assertTrue((jnp.abs(g - g_p) < 1e-6).all())
 
 
 @enzyme_jax_ir()
@@ -205,20 +208,9 @@ def esum(x):
     return jnp.sum(x)
 
 
-eres = esum(x)
-print(eres)
-assert jnp.abs(eres - 50 * 49 / 2) < 1e-6
-
-
 @jax.jit
 def sumfwd(in0, din0):
     return jax.jvp(esum, (in0,), (din0,))
-
-
-primals, tangents = sumfwd(x, dx)
-print(primals, tangents)
-assert jnp.abs(primals - 50 * 49 / 2) < 1e-6
-assert jnp.abs(tangents - 50 * 49 * 99 / 6) < 1e-6
 
 
 @jax.jit
@@ -228,10 +220,6 @@ def sumrev_p(in0):
     return primals, grads
 
 
-primals, grads = sumrev_p(x)
-print(primals, grads)
-
-
 @jax.jit
 def sumrev(in0):
     primals, f_vjp = jax.vjp(esum, in0)
@@ -239,10 +227,31 @@ def sumrev(in0):
     return primals, grads
 
 
-primals, grads = sumrev(x)
-print(primals, grads)
-assert jnp.abs(primals - 50 * 49 / 2) < 1e-6
-assert (jnp.abs(grads[0] - 1) < 1e-6).all()
+class Sum(absltest.TestCase):
+    def setUp(self):
+        self.x = jnp.array(range(50), dtype=jnp.float32)
+        self.dx = jnp.array([i * i for i in range(50)], dtype=jnp.float32)
+
+    def test_primal(self):
+        eres = esum(self.x)
+        print(eres)
+        self.assertTrue(jnp.abs(eres - 50 * 49 / 2) < 1e-6)
+
+    def test_forward(self):
+        primals, tangents = sumfwd(self.x, self.dx)
+        print(primals, tangents)
+        self.assertTrue(jnp.abs(primals - 50 * 49 / 2) < 1e-6)
+        self.assertTrue(jnp.abs(tangents - 50 * 49 * 99 / 6) < 1e-6)
+
+    def test_reverse_p(self):
+        primals, grads = sumrev_p(self.x)
+        print(primals, grads)
+
+    def test_reverse(self):
+        primals, grads = sumrev(self.x)
+        print(primals, grads)
+        self.assertTrue(jnp.abs(primals - 50 * 49 / 2) < 1e-6)
+        self.assertTrue((jnp.abs(grads[0] - 1) < 1e-6).all())
 
 
 @enzyme_jax_ir()
@@ -257,11 +266,19 @@ def cacherev(in0, din0):
     return grads
 
 
-dim = 288
+class Cache(absltest.TestCase):
+    def test_reverse(self):
+        dim = 288
 
-x = jnp.array(range(dim), dtype=jnp.float32)
-dx = jnp.array(range(dim), dtype=jnp.float32)
+        x = jnp.array(range(dim), dtype=jnp.float32)
+        dx = jnp.array(range(dim), dtype=jnp.float32)
 
-grads = cacherev(x, dx)
-assert jnp.abs(grads[0][0] - 287 * 288 * (2 * 287 + 1) / 6) < 1e-6
-assert (jnp.abs(grads[0][1:]) < 1e-6).all()
+        grads = cacherev(x, dx)
+        self.assertTrue(
+            jnp.abs(grads[0][0] - (dim - 1) * dim * (2 * (dim - 1) + 1) / 6) < 1e-6
+        )
+        self.assertTrue((jnp.abs(grads[0][1:]) < 1e-6).all())
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -1,85 +1,89 @@
+from absl.testing import absltest
 import jax
 import jax.numpy as jnp
-from enzyme_ad.jax import cpp_call
+from enzyme_ad.jax import cpp_call, enzyme_jax_ir
 
 
-@jax.jit
-def do_something(ones):
-    shape = jax.core.ShapedArray(ones.shape, ones.dtype)
-    a, b = cpp_call(
-        ones,
-        out_shapes=[shape, shape],
-        source="""
-    template<std::size_t N, std::size_t M>
-    void myfn(enzyme::tensor<float, N, M>& out0, enzyme::tensor<float, N, M>& out1, const enzyme::tensor<float, N, M>& in0) {
-        for (int j=0; j<N; j++) {
-        for (int k=0; k<M; k++) {
-            out0[j][k] = in0[j][k] + 42;
+class EnzymeJax(absltest.TestCase):
+    def test_custom_cpp_kernel(self):
+        @jax.jit
+        def do_something(ones):
+            shape = jax.core.ShapedArray(ones.shape, ones.dtype)
+            a, b = cpp_call(
+                ones,
+                out_shapes=[shape, shape],
+                source="""
+        template<std::size_t N, std::size_t M>
+        void myfn(enzyme::tensor<float, N, M>& out0,
+                  enzyme::tensor<float, N, M>& out1,
+                  const enzyme::tensor<float, N, M>& in0) {
+          for (int j=0; j<N; j++) {
+            for (int k=0; k<M; k++) {
+                out0[j][k] = in0[j][k] + 42;
+            }
+          }
+          for (int j=0; j<2; j++) {
+            for (int k=0; k<3; k++) {
+                out1[j][k] = in0[j][k] + 2 * 42;
+            }
+          }
         }
+        """,
+                fn="myfn",
+            )
+            c = cpp_call(
+                a,
+                out_shapes=[jax.core.ShapedArray([4, 4], jnp.float32)],
+                source="""
+        template<typename T1, typename T2>
+        void f(T1& out0, const T2& in1) {
+          out0 = 56.0f;
         }
-        for (int j=0; j<2; j++) {
-        for (int k=0; k<3; k++) {
-            out1[j][k] = in0[j][k] + 2 * 42;
-        }
-        }
-    }
-    """,
-        fn="myfn",
-    )
-    c = cpp_call(
-        a,
-        out_shapes=[jax.core.ShapedArray([4, 4], jnp.float32)],
-        source="""
-    template<typename T1, typename T2>
-    void f(T1& out0, const T2& in1) {
-    out0 = 56.0f;
-    }
-    """,
-    )
-    return a, b, c
+        """,
+            )
+            return a, b, c
+
+        ones = jnp.ones((2, 3), jnp.float32)
+        x, y, z = do_something(ones)
+
+        print(x)
+        print(y)
+        print(z)
+
+        # JVP
+        primals, tangents = jax.jvp(do_something, (ones,), (ones,))
+        print(primals)
+        print(tangents)
+
+        # VJP
+        primals, f_vjp = jax.vjp(do_something, ones)
+        (grads,) = f_vjp((x, y, z))
+        print(primals)
+        print(grads)
+
+    def test_enzyme_mlir_jit(self):
+        @enzyme_jax_ir()
+        def add_one(x: jax.Array, y) -> jax.Array:
+            return x + 1 + y
+
+        # But it should print LLVM IR in the process.
+        add_one(jnp.array([1.0, 2.0, 3.0]), jnp.array([10.0, 20.0, 30.0]))
+
+        primals, tangents = jax.jvp(
+            add_one,
+            (jnp.array([1.0, 2.0, 3.0]), jnp.array([10.0, 20.0, 30.0])),
+            (jnp.array([0.1, 0.2, 0.3]), jnp.array([50.0, 70.0, 110.0])),
+        )
+        print(primals)
+        print(tangents)
+
+        primals, f_vjp = jax.vjp(
+            add_one, jnp.array([1.0, 2.0, 3.0]), jnp.array([10.0, 20.0, 30.0])
+        )
+        grads = f_vjp(jnp.array([500.0, 700.0, 110.0]))
+        print(primals)
+        print(grads)
 
 
-ones = jnp.ones((2, 3), jnp.float32)
-x, y, z = do_something(ones)
-
-print(x)
-print(y)
-print(z)
-
-primals, tangents = jax.jvp(do_something, (ones,), (ones,))
-print(primals)
-print(tangents)
-
-
-primals, f_vjp = jax.vjp(do_something, ones)
-(grads,) = f_vjp((x, y, z))
-print(primals)
-print(grads)
-
-# Test enzyme mlir jit
-from enzyme_ad.jax import enzyme_jax_ir
-
-
-@enzyme_jax_ir()
-def add_one(x: jax.Array, y) -> jax.Array:
-    return x + 1 + y
-
-
-# TODO: this currently throws NYI as it is not yet connected to JIT and runtime.
-# But it should print LLVM IR in the process.
-add_one(jnp.array([1.0, 2.0, 3.0]), jnp.array([10.0, 20.0, 30.0]))
-
-primals, tangents = jax.jvp(
-    add_one,
-    (jnp.array([1.0, 2.0, 3.0]), jnp.array([10.0, 20.0, 30.0])),
-    (jnp.array([0.1, 0.2, 0.3]), jnp.array([50.0, 70.0, 110.0])),
-)
-print(primals)
-print(tangents)
-
-primals, f_vjp = jax.vjp(
-    add_one, jnp.array([1.0, 2.0, 3.0]), jnp.array([10.0, 20.0, 30.0])
-)
-grads = f_vjp(jnp.array([500.0, 700.0, 110.0]))
-print(primals)
-print(grads)
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
JAX already depends on absltest so we have it "for free" as a
dependency. Using a test framework composes better with build
infrastructure.