### PR TITLE
make XLADerivatives target public

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -372,6 +372,7 @@ gentbl_cc_library(
 
 cc_library(
     name = "XLADerivatives",
+    visibility = ["//visibility:public"],
     srcs = glob(
         [
             "Implementations/*.cpp",


### PR DESCRIPTION
I'd like access to this target to use Enzyme in my project. Is that OK?