### PR TITLE
fix cmplx stop

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -2757,7 +2757,7 @@ struct AddSimplify : public OpRewritePattern<mlir::stablehlo::AddOp> {
             op, op.getType(), res.cast<ElementsAttr>());
         return success();
       }
-    } else {
+    } else if (op.getType().getElementType().isa<IntegerType>()) {
       if (auto res = constFoldBinaryOpConditional<IntegerAttr,
                                                   IntegerAttr::ValueType, void>(
               constants,
@@ -2838,7 +2838,7 @@ struct SubSimplify : public OpRewritePattern<mlir::stablehlo::SubtractOp> {
             op, op.getType(), res.cast<ElementsAttr>());
         return success();
       }
-    } else {
+    } else if (op.getType().getElementType().isa<IntegerType>()) {
       if (auto res = constFoldBinaryOpConditional<IntegerAttr,
                                                   IntegerAttr::ValueType, void>(
               constants,
@@ -3015,7 +3015,7 @@ struct MulSimplify : public OpRewritePattern<mlir::stablehlo::MulOp> {
             op, op.getType(), res.cast<ElementsAttr>());
         return success();
       }
-    } else {
+    } else if (op.getType().getElementType().isa<IntegerType>()) {
       if (auto res = constFoldBinaryOpConditional<IntegerAttr,
                                                   IntegerAttr::ValueType, void>(
               constants,
@@ -3072,7 +3072,7 @@ struct DivSimplify : public OpRewritePattern<mlir::stablehlo::DivOp> {
             op, op.getType(), res.cast<ElementsAttr>());
         return success();
       }
-    } else {
+    } else if (op.getType().getElementType().isa<IntegerType>()) {
       if (auto res = constFoldBinaryOpConditional<IntegerAttr,
                                                   IntegerAttr::ValueType, void>(
               constants,
@@ -3118,7 +3118,7 @@ struct RemSimplify : public OpRewritePattern<mlir::stablehlo::RemOp> {
             op, op.getType(), res.cast<ElementsAttr>());
         return success();
       }
-    } else {
+    } else if (op.getType().getElementType().isa<IntegerType>()) {
       if (auto res = constFoldBinaryOpConditional<IntegerAttr,
                                                   IntegerAttr::ValueType, void>(
               constants,
@@ -3183,7 +3183,7 @@ struct PowSimplify : public OpRewritePattern<mlir::stablehlo::PowOp> {
           }
         }
       }
-    } else {
+    } else if (op.getType().getElementType().isa<IntegerType>()) {
       if (auto res = constFoldBinaryOpConditional<IntegerAttr,
                                                   IntegerAttr::ValueType, void>(
               constants,
@@ -3552,7 +3552,7 @@ struct MaxSimplify : public OpRewritePattern<mlir::stablehlo::MaxOp> {
             op, op.getType(), res.cast<ElementsAttr>());
         return success();
       }
-    } else {
+    } else if (op.getType().getElementType().isa<IntegerType>()) {
       if (auto res = constFoldBinaryOpConditional<IntegerAttr,
                                                   IntegerAttr::ValueType, void>(
               constants,
@@ -3594,7 +3594,7 @@ struct MinSimplify : public OpRewritePattern<mlir::stablehlo::MinOp> {
             op, op.getType(), res.cast<ElementsAttr>());
         return success();
       }
-    } else {
+    } else if (op.getType().getElementType().isa<IntegerType>()) {
       if (auto res = constFoldBinaryOpConditional<IntegerAttr,
                                                   IntegerAttr::ValueType, void>(
               constants,


### PR DESCRIPTION
@mofeing re https://github.com/EnzymeAD/Enzyme-JAX/issues/270 got it in gdb

So basically we were simplifying an add of tensor complex, but that only supported float and otherwise assumed int (which is wrong here since it was complex).

```
(lldb) p op.dump()
%6 = stablehlo.add %cst, %cst_2 : tensor<2x2xcomplex<f64>>
(lldb) p op.getOperand(0)
(mlir::Value) {
  impl = 0x0000600000a23de0
}
(lldb) p op.getOperand(0).dump()
%cst = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<2x2xcomplex<f64>>
(lldb) p op.getOperand(1).dump()
%cst_2 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<2x2xcomplex<f64>>
```

For now this PR should stop it from failing, but clearly this should be updated to also constprop complex values