### PR TITLE
fix compilation

### DIFF
--- a/src/enzyme_ad/jax/Passes/ControlFlowToSCF.cpp
+++ b/src/enzyme_ad/jax/Passes/ControlFlowToSCF.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/CFGToSCF.h"
 


### PR DESCRIPTION
bazel-out/darwin_arm64-dbg/bin/src/enzyme_ad/jax/Passes/Passes.h.inc:589:21: error: use of undeclared identifier 'ub'