### PR TITLE
Fix link problem by providing missing default impl for CallOpInterface

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -312,6 +312,7 @@ td_library(
     ],
     includes = ["."],
     deps = [
+        "@llvm-project//mlir:CallInterfacesTdFiles",
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
         "@llvm-project//mlir:FunctionInterfacesTdFiles",
         "@llvm-project//mlir:LoopLikeInterfaceTdFiles",
@@ -420,6 +421,7 @@ cc_library(
         "@llvm-project//mlir:AffineAnalysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
+        "@llvm-project//mlir:CallOpInterfaces",
         "@llvm-project//mlir:CommonFolders",
         "@llvm-project//mlir:ComplexDialect",
         "@llvm-project//mlir:ControlFlowDialect",

--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -57,6 +57,35 @@ def KernelCallOp: EnzymeXLA_Op<"kernel_call", [DeclareOpInterfaceMethods<SymbolU
   }];
 
   let hasCanonicalizer = 1;
+
+  // Provide default implementations for ArgumentAttributesMethods
+  let extraClassDefinition = [{
+    ::mlir::ArrayAttr $cppClass::getArgAttrsAttr() {
+      return ::mlir::ArrayAttr::get(getContext(), {});
+    }
+
+    ::mlir::ArrayAttr $cppClass::getResAttrsAttr() {
+      return ::mlir::ArrayAttr::get(getContext(), {});
+    }
+
+    void $cppClass::setArgAttrsAttr(::mlir::ArrayAttr attrs) {}
+
+    void $cppClass::setResAttrsAttr(::mlir::ArrayAttr attrs) {}
+
+    ::mlir::Attribute $cppClass::removeArgAttrsAttr() {
+      return ::mlir::Attribute();
+    }
+
+    ::mlir::Attribute $cppClass::removeResAttrsAttr() {
+      return ::mlir::Attribute();
+    }
+
+    void $cppClass::setCalleeFromCallable(::mlir::CallInterfaceCallable callee) {}
+
+    ::mlir::MutableOperandRange $cppClass::getArgOperandsMutable() {
+      return ::mlir::MutableOperandRange(*this, 0, 0);
+    }
+  }];
 }
 
 def JITCallOp: EnzymeXLA_Op<"jit_call", [DeclareOpInterfaceMethods<SymbolUserOpInterface>, DeclareOpInterfaceMethods<CallOpInterface>, Pure]> {
@@ -79,6 +108,35 @@ def JITCallOp: EnzymeXLA_Op<"jit_call", [DeclareOpInterfaceMethods<SymbolUserOpI
   }];
 
   let hasCanonicalizer = 1;
+
+  // Provide default implementations for ArgumentAttributesMethods
+  let extraClassDefinition = [{
+    ::mlir::ArrayAttr $cppClass::getArgAttrsAttr() {
+      return ::mlir::ArrayAttr::get(getContext(), {});
+    }
+
+    ::mlir::ArrayAttr $cppClass::getResAttrsAttr() {
+      return ::mlir::ArrayAttr::get(getContext(), {});
+    }
+
+    void $cppClass::setArgAttrsAttr(::mlir::ArrayAttr attrs) {}
+
+    void $cppClass::setResAttrsAttr(::mlir::ArrayAttr attrs) {}
+
+    ::mlir::Attribute $cppClass::removeArgAttrsAttr() {
+      return ::mlir::Attribute();
+    }
+
+    ::mlir::Attribute $cppClass::removeResAttrsAttr() {
+      return ::mlir::Attribute();
+    }
+
+    void $cppClass::setCalleeFromCallable(::mlir::CallInterfaceCallable callee) {}
+
+    ::mlir::MutableOperandRange $cppClass::getArgOperandsMutable() {
+      return ::mlir::MutableOperandRange(*this, 0, 0);
+    }
+  }];
 }
 
 def GetStreamOp : EnzymeXLA_Op<"get_stream", [Pure]> {


### PR DESCRIPTION
This fixes
```
ld: warning: ignoring duplicate libraries: '-lc++'
Undefined symbols for architecture arm64:
  "mlir::enzymexla::KernelCallOp::getArgAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::getArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::getResAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::getResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::setArgAttrsAttr(mlir::ArrayAttr)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::setArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::ArrayAttr) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::setResAttrsAttr(mlir::ArrayAttr)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::setResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::ArrayAttr) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::removeArgAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::removeArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::removeResAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::removeResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::getArgOperandsMutable()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::getArgOperandsMutable(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::KernelCallOp::setCalleeFromCallable(mlir::CallInterfaceCallable)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::KernelCallOp>::setCalleeFromCallable(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::CallInterfaceCallable) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::getArgAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::getArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::getResAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::getResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::setArgAttrsAttr(mlir::ArrayAttr)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::setArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::ArrayAttr) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::setResAttrsAttr(mlir::ArrayAttr)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::setResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::ArrayAttr) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::removeArgAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::removeArgAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::removeResAttrsAttr()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::removeResAttrsAttr(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::getArgOperandsMutable()", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::getArgOperandsMutable(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*) in libXLADerivatives.a[2](Dialect.o)
  "mlir::enzymexla::JITCallOp::setCalleeFromCallable(mlir::CallInterfaceCallable)", referenced from:
      mlir::detail::CallOpInterfaceInterfaceTraits::Model<mlir::enzymexla::JITCallOp>::setCalleeFromCallable(mlir::detail::CallOpInterfaceInterfaceTraits::Concept const*, mlir::Operation*, mlir::CallInterfaceCallable) in libXLADerivatives.a[2](Dialect.o)
ld: symbol(s) not found for architecture arm64
```
introduced after https://github.com/EnzymeAD/Enzyme-JAX/commit/cb17aacb16a04fdf80729c5664f79908a5276456

I didn't try to come up with a cleaner solution, so please share your thoughts!