### PR TITLE
Add opt to simplify select uses within if

### DIFF
--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -631,6 +631,11 @@ def IfToSelect : EnzymeHLOPatternOp<
   let patterns = ["IfToSelect"];
 }
 
+def SelectOpUsedWithinIf : EnzymeHLOPatternOp<
+    "select_op_used_within_if"> {
+  let patterns = ["SelectOpUsedWithinIf"];
+}
+
 def ZeroExtentTensorCanonPatterns : EnzymeHLOPatternOp<
     "zero_extent_tensor_canon"> {
   let patterns = ["ZeroExtentTensorCanon"];

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -181,6 +181,7 @@ scatter_to_dynamic_update_slice<1>;
 reduce_concat<1>;
 slice_concat<1>;
 concat_slice<1>;
+select_op_used_within_if<1>;
 replace_neg_add_with_subtract<16>;
 
 bin_broadcast_splat_add<1>;

--- a/test/lit_tests/diffrules/stablehlo/if_remove.mlir
+++ b/test/lit_tests/diffrules/stablehlo/if_remove.mlir
@@ -18,13 +18,12 @@ module {
 
 // REVERSE:  func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<i1>, %arg2: tensor<10xf32>) -> tensor<10xf32> {
 // REVERSE-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10xf32>
-// REVERSE-NEXT:    %0 = stablehlo.select %arg1, %arg0, %cst : tensor<i1>, tensor<10xf32>
-// REVERSE-NEXT:    %1 = "stablehlo.if"(%arg1) ({
-// REVERSE-NEXT:      %2 = stablehlo.multiply %arg2, %0 : tensor<10xf32>
-// REVERSE-NEXT:      %3 = stablehlo.add %2, %2 : tensor<10xf32>
-// REVERSE-NEXT:      stablehlo.return %3 : tensor<10xf32>
+// REVERSE-NEXT:    %0 = "stablehlo.if"(%arg1) ({
+// REVERSE-NEXT:      %1 = stablehlo.multiply %arg2, %arg0 : tensor<10xf32>
+// REVERSE-NEXT:      %2 = stablehlo.add %1, %1 : tensor<10xf32>
+// REVERSE-NEXT:      stablehlo.return %2 : tensor<10xf32>
 // REVERSE-NEXT:    }, {
 // REVERSE-NEXT:      stablehlo.return %cst : tensor<10xf32>
 // REVERSE-NEXT:    }) : (tensor<i1>) -> tensor<10xf32>
-// REVERSE-NEXT:    return %1 : tensor<10xf32>
+// REVERSE-NEXT:    return %0 : tensor<10xf32>
 // REVERSE-NEXT:  }

--- a/test/lit_tests/select_if.mlir
+++ b/test/lit_tests/select_if.mlir
@@ -1,0 +1,26 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+module {
+  func.func @main(%pred: tensor<i1>, %a: tensor<f32>, %b: tensor<f32>) -> tensor<f32> {
+    %0 = stablehlo.select %pred, %a, %b : tensor<i1>, tensor<f32>
+    %1 = "stablehlo.if"(%pred) ({
+      %2 = stablehlo.add %0, %0 : tensor<f32>
+      "stablehlo.return"(%2) : (tensor<f32>) -> ()
+    }, {
+      %3 = stablehlo.add %0, %0 : tensor<f32>
+      "stablehlo.return"(%3) : (tensor<f32>) -> ()
+    }) : (tensor<i1>) -> tensor<f32>
+    return %1 : tensor<f32>
+  }
+}
+
+// CHECK:  func.func @main(%arg0: tensor<i1>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<f32> {
+// CHECK-NEXT:    %0 = "stablehlo.if"(%arg0) ({
+// CHECK-NEXT:      %1 = stablehlo.add %arg1, %arg1 : tensor<f32>
+// CHECK-NEXT:      stablehlo.return %1 : tensor<f32>
+// CHECK-NEXT:    }, {
+// CHECK-NEXT:      %1 = stablehlo.add %arg2, %arg2 : tensor<f32>
+// CHECK-NEXT:      stablehlo.return %1 : tensor<f32>
+// CHECK-NEXT:    }) : (tensor<i1>) -> tensor<f32>
+// CHECK-NEXT:    return %0 : tensor<f32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
If a select has uses within a if with the same predicate, the uses can be replaced with either the true or false value.

In a follow-up, we can do the following:

if a select is itself within a if with the same predicate, its result can be replaced with the corresponding operand:

```mlir
%1 = stablehlo.if %pred ({
  %0 = stablehlo.select %pred, %a, %b
  stablehlo.return %0
}, {
  stablehlo.return %other
})

// Transform to

%1 = stablehlo.if %pred ({
  stablehlo.return %a
}, {
  stablehlo.return %other
})

```