### PR TITLE
Simplify If

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
@@ -15,8 +15,10 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/Support/Debug.h"
 
@@ -561,6 +563,126 @@ public:
   }
 };
 
+class SimplifyIfByRemovingEmptyThen final : public OpRewritePattern<scf::IfOp> {
+public:
+  using OpRewritePattern<scf::IfOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::IfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    if (ifOp.getNumResults() != 0)
+      return failure();
+
+    // Check if the then block is empty (contains only the terminator)
+    Block &thenBlock = ifOp.getThenRegion().front();
+    if (!llvm::hasSingleElement(thenBlock))
+      return failure();
+
+    // Check if there is an else region
+    bool hasElse = !ifOp.getElseRegion().empty();
+    if (!hasElse)
+      return failure();
+
+    // Get the condition and negate it
+    Value cond = ifOp.getCondition();
+    Value negatedCond = rewriter.create<arith::XOrIOp>(
+        ifOp.getLoc(), cond,
+        rewriter.create<arith::ConstantIntOp>(ifOp.getLoc(), 1,
+                                              rewriter.getI1Type()));
+
+    // Create new if operation with negated condition and no else region
+    auto newIf = rewriter.create<scf::IfOp>(ifOp.getLoc(),
+                                            ifOp.getResultTypes(), negatedCond,
+                                            /*withElseRegion=*/false);
+
+    // Move operations from old else block to new then block
+    Block &elseBlock = ifOp.getElseRegion().front();
+    Block &newThenBlock = newIf.getThenRegion().front();
+
+    // Move all operations except the terminator before the new block's
+    // terminator
+    auto &oldOps = elseBlock.getOperations();
+    auto &newOps = newThenBlock.getOperations();
+    auto terminator = newThenBlock.getTerminator();
+    newOps.splice(terminator->getIterator(), oldOps, oldOps.begin(),
+                  std::prev(oldOps.end()));
+
+    // Replace old if with new if
+    rewriter.replaceOp(ifOp, newIf.getResults());
+    return success();
+  }
+};
+
+class IfToSelect final : public OpRewritePattern<scf::IfOp> {
+public:
+  using OpRewritePattern<scf::IfOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::IfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    // Check if if has both then and else regions
+    bool hasElse = !ifOp.getElseRegion().empty();
+    if (!hasElse)
+      return failure();
+
+    Location loc = ifOp.getLoc();
+    Value condition = ifOp.getCondition();
+
+    // Get the yield ops from both branches
+    Block *thenBlock = ifOp.thenBlock();
+    Block *elseBlock = ifOp.elseBlock();
+    auto thenYield = cast<scf::YieldOp>(thenBlock->getTerminator());
+    auto elseYield = cast<scf::YieldOp>(elseBlock->getTerminator());
+
+    // Check if all operations in both blocks are pure
+    if (llvm::any_of(thenBlock->getOperations(),
+                     [](Operation &op) { return !isPure(&op); }))
+      return failure();
+    if (llvm::any_of(elseBlock->getOperations(),
+                     [](Operation &op) { return !isPure(&op); }))
+      return failure();
+
+    // Clone all operations from both branches before their yields
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(ifOp);
+
+    // Clone then block operations
+    IRMapping thenMapping;
+    for (auto &op : ifOp.thenBlock()->without_terminator()) {
+      Operation *clonedOp = rewriter.clone(op, thenMapping);
+      for (auto [orig, clone] :
+           llvm::zip(op.getResults(), clonedOp->getResults())) {
+        thenMapping.map(orig, clone);
+      }
+    }
+
+    // Clone else block operations
+    IRMapping elseMapping;
+    for (auto &op : ifOp.elseBlock()->without_terminator()) {
+      Operation *clonedOp = rewriter.clone(op, elseMapping);
+      for (auto [orig, clone] :
+           llvm::zip(op.getResults(), clonedOp->getResults())) {
+        elseMapping.map(orig, clone);
+      }
+    }
+
+    // Create selects for each result
+    SmallVector<Value, 4> results;
+    for (auto [thenVal, elseVal] :
+         llvm::zip(thenYield.getOperands(), elseYield.getOperands())) {
+      // Map the yield operands through our value mappings
+      Value mappedThenVal = thenMapping.lookupOrDefault(thenVal);
+      Value mappedElseVal = elseMapping.lookupOrDefault(elseVal);
+
+      // Create select op with same attributes as original if op
+      auto select = rewriter.create<arith::SelectOp>(
+          loc, condition, mappedThenVal, mappedElseVal);
+      results.push_back(select);
+    }
+
+    rewriter.replaceOp(ifOp, results);
+    return success();
+  }
+};
+
 } // end namespace
 
 struct CanonicalizeLoopsPass
@@ -570,7 +692,8 @@ struct CanonicalizeLoopsPass
     // Step 0: Canonicalize loops when possible.
     {
       RewritePatternSet patterns(&getContext());
-      patterns.add<RemoveAffineParallelSingleIter, SwitchToIf>(&getContext());
+      patterns.add<RemoveAffineParallelSingleIter, SwitchToIf,
+                   SimplifyIfByRemovingEmptyThen, IfToSelect>(&getContext());
 
       if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                               std::move(patterns)))) {

--- a/test/lit_tests/if-with-empyty-then.mlir
+++ b/test/lit_tests/if-with-empyty-then.mlir
@@ -1,0 +1,37 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(func.func(canonicalize-loops))" --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @if_with_empty_then
+// CHECK-SAME: %[[ARG0:.+]]: i1
+func.func @if_with_empty_then(%arg0: i1) {
+    // CHECK: %[[TRUE:.+]] = arith.constant true
+    // CHECK-NEXT: %[[COND:.+]] = arith.xori %[[ARG0]], %[[TRUE]] : i1
+    // CHECK: scf.if %[[COND]]
+    // CHECK-NOT: else
+    scf.if %arg0 {
+    } else {
+        func.call @some_effect() : () -> ()
+    }
+    return
+}
+
+func.func private @some_effect() 
+
+// -----
+
+// CHECK-LABEL: func @if_with_non_empty_then
+// CHECK-SAME: %[[ARG0:.+]]: i1
+func.func @if_with_non_empty_then(%arg0: i1) {
+    // CHECK: scf.if %[[ARG0]] {
+    // CHECK-NEXT:   func.call @some_effect
+    // CHECK-NEXT: } else {
+    // CHECK-NEXT:   func.call @some_effect
+    // CHECK-NEXT: }
+    scf.if %arg0 {
+        func.call @some_effect() : () -> ()
+    } else {
+        func.call @some_effect() : () -> ()
+    }
+    return
+}
+
+func.func private @some_effect() 

--- a/test/lit_tests/if_to_select.mlir
+++ b/test/lit_tests/if_to_select.mlir
@@ -1,0 +1,57 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(func.func(canonicalize-loops))" --split-input-file | FileCheck %s
+
+func.func @if_to_select(%arg0: i1, %arg1: i32, %arg2: i32) -> i32 {
+  %result = scf.if %arg0 -> i32 {
+    scf.yield %arg1 : i32
+  } else {
+    scf.yield %arg2 : i32
+  }
+  return %result : i32
+}
+
+// CHECK-LABEL: func @if_to_select
+// CHECK-SAME: (%[[ARG0:.*]]: i1, %[[ARG1:.*]]: i32, %[[ARG2:.*]]: i32)
+// CHECK: %[[SELECT:.*]] = arith.select %[[ARG0]], %[[ARG1]], %[[ARG2]] : i32
+// CHECK: return %[[SELECT]] : i32
+
+// -----
+
+func.func @if_to_select_multi_result(
+    %arg0: i1, %arg1: i64, %arg2: i32, 
+    %arg3: i32, %arg4: i64, %arg5: i32, %arg6: i32) -> (i64, i32, i32) {
+  %result:3 = scf.if %arg0 -> (i64, i32, i32) {
+    scf.yield %arg1, %arg2, %arg3 : i64, i32, i32
+  } else {
+    scf.yield %arg4, %arg5, %arg6 : i64, i32, i32
+  }
+  return %result#0, %result#1, %result#2 : i64, i32, i32
+}
+
+// CHECK-LABEL: func @if_to_select_multi_result
+// CHECK-SAME: (%[[ARG0:.*]]: i1, %[[ARG1:.*]]: i64, %[[ARG2:.*]]: i32, %[[ARG3:.*]]: i32, %[[ARG4:.*]]: i64, %[[ARG5:.*]]: i32, %[[ARG6:.*]]: i32)
+// CHECK: %[[SELECT0:.*]] = arith.select %[[ARG0]], %[[ARG1]], %[[ARG4]] : i64
+// CHECK: %[[SELECT1:.*]] = arith.select %[[ARG0]], %[[ARG2]], %[[ARG5]] : i32
+// CHECK: %[[SELECT2:.*]] = arith.select %[[ARG0]], %[[ARG3]], %[[ARG6]] : i32
+// CHECK: return %[[SELECT0]], %[[SELECT1]], %[[SELECT2]] : i64, i32, i32   
+
+// -----
+
+func.func @if_to_select_nested(%cond: i1, %val1: f64, %val2: f64, %const: f64, %const2: f64) -> f64 {
+  %result = scf.if %cond -> (f64) {
+    %cmp = arith.cmpf ogt, %val1, %const {fastmathFlags = #llvm.fastmath<none>} : f64
+    %sel = arith.select %cmp, %val1, %val2 {fastmathFlags = #llvm.fastmath<none>} : f64
+    scf.yield %sel : f64
+  } else {
+    %copy = math.copysign %val1, %const2 : f64
+    scf.yield %copy : f64
+  }
+  return %result : f64
+}
+
+// CHECK-LABEL: func @if_to_select_nested
+// CHECK-SAME: (%[[COND:.*]]: i1, %[[VAL1:.*]]: f64, %[[VAL2:.*]]: f64, %[[CONST:.*]]: f64, %[[CONST2:.*]]: f64)
+// CHECK: %[[CMP:.*]] = arith.cmpf ogt, %[[VAL1]], %[[CONST]] {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK: %[[SEL1:.*]] = arith.select %[[CMP]], %[[VAL1]], %[[VAL2]] {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK: %[[COPY:.*]] = math.copysign %[[VAL1]], %[[CONST2]] : f64
+// CHECK: %[[SEL2:.*]] = arith.select %[[COND]], %[[SEL1]], %[[COPY]] : f64
+// CHECK: return %[[SEL2]] : f64   

--- a/test/lit_tests/switch_to_if.mlir
+++ b/test/lit_tests/switch_to_if.mlir
@@ -1,17 +1,13 @@
 // RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(func.func(canonicalize-loops))" | FileCheck %s
 
 // CHECK-LABEL: func @switch_to_if
+// CHECK-SAME: %[[ARG0:.+]]: index
 func.func @switch_to_if(%arg0: index) -> i32 {
-  // CHECK-DAG: %[[CONST:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[VAL1:.*]] = arith.constant 42 : i32
-  // CHECK-DAG: %[[VAL2:.*]] = arith.constant 24 : i32
-  // CHECK: %[[CMP:.*]] = arith.cmpi eq, %arg0, %[[CONST]] : index
-  // CHECK: %[[RESULT:.*]] = scf.if %[[CMP]] -> (i32) {
-  // CHECK:   scf.yield %[[VAL1]] : i32
-  // CHECK: } else {
-  // CHECK:   scf.yield %[[VAL2]] : i32
-  // CHECK: }
-  // CHECK: return %[[RESULT]] : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK-DAG: %[[C24:.+]] = arith.constant 24 : i32
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK: %[[CMPI:.+]] = arith.cmpi eq, %[[ARG0]], %[[C0]] : index
+  // CHECK: %{{.+}} = arith.select %[[CMPI]], %[[C42]], %[[C24]] : i32
   %0 = scf.index_switch %arg0 -> i32
     case 0 {
       %1 = arith.constant 42 : i32
@@ -25,17 +21,13 @@ func.func @switch_to_if(%arg0: index) -> i32 {
 }
 
 // CHECK-LABEL: func @switch_to_if2
+// CHECK-SAME: %[[ARG0:.+]]: index
 func.func @switch_to_if2(%arg0: index) -> i32 {
-  // CHECK-DAG: %[[CONST:.*]] = arith.constant 20 : index
-  // CHECK-DAG: %[[VAL1:.*]] = arith.constant 42 : i32
-  // CHECK-DAG: %[[VAL2:.*]] = arith.constant 24 : i32
-  // CHECK: %[[CMP:.*]] = arith.cmpi eq, %arg0, %[[CONST]] : index
-  // CHECK: %[[RESULT:.*]] = scf.if %[[CMP]] -> (i32) {
-  // CHECK:   scf.yield %[[VAL1]] : i32
-  // CHECK: } else {
-  // CHECK:   scf.yield %[[VAL2]] : i32
-  // CHECK: }
-  // CHECK: return %[[RESULT]] : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK-DAG: %[[C24:.+]] = arith.constant 24 : i32
+  // CHECK-DAG: %[[C20:.+]] = arith.constant 20 : index
+  // CHECK: %[[CMPI:.+]] = arith.cmpi eq, %[[ARG0]], %[[C20]] : index
+  // CHECK: %{{.+}} = arith.select %[[CMPI]], %[[C42]], %[[C24]] : i32
   %0 = scf.index_switch %arg0 -> i32
     case 20 {
       %1 = arith.constant 42 : i32


### PR DESCRIPTION
This PR simplifies IF conditions in two cases: 1) The then branch is empty, and the else is not. In this case, we negate the condition and delete the other branch. 2) The if is flattened to select if both regions contain only pure operations. This allows us to remove problematic if mentioned in this conversation: https://github.com/PRONTOLab/GB-25/issues/11#issuecomment-2670386656