### PR TITLE
feat: common simplifications

### DIFF
--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -327,6 +327,10 @@ def ApplyNoNanSelfSubSimplify : EnzymeHLOPatternOp<
     "no_nan_self_sub_simplify"> {
   let patterns = ["NoNanSelfSubSimplify"];
 }
+def ApplyNoNanAddSubSimplify : EnzymeHLOPatternOp<
+    "no_nan_add_sub_simplify"> {
+  let patterns = ["NoNanAddSubSimplify"];
+}
 
 def ApplyConcatPushBinopAddPatterns : EnzymeHLOPatternOp<
     "concat_push_binop_add"> {

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -45,6 +45,10 @@ def ApplyAddSimplifyPatterns : EnzymeHLOPatternOp<
     "add_simplify"> {
   let patterns = ["AddSimplify"];
 }
+def ApplyReplaceNegAddWithSubtract: EnzymeHLOPatternOp<
+    "replace_neg_add_with_subtract"> {
+  let patterns = ["ReplaceNegAddWithSubtract"];
+}
 def ApplySubSimplifyPatterns : EnzymeHLOPatternOp<
     "sub_simplify"> {
   let patterns = ["SubSimplify"];

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -323,6 +323,10 @@ def ApplyNoNanPatterns : EnzymeHLOPatternOp<
     "no_nan"> {
   let patterns = ["NoNan"];
 }
+def ApplyNoNanSelfSubSimplify : EnzymeHLOPatternOp<
+    "no_nan_self_sub_simplify"> {
+  let patterns = ["NoNanSelfSubSimplify"];
+}
 
 def ApplyConcatPushBinopAddPatterns : EnzymeHLOPatternOp<
     "concat_push_binop_add"> {

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -356,6 +356,52 @@ def ApplyBinBroadcastSplatMulPatterns : EnzymeHLOPatternOp<
     "bin_broadcast_splat_mul"> {
   let patterns = ["BinBroadcastSplat<stablehlo::MulOp>"];
 }
+
+def ApplyBinaryOpTransposeSimplifyAddPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_add"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::AddOp>"];
+}
+def ApplyBinaryOpTransposeSimplifySubPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_sub"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::SubtractOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyMulPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_mul"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::MulOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyDivPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_div"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::DivOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyMinPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_min"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::MinOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyMaxPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_max"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::MaxOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyPowPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_pow"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::PowOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyAndPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_and"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::AndOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyOrPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_or"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::OrOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyXorPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_xor"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::XorOp>"];
+}
+def ApplyBinaryOpTransposeSimplifyRemPatterns : EnzymeHLOPatternOp<
+    "binary_op_transpose_simplify_rem"> {
+  let patterns = ["BinaryOpTransposeSimplify<stablehlo::RemOp>"];
+}
+
 def AddPadPadToConcatPatterns : EnzymeHLOPatternOp<
     "add_pad_pad_to_concat"> {
   let patterns = ["AddPadPadToConcat"];

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -131,6 +131,7 @@ cse_concatenate<16>;
 concatenate_op_canon<16>(1024);
 select_op_canon<16>(1024);
 add_simplify<16>;
+replace_neg_add_with_subtract<16>;
 sub_simplify<16>;
 and_simplify<16>;
 max_simplify<16>;

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -131,7 +131,6 @@ cse_concatenate<16>;
 concatenate_op_canon<16>(1024);
 select_op_canon<16>(1024);
 add_simplify<16>;
-replace_neg_add_with_subtract<16>;
 sub_simplify<16>;
 and_simplify<16>;
 max_simplify<16>;
@@ -181,6 +180,7 @@ scatter_to_dynamic_update_slice<1>;
 reduce_concat<1>;
 slice_concat<1>;
 concat_slice<1>;
+replace_neg_add_with_subtract<16>;
 
 bin_broadcast_splat_add<1>;
 bin_broadcast_splat_subtract<1>;

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -194,6 +194,18 @@ reshape_empty_broadcast<1>;
 add_pad_pad_to_concat<1>;
 broadcast_reshape<1>;
 
+binary_op_transpose_simplify_add<1>;
+binary_op_transpose_simplify_sub<1>;
+binary_op_transpose_simplify_mul<1>;
+binary_op_transpose_simplify_div<1>;
+binary_op_transpose_simplify_min<1>;
+binary_op_transpose_simplify_max<1>;
+binary_op_transpose_simplify_pow<1>;
+binary_op_transpose_simplify_and<1>;
+binary_op_transpose_simplify_or<1>;
+binary_op_transpose_simplify_xor<1>;
+binary_op_transpose_simplify_rem<1>;
+
 slice_reshape_concat<1>;
 slice_reshape_elementwise<1>;
 slice_reshape_transpose<1>;

--- a/test/lit_tests/addnegate.mlir
+++ b/test/lit_tests/addnegate.mlir
@@ -1,0 +1,14 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt %s | FileCheck %s
+
+module {
+  func.func @test(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %0 = stablehlo.negate %arg0 : tensor<4x4xf32>
+    %1 = stablehlo.add %arg1, %0 : tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+}
+
+// CHECK:  func.func @test(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+// CHECK-NEXT:    %0 = stablehlo.subtract %arg1, %arg0 : tensor<4x4xf32>
+// CHECK-NEXT:    return %0 : tensor<4x4xf32>
+// CHECK-NEXT:  }

--- a/test/lit_tests/addsumsimplify.mlir
+++ b/test/lit_tests/addsumsimplify.mlir
@@ -1,0 +1,76 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{no_nan=true})" %s | FileCheck %s --check-prefix=NONAN
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{no_nan=false})" %s | FileCheck %s --check-prefix=NAN
+
+module {
+  func.func @t1(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<3xf64>
+    %1 = stablehlo.subtract %arg1, %0 : tensor<3xf64>
+    return %1 : tensor<3xf64>
+  }
+}
+
+// NONAN:  func.func @t1(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// NONAN-NEXT:    %0 = stablehlo.negate %arg0 : tensor<3xf64>
+// NONAN-NEXT:    return %0 : tensor<3xf64>
+// NONAN-NEXT:  }
+
+// NAN:  func.func @t1(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// NAN-NEXT:    %0 = stablehlo.add %arg0, %arg1 : tensor<3xf64>
+// NAN-NEXT:    %1 = stablehlo.subtract %arg1, %0 : tensor<3xf64>
+// NAN-NEXT:    return %1 : tensor<3xf64>
+// NAN-NEXT:  }
+
+module {
+  func.func @t2(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<3xf64>
+    %1 = stablehlo.subtract %0, %arg1 : tensor<3xf64>
+    return %1 : tensor<3xf64>
+  }
+}
+
+// NONAN:  func.func @t2(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// NONAN-NEXT:    return %arg0 : tensor<3xf64>
+// NONAN-NEXT:  }
+
+// NAN:  func.func @t2(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// NAN-NEXT:    %0 = stablehlo.add %arg0, %arg1 : tensor<3xf64>
+// NAN-NEXT:    %1 = stablehlo.subtract %0, %arg1 : tensor<3xf64>
+// NAN-NEXT:    return %1 : tensor<3xf64>
+// NAN-NEXT:  }
+
+module {
+  func.func @t3(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+    %0 = stablehlo.add %arg1, %arg0 : tensor<3xf64>
+    %1 = stablehlo.subtract %arg1, %0 : tensor<3xf64>
+    return %1 : tensor<3xf64>
+  }
+}
+
+// NONAN:  func.func @t3(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// NONAN-NEXT:    %0 = stablehlo.negate %arg0 : tensor<3xf64>
+// NONAN-NEXT:    return %0 : tensor<3xf64>
+// NONAN-NEXT:  }
+
+// NAN:  func.func @t3(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// NAN-NEXT:    %0 = stablehlo.add %arg1, %arg0 : tensor<3xf64>
+// NAN-NEXT:    %1 = stablehlo.subtract %arg1, %0 : tensor<3xf64>
+// NAN-NEXT:    return %1 : tensor<3xf64>
+// NAN-NEXT:  }
+
+module {
+  func.func @t4(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+    %0 = stablehlo.add %arg1, %arg0 : tensor<3xf64>
+    %1 = stablehlo.subtract %0, %arg1 : tensor<3xf64>
+    return %1 : tensor<3xf64>
+  }
+}
+
+// NONAN:  func.func @t4(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// NONAN-NEXT:    return %arg0 : tensor<3xf64>
+// NONAN-NEXT:  }
+
+// NAN:  func.func @t4(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// NAN-NEXT:    %0 = stablehlo.add %arg1, %arg0 : tensor<3xf64>
+// NAN-NEXT:    %1 = stablehlo.subtract %0, %arg1 : tensor<3xf64>
+// NAN-NEXT:    return %1 : tensor<3xf64>
+// NAN-NEXT:  }

--- a/test/lit_tests/binarytranspose.mlir
+++ b/test/lit_tests/binarytranspose.mlir
@@ -1,0 +1,188 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt %s | FileCheck %s
+
+func.func @t1(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %2 = stablehlo.multiply %0, %1 : tensor<2x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    return %3 : tensor<3x2xf64>
+}
+
+// CHECK:  func.func @t1(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+// CHECK-NEXT:    %0 = stablehlo.multiply %arg0, %arg1 : tensor<3x2xf64>
+// CHECK-NEXT:    return %0 : tensor<3x2xf64>
+// CHECK-NEXT:  }
+
+func.func @t2(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %2 = stablehlo.add %0, %1 : tensor<2x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    return %3 : tensor<3x2xf64>
+}
+
+// CHECK:  func.func @t2(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+// CHECK-NEXT:    %0 = stablehlo.add %arg0, %arg1 : tensor<3x2xf64>
+// CHECK-NEXT:    return %0 : tensor<3x2xf64>
+// CHECK-NEXT:  }
+
+func.func @t4(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %2 = stablehlo.subtract %0, %1 : tensor<2x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    return %3 : tensor<3x2xf64>
+}
+
+// CHECK:  func.func @t4(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+// CHECK-NEXT:    %0 = stablehlo.subtract %arg0, %arg1 : tensor<3x2xf64>
+// CHECK-NEXT:    return %0 : tensor<3x2xf64>
+// CHECK-NEXT:  }
+
+func.func @t5(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %2 = stablehlo.divide %0, %1 : tensor<2x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    return %3 : tensor<3x2xf64>
+}
+
+// CHECK:  func.func @t5(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+// CHECK-NEXT:    %0 = stablehlo.divide %arg0, %arg1 : tensor<3x2xf64>
+// CHECK-NEXT:    return %0 : tensor<3x2xf64>
+// CHECK-NEXT:  }
+
+func.func @t7(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %2 = stablehlo.minimum %0, %1 : tensor<2x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    return %3 : tensor<3x2xf64>
+}
+
+// CHECK:  func.func @t7(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+// CHECK-NEXT:    %0 = stablehlo.minimum %arg0, %arg1 : tensor<3x2xf64>
+// CHECK-NEXT:    return %0 : tensor<3x2xf64>
+// CHECK-NEXT:  }
+
+func.func @t8(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %2 = stablehlo.maximum %0, %1 : tensor<2x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    return %3 : tensor<3x2xf64>
+}
+
+// CHECK:  func.func @t8(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+// CHECK-NEXT:    %0 = stablehlo.maximum %arg0, %arg1 : tensor<3x2xf64>
+// CHECK-NEXT:    return %0 : tensor<3x2xf64>
+// CHECK-NEXT:  }
+
+func.func @t9(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %2 = stablehlo.power %0, %1 : tensor<2x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    return %3 : tensor<3x2xf64>
+}
+
+// CHECK:  func.func @t9(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+// CHECK-NEXT:    %0 = stablehlo.power %arg0, %arg1 : tensor<3x2xf64>
+// CHECK-NEXT:    return %0 : tensor<3x2xf64>
+// CHECK-NEXT:  }
+
+func.func @t10(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+    %2 = stablehlo.remainder %0, %1 : tensor<2x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    return %3 : tensor<3x2xf64>
+}
+
+// CHECK:  func.func @t10(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>) -> tensor<3x2xf64> {
+// CHECK-NEXT:    %0 = stablehlo.remainder %arg0, %arg1 : tensor<3x2xf64>
+// CHECK-NEXT:    return %0 : tensor<3x2xf64>
+// CHECK-NEXT:  }
+
+func.func @t11(%arg0: tensor<3x2xi1>, %arg1: tensor<3x2xi1>) -> tensor<3x2xi1> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xi1>) -> tensor<2x3xi1>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xi1>) -> tensor<2x3xi1>
+    %2 = stablehlo.and %0, %1 : tensor<2x3xi1>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xi1>) -> tensor<3x2xi1>
+    return %3 : tensor<3x2xi1>
+}
+
+// CHECK:  func.func @t11(%arg0: tensor<3x2xi1>, %arg1: tensor<3x2xi1>) -> tensor<3x2xi1> {
+// CHECK-NEXT:    %0 = stablehlo.and %arg0, %arg1 : tensor<3x2xi1>
+// CHECK-NEXT:    return %0 : tensor<3x2xi1>
+// CHECK-NEXT:  }
+
+func.func @t12(%arg0: tensor<3x2xi1>, %arg1: tensor<3x2xi1>) -> tensor<3x2xi1> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xi1>) -> tensor<2x3xi1>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xi1>) -> tensor<2x3xi1>
+    %2 = stablehlo.or %0, %1 : tensor<2x3xi1>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xi1>) -> tensor<3x2xi1>
+    return %3 : tensor<3x2xi1>
+}
+
+// CHECK:  func.func @t12(%arg0: tensor<3x2xi1>, %arg1: tensor<3x2xi1>) -> tensor<3x2xi1> {
+// CHECK-NEXT:    %0 = stablehlo.or %arg0, %arg1 : tensor<3x2xi1>
+// CHECK-NEXT:    return %0 : tensor<3x2xi1>
+// CHECK-NEXT:  }
+
+func.func @t13(%arg0: tensor<3x2xi1>, %arg1: tensor<3x2xi1>) -> tensor<3x2xi1> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xi1>) -> tensor<2x3xi1>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xi1>) -> tensor<2x3xi1>
+    %2 = stablehlo.xor %0, %1 : tensor<2x3xi1>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<2x3xi1>) -> tensor<3x2xi1>
+    return %3 : tensor<3x2xi1>
+}
+
+// CHECK:  func.func @t13(%arg0: tensor<3x2xi1>, %arg1: tensor<3x2xi1>) -> tensor<3x2xi1> {
+// CHECK-NEXT:    %0 = stablehlo.xor %arg0, %arg1 : tensor<3x2xi1>
+// CHECK-NEXT:    return %0 : tensor<3x2xi1>
+// CHECK-NEXT:  }
+
+func.func @t14(%arg0: tensor<3x3xf64>, %arg1: tensor<3x3xf64>) -> tensor<3x3xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x3xf64>) -> tensor<3x3xf64>
+    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x3xf64>) -> tensor<3x3xf64>
+    %2 = stablehlo.multiply %0, %1 : tensor<3x3xf64>
+    %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<3x3xf64>) -> tensor<3x3xf64>
+    %4 = stablehlo.cosine %2 : tensor<3x3xf64>
+    return %4 : tensor<3x3xf64>
+}
+
+// CHECK:  func.func @t14(%arg0: tensor<3x3xf64>, %arg1: tensor<3x3xf64>) -> tensor<3x3xf64> {
+// CHECK-NEXT:    %0 = stablehlo.multiply %arg0, %arg1 : tensor<3x3xf64>
+// CHECK-NEXT:    %1 = stablehlo.cosine %0 : tensor<3x3xf64>
+// CHECK-NEXT:    %2 = stablehlo.transpose %1, dims = [1, 0] : (tensor<3x3xf64>) -> tensor<3x3xf64>
+// CHECK-NEXT:    return %2 : tensor<3x3xf64>
+// CHECK-NEXT:  }
+
+func.func @t15(%arg0: tensor<3x4xf64>) -> tensor<3x4xf64> {
+    %cst = stablehlo.constant dense<[[0.6496222808917268, 0.096212809753773776, 0.15377221949977682], [0.96568572693987941, 0.023023752185516666, 0.79410616419530333], [0.23747479566982688, 0.094921128460392024, 0.79170861871474563], [0.38420536250190751, 0.13376956140378637, 0.91958862661700169]]> : tensor<4x3xf64>
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x4xf64>) -> tensor<4x3xf64>
+    %1 = stablehlo.add %0, %cst : tensor<4x3xf64>
+    %2 = stablehlo.transpose %1, dims = [1, 0] : (tensor<4x3xf64>) -> tensor<3x4xf64>
+    return %2 : tensor<3x4xf64>
+}
+
+// CHECK:  func.func @t15(%arg0: tensor<3x4xf64>) -> tensor<3x4xf64> {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<{{\[\[}}0.6496222808917268, 0.96568572693987941, 0.23747479566982688, 0.38420536250190751{{\]}}, {{\[}}0.096212809753773776, 0.023023752185516666, 0.094921128460392024, 0.13376956140378637{{\]}}, {{\[}}0.15377221949977682, 0.79410616419530333, 0.79170861871474563, 0.91958862661700169{{\]\]}}> : tensor<3x4xf64>
+// CHECK-NEXT:    %0 = stablehlo.add %arg0, %cst : tensor<3x4xf64>
+// CHECK-NEXT:    return %0 : tensor<3x4xf64>
+// CHECK-NEXT:  }
+
+func.func @t16(%arg0: tensor<3x4xf64>) -> tensor<3x4xf64> {
+    %cst = stablehlo.constant dense<[[0.27420692997448848, 0.942463642354195, 0.38939691245710661], [0.78824309336664444, 0.89589669457637566, 0.89695004003823775], [0.29780552679309602, 0.78345118987434825, 0.73322208573165204], [0.76793662184643451, 0.47269648986329182, 0.30380322872102516]]> : tensor<4x3xf64>
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x4xf64>) -> tensor<4x3xf64>
+    %1 = stablehlo.add %cst, %0 : tensor<4x3xf64>
+    %2 = stablehlo.transpose %1, dims = [1, 0] : (tensor<4x3xf64>) -> tensor<3x4xf64>
+    return %2 : tensor<3x4xf64>
+}
+
+// CHECK:  func.func @t16(%arg0: tensor<3x4xf64>) -> tensor<3x4xf64> {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<{{\[\[}}0.27420692997448848, 0.78824309336664444, 0.29780552679309602, 0.76793662184643451{{\]}}, {{\[}}0.942463642354195, 0.89589669457637566, 0.78345118987434825, 0.47269648986329182{{\]}}, {{\[}}0.38939691245710661, 0.89695004003823775, 0.73322208573165204, 0.30380322872102516{{\]\]}}> : tensor<3x4xf64>
+// CHECK-NEXT:    %0 = stablehlo.add %cst, %arg0 : tensor<3x4xf64>
+// CHECK-NEXT:    return %0 : tensor<3x4xf64>
+// CHECK-NEXT:  }

--- a/test/lit_tests/selfsubtract.mlir
+++ b/test/lit_tests/selfsubtract.mlir
@@ -1,0 +1,23 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{no_nan=true})" %s | FileCheck %s --check-prefix=NONAN
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{no_nan=false})" %s | FileCheck %s --check-prefix=NAN
+
+module {
+  func.func @main(%arg0: tensor<3x4xf64>) -> tensor<3x4xf64> {
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x4xf64>) -> tensor<4x3xf64>
+    %1 = stablehlo.subtract %0, %0 : tensor<4x3xf64>
+    %2 = stablehlo.transpose %1, dims = [1, 0] : (tensor<4x3xf64>) -> tensor<3x4xf64>
+    return %2 : tensor<3x4xf64>
+  }
+}
+
+// NONAN:  func.func @main(%arg0: tensor<3x4xf64>) -> tensor<3x4xf64> {
+// NONAN-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<3x4xf64>
+// NONAN-NEXT:    return %cst : tensor<3x4xf64>
+// NONAN-NEXT:  }
+
+// NAN:  func.func @main(%arg0: tensor<3x4xf64>) -> tensor<3x4xf64> {
+// NAN-NEXT:    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x4xf64>) -> tensor<4x3xf64>
+// NAN-NEXT:    %1 = stablehlo.subtract %0, %0 : tensor<4x3xf64>
+// NAN-NEXT:    %2 = stablehlo.transpose %1, dims = [1, 0] : (tensor<4x3xf64>) -> tensor<3x4xf64>
+// NAN-NEXT:    return %2 : tensor<3x4xf64>
+// NAN-NEXT:  }


### PR DESCRIPTION
- [x] `a + (-b)` => `a - b` if `-b` isn't used anywhere
- [x] `<op>(transpose(a), transpose(b))` => `transpose(<op>(a, b))` if only use
- [x] `<op>(transpose(a), cst)` => `transpose(<op>(a, transposed_cst))`
- [x] no_nan simplifications
  - [x] `a - a` => `0`
  - [x] `c = a + b`; `d = c - b` => `d = a`
  - [x] `c = a + b`; `d = b - c` => `d = -a`
