### PR TITLE
Propagate constant for thread/block index in kernels

### DIFF
--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -53,13 +53,6 @@ def KernelCallOp: EnzymeXLA_Op<"kernel_call", [DeclareOpInterfaceMethods<SymbolU
     OptionalAttr<AnyAttr>:$result_layouts,
     DefaultValuedOptionalAttr<
         ArrayAttr, "{}">:$output_operand_aliases
-    //OptionalAttr<StableHLO_ArrayOfLayoutAttr>:$operand_layouts,
-    //OptionalAttr<StableHLO_ArrayOfLayoutAttr>:$result_layouts,
-    //DefaultValuedOptionalAttr<
-    //    TypedArrayAttrBase<
-    //        StableHLO_OutputOperandAlias,
-    //        "Aliasing attribute for outputs and operands of CustomCall">,
-    //    "{}">:$output_operand_aliases
   );
 
   let results = (outs Variadic<AnyType>);

--- a/src/enzyme_ad/jax/Passes/Passes.h
+++ b/src/enzyme_ad/jax/Passes/Passes.h
@@ -17,6 +17,7 @@ class PatternRewriter;
 class RewritePatternSet;
 class DominanceInfo;
 namespace enzyme {
+std::unique_ptr<Pass> createPropagateConstantBoundsPass();
 std::unique_ptr<Pass> createRemoveDuplicateFuncDefPass();
 std::unique_ptr<Pass> createArithRaisingPass();
 std::unique_ptr<Pass> createConsumingInterpreterPass();

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -19,6 +19,15 @@ def RemoveDuplicateFuncDefPass : Pass<"remove-duplicate-func-def", "mlir::Module
   ]; 
 }
 
+def PropagateConstantBoundsPass : Pass<"propagate-constant-bounds", "ModuleOp"> {
+  let summary = "Propagate constant bounds";
+  let constructor = "mlir::enzyme::createPropagateConstantBoundsPass()";
+  let dependentDialects = [
+    "mlir::LLVM::LLVMDialect",
+    "mlir::NVVM::NVVMDialect",
+  ]; 
+}
+
 def ArithRaisingPass : Pass<"arith-raise"> {
   let summary = "Raise Arith to mhlo";
   let dependentDialects = [
@@ -135,8 +144,7 @@ def PrintPass : Pass<"print"> {
 }
 
 def SROAWrappersPass : Pass<"sroa-wrappers", "mlir::ModuleOp"> {
-  let summary = "";
-  let dependentDialects = [];
+  let summary = "Run LLVM SROA (Scalar Replacement of Aggregates)";
   let constructor = "mlir::enzyme::createSROAWrappersPass()";
   let dependentDialects = [
     "mlir::LLVM::LLVMDialect",

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -24,7 +24,7 @@ def PropagateConstantBoundsPass : Pass<"propagate-constant-bounds", "ModuleOp"> 
   let constructor = "mlir::enzyme::createPropagateConstantBoundsPass()";
   let dependentDialects = [
     "mlir::LLVM::LLVMDialect",
-    "mlir::NVVM::NVVMDialect",
+    "mlir::NVVM::NVVMDialect"
   ]; 
 }
 

--- a/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
+++ b/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
@@ -61,7 +61,7 @@ struct PropagateConstantBoundsPass
       auto symbolName = callOp.getFn();
       auto callee = symTable.lookup<LLVM::LLVMFuncOp>(symbolName);
       if (!callee)
-        return WalkResult::advance();
+        return;
       Region *reg = callee.getCallableRegion();
       // thread idx
       reg->walk([&](NVVM::ThreadIdXOp idxOp) {

--- a/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
+++ b/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
@@ -1,0 +1,99 @@
+//===- RemoveDuplicateFuncDef.cpp - Remove duplicate fund def -------------- //
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// This file implements a pass to remove duplicate function definitions.
+//===---------------------------------------------------------------------===//
+
+#include "src/enzyme_ad/jax/Passes/PassDetails.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+#include "src/enzyme_ad/jax/Dialect/Ops.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Region.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Visitors.h"
+
+using namespace mlir;
+using namespace mlir::enzyme;
+
+namespace {
+struct PropagateConstantBoundsPass
+    : public PropagateConstantBoundsPassBase<PropagateConstantBoundsPass> {
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    auto *ctx = moduleOp->getContext();
+    SymbolTable symTable(moduleOp);
+
+    // nvvm.read.ptx.sreg.tid.x
+    auto walkResult = moduleOp->walk([&](enzymexla::KernelCallOp callOp) {
+      auto symbolName = callOp.getFn();
+      auto callee = symTable.lookup<LLVM::LLVMFuncOp>(symbolName);
+      if (!callee)
+        return WalkResult::advance();
+      Region *reg = callee.getCallableRegion();
+      // thread idx
+      reg->walk([&](NVVM::ThreadIdXOp idxOp) {
+        auto cst = callOp.getGridx().getDefiningOp();
+        APInt intValue;
+        if (matchPattern(cst, m_ConstantInt(&intValue)))
+          idxOp->setAttr("range", LLVM::ConstantRangeAttr::get(
+                                      ctx, 32, 0, intValue.getSExtValue()));
+      });
+      reg->walk([&](NVVM::ThreadIdYOp idyOp) {
+        auto cst = callOp.getGridy().getDefiningOp();
+        APInt intValue;
+        if (matchPattern(cst, m_ConstantInt(&intValue)))
+          idyOp->setAttr("range", LLVM::ConstantRangeAttr::get(
+                                      ctx, 32, 0, intValue.getSExtValue()));
+      });
+      reg->walk([&](NVVM::ThreadIdZOp idzOp) {
+        auto cst = callOp.getGridz().getDefiningOp();
+        APInt intValue;
+        if (matchPattern(cst, m_ConstantInt(&intValue)))
+          idzOp->setAttr("range", LLVM::ConstantRangeAttr::get(
+                                      ctx, 32, 0, intValue.getSExtValue()));
+      });
+      // block index
+      reg->walk([&](NVVM::BlockIdXOp blkIdxOp) {
+        auto cst = callOp.getBlockx().getDefiningOp();
+        APInt intValue;
+        if (matchPattern(cst, m_ConstantInt(&intValue)))
+          blkIdxOp->setAttr("range", LLVM::ConstantRangeAttr::get(
+                                         ctx, 32, 0, intValue.getSExtValue()));
+      });
+      reg->walk([&](NVVM::BlockIdYOp blkIdyOp) {
+        auto cst = callOp.getBlocky().getDefiningOp();
+        APInt intValue;
+        if (matchPattern(cst, m_ConstantInt(&intValue)))
+          blkIdyOp->setAttr("range", LLVM::ConstantRangeAttr::get(
+                                         ctx, 32, 0, intValue.getSExtValue()));
+      });
+      reg->walk([&](NVVM::BlockIdZOp blkIdzOp) {
+        auto cst = callOp.getBlockz().getDefiningOp();
+        APInt intValue;
+        if (matchPattern(cst, m_ConstantInt(&intValue)))
+          blkIdzOp->setAttr("range", LLVM::ConstantRangeAttr::get(
+                                         ctx, 32, 0, intValue.getSExtValue()));
+      });
+    });
+  }
+};
+} // end namespace
+
+namespace mlir {
+namespace enzyme {
+std::unique_ptr<Pass> createPropagateConstantBoundsPass() {
+  return std::make_unique<PropagateConstantBoundsPass>();
+}
+} // namespace enzyme
+} // namespace mlir

--- a/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
+++ b/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
@@ -1,12 +1,9 @@
-//===- RemoveDuplicateFuncDef.cpp - Remove duplicate fund def -------------- //
+//===- PropagateConstantBounds.cpp - Remove duplicate fund def ------------- //
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===---------------------------------------------------------------------===//
-//
-// This file implements a pass to remove duplicate function definitions.
 //===---------------------------------------------------------------------===//
 
 #include "src/enzyme_ad/jax/Passes/PassDetails.h"

--- a/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
+++ b/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
@@ -57,7 +57,7 @@ struct PropagateConstantBoundsPass
     OpBuilder builder(ctx);
     SymbolTable symTable(moduleOp);
 
-    auto walkResult = moduleOp->walk([&](enzymexla::KernelCallOp callOp) {
+    moduleOp->walk([&](enzymexla::KernelCallOp callOp) {
       auto symbolName = callOp.getFn();
       auto callee = symTable.lookup<LLVM::LLVMFuncOp>(symbolName);
       if (!callee)

--- a/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
+++ b/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
@@ -57,7 +57,6 @@ struct PropagateConstantBoundsPass
     OpBuilder builder(ctx);
     SymbolTable symTable(moduleOp);
 
-    // nvvm.read.ptx.sreg.tid.x
     auto walkResult = moduleOp->walk([&](enzymexla::KernelCallOp callOp) {
       auto symbolName = callOp.getFn();
       auto callee = symTable.lookup<LLVM::LLVMFuncOp>(symbolName);

--- a/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
+++ b/src/enzyme_ad/jax/Passes/PropagateConstantBound.cpp
@@ -65,45 +65,61 @@ struct PropagateConstantBoundsPass
       Region *reg = callee.getCallableRegion();
       // thread idx
       reg->walk([&](NVVM::ThreadIdXOp idxOp) {
-        attachConstantRangeIfConstant(ctx, callOp.getGridx().getDefiningOp(),
+        attachConstantRangeIfConstant(ctx, callOp.getBlockx().getDefiningOp(),
                                       idxOp.getOperation());
       });
       reg->walk([&](NVVM::ThreadIdYOp idyOp) {
-        attachConstantRangeIfConstant(ctx, callOp.getGridy().getDefiningOp(),
+        attachConstantRangeIfConstant(ctx, callOp.getBlocky().getDefiningOp(),
                                       idyOp.getOperation());
       });
       reg->walk([&](NVVM::ThreadIdZOp idzOp) {
-        attachConstantRangeIfConstant(ctx, callOp.getGridz().getDefiningOp(),
+        attachConstantRangeIfConstant(ctx, callOp.getBlockz().getDefiningOp(),
                                       idzOp.getOperation());
       });
       // thread range
       reg->walk([&](NVVM::BlockDimXOp blockIdxOp) {
         replaceWithConstantIfConstant(builder,
-                                      callOp.getGridx().getDefiningOp(),
+                                      callOp.getBlockx().getDefiningOp(),
                                       blockIdxOp.getOperation());
       });
       reg->walk([&](NVVM::BlockDimYOp blockIdyOp) {
         replaceWithConstantIfConstant(builder,
-                                      callOp.getGridy().getDefiningOp(),
+                                      callOp.getBlocky().getDefiningOp(),
                                       blockIdyOp.getOperation());
       });
       reg->walk([&](NVVM::BlockDimZOp blockIdzOp) {
         replaceWithConstantIfConstant(builder,
-                                      callOp.getGridz().getDefiningOp(),
+                                      callOp.getBlockz().getDefiningOp(),
                                       blockIdzOp.getOperation());
       });
       // block index
       reg->walk([&](NVVM::BlockIdXOp blkIdxOp) {
-        attachConstantRangeIfConstant(ctx, callOp.getBlockx().getDefiningOp(),
+        attachConstantRangeIfConstant(ctx, callOp.getGridx().getDefiningOp(),
                                       blkIdxOp.getOperation());
       });
       reg->walk([&](NVVM::BlockIdYOp blkIdyOp) {
-        attachConstantRangeIfConstant(ctx, callOp.getBlocky().getDefiningOp(),
+        attachConstantRangeIfConstant(ctx, callOp.getGridy().getDefiningOp(),
                                       blkIdyOp.getOperation());
       });
       reg->walk([&](NVVM::BlockIdZOp blkIdzOp) {
-        attachConstantRangeIfConstant(ctx, callOp.getBlockz().getDefiningOp(),
+        attachConstantRangeIfConstant(ctx, callOp.getGridz().getDefiningOp(),
                                       blkIdzOp.getOperation());
+      });
+      // block range
+      reg->walk([&](NVVM::GridDimXOp gridIdxOp) {
+        replaceWithConstantIfConstant(builder,
+                                      callOp.getGridx().getDefiningOp(),
+                                      gridIdxOp.getOperation());
+      });
+      reg->walk([&](NVVM::GridDimYOp gridIdyOp) {
+        replaceWithConstantIfConstant(builder,
+                                      callOp.getGridy().getDefiningOp(),
+                                      gridIdyOp.getOperation());
+      });
+      reg->walk([&](NVVM::GridDimZOp gridIdzOp) {
+        replaceWithConstantIfConstant(builder,
+                                      callOp.getGridz().getDefiningOp(),
+                                      gridIdzOp.getOperation());
       });
     });
   }

--- a/test/lit_tests/propagate-constant-values.mlir
+++ b/test/lit_tests/propagate-constant-values.mlir
@@ -1,0 +1,19 @@
+// RUN: enzymexlamlir-opt %s --propagate-constant-bounds | FileCheck %s
+
+// CHECK-LABEL: ptx_kernelcc
+llvm.func ptx_kernelcc @"##foo#3846"() {
+    // CHECK: nvvm.read.ptx.sreg.tid.x range <i32, 0, 2> : i32
+    %0 = nvvm.read.ptx.sreg.tid.x : i32
+    // CHECK-NEXT: nvvm.read.ptx.sreg.ctaid.x range <i32, 0, 1> : i32
+    %1 = nvvm.read.ptx.sreg.ctaid.x : i32
+    llvm.return
+}
+
+func.func @main() {
+  %c_4 = stablehlo.constant dense<1> : tensor<i64>
+  %c_5 = stablehlo.constant dense<2> : tensor<i64>
+  %c_6 = stablehlo.constant dense<3> : tensor<i64>
+  %c_8 = stablehlo.constant dense<4> : tensor<i64>
+  enzymexla.kernel_call @"##foo#3846" blocks in(%c_5, %c_8, %c_8) threads in(%c_4, %c_8, %c_8) shmem = %c_6 () {} : () -> ()
+  return
+}

--- a/test/lit_tests/propagate-constant-values.mlir
+++ b/test/lit_tests/propagate-constant-values.mlir
@@ -6,11 +6,11 @@ llvm.func @foo(%arg0: i32) -> i32 {
 
 // CHECK-LABEL: ptx_kernelcc
 llvm.func ptx_kernelcc @"##foo#3846"() {
-    // CHECK: nvvm.read.ptx.sreg.tid.x range <i32, 0, 2> : i32
+    // CHECK: nvvm.read.ptx.sreg.tid.x range <i32, 0, 1> : i32
     %0 = nvvm.read.ptx.sreg.tid.x : i32
-    // CHECK-NEXT: nvvm.read.ptx.sreg.ctaid.x range <i32, 0, 1> : i32
+    // CHECK-NEXT: nvvm.read.ptx.sreg.ctaid.x range <i32, 0, 2> : i32
     %1 = nvvm.read.ptx.sreg.ctaid.x : i32
-    // CHECK-NEXT: %[[CST:.+]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-NEXT: %[[CST:.+]] = llvm.mlir.constant(1 : i32) : i32
     %2 = nvvm.read.ptx.sreg.ntid.x : i32
     // CHECK: %{{.+}} = llvm.call @foo(%[[CST]]) : (i32) -> i32
     llvm.call @foo(%2) : (i32) -> i32

--- a/test/lit_tests/propagate-constant-values.mlir
+++ b/test/lit_tests/propagate-constant-values.mlir
@@ -1,11 +1,19 @@
 // RUN: enzymexlamlir-opt %s --propagate-constant-bounds | FileCheck %s
 
+llvm.func @foo(%arg0: i32) -> i32 {
+  llvm.return %arg0 : i32
+}
+
 // CHECK-LABEL: ptx_kernelcc
 llvm.func ptx_kernelcc @"##foo#3846"() {
     // CHECK: nvvm.read.ptx.sreg.tid.x range <i32, 0, 2> : i32
     %0 = nvvm.read.ptx.sreg.tid.x : i32
     // CHECK-NEXT: nvvm.read.ptx.sreg.ctaid.x range <i32, 0, 1> : i32
     %1 = nvvm.read.ptx.sreg.ctaid.x : i32
+    // CHECK-NEXT: %[[CST:.+]] = llvm.mlir.constant(2 : i32) : i32
+    %2 = nvvm.read.ptx.sreg.ntid.x : i32
+    // CHECK: %{{.+}} = llvm.call @foo(%[[CST]]) : (i32) -> i32
+    llvm.call @foo(%2) : (i32) -> i32
     llvm.return
 }
 


### PR DESCRIPTION
Since thread and block IDs are constants, we can propagate these constants in the kernel using the LLVM Range attribute.  When running this pass before the SROA, I saw a reduction in operation counts for `exported_oc.mlir` (from 43131 to 39151), which looks related to bound computations. 

