### PR TITLE
Complete CallOpInterface implementation for Kernel and JIT call ops

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -57,11 +57,45 @@ KernelCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
+void KernelCallOp::setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
+  auto symbol = cast<SymbolRefAttr>(callee);
+  setFnAttr(cast<FlatSymbolRefAttr>(symbol));
+}
+
 CallInterfaceCallable KernelCallOp::getCallableForCallee() {
   return SymbolRefAttr::get(getContext(), getFn());
 }
 
 Operation::operand_range KernelCallOp::getArgOperands() { return getInputs(); }
+
+mlir::MutableOperandRange KernelCallOp::getArgOperandsMutable() {
+  MutableOperandRange range(*this);
+  return range;
+}
+
+mlir::ArrayAttr KernelCallOp::getArgAttrsAttr() {
+  mlir::ArrayAttr arr;
+  return arr;
+}
+
+void KernelCallOp::setArgAttrsAttr(mlir::ArrayAttr attr) { (void)attr; }
+
+mlir::ArrayAttr KernelCallOp::getResAttrsAttr() {
+  mlir::ArrayAttr arr;
+  return arr;
+}
+
+void KernelCallOp::setResAttrsAttr(mlir::ArrayAttr attr) { (void)attr; }
+
+mlir::Attribute KernelCallOp::removeArgAttrsAttr() {
+  mlir::Attribute attr;
+  return attr;
+}
+
+mlir::Attribute KernelCallOp::removeResAttrsAttr() {
+  mlir::Attribute attr;
+  return attr;
+}
 
 LogicalResult JITCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // TODO: Verify that the result type is same as the type of the referenced
@@ -75,11 +109,45 @@ LogicalResult JITCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
+void JITCallOp::setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
+  auto symbol = cast<SymbolRefAttr>(callee);
+  setFnAttr(cast<FlatSymbolRefAttr>(symbol));
+}
+
 CallInterfaceCallable JITCallOp::getCallableForCallee() {
   return SymbolRefAttr::get(getContext(), getFn());
 }
 
+mlir::MutableOperandRange JITCallOp::getArgOperandsMutable() {
+  MutableOperandRange range(*this);
+  return range;
+}
+
 Operation::operand_range JITCallOp::getArgOperands() { return getInputs(); }
+
+mlir::ArrayAttr JITCallOp::getArgAttrsAttr() {
+  mlir::ArrayAttr arr;
+  return arr;
+}
+
+void JITCallOp::setArgAttrsAttr(mlir::ArrayAttr attr) { (void)attr; }
+
+mlir::ArrayAttr JITCallOp::getResAttrsAttr() {
+  mlir::ArrayAttr arr;
+  return arr;
+}
+
+void JITCallOp::setResAttrsAttr(mlir::ArrayAttr attr) { (void)attr; }
+
+mlir::Attribute JITCallOp::removeArgAttrsAttr() {
+  mlir::Attribute attr;
+  return attr;
+}
+
+mlir::Attribute JITCallOp::removeResAttrsAttr() {
+  mlir::Attribute attr;
+  return attr;
+}
 
 /// Replace cast(subindex(x, InterimType), FinalType) with subindex(x,
 /// FinalType)


### PR DESCRIPTION
I get a linkage error otherwise. CC @chelini you might now more about this error.

```
"mlir::enzymexla::KernelCallOp::getArgAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::getArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::getResAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::getResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::setArgAttrsAttr(mlir::ArrayAttr)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::setArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::ArrayAttr) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::setResAttrsAttr(mlir::ArrayAttr)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::setResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::ArrayAttr) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::removeArgAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::removeArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::removeResAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::removeResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::getArgOperandsMutable()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::getArgOperandsMutable(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::setCalleeFromCallable(mlir::CallInterfaceCallable)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::setCalleeFromCallable(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::CallInterfaceCallable) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::getArgAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::getArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::getResAttrsAttr()", referenced from: