### PR TITLE
feat: derivative rule for gather op

### DIFF
--- a/src/enzyme_ad/jax/Implementations/CHLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/CHLODerivatives.td
@@ -2,7 +2,7 @@ include "src/enzyme_ad/jax/Implementations/Common.td"
 
 class HLODerivative<string opName_, dag patternToMatch, list<dag> resultOps, dag forwardOps=(ForwardFromSummedReverse)> : MLIRDerivative<"chlo", opName_, patternToMatch, resultOps, forwardOps>;
 
-class HLOInst<string m, string postopt=""> : Inst<m, "chlo", postopt>;
+class HLOInst<string m, string postopt="", string preopt=""> : Inst<m, "chlo", postopt, preopt>;
 
 class HLOMemoryIdentityOp<string opName_, list<int> ptrargs_, list<int> storedargs_ = [], dag patternToMatch=(Unimplemented), list<dag> reverse_ = []>  : MemoryIdentityOp<"chlo", opName_, ptrargs_, storedargs_, patternToMatch, reverse_>;
 

--- a/src/enzyme_ad/jax/Implementations/HLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/HLODerivatives.td
@@ -82,7 +82,6 @@ def RngBitGenerator : HLOInst<"RngBitGeneratorOp">;
 def Round : HLOInst<"RoundOp">; // round_nearest_afz
 def RoundNearestEven : HLOInst<"RoundNearestEvenOp">;
 def Rsqrt : HLOInst<"RsqrtOp">;
-def Scatter : HLOInst<"ScatterOp", "->getResult(0)">;
 def Select : HLOInst<"SelectOp">;
 def SelectAndScatter : HLOInst<"SelectAndScatterOp">;
 def Send : HLOInst<"SendOp">;
@@ -950,31 +949,6 @@ def GatherToScatterDimNumbers : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [
   );
 }]>;
 
-def BinaryAdd : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
-  auto region = std::make_unique<Region>();
-  auto *block = new Block;
-  region->push_back(block);
-
-  auto elemType = op->getResult(0).getType().cast<ShapedType>().getElementType();
-  auto tensorType = RankedTensorType::get({}, elemType);
-
-  block->addArguments({tensorType, tensorType}, {op.getLoc(), op.getLoc()});
-
-  OpBuilder::InsertionGuard guard(builder);
-  builder.setInsertionPointToEnd(block);
-
-  auto addOp = builder.create<AddOp>(op.getLoc(), block->getArgument(0),
-                                     block->getArgument(1));
-  auto retOp = builder.create<ReturnOp>(op.getLoc(), addOp.getResult());
-
-  addOp->remove();
-  retOp->remove();
-  block->push_back(addOp);
-  block->push_back(retOp);
-
-  region.release();
-}]>;
-
 def GatherScatterInputData : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
   auto operand = op->getOperand(0);
   auto operandType = operand.getType();
@@ -985,17 +959,18 @@ def GatherScatterResultType : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
   op->getOperand(0).getType();
 }]>;
 
+def ScatterAdd : HLOInst<"ScatterOp", ")->getResult(0)", "createAddRegion(">;
+
 def : HLODerivative<"GatherOp", (Op $operand, $start_indices),
                     [
-                      (Scatter 
+                      (ScatterAdd
                         (GatherScatterResultType),
                         (GatherScatterInputData),
                         $start_indices,
                         (DiffeRet),
-                        (GatherToScatterDimNumbers),
-                        (BinaryAdd)
+                        (GatherToScatterDimNumbers)
                       ),
-                      (HLOConstantFP<"0">)
+                      (InactiveArg)
                     ],
                     // Forward shadow rule
                     (SelectIfActive $operand,

--- a/src/enzyme_ad/jax/Implementations/HLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/HLODerivatives.td
@@ -920,7 +920,75 @@ def : HLODerivative<"Atan2Op", (Op $x, $y),
 
 def : HLOReadOnlyIdentityOp<"BroadcastInDimOp">;
 
-def : HLOReadOnlyIdentityOp<"GatherOp", [0]>;
+def ResultDimensionNumbers : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
+  op.getDimensionNumbers();
+}]>;
+
+def ResultSliceSizes : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
+  op.getSliceSizes();
+}]>;
+
+def GatherToScatterDimNumbers : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
+  auto gatherDims = op.getDimensionNumbers();
+  
+  auto updateWindowDims = gatherDims.getOffsetDims();
+  auto insertedWindowDims = gatherDims.getCollapsedSliceDims();
+  auto inputBatchingDims = gatherDims.getOperandBatchingDims();
+  auto indicesBatchingDims = gatherDims.getStartIndicesBatchingDims();
+  auto scatterDimsToOperandDims = gatherDims.getStartIndexMap();
+  auto indexVectorDim = gatherDims.getIndexVectorDim();
+  
+  ScatterDimensionNumbersAttr::get(
+    op.getContext(),
+    updateWindowDims,
+    insertedWindowDims,
+    inputBatchingDims,
+    indicesBatchingDims,
+    scatterDimsToOperandDims,
+    indexVectorDim
+  );
+}]>;
+
+def Binary2ndArgSetOp : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
+  Region *region = new Region;
+  Block *block = new Block;
+  region->push_back(block);
+  
+  auto loc = builder.getUnknownLoc();
+  auto elemType = op->getResult(0).getType().cast<ShapedType>().getElementType();
+  auto tensorType = RankedTensorType::get({}, elemType);
+  
+  block->addArgument(tensorType, loc);
+  block->addArgument(tensorType, loc);
+
+  builder.create<ReturnOp>(loc, block->getArgument(1));
+  
+  region;
+}]>;
+
+def : HLODerivative<"GatherOp", (Op $operand, $start_indices),
+                    [
+                      (Scatter 
+                        $operand,
+                        $start_indices,
+                        (DiffeRet),
+                        (GatherToScatterDimNumbers),
+                        (Binary2ndArgSetOp)
+                      ),
+                      (AssertingInactiveArg)
+                    ],
+                    // Forward shadow rule
+                    (SelectIfActive $operand,
+                      (Gather 
+                        (ResultTypes),
+                        (Shadow $operand),
+                        $start_indices,
+                        (ResultDimensionNumbers),
+                        (ResultSliceSizes)
+                      ),
+                      (HLOConstantFP<"0">)
+                    )
+                  >;
 
 def : HLOInactiveOp<"CeilOp">;
 

--- a/src/enzyme_ad/jax/Implementations/HLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/HLODerivatives.td
@@ -969,7 +969,7 @@ def Binary2ndArgSetOp : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
 def : HLODerivative<"GatherOp", (Op $operand, $start_indices),
                     [
                       (Scatter 
-                        $operand,
+                        (HLOConstantFP<"0"> $operand),
                         $start_indices,
                         (DiffeRet),
                         (GatherToScatterDimNumbers),

--- a/src/enzyme_ad/jax/Implementations/HLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/HLODerivatives.td
@@ -951,40 +951,51 @@ def GatherToScatterDimNumbers : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [
 }]>;
 
 def BinaryAdd : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
-  Region *region = new Region;
-  Block *block = new Block;
+  auto region = std::make_unique<Region>();
+  auto *block = new Block;
   region->push_back(block);
-  
-  auto loc = builder.getUnknownLoc();
+
   auto elemType = op->getResult(0).getType().cast<ShapedType>().getElementType();
   auto tensorType = RankedTensorType::get({}, elemType);
-  
-  block->addArgument(tensorType, loc);
-  block->addArgument(tensorType, loc);
 
-  auto addOp = builder.create<AddOp>(loc, block->getArgument(0), block->getArgument(1));
-  builder.create<ReturnOp>(loc, addOp->getResult(0));
-  
-  region;
+  block->addArguments({tensorType, tensorType}, {op.getLoc(), op.getLoc()});
+
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToEnd(block);
+
+  auto addOp = builder.create<AddOp>(op.getLoc(), block->getArgument(0),
+                                     block->getArgument(1));
+  auto retOp = builder.create<ReturnOp>(op.getLoc(), addOp.getResult());
+
+  addOp->remove();
+  retOp->remove();
+  block->push_back(addOp);
+  block->push_back(retOp);
+
+  region.release();
 }]>;
 
 def GatherScatterInputData : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
   auto operand = op->getOperand(0);
-  auto operandType = operand.getType().cast<ShapedType>();
-  auto elemType = operandType.getElementType();
-  cast<AutoDiffTypeInterface>(elemType).createNullValue(builder, op.getLoc()); 
+  auto operandType = operand.getType();
+  cast<AutoDiffTypeInterface>(operandType).createNullValue(builder, op.getLoc()); 
+}]>;
+
+def GatherScatterResultType : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
+  op->getOperand(0).getType();
 }]>;
 
 def : HLODerivative<"GatherOp", (Op $operand, $start_indices),
                     [
                       (Scatter 
+                        (GatherScatterResultType),
                         (GatherScatterInputData),
                         $start_indices,
                         (DiffeRet),
                         (GatherToScatterDimNumbers),
                         (BinaryAdd)
                       ),
-                      (AssertingInactiveArg)
+                      (HLOConstantFP<"0">)
                     ],
                     // Forward shadow rule
                     (SelectIfActive $operand,

--- a/src/enzyme_ad/jax/Implementations/HLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/HLODerivatives.td
@@ -920,6 +920,7 @@ def : HLODerivative<"Atan2Op", (Op $x, $y),
 
 def : HLOReadOnlyIdentityOp<"BroadcastInDimOp">;
 
+// Gather Adjoint
 def ResultDimensionNumbers : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
   op.getDimensionNumbers();
 }]>;
@@ -949,7 +950,7 @@ def GatherToScatterDimNumbers : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [
   );
 }]>;
 
-def Binary2ndArgSetOp : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
+def BinaryAdd : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
   Region *region = new Region;
   Block *block = new Block;
   region->push_back(block);
@@ -961,19 +962,50 @@ def Binary2ndArgSetOp : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
   block->addArgument(tensorType, loc);
   block->addArgument(tensorType, loc);
 
-  builder.create<ReturnOp>(loc, block->getArgument(1));
+  auto addOp = builder.create<AddOp>(loc, block->getArgument(0), block->getArgument(1));
+  builder.create<ReturnOp>(loc, addOp->getResult());
   
   region;
+}]>;
+
+def GatherScatterInputData : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
+  auto operand = op->getOperand(0);
+  auto operandType = operand.getType().cast<ShapedType>();
+  auto elemType = operandType.getElementType();
+  
+  // Create appropriate zero attribute based on element type
+  Attribute zeroAttr;
+  if (elemType.isa<FloatType>()) {
+    zeroAttr = builder.getFloatAttr(elemType, 0.0);
+  } else if (elemType.isa<IntegerType>()) {
+    zeroAttr = builder.getIntegerAttr(elemType, 0);
+  } else if (elemType.isa<ComplexType>()) {
+    auto complexTy = elemType.cast<ComplexType>();
+    if (complexTy.getElementType().isa<FloatType>()) {
+      zeroAttr = builder.getFloatAttr(complexTy.getElementType(), 0.0);
+    } else {
+      llvm_unreachable("unsupported complex element type");
+    }
+  } else {
+    llvm_unreachable("unsupported element type");
+  }
+  
+  // Create constant op with the zero tensor
+  auto constantOp = builder.create<mhlo::ConstantOp>(
+    operand.getLoc(), operandType, DenseElementsAttr::get(operandType, zeroAttr)
+  );
+  
+  constantOp.getResult();
 }]>;
 
 def : HLODerivative<"GatherOp", (Op $operand, $start_indices),
                     [
                       (Scatter 
-                        (HLOConstantFP<"0"> $operand),
+                        (GatherScatterInputData),
                         $start_indices,
                         (DiffeRet),
                         (GatherToScatterDimNumbers),
-                        (Binary2ndArgSetOp)
+                        (BinaryAdd)
                       ),
                       (AssertingInactiveArg)
                     ],

--- a/src/enzyme_ad/jax/Implementations/HLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/HLODerivatives.td
@@ -963,7 +963,7 @@ def BinaryAdd : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
   block->addArgument(tensorType, loc);
 
   auto addOp = builder.create<AddOp>(loc, block->getArgument(0), block->getArgument(1));
-  builder.create<ReturnOp>(loc, addOp->getResult());
+  builder.create<ReturnOp>(loc, addOp->getResult(0));
   
   region;
 }]>;

--- a/src/enzyme_ad/jax/Implementations/HLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/HLODerivatives.td
@@ -82,7 +82,7 @@ def RngBitGenerator : HLOInst<"RngBitGeneratorOp">;
 def Round : HLOInst<"RoundOp">; // round_nearest_afz
 def RoundNearestEven : HLOInst<"RoundNearestEvenOp">;
 def Rsqrt : HLOInst<"RsqrtOp">;
-def Scatter : HLOInst<"ScatterOp">;
+def Scatter : HLOInst<"ScatterOp", "->getResult(0)">;
 def Select : HLOInst<"SelectOp">;
 def SelectAndScatter : HLOInst<"SelectAndScatterOp">;
 def Send : HLOInst<"SendOp">;
@@ -972,30 +972,7 @@ def GatherScatterInputData : GlobalExpr</*needsprimal*/0, /*needsshadow*/0, [{
   auto operand = op->getOperand(0);
   auto operandType = operand.getType().cast<ShapedType>();
   auto elemType = operandType.getElementType();
-  
-  // Create appropriate zero attribute based on element type
-  Attribute zeroAttr;
-  if (elemType.isa<FloatType>()) {
-    zeroAttr = builder.getFloatAttr(elemType, 0.0);
-  } else if (elemType.isa<IntegerType>()) {
-    zeroAttr = builder.getIntegerAttr(elemType, 0);
-  } else if (elemType.isa<ComplexType>()) {
-    auto complexTy = elemType.cast<ComplexType>();
-    if (complexTy.getElementType().isa<FloatType>()) {
-      zeroAttr = builder.getFloatAttr(complexTy.getElementType(), 0.0);
-    } else {
-      llvm_unreachable("unsupported complex element type");
-    }
-  } else {
-    llvm_unreachable("unsupported element type");
-  }
-  
-  // Create constant op with the zero tensor
-  auto constantOp = builder.create<mhlo::ConstantOp>(
-    operand.getLoc(), operandType, DenseElementsAttr::get(operandType, zeroAttr)
-  );
-  
-  constantOp.getResult();
+  cast<AutoDiffTypeInterface>(elemType).createNullValue(builder, op.getLoc()); 
 }]>;
 
 def : HLODerivative<"GatherOp", (Op $operand, $start_indices),

--- a/src/enzyme_ad/jax/Implementations/MHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/MHLOAutoDiffOpInterfaceImpl.cpp
@@ -49,6 +49,23 @@ static mlir::DenseElementsAttr getBoolAttr(OpBuilder &builder,
 static auto getBoolIter(mlir::DenseElementsAttr attr) {
   return attr.getValues<bool>();
 }
+static inline Operation *createAddRegion(Operation *op) {
+  mlir::OpBuilder builder(op->getContext());
+  mlir::Block *block = new Block();
+  op->getRegion(0).push_back(block);
+  auto elemType =
+      op->getResult(0).getType().cast<ShapedType>().getElementType();
+  auto tensorType = RankedTensorType::get({}, elemType);
+  block->addArguments({tensorType, tensorType}, {op->getLoc(), op->getLoc()});
+  builder.setInsertionPointToEnd(block);
+  builder.create<mlir::mhlo::ReturnOp>(
+      op->getLoc(),
+      builder
+          .create<mlir::mhlo::AddOp>(op->getLoc(), block->getArgument(0),
+                                     block->getArgument(1))
+          ->getResult(0));
+  return op;
+}
 
 namespace {
 #include "src/enzyme_ad/jax/Implementations/MHLODerivatives.inc"

--- a/src/enzyme_ad/jax/Implementations/MHLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/MHLODerivatives.td
@@ -2,7 +2,7 @@ include "src/enzyme_ad/jax/Implementations/Common.td"
 
 class HLODerivative<string opName_, dag patternToMatch, list<dag> resultOps, dag forwardOps=(ForwardFromSummedReverse)> : MLIRDerivative<"mhlo", opName_, patternToMatch, resultOps, forwardOps>;
 
-class HLOInst<string m, string postopt=""> : Inst<m, "mhlo", postopt>;
+class HLOInst<string m, string postopt="", string preopt=""> : Inst<m, "mhlo", postopt, preopt>;
 
 class HLOMemoryIdentityOp<string opName_, list<int> ptrargs_, list<int> storedargs_ = [], dag patternToMatch=(Unimplemented), list<dag> reverse_ = []>  : MemoryIdentityOp<"mhlo", opName_, ptrargs_, storedargs_, patternToMatch, reverse_>;
 

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -62,6 +62,23 @@ static Value makeI64Constant(Location loc, OpBuilder &builder, int64_t val) {
                               ArrayRef<Attribute>(IntegerAttr::get(Ty, val))))
       .getResult();
 }
+static inline Operation *createAddRegion(Operation *op) {
+  mlir::OpBuilder builder(op->getContext());
+  mlir::Block *block = new Block();
+  op->getRegion(0).push_back(block);
+  auto elemType =
+      op->getResult(0).getType().cast<ShapedType>().getElementType();
+  auto tensorType = RankedTensorType::get({}, elemType);
+  block->addArguments({tensorType, tensorType}, {op->getLoc(), op->getLoc()});
+  builder.setInsertionPointToEnd(block);
+  builder.create<mlir::stablehlo::ReturnOp>(
+      op->getLoc(),
+      builder
+          .create<mlir::stablehlo::AddOp>(op->getLoc(), block->getArgument(0),
+                                          block->getArgument(1))
+          ->getResult(0));
+  return op;
+}
 
 namespace {
 #include "src/enzyme_ad/jax/Implementations/StableHLODerivatives.inc"

--- a/src/enzyme_ad/jax/Implementations/StableHLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/StableHLODerivatives.td
@@ -2,7 +2,7 @@ include "src/enzyme_ad/jax/Implementations/Common.td"
 
 class HLODerivative<string opName_, dag patternToMatch, list<dag> resultOps, dag forwardOps=(ForwardFromSummedReverse)> : MLIRDerivative<"stablehlo", opName_, patternToMatch, resultOps, forwardOps>;
 
-class HLOInst<string m, string postopt=""> : Inst<m, "stablehlo", postopt>;
+class HLOInst<string m, string postopt="", string preopt=""> : Inst<m, "stablehlo", postopt, preopt>;
 
 class HLOMemoryIdentityOp<string opName_, list<int> ptrargs_, list<int> storedargs_ = [], dag patternToMatch=(Unimplemented), list<dag> reverse_ = []>  : MemoryIdentityOp<"stablehlo", opName_, ptrargs_, storedargs_, patternToMatch, reverse_>;
 

--- a/src/enzyme_ad/jax/Implementations/XLADerivatives.h
+++ b/src/enzyme_ad/jax/Implementations/XLADerivatives.h
@@ -18,3 +18,4 @@ registerXLAAutoDiffInterfaces(mlir::DialectRegistry &registry) {
 }
 } // namespace enzyme
 } // namespace mlir
+  //

--- a/test/lit_tests/diffrules/stablehlo/gather.mlir
+++ b/test/lit_tests/diffrules/stablehlo/gather.mlir
@@ -1,5 +1,5 @@
 // RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup,enzyme_dup mode=ForwardMode" | FileCheck %s --check-prefix=FORWARD
-// TODO: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
 
 module {
   func.func @main(%arg0 : tensor<64x3xf32>, %7 : tensor<45x1xi32>) -> tensor<45x3xf32> {

--- a/test/lit_tests/diffrules/stablehlo/gather.mlir
+++ b/test/lit_tests/diffrules/stablehlo/gather.mlir
@@ -1,5 +1,5 @@
 // RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup,enzyme_dup mode=ForwardMode" | FileCheck %s --check-prefix=FORWARD
-// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --arith-raise --enzyme-hlo-opt | FileCheck %s --check-prefix=REVERSE
 
 module {
   func.func @main(%arg0 : tensor<64x3xf32>, %7 : tensor<45x1xi32>) -> tensor<45x3xf32> {
@@ -13,3 +13,16 @@ module {
 // FORWARD-NEXT:    %1 = "stablehlo.gather"(%arg0, %arg2) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 3>}> : (tensor<64x3xf32>, tensor<45x1xi32>) -> tensor<45x3xf32>
 // FORWARD-NEXT:    return %1, %0 : tensor<45x3xf32>, tensor<45x3xf32>
 // FORWARD-NEXT:  }
+
+// REVERSE:  func.func @main(%arg0: tensor<64x3xf32>, %arg1: tensor<45x1xi32>, %arg2: tensor<45x3xf32>) -> (tensor<64x3xf32>, tensor<45x1xi32>) {
+// REVERSE-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<64x3xf32>
+// REVERSE-NEXT:    %c = stablehlo.constant dense<0> : tensor<45x1xi32>
+// REVERSE-NEXT:    %0 = "stablehlo.scatter"(%cst, %arg1, %arg2) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// REVERSE-NEXT:    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+// REVERSE-NEXT:      %1 = stablehlo.add %arg3, %arg4 : tensor<f32>
+// REVERSE-NEXT:      stablehlo.return %1 : tensor<f32>
+// REVERSE-NEXT:    }) : (tensor<64x3xf32>, tensor<45x1xi32>, tensor<45x3xf32>) -> tensor<64x3xf32>
+// REVERSE-NEXT:    return %0, %c : tensor<64x3xf32>, tensor<45x1xi32>
+// REVERSE-NEXT:  }
+
+

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -1,7 +1,7 @@
 JAX_COMMIT = "0fb278a0b9152f341df69662c573d14f991fd51a"
 JAX_SHA256 = ""
 
-ENZYME_COMMIT = "8eda577e8089e5f2134e01fed1c306f2eb20e062"
+ENZYME_COMMIT = "e394dbf8856ca5eea78a7cded6d81ec5e2f5e81b"
 ENZYME_SHA256 = ""
 # If the empty string this will automatically use the commit above
 # otherwise this should be a path to the folder containing the BUILD file for enzyme


### PR DESCRIPTION
ScatterOp has multiple results, so we need to get the first result (not sure how)

```
bazel-out/k8-dbg/bin/src/enzyme_ad/jax/Implementations/MHLODerivatives.inc:1057:31: error: conversion from 'mlir::mhlo::ScatterOp' to non-scalar type 'mlir::Value' requested 
```