### PR TITLE
Add missing dependency to `src/enzyme_ad/jax:XLADerivatives`

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -419,6 +419,7 @@ cc_library(
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineAnalysis",
         "@llvm-project//mlir:AffineTransforms",
+        "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:CallOpInterfaces",


### PR DESCRIPTION
This seems to solve for me locally the error
```
[05:01:02] external/enzyme_ad/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp:19:10: error: module @enzyme_ad//src/enzyme_ad/jax:XLADerivatives does not depend on a module exporting 'mlir/Dialect/Affine/LoopUtils.h'
[05:01:02]    19 | #include "mlir/Dialect/Affine/LoopUtils.h"
[05:01:02]       |          ^
[05:01:02] 1 error generated.
```
As far as I understand, this is defined in https://github.com/llvm/llvm-project/blob/4e44bd027bf4e490380be770172994561616bd2d/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel#L4210-L4239.

Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/10587#issuecomment-2676019451