### PR TITLE
optimize convolution of transpose

### DIFF
--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -219,6 +219,10 @@ def ApplyEinsumTransposePatterns : EnzymeHLOPatternOp<
     "einsum_transpose"> {
   let patterns = ["EinsumTranspose"];
 }
+def ApplyConvolutionTransposePatterns : EnzymeHLOPatternOp<
+    "convolution_transpose"> {
+  let patterns = ["ConvolutionTranspose"];
+}
 def ApplyDotTransposePatterns : EnzymeHLOPatternOp<
     "dot_transpose"> {
   let patterns = ["DotTranspose"];

--- a/test/lit_tests/convolutiontranpose.mlir
+++ b/test/lit_tests/convolutiontranpose.mlir
@@ -4,14 +4,12 @@ module {
   func.func @main(%arg0: tensor<5x3x224x224xf32>, %arg1: tensor<2x3x10x10xf32>) -> tensor<5x2x215x215xf32> {
     %0 = stablehlo.transpose %arg0, dims = [3, 2, 1, 0] : (tensor<5x3x224x224xf32>) -> tensor<224x224x3x5xf32>
     %1 = stablehlo.transpose %arg1, dims = [3, 2, 1, 0] : (tensor<2x3x10x10xf32>) -> tensor<10x10x3x2xf32>
-    %2 = stablehlo.convolution(%0, %1) dim_numbers = [0, 1, f, b]x[0, 1, i, o]->[0, 1, f, b], window = {stride = [1, 1], lhs_dilate = [1, 1], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<224x224x3x5xf32>, tensor<10x10x3x2xf32>) -> tensor<215x215x2x5xf32>
-    %3 = stablehlo.transpose %2, dims = [3, 2, 1, 0] : (tensor<215x215x2x5xf32>) -> tensor<5x2x215x215xf32>
-    return %3 : tensor<5x2x215x215xf32>
+    %2 = stablehlo.convolution(%0, %1) dim_numbers = [0, 1, f, b]x[0, 1, i, o]->[b, f, 1, 0], window = {stride = [1, 1], lhs_dilate = [1, 1], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<224x224x3x5xf32>, tensor<10x10x3x2xf32>) -> tensor<5x2x215x215xf32>
+    return %2 : tensor<5x2x215x215xf32>
   }
 }
 
 // CHECK:  func.func @main(%arg0: tensor<5x3x224x224xf32>, %arg1: tensor<2x3x10x10xf32>) -> tensor<5x2x215x215xf32> {
-// CHECK-NEXT:    %0 = stablehlo.convolution(%arg0, %arg1) dim_numbers = [b, f, 1, 0]x[o, i, 1, 0]->[0, 1, f, b], window = {stride = [1, 1], lhs_dilate = [1, 1], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<5x3x224x224xf32>, tensor<2x3x10x10xf32>) -> tensor<215x215x2x5xf32>
-// CHECK-NEXT:    %1 = stablehlo.transpose %0, dims = [3, 2, 1, 0] : (tensor<215x215x2x5xf32>) -> tensor<5x2x215x215xf32>
-// CHECK-NEXT:    return %1 : tensor<5x2x215x215xf32>
+// CHECK-NEXT:    %0 = stablehlo.convolution(%arg0, %arg1) dim_numbers = [b, f, 1, 0]x[o, i, 1, 0]->[b, f, 1, 0], window = {stride = [1, 1], lhs_dilate = [1, 1], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<5x3x224x224xf32>, tensor<2x3x10x10xf32>) -> tensor<5x2x215x215xf32>
+// CHECK-NEXT:    return %0 : tensor<5x2x215x215xf32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/convolutiontranpose.mlir
+++ b/test/lit_tests/convolutiontranpose.mlir
@@ -1,0 +1,17 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{max_constant_expansion=1})" %s | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<5x3x224x224xf32>, %arg1: tensor<2x3x10x10xf32>) -> tensor<5x2x215x215xf32> {
+    %0 = stablehlo.transpose %arg0, dims = [3, 2, 1, 0] : (tensor<5x3x224x224xf32>) -> tensor<224x224x3x5xf32>
+    %1 = stablehlo.transpose %arg1, dims = [3, 2, 1, 0] : (tensor<2x3x10x10xf32>) -> tensor<10x10x3x2xf32>
+    %2 = stablehlo.convolution(%0, %1) dim_numbers = [0, 1, f, b]x[0, 1, i, o]->[0, 1, f, b], window = {stride = [1, 1], lhs_dilate = [1, 1], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<224x224x3x5xf32>, tensor<10x10x3x2xf32>) -> tensor<215x215x2x5xf32>
+    %3 = stablehlo.transpose %2, dims = [3, 2, 1, 0] : (tensor<215x215x2x5xf32>) -> tensor<5x2x215x215xf32>
+    return %3 : tensor<5x2x215x215xf32>
+  }
+}
+
+// CHECK:  func.func @main(%arg0: tensor<5x3x224x224xf32>, %arg1: tensor<2x3x10x10xf32>) -> tensor<5x2x215x215xf32> {
+// CHECK-NEXT:    %0 = stablehlo.convolution(%arg0, %arg1) dim_numbers = [b, f, 1, 0]x[o, i, 1, 0]->[0, 1, f, b], window = {stride = [1, 1], lhs_dilate = [1, 1], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<5x3x224x224xf32>, tensor<2x3x10x10xf32>) -> tensor<215x215x2x5xf32>
+// CHECK-NEXT:    %1 = stablehlo.transpose %0, dims = [3, 2, 1, 0] : (tensor<215x215x2x5xf32>) -> tensor<5x2x215x215xf32>
+// CHECK-NEXT:    return %1 : tensor<5x2x215x215xf32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
I wrote the optimization we discussed about but for stablehlo.convolution.

```mlir
    %0 = stablehlo.transpose %arg0, dims = [3, 2, 1, 0] : (tensor<5x3x224x224xf32>) -> tensor<224x224x3x5xf32>
    %1 = stablehlo.transpose %arg1, dims = [3, 2, 1, 0] : (tensor<2x3x10x10xf32>) -> tensor<10x10x3x2xf32>
    %2 = stablehlo.convolution(%0, %1) dim_numbers = [0, 1, f, b]x[0, 1, i, o]->[0, 1, f, b], window = {stride = [1, 1], lhs_dilate = [1, 1], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<224x224x3x5xf32>, tensor<10x10x3x2xf32>) -> tensor<215x215x2x5xf32>
```

to

```mlir
    %0 = stablehlo.convolution(%arg0, %arg1) dim_numbers = [b, f, 1, 0]x[o, i, 1, 0]->[0, 1, f, b], window = {stride = [1, 1], lhs_dilate = [1, 1], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<5x3x224x224xf32>, tensor<2x3x10x10xf32>) -> tensor<215x215x2x5xf32>
```

There is still the case where we have `transpose(conv)` which could be optimized if there is only one user of the convolution to be implemented next.

@mofeing We can call to do a similar optimization for Einsum, it seems it is [not present in the spec](https://github.com/openxla/stablehlo/blob/2f89787c8f663e39db3b47a161be98f0f2e72ced/stablehlo/dialect/StablehloOps.td#L2491-L2492) so you may be able to help me here.