### PR TITLE
Use the right builder for CallOp

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -905,8 +905,8 @@ public:
     }
 
     auto newCallOp = rewriter.create<LLVM::CallOp>(
-        callOp->getLoc(), callResultTypes, adaptor.getOperands(),
-        callOp->getAttrs());
+        callOp->getLoc(), callResultTypes, callOp.getCallee(),
+        adaptor.getOperands());
 
     if (numResults <= 1) {
       rewriter.replaceOp(callOp, newCallOp->getResults());

--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -907,6 +907,7 @@ public:
     auto newCallOp = rewriter.create<LLVM::CallOp>(
         callOp->getLoc(), callResultTypes, callOp.getCallee(),
         adaptor.getOperands());
+    newCallOp->setAttrs(callOp->getAttrs());
 
     if (numResults <= 1) {
       rewriter.replaceOp(callOp, newCallOp->getResults());

--- a/test/lit_tests/convert-polygeist-to-llvm.mlir
+++ b/test/lit_tests/convert-polygeist-to-llvm.mlir
@@ -1,0 +1,11 @@
+// RUN: enzymexlamlir-opt %s --convert-polygeist-to-llvm  | FileCheck %s
+
+func.func @foo(%arg0 : f64) -> f64 {
+  %0 = math.cbrt %arg0 : f64
+  return %0 : f64
+}
+
+// CHECK: llvm.func @cbrt(f64) -> f64 attributes {llvm.readnone, sym_visibility = "private"}
+// CHECK-LABEL: foo
+// CHECK-SAME: %[[ARG0:.+]]: f64
+// CHECK: llvm.call @cbrt(%[[ARG0]]) : (f64) -> f64

--- a/test/lit_tests/convert-polygeist-to-llvm.mlir
+++ b/test/lit_tests/convert-polygeist-to-llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt %s --convert-polygeist-to-llvm  | FileCheck %s
+// RUN: enzymexlamlir-opt %s --convert-polygeist-to-llvm -split-input-file  | FileCheck %s
 
 func.func @foo(%arg0 : f64) -> f64 {
   %0 = math.cbrt %arg0 : f64
@@ -9,3 +9,16 @@ func.func @foo(%arg0 : f64) -> f64 {
 // CHECK-LABEL: foo
 // CHECK-SAME: %[[ARG0:.+]]: f64
 // CHECK: llvm.call @cbrt(%[[ARG0]]) : (f64) -> f64
+
+// -----
+
+func.func @bar(%arg0: i32) -> i32 {
+  return %arg0: i32
+}
+
+// CHECK-LABEL: foo
+func.func @foo(%arg0: i32) -> i32 {
+  // CHECK: llvm.call @bar(%{{.+}}) {my_attribute = "florence"} : (i32) -> i32
+  %0 = func.call @bar(%arg0) {my_attribute = "florence"} : (i32) -> i32
+  return %0 : i32
+}


### PR DESCRIPTION
The CallOp lowering pattern was incorrectly passing all operands as a single array to LLVM::CallOp. This caused issues with operand segment sizes since LLVM::CallOp expects the callee and arguments to be passed separately.

This change eliminates the need for manual operand segment size handling since the operation definition now correctly structures the operands.

Fix: #350