### PR TITLE
Make enzyme_ref delete in_shapes instead of out_shapes

### DIFF
--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -284,7 +284,7 @@ def _enzyme_rev_impl(
     lang: enzyme_call.Language,
     pipeline_options
 ) -> Sequence[jax.Array]:
-    del args_flat, source, out_shapes
+    del args_flat, source, in_shapes
     raise RuntimeError("must be JIT'ed")
 
 


### PR DESCRIPTION
Fixes a reference count issue  during a timeit call where we tried to erroneously delete out_shapes.