### PR TITLE
Add missing deps needed for running the tests

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -742,7 +742,10 @@ pybind_extension(
         "@xla//xla/mlir_hlo:deallocation_passes",
         "@xla//xla/mlir_hlo:mlir_hlo",
         "@xla//xla/service/cpu:cpu_executable",
+        "@xla//xla/service:buffer_assignment_proto_cc_impl",
         "@xla//xla/stream_executor:stream_executor_impl",
-        "@xla//xla/stream_executor/cuda:cuda_compute_capability_proto_cc_impl"
+        "@xla//xla/stream_executor/cuda:cuda_compute_capability_proto_cc_impl",
+        "@xla//xla/stream_executor:device_description_proto_cc_impl",
+        "@xla//xla/tsl/profiler/backends/cpu:annotation_stack_impl",
     ],
 )

--- a/test/lit_tests/BUILD
+++ b/test/lit_tests/BUILD
@@ -3,6 +3,7 @@ load("@llvm-project//llvm:lit_test.bzl", "lit_test")
 [
     lit_test(
         name = "%s.test" % src,
+        timeout = "short",
         srcs = [src],
         data = [
             "@llvm-project//llvm:FileCheck",


### PR DESCRIPTION
Addresses https://github.com/EnzymeAD/Enzyme-JAX/pull/394#issuecomment-2684003696.

Opening as draft because I'm not 100% sure this is enough for making tests pass on macOS, but at least on hydra all errors about undefined symbols are gone.