### PR TITLE
remove transform.with_named_sequence attribute

### DIFF
--- a/src/enzyme_ad/jax/TransformOps/GenerateApplyPatterns.cpp
+++ b/src/enzyme_ad/jax/TransformOps/GenerateApplyPatterns.cpp
@@ -197,7 +197,10 @@ public:
   }
 
   void runOnOperation() override {
-    getOperation()->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    auto op = getOperation();
+    if (op->hasAttr(transform::TransformDialect::kWithNamedSequenceAttrName))
+      op->removeAttr(transform::TransformDialect::kWithNamedSequenceAttrName);
+    op->walk<WalkOrder::PreOrder>([&](Operation *op) {
       if (isa<transform::TransformOpInterface>(op)) {
         op->erase();
         return WalkResult::skip();

--- a/test/lit_tests/generate_td.mlir
+++ b/test/lit_tests/generate_td.mlir
@@ -22,6 +22,7 @@
 
 // TD: module attributes {transform.with_named_sequence} {
 // TD:  transform.named_sequence @__transform_main(%[[ROOT:.+]]: !transform.any_op) {
+// CLEAN-NOT: attributes {transform.with_named_sequence}
 // CLEAN-NOT: transform.named_sequence
 // TD:    %[[FUNC:.+]] = transform.structured.match ops{["func.func"]} in %[[ROOT]] : (!transform.any_op) -> !transform.any_op
 // TD:    transform.apply_patterns to %[[FUNC]] {


### PR DESCRIPTION
To clean up `Reactant.@code_hlo` output