### PR TITLE
IfOp

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6311,6 +6311,76 @@ struct IfInline final : OpRewritePattern<mlir::stablehlo::IfOp> {
   }
 };
 
+// https://github.com/llvm/llvm-project/blob/74d8f3952c4acf6d57948983d7c5b0d0a7763c28/mlir/lib/Dialect/SCF/IR/SCF.cpp#L2313
+struct IfToSelect final : public OpRewritePattern<mlir::stablehlo::IfOp> {
+  using OpRewritePattern<mlir::stablehlo::IfOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::stablehlo::IfOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op->getNumResults() == 0 || op.getTrueBranch().empty() ||
+        op.getFalseBranch().empty())
+      return failure();
+
+    auto pred = op.getPred();
+
+    auto trueOperands =
+        op.getTrueBranch().front().getTerminator()->getOperands();
+    auto falseOperands =
+        op.getFalseBranch().front().getTerminator()->getOperands();
+
+    SmallVector<Type> nonHoistable;
+    for (auto [trueVal, falseVal] : llvm::zip(trueOperands, falseOperands)) {
+      if (&op.getTrueBranch() == trueVal.getParentRegion() ||
+          &op.getFalseBranch() == falseVal.getParentRegion())
+        nonHoistable.push_back(trueVal.getType());
+    }
+
+    // Early exit if there aren't any yielded values we can
+    // hoist outside the if.
+    if (nonHoistable.size() == op->getNumResults())
+      return failure();
+
+    auto replacement =
+        rewriter.create<mlir::stablehlo::IfOp>(op.getLoc(), nonHoistable, pred);
+    replacement.getTrueBranch().takeBody(op.getTrueBranch());
+    replacement.getFalseBranch().takeBody(op.getFalseBranch());
+
+    SmallVector<Value> results(op->getNumResults());
+    assert(trueOperands.size() == results.size());
+    assert(falseOperands.size() == results.size());
+
+    SmallVector<Value> trueReturns;
+    SmallVector<Value> falseReturns;
+    rewriter.setInsertionPoint(replacement);
+    for (const auto &it :
+         llvm::enumerate(llvm::zip(trueOperands, falseOperands))) {
+      Value trueVal = std::get<0>(it.value());
+      Value falseVal = std::get<1>(it.value());
+      if (&replacement.getTrueBranch() == trueVal.getParentRegion() ||
+          &replacement.getFalseBranch() == falseVal.getParentRegion()) {
+        results[it.index()] = replacement.getResult(trueReturns.size());
+        trueReturns.push_back(trueVal);
+        falseReturns.push_back(falseVal);
+      } else if (trueVal == falseVal)
+        results[it.index()] = trueVal;
+      else
+        results[it.index()] = rewriter.create<mlir::stablehlo::SelectOp>(
+            op.getLoc(), pred, trueVal, falseVal);
+    }
+
+    rewriter.setInsertionPointToEnd(&replacement.getTrueBranch().front());
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ReturnOp>(
+        replacement.getTrueBranch().front().getTerminator(), trueReturns);
+
+    rewriter.setInsertionPointToEnd(&replacement.getFalseBranch().front());
+    rewriter.replaceOpWithNewOp<mlir::stablehlo::ReturnOp>(
+        replacement.getFalseBranch().front().getTerminator(), falseReturns);
+
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
+
 /// Check if a `t` is a tensor with zero extents.
 static std::optional<RankedTensorType> isZeroExtent(Type t) {
   auto type = t.dyn_cast<RankedTensorType>();
@@ -6565,8 +6635,8 @@ struct EnzymeHLOOptPass : public EnzymeHLOOptPassBase<EnzymeHLOOptPass> {
              EmptyReduceOpCanon, DynamicReshapeOpCanon, GetTupleElementOpCanon,
              RealOpCanon, ImagOpCanon, GetDimensionSizeOpCanon, GatherOpCanon,
              ReshapeOpCanon, MergeConsecutiveReshapes, TransposeIsReshape,
-             IfInline, ZeroExtentTensorCanon, ReorderElementwiseAndShapeOp>(
-            context);
+             IfInline, IfToSelect, ZeroExtentTensorCanon,
+             ReorderElementwiseAndShapeOp>(context);
     patterns.add<SelectOpCanon>(max_constant_expansion, context,
                                 PatternBenefit(65000));
     patterns.add<ConcatenateOpCanon>(max_constant_expansion, context,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -551,6 +551,11 @@ def IfInline : EnzymeHLOPatternOp<
   let patterns = ["IfInline"];
 }
 
+def IfToSelect : EnzymeHLOPatternOp<
+    "if_to_select"> {
+  let patterns = ["IfToSelect"];
+}
+
 def ZeroExtentTensorCanonPatterns : EnzymeHLOPatternOp<
     "zero_extent_tensor_canon"> {
   let patterns = ["ZeroExtentTensorCanon"];

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -546,6 +546,11 @@ def TransposeIsReshapePatterns : EnzymeHLOPatternOp<
   let patterns = ["TransposeIsReshape"];
 }
 
+def IfInline : EnzymeHLOPatternOp<
+    "if_inline"> {
+  let patterns = ["IfInline"];
+}
+
 def ZeroExtentTensorCanonPatterns : EnzymeHLOPatternOp<
     "zero_extent_tensor_canon"> {
   let patterns = ["ZeroExtentTensorCanon"];

--- a/test/lit_tests/diffrules/stablehlo/if.mlir
+++ b/test/lit_tests/diffrules/stablehlo/if.mlir
@@ -1,0 +1,53 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup,enzyme_const mode=ForwardMode" --canonicalize | FileCheck %s --check-prefix=FORWARD
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_const mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+
+module {
+  func.func @main(%arg0: tensor<10xf32>, %pred: tensor<i1>) -> tensor<10xf32> {
+    %cst = stablehlo.constant dense<1.0> : tensor<10xf32>
+
+    %0 = "stablehlo.if"(%pred) ({
+      %1 = stablehlo.add %arg0, %cst : tensor<10xf32>
+      "stablehlo.return"(%1) : (tensor<10xf32>) -> ()
+    }, {
+      "stablehlo.return"(%cst) : (tensor<10xf32>) -> ()
+    }) : (tensor<i1>) -> tensor<10xf32>
+
+    return %0 : tensor<10xf32>
+  }
+}
+
+// FORWARD:  func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<10xf32>, %arg2: tensor<i1>) -> (tensor<10xf32>, tensor<10xf32>) {
+// FORWARD-NEXT:    %cst = arith.constant dense<0.000000e+00> : tensor<10xf32>
+// FORWARD-NEXT:    %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<10xf32>
+// FORWARD-NEXT:    %0:2 = "stablehlo.if"(%arg2) ({
+// FORWARD-NEXT:      %1 = stablehlo.add %arg1, %cst : tensor<10xf32>
+// FORWARD-NEXT:      %2 = stablehlo.add %arg0, %cst_0 : tensor<10xf32>
+// FORWARD-NEXT:      stablehlo.return %2, %1 : tensor<10xf32>, tensor<10xf32>
+// FORWARD-NEXT:    }, {
+// FORWARD-NEXT:      stablehlo.return %cst_0, %cst : tensor<10xf32>, tensor<10xf32>
+// FORWARD-NEXT:    }) : (tensor<i1>) -> (tensor<10xf32>, tensor<10xf32>)
+// FORWARD-NEXT:    return %0#0, %0#1 : tensor<10xf32>, tensor<10xf32>
+// FORWARD-NEXT:  }
+
+// REVERSE:  func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<i1>, %arg2: tensor<10xf32>) -> tensor<10xf32> {
+// REVERSE-NEXT:    %cst = arith.constant dense<0.000000e+00> : tensor<10xf32>
+// REVERSE-NEXT:    %0 = "enzyme.init"() : () -> !enzyme.Gradient<tensor<10xf32>>
+// REVERSE-NEXT:    "enzyme.set"(%0, %cst) : (!enzyme.Gradient<tensor<10xf32>>, tensor<10xf32>) -> ()
+// REVERSE-NEXT:    %1 = "enzyme.init"() : () -> !enzyme.Gradient<tensor<10xf32>>
+// REVERSE-NEXT:    "enzyme.set"(%1, %cst) : (!enzyme.Gradient<tensor<10xf32>>, tensor<10xf32>) -> ()
+// REVERSE-NEXT:    %2 = arith.addf %arg2, %cst : tensor<10xf32>
+// REVERSE-NEXT:    "stablehlo.if"(%arg1) ({
+// REVERSE-NEXT:      %4 = "enzyme.get"(%1) : (!enzyme.Gradient<tensor<10xf32>>) -> tensor<10xf32>
+// REVERSE-NEXT:      %5 = arith.addf %4, %2 : tensor<10xf32>
+// REVERSE-NEXT:      "enzyme.set"(%1, %5) : (!enzyme.Gradient<tensor<10xf32>>, tensor<10xf32>) -> ()
+// REVERSE-NEXT:      "enzyme.set"(%1, %cst) : (!enzyme.Gradient<tensor<10xf32>>, tensor<10xf32>) -> ()
+// REVERSE-NEXT:      %6 = "enzyme.get"(%0) : (!enzyme.Gradient<tensor<10xf32>>) -> tensor<10xf32>
+// REVERSE-NEXT:      %7 = arith.addf %6, %5 : tensor<10xf32>
+// REVERSE-NEXT:      "enzyme.set"(%0, %7) : (!enzyme.Gradient<tensor<10xf32>>, tensor<10xf32>) -> ()
+// REVERSE-NEXT:      stablehlo.return 
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      stablehlo.return 
+// REVERSE-NEXT:    }) : (tensor<i1>) -> ()
+// REVERSE-NEXT:    %3 = "enzyme.get"(%0) : (!enzyme.Gradient<tensor<10xf32>>) -> tensor<10xf32>
+// REVERSE-NEXT:    return %3 : tensor<10xf32>
+// REVERSE-NEXT:  }

--- a/test/lit_tests/if.mlir
+++ b/test/lit_tests/if.mlir
@@ -26,10 +26,52 @@ module {
     return %result : tensor<i32>
   }
 
+  func.func @if_to_select(%result_true_branch: tensor<i32>, %result_false_branch: tensor<i32>, %pred: tensor<i1>) -> tensor<i32> {
+    %result = "stablehlo.if"(%pred) ({
+      "stablehlo.return"(%result_true_branch) : (tensor<i32>) -> ()
+    }, {
+      "stablehlo.return"(%result_false_branch) : (tensor<i32>) -> ()
+    }) : (tensor<i1>) -> tensor<i32>
+    return %result : tensor<i32>
+  }
+
+  func.func @if_to_select2(%result_true_branch: tensor<i32>, %result_false_branch: tensor<i32>, %pred: tensor<i1>) -> tensor<i32> {
+    %result:2 = "stablehlo.if"(%pred) ({
+      %c = stablehlo.constant dense<1> : tensor<i32>
+      %1 = stablehlo.add %c, %result_true_branch : tensor<i32>
+      "stablehlo.return"(%result_true_branch, %1) : (tensor<i32>, tensor<i32>) -> ()
+    }, {
+      %c = stablehlo.constant dense<2> : tensor<i32>
+      %1 = stablehlo.add %c, %result_false_branch : tensor<i32>
+      "stablehlo.return"(%result_false_branch, %1) : (tensor<i32>, tensor<i32>) -> ()
+    }) : (tensor<i1>) -> (tensor<i32>, tensor<i32>)
+    %0 = stablehlo.add %result#0, %result#1 : tensor<i32>
+    return %0 : tensor<i32>
+  }
 }
 
 // CHECK:  func.func @f(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
 // CHECK-NEXT:    %c = stablehlo.constant dense<42> : tensor<i32>
 // CHECK-NEXT:    %0 = stablehlo.add %arg0, %c : tensor<i32>
 // CHECK-NEXT:    return %0 : tensor<i32>
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @if_to_select(%arg0: tensor<i32>, %arg1: tensor<i32>, %arg2: tensor<i1>) -> tensor<i32> {
+// CHECK-NEXT:    %0 = stablehlo.select %arg2, %arg0, %arg1 : tensor<i1>, tensor<i32>
+// CHECK-NEXT:    return %0 : tensor<i32>
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @if_to_select2(%arg0: tensor<i32>, %arg1: tensor<i32>, %arg2: tensor<i1>) -> tensor<i32> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<2> : tensor<i32>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i32>
+// CHECK-NEXT:    %0 = stablehlo.select %arg2, %arg0, %arg1 : tensor<i1>, tensor<i32>
+// CHECK-NEXT:    %1 = "stablehlo.if"(%arg2) ({
+// CHECK-NEXT:      %3 = stablehlo.add %c_0, %arg0 : tensor<i32>
+// CHECK-NEXT:      stablehlo.return %3 : tensor<i32>
+// CHECK-NEXT:    }, {
+// CHECK-NEXT:      %3 = stablehlo.add %c, %arg1 : tensor<i32>
+// CHECK-NEXT:      stablehlo.return %3 : tensor<i32>
+// CHECK-NEXT:    }) : (tensor<i1>) -> tensor<i32>
+// CHECK-NEXT:    %2 = stablehlo.add %0, %1 : tensor<i32>
+// CHECK-NEXT:    return %2 : tensor<i32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/if.mlir
+++ b/test/lit_tests/if.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+module {
+
+  func.func @f(%result_true_branch: tensor<i32>, %result_false_branch: tensor<i32>) -> tensor<i32> {
+    %pred = stablehlo.constant dense<1> : tensor<i1>
+    %pred2 = stablehlo.constant dense<0> : tensor<i1>
+
+    %result = "stablehlo.if"(%pred) ({
+      %c = stablehlo.constant dense<42> : tensor<i32>
+      %0 = stablehlo.add %result_true_branch, %c : tensor<i32>
+
+      %result1 = "stablehlo.if"(%pred2) ({
+        %c1 = stablehlo.constant dense<42> : tensor<i32>
+        %01 = stablehlo.add %0, %c1 : tensor<i32>
+        "stablehlo.return"(%01) : (tensor<i32>) -> ()
+      }, {
+        "stablehlo.return"(%0) : (tensor<i32>) -> ()
+      }) : (tensor<i1>) -> tensor<i32>
+
+      "stablehlo.return"(%result1) : (tensor<i32>) -> ()
+    }, {
+      "stablehlo.return"(%result_false_branch) : (tensor<i32>) -> ()
+    }) : (tensor<i1>) -> tensor<i32>
+
+    return %result : tensor<i32>
+  }
+
+}
+
+// CHECK:  func.func @f(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<42> : tensor<i32>
+// CHECK-NEXT:    %0 = stablehlo.add %arg0, %c : tensor<i32>
+// CHECK-NEXT:    return %0 : tensor<i32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
 - region inlining if predicate is known
 - transform to select for values which are not defined in inner regions
 - forward
 - reverse

I don't think the reverse could be used as is in a XLA pipeline since Enzyme is not yet able to remove all enzyme ops (which I think it technically could if there is no loop?).