### PR TITLE
[CI] Fix paths triggers for `build` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ on:
       - '**/BUILD'
       - '**/WORKSPACE'
       - '**/*.bzl'
-      - 'builddeps/'
-      - 'patches/'
-      - 'src/'
-      - 'test/'
-      - 'third_party/'
+      - 'builddeps/**'
+      - 'patches/**'
+      - 'src/**'
+      - 'test/**'
+      - 'third_party/**'
   pull_request:
     branches:
     - main
@@ -22,11 +22,11 @@ on:
       - '**/BUILD'
       - '**/WORKSPACE'
       - '**/*.bzl'
-      - 'builddeps/'
-      - 'patches/'
-      - 'src/'
-      - 'test/'
-      - 'third_party/'
+      - 'builddeps/**'
+      - 'patches/**'
+      - 'src/**'
+      - 'test/**'
+      - 'third_party/**'
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
Follow up to #378, I missed some `**`s and now CI isn't running in #382, oops!