### PR TITLE
Raise `llvm.load/store` to `memref.load/store`

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -331,7 +331,7 @@ static MemRefVal convertToMemref(PtrVal addr) {
           MemRefLayoutAttrInterface{}, origMemrefType.getMemorySpace());
 
       auto ptr2memref = builder.create<enzymexla::Pointer2MemrefOp>(
-          addr.getLoc(), collapsedType, addr);
+          addr.getLoc(), collapsedType, basePtr);
       return cast<MemRefVal>(ptr2memref.getResult());
     }
   }

--- a/test/lit_tests/raising/llvm_to_memref_access_not_affine.mlir
+++ b/test/lit_tests/raising/llvm_to_memref_access_not_affine.mlir
@@ -1,0 +1,564 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access,canonicalize)" --split-input-file | FileCheck %s
+
+#tbaa_root = #llvm.tbaa_root<id = "custom_tbaa">
+#tbaa_type_desc = #llvm.tbaa_type_desc<id = "custom_tbaa_addrspace(1)", members = {<#tbaa_root, 0>}>
+#tbaa_tag = #llvm.tbaa_tag<base_type = #tbaa_type_desc, access_type = #tbaa_type_desc, offset = 0>
+module {
+
+  func.func private @"##call__Z43gpu__interpolate_primary_atmospheric_state_16CompilerMetadataI16OffsetStaticSizeI13_0_181__0_86_E12DynamicCheckvv7NDRangeILi2E10StaticSizeI7_12__6_ES4_I8_16__16_E5TupleI5Int64S8_E13KernelOffsetsIS9_EEE10NamedTupleI35__u___v___T___p___q___Qs___Q____Mp_S7_I11OffsetArrayI7Float64Li3E13CuTracedArrayISG_Li3ELi1E12_194__99__1_EESJ_SJ_SJ_SJ_SJ_SJ_SJ_EESE_I8__i___j_S7_I5FieldI6CenterSN_vvvvSJ_SG_vvvESO_EE16TimeInterpolatorISG_S8_S8_S8_E20ImmersedBoundaryGridISG_8Periodic14RightConnected7Bounded28OrthogonalSphericalShellGridISG_SU_SV_SW_28StaticVerticalDiscretizationISF_ISG_Li1ESH_ISG_Li1ELi1E5_35__EESF_ISG_Li1ESH_ISG_Li1ELi1E5_34__EES10_S12_E8TripolarIS8_S8_S8_ESF_ISG_Li2ESH_ISG_Li2ELi1E9_194__99_EES17_S17_S17_vE16GridFittedBottomISO_23CenterImmersedConditionEvvvESE_I8__u___v_S7_ISF_ISG_Li4ESH_ISG_Li4ELi1E17_366__186__1__24_EES1E_EESE_I8__T___q_S1F_ES1E_SE_I23__shortwave___longwave_S1F_ESE_I14__rain___snow_S1F_E8InMemoryIvE5Clamp#1087$par58"(%arg0: memref<1x99x194xf64, 1>, %arg1: memref<1x99x194xf64, 1>, %arg2: memref<1x99x194xf64, 1>, %arg3: memref<1x99x194xf64, 1>, %arg4: memref<1x99x194xf64, 1>, %arg5: memref<1x99x194xf64, 1>, %arg6: memref<1x99x194xf64, 1>, %arg7: memref<1x99x194xf64, 1>, %arg8: memref<1x99x194xf64, 1>, %arg9: memref<1x99x194xf64, 1>, %arg10: memref<99x194xf64, 1>, %arg11: memref<99x194xf64, 1>, %arg12: memref<99x194xf64, 1>, %arg13: memref<24x1x186x366xf64, 1>, %arg14: memref<24x1x186x366xf64, 1>, %arg15: memref<24x1x186x366xf64, 1>, %arg16: memref<24x1x186x366xf64, 1>, %arg17: memref<24x1x186x366xf64, 1>, %arg18: memref<24x1x186x366xf64, 1>, %arg19: memref<24x1x186x366xf64, 1>, %arg20: memref<24x1x186x366xf64, 1>, %arg21: memref<24x1x186x366xf64, 1>) {
+    %c68079_i64 = arith.constant 68079 : i64
+    %c68078_i64 = arith.constant 68078 : i64
+    %c3_i64 = arith.constant 3 : i64
+    %cst = arith.constant 1.000000e+00 : f64
+    %cst_0 = arith.constant 0.000000e+00 : f64
+    %c2_i64 = arith.constant 2 : i64
+    %c366_i64 = arith.constant 366 : i64
+    %cst_1 = arith.constant 0.31944444444444442 : f64
+    %cst_2 = arith.constant 0.68055555555555558 : f64
+    %cst_3 = arith.constant 0.017453292519943295 : f64
+    %cst_4 = arith.constant 2.000000e+00 : f64
+    %0 = "enzymexla.memref2pointer"(%arg13) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    %1 = "enzymexla.memref2pointer"(%arg14) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    %2 = "enzymexla.memref2pointer"(%arg15) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    %3 = "enzymexla.memref2pointer"(%arg16) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    %4 = "enzymexla.memref2pointer"(%arg17) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    %5 = "enzymexla.memref2pointer"(%arg18) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    %6 = "enzymexla.memref2pointer"(%arg19) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    %7 = "enzymexla.memref2pointer"(%arg20) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    %8 = "enzymexla.memref2pointer"(%arg21) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+    affine.parallel (%arg22, %arg23) = (0, 0) to (87, 182) {
+      %9 = affine.load %arg8[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      %10 = affine.load %arg9[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      %11 = arith.fptosi %9 : f64 to i64
+      %12 = arith.remf %9, %cst : f64
+      %13 = arith.cmpf oeq, %12, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %14 = math.copysign %12, %cst : f64
+      %15 = arith.cmpf olt, %cst_0, %12 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %16 = arith.addf %12, %cst {fastmathFlags = #llvm.fastmath<none>} : f64
+      %17 = arith.select %15, %12, %16 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %18 = arith.select %13, %14, %17 : f64
+      %19 = arith.fptosi %10 : f64 to i64
+      %20 = arith.remf %10, %cst : f64
+      %21 = arith.cmpf oeq, %20, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %22 = math.copysign %20, %cst : f64
+      %23 = arith.cmpf olt, %cst_0, %20 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %24 = arith.addf %20, %cst {fastmathFlags = #llvm.fastmath<none>} : f64
+      %25 = arith.select %23, %20, %24 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %26 = arith.select %21, %22, %25 : f64
+      %27 = arith.subf %cst, %18 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %28 = arith.subf %cst, %26 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %29 = arith.mulf %27, %28 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %30 = arith.addi %19, %c2_i64 : i64
+      %31 = arith.muli %30, %c366_i64 : i64
+      %32 = arith.addi %31, %11 : i64
+      %33 = arith.addi %32, %c2_i64 : i64
+      %34 = llvm.getelementptr inbounds %0[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %35 = llvm.load %34 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %36 = arith.mulf %29, %35 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %37 = arith.mulf %29, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %38 = arith.mulf %37, %35 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %39 = arith.mulf %27, %26 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %40 = arith.addi %19, %c3_i64 : i64
+      %41 = arith.muli %40, %c366_i64 : i64
+      %42 = arith.addi %41, %11 : i64
+      %43 = arith.addi %42, %c2_i64 : i64
+      %44 = llvm.getelementptr inbounds %0[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %45 = llvm.load %44 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %46 = arith.mulf %39, %45 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %47 = arith.mulf %39, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %48 = arith.mulf %47, %45 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %49 = arith.mulf %18, %28 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %50 = arith.addi %32, %c3_i64 : i64
+      %51 = llvm.getelementptr inbounds %0[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %52 = llvm.load %51 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %53 = arith.mulf %49, %52 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %54 = arith.mulf %49, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %55 = arith.mulf %54, %52 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %56 = arith.mulf %18, %26 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %57 = arith.addi %42, %c3_i64 : i64
+      %58 = llvm.getelementptr inbounds %0[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %59 = llvm.load %58 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %60 = arith.mulf %56, %59 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %61 = arith.mulf %56, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %62 = arith.mulf %61, %59 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %63 = arith.addf %36, %38 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %64 = arith.addf %63, %46 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %65 = arith.addf %64, %48 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %66 = arith.addf %65, %53 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %67 = arith.addf %66, %55 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %68 = arith.addf %67, %60 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %69 = arith.addf %68, %62 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %70 = arith.addi %32, %c68078_i64 : i64
+      %71 = llvm.getelementptr inbounds %0[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %72 = llvm.load %71 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %73 = arith.mulf %29, %72 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %74 = arith.mulf %37, %72 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %75 = arith.addi %42, %c68078_i64 : i64
+      %76 = llvm.getelementptr inbounds %0[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %77 = llvm.load %76 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %78 = arith.mulf %39, %77 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %79 = arith.mulf %47, %77 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %80 = arith.addi %32, %c68079_i64 : i64
+      %81 = llvm.getelementptr inbounds %0[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %82 = llvm.load %81 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %83 = arith.mulf %49, %82 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %84 = arith.mulf %54, %82 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %85 = arith.addi %42, %c68079_i64 : i64
+      %86 = llvm.getelementptr inbounds %0[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %87 = llvm.load %86 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %88 = arith.mulf %56, %87 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %89 = arith.mulf %61, %87 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %90 = arith.addf %73, %74 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %91 = arith.addf %90, %78 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %92 = arith.addf %91, %79 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %93 = arith.addf %92, %83 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %94 = arith.addf %93, %84 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %95 = arith.addf %94, %88 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %96 = arith.addf %95, %89 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %97 = arith.mulf %96, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %98 = arith.mulf %69, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %99 = arith.addf %97, %98 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %100 = llvm.getelementptr inbounds %1[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %101 = llvm.load %100 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %102 = arith.mulf %29, %101 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %103 = arith.mulf %37, %101 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %104 = llvm.getelementptr inbounds %1[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %105 = llvm.load %104 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %106 = arith.mulf %39, %105 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %107 = arith.mulf %47, %105 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %108 = llvm.getelementptr inbounds %1[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %109 = llvm.load %108 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %110 = arith.mulf %49, %109 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %111 = arith.mulf %54, %109 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %112 = llvm.getelementptr inbounds %1[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %113 = llvm.load %112 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %114 = arith.mulf %56, %113 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %115 = arith.mulf %61, %113 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %116 = arith.addf %102, %103 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %117 = arith.addf %116, %106 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %118 = arith.addf %117, %107 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %119 = arith.addf %118, %110 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %120 = arith.addf %119, %111 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %121 = arith.addf %120, %114 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %122 = arith.addf %121, %115 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %123 = llvm.getelementptr inbounds %1[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %124 = llvm.load %123 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %125 = arith.mulf %29, %124 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %126 = arith.mulf %37, %124 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %127 = llvm.getelementptr inbounds %1[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %128 = llvm.load %127 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %129 = arith.mulf %39, %128 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %130 = arith.mulf %47, %128 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %131 = llvm.getelementptr inbounds %1[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %132 = llvm.load %131 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %133 = arith.mulf %49, %132 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %134 = arith.mulf %54, %132 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %135 = llvm.getelementptr inbounds %1[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %136 = llvm.load %135 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %137 = arith.mulf %56, %136 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %138 = arith.mulf %61, %136 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %139 = arith.addf %125, %126 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %140 = arith.addf %139, %129 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %141 = arith.addf %140, %130 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %142 = arith.addf %141, %133 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %143 = arith.addf %142, %134 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %144 = arith.addf %143, %137 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %145 = arith.addf %144, %138 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %146 = arith.mulf %145, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %147 = arith.mulf %122, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %148 = arith.addf %146, %147 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %149 = llvm.getelementptr inbounds %2[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %150 = llvm.load %149 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %151 = arith.mulf %29, %150 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %152 = arith.mulf %37, %150 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %153 = llvm.getelementptr inbounds %2[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %154 = llvm.load %153 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %155 = arith.mulf %39, %154 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %156 = arith.mulf %47, %154 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %157 = llvm.getelementptr inbounds %2[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %158 = llvm.load %157 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %159 = arith.mulf %49, %158 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %160 = arith.mulf %54, %158 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %161 = llvm.getelementptr inbounds %2[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %162 = llvm.load %161 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %163 = arith.mulf %56, %162 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %164 = arith.mulf %61, %162 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %165 = arith.addf %151, %152 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %166 = arith.addf %165, %155 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %167 = arith.addf %166, %156 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %168 = arith.addf %167, %159 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %169 = arith.addf %168, %160 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %170 = arith.addf %169, %163 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %171 = arith.addf %170, %164 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %172 = llvm.getelementptr inbounds %2[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %173 = llvm.load %172 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %174 = arith.mulf %29, %173 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %175 = arith.mulf %37, %173 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %176 = llvm.getelementptr inbounds %2[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %177 = llvm.load %176 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %178 = arith.mulf %39, %177 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %179 = arith.mulf %47, %177 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %180 = llvm.getelementptr inbounds %2[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %181 = llvm.load %180 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %182 = arith.mulf %49, %181 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %183 = arith.mulf %54, %181 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %184 = llvm.getelementptr inbounds %2[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %185 = llvm.load %184 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %186 = arith.mulf %56, %185 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %187 = arith.mulf %61, %185 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %188 = arith.addf %174, %175 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %189 = arith.addf %188, %178 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %190 = arith.addf %189, %179 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %191 = arith.addf %190, %182 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %192 = arith.addf %191, %183 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %193 = arith.addf %192, %186 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %194 = arith.addf %193, %187 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %195 = arith.mulf %194, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %196 = arith.mulf %171, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %197 = arith.addf %195, %196 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %198 = llvm.getelementptr inbounds %3[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %199 = llvm.load %198 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %200 = arith.mulf %29, %199 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %201 = arith.mulf %37, %199 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %202 = llvm.getelementptr inbounds %3[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %203 = llvm.load %202 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %204 = arith.mulf %39, %203 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %205 = arith.mulf %47, %203 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %206 = llvm.getelementptr inbounds %3[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %207 = llvm.load %206 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %208 = arith.mulf %49, %207 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %209 = arith.mulf %54, %207 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %210 = llvm.getelementptr inbounds %3[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %211 = llvm.load %210 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %212 = arith.mulf %56, %211 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %213 = arith.mulf %61, %211 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %214 = arith.addf %200, %201 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %215 = arith.addf %214, %204 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %216 = arith.addf %215, %205 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %217 = arith.addf %216, %208 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %218 = arith.addf %217, %209 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %219 = arith.addf %218, %212 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %220 = arith.addf %219, %213 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %221 = llvm.getelementptr inbounds %3[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %222 = llvm.load %221 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %223 = arith.mulf %29, %222 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %224 = arith.mulf %37, %222 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %225 = llvm.getelementptr inbounds %3[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %226 = llvm.load %225 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %227 = arith.mulf %39, %226 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %228 = arith.mulf %47, %226 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %229 = llvm.getelementptr inbounds %3[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %230 = llvm.load %229 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %231 = arith.mulf %49, %230 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %232 = arith.mulf %54, %230 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %233 = llvm.getelementptr inbounds %3[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %234 = llvm.load %233 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %235 = arith.mulf %56, %234 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %236 = arith.mulf %61, %234 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %237 = arith.addf %223, %224 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %238 = arith.addf %237, %227 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %239 = arith.addf %238, %228 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %240 = arith.addf %239, %231 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %241 = arith.addf %240, %232 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %242 = arith.addf %241, %235 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %243 = arith.addf %242, %236 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %244 = arith.mulf %243, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %245 = arith.mulf %220, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %246 = arith.addf %244, %245 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %247 = llvm.getelementptr inbounds %4[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %248 = llvm.load %247 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %249 = arith.mulf %29, %248 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %250 = arith.mulf %37, %248 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %251 = llvm.getelementptr inbounds %4[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %252 = llvm.load %251 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %253 = arith.mulf %39, %252 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %254 = arith.mulf %47, %252 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %255 = llvm.getelementptr inbounds %4[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %256 = llvm.load %255 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %257 = arith.mulf %49, %256 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %258 = arith.mulf %54, %256 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %259 = llvm.getelementptr inbounds %4[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %260 = llvm.load %259 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %261 = arith.mulf %56, %260 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %262 = arith.mulf %61, %260 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %263 = arith.addf %249, %250 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %264 = arith.addf %263, %253 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %265 = arith.addf %264, %254 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %266 = arith.addf %265, %257 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %267 = arith.addf %266, %258 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %268 = arith.addf %267, %261 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %269 = arith.addf %268, %262 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %270 = llvm.getelementptr inbounds %4[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %271 = llvm.load %270 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %272 = arith.mulf %29, %271 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %273 = arith.mulf %37, %271 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %274 = llvm.getelementptr inbounds %4[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %275 = llvm.load %274 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %276 = arith.mulf %39, %275 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %277 = arith.mulf %47, %275 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %278 = llvm.getelementptr inbounds %4[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %279 = llvm.load %278 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %280 = arith.mulf %49, %279 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %281 = arith.mulf %54, %279 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %282 = llvm.getelementptr inbounds %4[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %283 = llvm.load %282 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %284 = arith.mulf %56, %283 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %285 = arith.mulf %61, %283 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %286 = arith.addf %272, %273 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %287 = arith.addf %286, %276 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %288 = arith.addf %287, %277 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %289 = arith.addf %288, %280 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %290 = arith.addf %289, %281 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %291 = arith.addf %290, %284 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %292 = arith.addf %291, %285 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %293 = arith.mulf %292, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %294 = arith.mulf %269, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %295 = arith.addf %293, %294 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %296 = llvm.getelementptr inbounds %5[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %297 = llvm.load %296 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %298 = arith.mulf %29, %297 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %299 = arith.mulf %37, %297 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %300 = llvm.getelementptr inbounds %5[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %301 = llvm.load %300 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %302 = arith.mulf %39, %301 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %303 = arith.mulf %47, %301 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %304 = llvm.getelementptr inbounds %5[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %305 = llvm.load %304 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %306 = arith.mulf %49, %305 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %307 = arith.mulf %54, %305 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %308 = llvm.getelementptr inbounds %5[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %309 = llvm.load %308 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %310 = arith.mulf %56, %309 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %311 = arith.mulf %61, %309 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %312 = arith.addf %298, %299 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %313 = arith.addf %312, %302 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %314 = arith.addf %313, %303 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %315 = arith.addf %314, %306 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %316 = arith.addf %315, %307 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %317 = arith.addf %316, %310 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %318 = arith.addf %317, %311 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %319 = llvm.getelementptr inbounds %5[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %320 = llvm.load %319 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %321 = arith.mulf %29, %320 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %322 = arith.mulf %37, %320 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %323 = llvm.getelementptr inbounds %5[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %324 = llvm.load %323 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %325 = arith.mulf %39, %324 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %326 = arith.mulf %47, %324 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %327 = llvm.getelementptr inbounds %5[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %328 = llvm.load %327 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %329 = arith.mulf %49, %328 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %330 = arith.mulf %54, %328 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %331 = llvm.getelementptr inbounds %5[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %332 = llvm.load %331 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %333 = arith.mulf %56, %332 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %334 = arith.mulf %61, %332 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %335 = arith.addf %321, %322 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %336 = arith.addf %335, %325 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %337 = arith.addf %336, %326 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %338 = arith.addf %337, %329 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %339 = arith.addf %338, %330 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %340 = arith.addf %339, %333 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %341 = arith.addf %340, %334 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %342 = arith.mulf %341, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %343 = arith.mulf %318, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %344 = arith.addf %342, %343 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %345 = llvm.getelementptr inbounds %6[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %346 = llvm.load %345 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %347 = arith.mulf %29, %346 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %348 = arith.mulf %37, %346 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %349 = llvm.getelementptr inbounds %6[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %350 = llvm.load %349 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %351 = arith.mulf %39, %350 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %352 = arith.mulf %47, %350 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %353 = llvm.getelementptr inbounds %6[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %354 = llvm.load %353 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %355 = arith.mulf %49, %354 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %356 = arith.mulf %54, %354 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %357 = llvm.getelementptr inbounds %6[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %358 = llvm.load %357 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %359 = arith.mulf %56, %358 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %360 = arith.mulf %61, %358 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %361 = arith.addf %347, %348 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %362 = arith.addf %361, %351 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %363 = arith.addf %362, %352 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %364 = arith.addf %363, %355 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %365 = arith.addf %364, %356 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %366 = arith.addf %365, %359 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %367 = arith.addf %366, %360 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %368 = llvm.getelementptr inbounds %6[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %369 = llvm.load %368 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %370 = arith.mulf %29, %369 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %371 = arith.mulf %37, %369 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %372 = llvm.getelementptr inbounds %6[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %373 = llvm.load %372 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %374 = arith.mulf %39, %373 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %375 = arith.mulf %47, %373 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %376 = llvm.getelementptr inbounds %6[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %377 = llvm.load %376 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %378 = arith.mulf %49, %377 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %379 = arith.mulf %54, %377 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %380 = llvm.getelementptr inbounds %6[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %381 = llvm.load %380 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %382 = arith.mulf %56, %381 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %383 = arith.mulf %61, %381 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %384 = arith.addf %370, %371 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %385 = arith.addf %384, %374 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %386 = arith.addf %385, %375 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %387 = arith.addf %386, %378 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %388 = arith.addf %387, %379 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %389 = arith.addf %388, %382 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %390 = arith.addf %389, %383 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %391 = arith.mulf %390, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %392 = arith.mulf %367, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %393 = arith.addf %391, %392 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %394 = llvm.getelementptr inbounds %7[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %395 = llvm.load %394 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %396 = arith.mulf %29, %395 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %397 = arith.mulf %37, %395 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %398 = llvm.getelementptr inbounds %7[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %399 = llvm.load %398 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %400 = arith.mulf %39, %399 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %401 = arith.mulf %47, %399 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %402 = llvm.getelementptr inbounds %7[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %403 = llvm.load %402 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %404 = arith.mulf %49, %403 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %405 = arith.mulf %54, %403 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %406 = llvm.getelementptr inbounds %7[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %407 = llvm.load %406 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %408 = arith.mulf %56, %407 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %409 = arith.mulf %61, %407 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %410 = arith.addf %396, %397 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %411 = arith.addf %410, %400 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %412 = arith.addf %411, %401 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %413 = arith.addf %412, %404 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %414 = arith.addf %413, %405 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %415 = arith.addf %414, %408 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %416 = arith.addf %415, %409 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %417 = llvm.getelementptr inbounds %7[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %418 = llvm.load %417 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %419 = arith.mulf %29, %418 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %420 = arith.mulf %37, %418 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %421 = llvm.getelementptr inbounds %7[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %422 = llvm.load %421 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %423 = arith.mulf %39, %422 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %424 = arith.mulf %47, %422 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %425 = llvm.getelementptr inbounds %7[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %426 = llvm.load %425 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %427 = arith.mulf %49, %426 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %428 = arith.mulf %54, %426 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %429 = llvm.getelementptr inbounds %7[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %430 = llvm.load %429 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %431 = arith.mulf %56, %430 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %432 = arith.mulf %61, %430 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %433 = arith.addf %419, %420 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %434 = arith.addf %433, %423 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %435 = arith.addf %434, %424 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %436 = arith.addf %435, %427 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %437 = arith.addf %436, %428 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %438 = arith.addf %437, %431 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %439 = arith.addf %438, %432 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %440 = arith.mulf %439, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %441 = arith.mulf %416, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %442 = arith.addf %440, %441 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %443 = llvm.getelementptr inbounds %8[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %444 = llvm.load %443 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %445 = arith.mulf %29, %444 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %446 = arith.mulf %37, %444 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %447 = llvm.getelementptr inbounds %8[%43] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %448 = llvm.load %447 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %449 = arith.mulf %39, %448 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %450 = arith.mulf %47, %448 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %451 = llvm.getelementptr inbounds %8[%50] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %452 = llvm.load %451 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %453 = arith.mulf %49, %452 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %454 = arith.mulf %54, %452 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %455 = llvm.getelementptr inbounds %8[%57] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %456 = llvm.load %455 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %457 = arith.mulf %56, %456 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %458 = arith.mulf %61, %456 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %459 = arith.addf %445, %446 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %460 = arith.addf %459, %449 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %461 = arith.addf %460, %450 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %462 = arith.addf %461, %453 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %463 = arith.addf %462, %454 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %464 = arith.addf %463, %457 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %465 = arith.addf %464, %458 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %466 = llvm.getelementptr inbounds %8[%70] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %467 = llvm.load %466 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %468 = arith.mulf %29, %467 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %469 = arith.mulf %37, %467 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %470 = llvm.getelementptr inbounds %8[%75] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %471 = llvm.load %470 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %472 = arith.mulf %39, %471 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %473 = arith.mulf %47, %471 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %474 = llvm.getelementptr inbounds %8[%80] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %475 = llvm.load %474 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %476 = arith.mulf %49, %475 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %477 = arith.mulf %54, %475 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %478 = llvm.getelementptr inbounds %8[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %479 = llvm.load %478 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %480 = arith.mulf %56, %479 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %481 = arith.mulf %61, %479 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %482 = arith.addf %468, %469 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %483 = arith.addf %482, %472 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %484 = arith.addf %483, %473 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %485 = arith.addf %484, %476 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %486 = arith.addf %485, %477 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %487 = arith.addf %486, %480 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %488 = arith.addf %487, %481 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %489 = arith.mulf %488, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %490 = arith.mulf %465, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %491 = arith.addf %489, %490 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %492 = arith.addf %442, %491 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %493 = affine.load %arg10[%arg22 + 7, %arg23 + 7] : memref<99x194xf64, 1>
+      %494 = affine.load %arg10[%arg22 + 6, %arg23 + 7] : memref<99x194xf64, 1>
+      %495 = affine.load %arg10[%arg22 + 7, %arg23 + 6] : memref<99x194xf64, 1>
+      %496 = affine.load %arg10[%arg22 + 6, %arg23 + 6] : memref<99x194xf64, 1>
+      %497 = affine.load %arg12[%arg22 + 6, %arg23 + 7] : memref<99x194xf64, 1>
+      %498 = affine.load %arg12[%arg22 + 6, %arg23 + 6] : memref<99x194xf64, 1>
+      %499 = affine.load %arg11[%arg22 + 7, %arg23 + 6] : memref<99x194xf64, 1>
+      %500 = affine.load %arg11[%arg22 + 6, %arg23 + 6] : memref<99x194xf64, 1>
+      %501 = arith.subf %493, %494 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %502 = arith.mulf %501, %cst_3 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %503 = arith.divf %502, %497 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %504 = arith.subf %495, %496 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %505 = arith.mulf %504, %cst_3 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %506 = arith.divf %505, %498 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %507 = arith.addf %503, %506 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %508 = arith.divf %507, %cst_4 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %509 = arith.subf %493, %495 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %510 = arith.mulf %509, %cst_3 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %511 = arith.divf %510, %499 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %512 = arith.subf %494, %496 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %513 = arith.mulf %512, %cst_3 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %514 = arith.divf %513, %500 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %515 = arith.addf %511, %514 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %516 = arith.negf %515 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %517 = arith.divf %516, %cst_4 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %518 = arith.mulf %508, %508 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %519 = arith.mulf %517, %517 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %520 = arith.addf %518, %519 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %521 = math.sqrt %520 : f64
+      %522 = arith.divf %508, %521 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %523 = arith.divf %517, %521 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %524 = arith.mulf %99, %522 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %525 = arith.mulf %148, %523 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %526 = arith.addf %524, %525 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %527 = arith.negf %99 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %528 = arith.mulf %527, %523 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %529 = arith.mulf %148, %522 {fastmathFlags = #llvm.fastmath<none>} : f64
+      %530 = arith.addf %529, %528 {fastmathFlags = #llvm.fastmath<none>} : f64
+      affine.store %526, %arg0[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      affine.store %530, %arg1[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      affine.store %197, %arg2[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      affine.store %295, %arg3[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      affine.store %246, %arg4[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      affine.store %344, %arg5[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      affine.store %393, %arg6[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+      affine.store %492, %arg7[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+    }
+    return
+  }
+}
+

--- a/test/lit_tests/raising/llvm_to_memref_access_not_affine.mlir
+++ b/test/lit_tests/raising/llvm_to_memref_access_not_affine.mlir
@@ -562,3 +562,640 @@ module {
   }
 }
 
+
+// CHECK: func.func private @"##call__Z43gpu__interpolate_primary_atmospheric_state_16CompilerMetadataI16OffsetStaticSizeI13_0_181__0_86_E12DynamicCheckvv7NDRangeILi2E10StaticSizeI7_12__6_ES4_I8_16__16_E5TupleI5Int64S8_E13KernelOffsetsIS9_EEE10NamedTupleI35__u___v___T___p___q___Qs___Q____Mp_S7_I11OffsetArrayI7Float64Li3E13CuTracedArrayISG_Li3ELi1E12_194__99__1_EESJ_SJ_SJ_SJ_SJ_SJ_SJ_EESE_I8__i___j_S7_I5FieldI6CenterSN_vvvvSJ_SG_vvvESO_EE16TimeInterpolatorISG_S8_S8_S8_E20ImmersedBoundaryGridISG_8Periodic14RightConnected7Bounded28OrthogonalSphericalShellGridISG_SU_SV_SW_28StaticVerticalDiscretizationISF_ISG_Li1ESH_ISG_Li1ELi1E5_35__EESF_ISG_Li1ESH_ISG_Li1ELi1E5_34__EES10_S12_E8TripolarIS8_S8_S8_ESF_ISG_Li2ESH_ISG_Li2ELi1E9_194__99_EES17_S17_S17_vE16GridFittedBottomISO_23CenterImmersedConditionEvvvESE_I8__u___v_S7_ISF_ISG_Li4ESH_ISG_Li4ELi1E17_366__186__1__24_EES1E_EESE_I8__T___q_S1F_ES1E_SE_I23__shortwave___longwave_S1F_ESE_I14__rain___snow_S1F_E8InMemoryIvE5Clamp#1087$par58"(%arg0: memref<1x99x194xf64, 1>, %arg1: memref<1x99x194xf64, 1>, %arg2: memref<1x99x194xf64, 1>, %arg3: memref<1x99x194xf64, 1>, %arg4: memref<1x99x194xf64, 1>, %arg5: memref<1x99x194xf64, 1>, %arg6: memref<1x99x194xf64, 1>, %arg7: memref<1x99x194xf64, 1>, %arg8: memref<1x99x194xf64, 1>, %arg9: memref<1x99x194xf64, 1>, %arg10: memref<99x194xf64, 1>, %arg11: memref<99x194xf64, 1>, %arg12: memref<99x194xf64, 1>, %arg13: memref<24x1x186x366xf64, 1>, %arg14: memref<24x1x186x366xf64, 1>, %arg15: memref<24x1x186x366xf64, 1>, %arg16: memref<24x1x186x366xf64, 1>, %arg17: memref<24x1x186x366xf64, 1>, %arg18: memref<24x1x186x366xf64, 1>, %arg19: memref<24x1x186x366xf64, 1>, %arg20: memref<24x1x186x366xf64, 1>, %arg21: memref<24x1x186x366xf64, 1>) {
+// CHECK-NEXT:   %c68079_i64 = arith.constant 68079 : i64
+// CHECK-NEXT:   %c68078_i64 = arith.constant 68078 : i64
+// CHECK-NEXT:   %c3_i64 = arith.constant 3 : i64
+// CHECK-NEXT:   %cst = arith.constant 1.000000e+00 : f64
+// CHECK-NEXT:   %cst_0 = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %c2_i64 = arith.constant 2 : i64
+// CHECK-NEXT:   %c366_i64 = arith.constant 366 : i64
+// CHECK-NEXT:   %cst_1 = arith.constant 0.31944444444444442 : f64
+// CHECK-NEXT:   %cst_2 = arith.constant 0.68055555555555558 : f64
+// CHECK-NEXT:   %cst_3 = arith.constant 0.017453292519943295 : f64
+// CHECK-NEXT:   %cst_4 = arith.constant 2.000000e+00 : f64
+// CHECK-NEXT:   %0 = "enzymexla.memref2pointer"(%arg13) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   %1 = "enzymexla.memref2pointer"(%arg14) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   %2 = "enzymexla.memref2pointer"(%arg15) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   %3 = "enzymexla.memref2pointer"(%arg16) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   %4 = "enzymexla.memref2pointer"(%arg17) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   %5 = "enzymexla.memref2pointer"(%arg18) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   %6 = "enzymexla.memref2pointer"(%arg19) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   %7 = "enzymexla.memref2pointer"(%arg20) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   %8 = "enzymexla.memref2pointer"(%arg21) : (memref<24x1x186x366xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:   affine.parallel (%arg22, %arg23) = (0, 0) to (87, 182) {
+// CHECK-NEXT:     %9 = affine.load %arg8[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     %10 = affine.load %arg9[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     %11 = arith.fptosi %9 : f64 to i64
+// CHECK-NEXT:     %12 = arith.remf %9, %cst : f64
+// CHECK-NEXT:     %13 = arith.cmpf oeq, %12, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %14 = math.copysign %12, %cst : f64
+// CHECK-NEXT:     %15 = arith.cmpf olt, %cst_0, %12 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %16 = arith.addf %12, %cst {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %17 = arith.select %15, %12, %16 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %18 = arith.select %13, %14, %17 : f64
+// CHECK-NEXT:     %19 = arith.fptosi %10 : f64 to i64
+// CHECK-NEXT:     %20 = arith.remf %10, %cst : f64
+// CHECK-NEXT:     %21 = arith.cmpf oeq, %20, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %22 = math.copysign %20, %cst : f64
+// CHECK-NEXT:     %23 = arith.cmpf olt, %cst_0, %20 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %24 = arith.addf %20, %cst {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %25 = arith.select %23, %20, %24 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %26 = arith.select %21, %22, %25 : f64
+// CHECK-NEXT:     %27 = arith.subf %cst, %18 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %28 = arith.subf %cst, %26 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %29 = arith.mulf %27, %28 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %30 = arith.addi %19, %c2_i64 : i64
+// CHECK-NEXT:     %31 = arith.muli %30, %c366_i64 : i64
+// CHECK-NEXT:     %32 = arith.addi %31, %11 : i64
+// CHECK-NEXT:     %33 = arith.addi %32, %c2_i64 : i64
+// CHECK-NEXT:     %34 = arith.index_cast %33 : i64 to index
+// CHECK-NEXT:     %35 = llvm.getelementptr inbounds %0[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %36 = "enzymexla.pointer2memref"(%35) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %37 = memref.load %36[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %38 = arith.mulf %29, %37 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %39 = arith.mulf %29, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %40 = arith.mulf %39, %37 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %41 = arith.mulf %27, %26 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %42 = arith.addi %19, %c3_i64 : i64
+// CHECK-NEXT:     %43 = arith.muli %42, %c366_i64 : i64
+// CHECK-NEXT:     %44 = arith.addi %43, %11 : i64
+// CHECK-NEXT:     %45 = arith.addi %44, %c2_i64 : i64
+// CHECK-NEXT:     %46 = arith.index_cast %45 : i64 to index
+// CHECK-NEXT:     %47 = llvm.getelementptr inbounds %0[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %48 = "enzymexla.pointer2memref"(%47) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %49 = memref.load %48[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %50 = arith.mulf %41, %49 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %51 = arith.mulf %41, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %52 = arith.mulf %51, %49 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %53 = arith.mulf %18, %28 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %54 = arith.addi %32, %c3_i64 : i64
+// CHECK-NEXT:     %55 = arith.index_cast %54 : i64 to index
+// CHECK-NEXT:     %56 = llvm.getelementptr inbounds %0[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %57 = "enzymexla.pointer2memref"(%56) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %58 = memref.load %57[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %59 = arith.mulf %53, %58 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %60 = arith.mulf %53, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %61 = arith.mulf %60, %58 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %62 = arith.mulf %18, %26 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %63 = arith.addi %44, %c3_i64 : i64
+// CHECK-NEXT:     %64 = arith.index_cast %63 : i64 to index
+// CHECK-NEXT:     %65 = llvm.getelementptr inbounds %0[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %66 = "enzymexla.pointer2memref"(%65) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %67 = memref.load %66[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %68 = arith.mulf %62, %67 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %69 = arith.mulf %62, %cst_0 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %70 = arith.mulf %69, %67 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %71 = arith.addf %38, %40 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %72 = arith.addf %71, %50 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %73 = arith.addf %72, %52 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %74 = arith.addf %73, %59 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %75 = arith.addf %74, %61 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %76 = arith.addf %75, %68 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %77 = arith.addf %76, %70 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %78 = arith.addi %32, %c68078_i64 : i64
+// CHECK-NEXT:     %79 = arith.index_cast %78 : i64 to index
+// CHECK-NEXT:     %80 = llvm.getelementptr inbounds %0[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %81 = "enzymexla.pointer2memref"(%80) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %82 = memref.load %81[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %83 = arith.mulf %29, %82 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %84 = arith.mulf %39, %82 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %85 = arith.addi %44, %c68078_i64 : i64
+// CHECK-NEXT:     %86 = arith.index_cast %85 : i64 to index
+// CHECK-NEXT:     %87 = llvm.getelementptr inbounds %0[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %88 = "enzymexla.pointer2memref"(%87) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %89 = memref.load %88[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %90 = arith.mulf %41, %89 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %91 = arith.mulf %51, %89 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %92 = arith.addi %32, %c68079_i64 : i64
+// CHECK-NEXT:     %93 = arith.index_cast %92 : i64 to index
+// CHECK-NEXT:     %94 = llvm.getelementptr inbounds %0[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %95 = "enzymexla.pointer2memref"(%94) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %96 = memref.load %95[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %97 = arith.mulf %53, %96 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %98 = arith.mulf %60, %96 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %99 = arith.addi %44, %c68079_i64 : i64
+// CHECK-NEXT:     %100 = arith.index_cast %99 : i64 to index
+// CHECK-NEXT:     %101 = llvm.getelementptr inbounds %0[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %102 = "enzymexla.pointer2memref"(%101) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %103 = memref.load %102[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %104 = arith.mulf %62, %103 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %105 = arith.mulf %69, %103 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %106 = arith.addf %83, %84 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %107 = arith.addf %106, %90 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %108 = arith.addf %107, %91 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %109 = arith.addf %108, %97 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %110 = arith.addf %109, %98 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %111 = arith.addf %110, %104 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %112 = arith.addf %111, %105 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %113 = arith.mulf %112, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %114 = arith.mulf %77, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %115 = arith.addf %113, %114 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %116 = llvm.getelementptr inbounds %1[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %117 = "enzymexla.pointer2memref"(%116) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %118 = memref.load %117[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %119 = arith.mulf %29, %118 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %120 = arith.mulf %39, %118 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %121 = llvm.getelementptr inbounds %1[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %122 = "enzymexla.pointer2memref"(%121) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %123 = memref.load %122[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %124 = arith.mulf %41, %123 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %125 = arith.mulf %51, %123 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %126 = llvm.getelementptr inbounds %1[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %127 = "enzymexla.pointer2memref"(%126) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %128 = memref.load %127[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %129 = arith.mulf %53, %128 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %130 = arith.mulf %60, %128 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %131 = llvm.getelementptr inbounds %1[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %132 = "enzymexla.pointer2memref"(%131) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %133 = memref.load %132[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %134 = arith.mulf %62, %133 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %135 = arith.mulf %69, %133 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %136 = arith.addf %119, %120 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %137 = arith.addf %136, %124 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %138 = arith.addf %137, %125 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %139 = arith.addf %138, %129 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %140 = arith.addf %139, %130 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %141 = arith.addf %140, %134 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %142 = arith.addf %141, %135 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %143 = llvm.getelementptr inbounds %1[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %144 = "enzymexla.pointer2memref"(%143) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %145 = memref.load %144[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %146 = arith.mulf %29, %145 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %147 = arith.mulf %39, %145 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %148 = llvm.getelementptr inbounds %1[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %149 = "enzymexla.pointer2memref"(%148) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %150 = memref.load %149[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %151 = arith.mulf %41, %150 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %152 = arith.mulf %51, %150 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %153 = llvm.getelementptr inbounds %1[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %154 = "enzymexla.pointer2memref"(%153) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %155 = memref.load %154[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %156 = arith.mulf %53, %155 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %157 = arith.mulf %60, %155 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %158 = llvm.getelementptr inbounds %1[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %159 = "enzymexla.pointer2memref"(%158) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %160 = memref.load %159[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %161 = arith.mulf %62, %160 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %162 = arith.mulf %69, %160 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %163 = arith.addf %146, %147 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %164 = arith.addf %163, %151 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %165 = arith.addf %164, %152 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %166 = arith.addf %165, %156 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %167 = arith.addf %166, %157 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %168 = arith.addf %167, %161 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %169 = arith.addf %168, %162 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %170 = arith.mulf %169, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %171 = arith.mulf %142, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %172 = arith.addf %170, %171 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %173 = llvm.getelementptr inbounds %2[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %174 = "enzymexla.pointer2memref"(%173) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %175 = memref.load %174[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %176 = arith.mulf %29, %175 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %177 = arith.mulf %39, %175 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %178 = llvm.getelementptr inbounds %2[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %179 = "enzymexla.pointer2memref"(%178) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %180 = memref.load %179[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %181 = arith.mulf %41, %180 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %182 = arith.mulf %51, %180 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %183 = llvm.getelementptr inbounds %2[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %184 = "enzymexla.pointer2memref"(%183) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %185 = memref.load %184[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %186 = arith.mulf %53, %185 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %187 = arith.mulf %60, %185 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %188 = llvm.getelementptr inbounds %2[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %189 = "enzymexla.pointer2memref"(%188) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %190 = memref.load %189[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %191 = arith.mulf %62, %190 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %192 = arith.mulf %69, %190 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %193 = arith.addf %176, %177 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %194 = arith.addf %193, %181 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %195 = arith.addf %194, %182 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %196 = arith.addf %195, %186 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %197 = arith.addf %196, %187 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %198 = arith.addf %197, %191 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %199 = arith.addf %198, %192 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %200 = llvm.getelementptr inbounds %2[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %201 = "enzymexla.pointer2memref"(%200) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %202 = memref.load %201[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %203 = arith.mulf %29, %202 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %204 = arith.mulf %39, %202 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %205 = llvm.getelementptr inbounds %2[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %206 = "enzymexla.pointer2memref"(%205) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %207 = memref.load %206[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %208 = arith.mulf %41, %207 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %209 = arith.mulf %51, %207 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %210 = llvm.getelementptr inbounds %2[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %211 = "enzymexla.pointer2memref"(%210) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %212 = memref.load %211[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %213 = arith.mulf %53, %212 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %214 = arith.mulf %60, %212 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %215 = llvm.getelementptr inbounds %2[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %216 = "enzymexla.pointer2memref"(%215) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %217 = memref.load %216[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %218 = arith.mulf %62, %217 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %219 = arith.mulf %69, %217 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %220 = arith.addf %203, %204 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %221 = arith.addf %220, %208 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %222 = arith.addf %221, %209 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %223 = arith.addf %222, %213 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %224 = arith.addf %223, %214 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %225 = arith.addf %224, %218 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %226 = arith.addf %225, %219 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %227 = arith.mulf %226, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %228 = arith.mulf %199, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %229 = arith.addf %227, %228 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %230 = llvm.getelementptr inbounds %3[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %231 = "enzymexla.pointer2memref"(%230) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %232 = memref.load %231[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %233 = arith.mulf %29, %232 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %234 = arith.mulf %39, %232 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %235 = llvm.getelementptr inbounds %3[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %236 = "enzymexla.pointer2memref"(%235) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %237 = memref.load %236[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %238 = arith.mulf %41, %237 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %239 = arith.mulf %51, %237 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %240 = llvm.getelementptr inbounds %3[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %241 = "enzymexla.pointer2memref"(%240) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %242 = memref.load %241[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %243 = arith.mulf %53, %242 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %244 = arith.mulf %60, %242 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %245 = llvm.getelementptr inbounds %3[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %246 = "enzymexla.pointer2memref"(%245) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %247 = memref.load %246[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %248 = arith.mulf %62, %247 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %249 = arith.mulf %69, %247 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %250 = arith.addf %233, %234 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %251 = arith.addf %250, %238 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %252 = arith.addf %251, %239 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %253 = arith.addf %252, %243 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %254 = arith.addf %253, %244 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %255 = arith.addf %254, %248 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %256 = arith.addf %255, %249 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %257 = llvm.getelementptr inbounds %3[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %258 = "enzymexla.pointer2memref"(%257) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %259 = memref.load %258[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %260 = arith.mulf %29, %259 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %261 = arith.mulf %39, %259 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %262 = llvm.getelementptr inbounds %3[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %263 = "enzymexla.pointer2memref"(%262) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %264 = memref.load %263[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %265 = arith.mulf %41, %264 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %266 = arith.mulf %51, %264 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %267 = llvm.getelementptr inbounds %3[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %268 = "enzymexla.pointer2memref"(%267) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %269 = memref.load %268[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %270 = arith.mulf %53, %269 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %271 = arith.mulf %60, %269 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %272 = llvm.getelementptr inbounds %3[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %273 = "enzymexla.pointer2memref"(%272) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %274 = memref.load %273[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %275 = arith.mulf %62, %274 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %276 = arith.mulf %69, %274 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %277 = arith.addf %260, %261 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %278 = arith.addf %277, %265 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %279 = arith.addf %278, %266 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %280 = arith.addf %279, %270 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %281 = arith.addf %280, %271 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %282 = arith.addf %281, %275 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %283 = arith.addf %282, %276 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %284 = arith.mulf %283, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %285 = arith.mulf %256, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %286 = arith.addf %284, %285 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %287 = llvm.getelementptr inbounds %4[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %288 = "enzymexla.pointer2memref"(%287) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %289 = memref.load %288[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %290 = arith.mulf %29, %289 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %291 = arith.mulf %39, %289 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %292 = llvm.getelementptr inbounds %4[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %293 = "enzymexla.pointer2memref"(%292) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %294 = memref.load %293[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %295 = arith.mulf %41, %294 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %296 = arith.mulf %51, %294 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %297 = llvm.getelementptr inbounds %4[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %298 = "enzymexla.pointer2memref"(%297) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %299 = memref.load %298[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %300 = arith.mulf %53, %299 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %301 = arith.mulf %60, %299 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %302 = llvm.getelementptr inbounds %4[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %303 = "enzymexla.pointer2memref"(%302) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %304 = memref.load %303[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %305 = arith.mulf %62, %304 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %306 = arith.mulf %69, %304 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %307 = arith.addf %290, %291 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %308 = arith.addf %307, %295 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %309 = arith.addf %308, %296 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %310 = arith.addf %309, %300 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %311 = arith.addf %310, %301 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %312 = arith.addf %311, %305 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %313 = arith.addf %312, %306 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %314 = llvm.getelementptr inbounds %4[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %315 = "enzymexla.pointer2memref"(%314) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %316 = memref.load %315[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %317 = arith.mulf %29, %316 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %318 = arith.mulf %39, %316 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %319 = llvm.getelementptr inbounds %4[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %320 = "enzymexla.pointer2memref"(%319) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %321 = memref.load %320[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %322 = arith.mulf %41, %321 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %323 = arith.mulf %51, %321 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %324 = llvm.getelementptr inbounds %4[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %325 = "enzymexla.pointer2memref"(%324) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %326 = memref.load %325[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %327 = arith.mulf %53, %326 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %328 = arith.mulf %60, %326 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %329 = llvm.getelementptr inbounds %4[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %330 = "enzymexla.pointer2memref"(%329) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %331 = memref.load %330[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %332 = arith.mulf %62, %331 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %333 = arith.mulf %69, %331 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %334 = arith.addf %317, %318 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %335 = arith.addf %334, %322 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %336 = arith.addf %335, %323 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %337 = arith.addf %336, %327 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %338 = arith.addf %337, %328 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %339 = arith.addf %338, %332 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %340 = arith.addf %339, %333 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %341 = arith.mulf %340, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %342 = arith.mulf %313, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %343 = arith.addf %341, %342 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %344 = llvm.getelementptr inbounds %5[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %345 = "enzymexla.pointer2memref"(%344) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %346 = memref.load %345[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %347 = arith.mulf %29, %346 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %348 = arith.mulf %39, %346 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %349 = llvm.getelementptr inbounds %5[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %350 = "enzymexla.pointer2memref"(%349) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %351 = memref.load %350[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %352 = arith.mulf %41, %351 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %353 = arith.mulf %51, %351 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %354 = llvm.getelementptr inbounds %5[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %355 = "enzymexla.pointer2memref"(%354) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %356 = memref.load %355[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %357 = arith.mulf %53, %356 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %358 = arith.mulf %60, %356 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %359 = llvm.getelementptr inbounds %5[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %360 = "enzymexla.pointer2memref"(%359) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %361 = memref.load %360[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %362 = arith.mulf %62, %361 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %363 = arith.mulf %69, %361 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %364 = arith.addf %347, %348 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %365 = arith.addf %364, %352 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %366 = arith.addf %365, %353 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %367 = arith.addf %366, %357 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %368 = arith.addf %367, %358 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %369 = arith.addf %368, %362 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %370 = arith.addf %369, %363 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %371 = llvm.getelementptr inbounds %5[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %372 = "enzymexla.pointer2memref"(%371) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %373 = memref.load %372[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %374 = arith.mulf %29, %373 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %375 = arith.mulf %39, %373 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %376 = llvm.getelementptr inbounds %5[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %377 = "enzymexla.pointer2memref"(%376) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %378 = memref.load %377[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %379 = arith.mulf %41, %378 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %380 = arith.mulf %51, %378 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %381 = llvm.getelementptr inbounds %5[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %382 = "enzymexla.pointer2memref"(%381) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %383 = memref.load %382[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %384 = arith.mulf %53, %383 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %385 = arith.mulf %60, %383 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %386 = llvm.getelementptr inbounds %5[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %387 = "enzymexla.pointer2memref"(%386) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %388 = memref.load %387[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %389 = arith.mulf %62, %388 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %390 = arith.mulf %69, %388 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %391 = arith.addf %374, %375 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %392 = arith.addf %391, %379 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %393 = arith.addf %392, %380 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %394 = arith.addf %393, %384 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %395 = arith.addf %394, %385 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %396 = arith.addf %395, %389 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %397 = arith.addf %396, %390 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %398 = arith.mulf %397, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %399 = arith.mulf %370, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %400 = arith.addf %398, %399 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %401 = llvm.getelementptr inbounds %6[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %402 = "enzymexla.pointer2memref"(%401) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %403 = memref.load %402[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %404 = arith.mulf %29, %403 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %405 = arith.mulf %39, %403 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %406 = llvm.getelementptr inbounds %6[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %407 = "enzymexla.pointer2memref"(%406) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %408 = memref.load %407[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %409 = arith.mulf %41, %408 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %410 = arith.mulf %51, %408 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %411 = llvm.getelementptr inbounds %6[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %412 = "enzymexla.pointer2memref"(%411) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %413 = memref.load %412[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %414 = arith.mulf %53, %413 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %415 = arith.mulf %60, %413 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %416 = llvm.getelementptr inbounds %6[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %417 = "enzymexla.pointer2memref"(%416) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %418 = memref.load %417[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %419 = arith.mulf %62, %418 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %420 = arith.mulf %69, %418 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %421 = arith.addf %404, %405 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %422 = arith.addf %421, %409 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %423 = arith.addf %422, %410 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %424 = arith.addf %423, %414 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %425 = arith.addf %424, %415 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %426 = arith.addf %425, %419 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %427 = arith.addf %426, %420 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %428 = llvm.getelementptr inbounds %6[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %429 = "enzymexla.pointer2memref"(%428) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %430 = memref.load %429[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %431 = arith.mulf %29, %430 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %432 = arith.mulf %39, %430 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %433 = llvm.getelementptr inbounds %6[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %434 = "enzymexla.pointer2memref"(%433) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %435 = memref.load %434[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %436 = arith.mulf %41, %435 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %437 = arith.mulf %51, %435 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %438 = llvm.getelementptr inbounds %6[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %439 = "enzymexla.pointer2memref"(%438) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %440 = memref.load %439[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %441 = arith.mulf %53, %440 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %442 = arith.mulf %60, %440 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %443 = llvm.getelementptr inbounds %6[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %444 = "enzymexla.pointer2memref"(%443) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %445 = memref.load %444[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %446 = arith.mulf %62, %445 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %447 = arith.mulf %69, %445 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %448 = arith.addf %431, %432 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %449 = arith.addf %448, %436 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %450 = arith.addf %449, %437 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %451 = arith.addf %450, %441 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %452 = arith.addf %451, %442 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %453 = arith.addf %452, %446 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %454 = arith.addf %453, %447 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %455 = arith.mulf %454, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %456 = arith.mulf %427, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %457 = arith.addf %455, %456 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %458 = llvm.getelementptr inbounds %7[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %459 = "enzymexla.pointer2memref"(%458) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %460 = memref.load %459[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %461 = arith.mulf %29, %460 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %462 = arith.mulf %39, %460 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %463 = llvm.getelementptr inbounds %7[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %464 = "enzymexla.pointer2memref"(%463) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %465 = memref.load %464[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %466 = arith.mulf %41, %465 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %467 = arith.mulf %51, %465 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %468 = llvm.getelementptr inbounds %7[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %469 = "enzymexla.pointer2memref"(%468) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %470 = memref.load %469[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %471 = arith.mulf %53, %470 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %472 = arith.mulf %60, %470 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %473 = llvm.getelementptr inbounds %7[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %474 = "enzymexla.pointer2memref"(%473) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %475 = memref.load %474[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %476 = arith.mulf %62, %475 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %477 = arith.mulf %69, %475 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %478 = arith.addf %461, %462 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %479 = arith.addf %478, %466 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %480 = arith.addf %479, %467 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %481 = arith.addf %480, %471 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %482 = arith.addf %481, %472 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %483 = arith.addf %482, %476 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %484 = arith.addf %483, %477 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %485 = llvm.getelementptr inbounds %7[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %486 = "enzymexla.pointer2memref"(%485) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %487 = memref.load %486[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %488 = arith.mulf %29, %487 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %489 = arith.mulf %39, %487 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %490 = llvm.getelementptr inbounds %7[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %491 = "enzymexla.pointer2memref"(%490) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %492 = memref.load %491[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %493 = arith.mulf %41, %492 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %494 = arith.mulf %51, %492 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %495 = llvm.getelementptr inbounds %7[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %496 = "enzymexla.pointer2memref"(%495) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %497 = memref.load %496[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %498 = arith.mulf %53, %497 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %499 = arith.mulf %60, %497 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %500 = llvm.getelementptr inbounds %7[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %501 = "enzymexla.pointer2memref"(%500) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %502 = memref.load %501[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %503 = arith.mulf %62, %502 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %504 = arith.mulf %69, %502 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %505 = arith.addf %488, %489 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %506 = arith.addf %505, %493 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %507 = arith.addf %506, %494 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %508 = arith.addf %507, %498 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %509 = arith.addf %508, %499 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %510 = arith.addf %509, %503 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %511 = arith.addf %510, %504 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %512 = arith.mulf %511, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %513 = arith.mulf %484, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %514 = arith.addf %512, %513 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %515 = llvm.getelementptr inbounds %8[%33] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %516 = "enzymexla.pointer2memref"(%515) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %517 = memref.load %516[%34] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %518 = arith.mulf %29, %517 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %519 = arith.mulf %39, %517 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %520 = llvm.getelementptr inbounds %8[%45] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %521 = "enzymexla.pointer2memref"(%520) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %522 = memref.load %521[%46] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %523 = arith.mulf %41, %522 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %524 = arith.mulf %51, %522 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %525 = llvm.getelementptr inbounds %8[%54] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %526 = "enzymexla.pointer2memref"(%525) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %527 = memref.load %526[%55] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %528 = arith.mulf %53, %527 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %529 = arith.mulf %60, %527 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %530 = llvm.getelementptr inbounds %8[%63] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %531 = "enzymexla.pointer2memref"(%530) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %532 = memref.load %531[%64] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %533 = arith.mulf %62, %532 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %534 = arith.mulf %69, %532 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %535 = arith.addf %518, %519 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %536 = arith.addf %535, %523 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %537 = arith.addf %536, %524 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %538 = arith.addf %537, %528 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %539 = arith.addf %538, %529 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %540 = arith.addf %539, %533 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %541 = arith.addf %540, %534 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %542 = llvm.getelementptr inbounds %8[%78] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %543 = "enzymexla.pointer2memref"(%542) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %544 = memref.load %543[%79] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %545 = arith.mulf %29, %544 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %546 = arith.mulf %39, %544 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %547 = llvm.getelementptr inbounds %8[%85] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %548 = "enzymexla.pointer2memref"(%547) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %549 = memref.load %548[%86] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %550 = arith.mulf %41, %549 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %551 = arith.mulf %51, %549 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %552 = llvm.getelementptr inbounds %8[%92] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %553 = "enzymexla.pointer2memref"(%552) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %554 = memref.load %553[%93] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %555 = arith.mulf %53, %554 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %556 = arith.mulf %60, %554 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %557 = llvm.getelementptr inbounds %8[%99] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT:     %558 = "enzymexla.pointer2memref"(%557) : (!llvm.ptr<1>) -> memref<1633824xf64, 1>
+// CHECK-NEXT:     %559 = memref.load %558[%100] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1633824xf64, 1>
+// CHECK-NEXT:     %560 = arith.mulf %62, %559 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %561 = arith.mulf %69, %559 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %562 = arith.addf %545, %546 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %563 = arith.addf %562, %550 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %564 = arith.addf %563, %551 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %565 = arith.addf %564, %555 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %566 = arith.addf %565, %556 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %567 = arith.addf %566, %560 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %568 = arith.addf %567, %561 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %569 = arith.mulf %568, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %570 = arith.mulf %541, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %571 = arith.addf %569, %570 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %572 = arith.addf %514, %571 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %573 = affine.load %arg10[%arg22 + 7, %arg23 + 7] : memref<99x194xf64, 1>
+// CHECK-NEXT:     %574 = affine.load %arg10[%arg22 + 6, %arg23 + 7] : memref<99x194xf64, 1>
+// CHECK-NEXT:     %575 = affine.load %arg10[%arg22 + 7, %arg23 + 6] : memref<99x194xf64, 1>
+// CHECK-NEXT:     %576 = affine.load %arg10[%arg22 + 6, %arg23 + 6] : memref<99x194xf64, 1>
+// CHECK-NEXT:     %577 = affine.load %arg12[%arg22 + 6, %arg23 + 7] : memref<99x194xf64, 1>
+// CHECK-NEXT:     %578 = affine.load %arg12[%arg22 + 6, %arg23 + 6] : memref<99x194xf64, 1>
+// CHECK-NEXT:     %579 = affine.load %arg11[%arg22 + 7, %arg23 + 6] : memref<99x194xf64, 1>
+// CHECK-NEXT:     %580 = affine.load %arg11[%arg22 + 6, %arg23 + 6] : memref<99x194xf64, 1>
+// CHECK-NEXT:     %581 = arith.subf %573, %574 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %582 = arith.mulf %581, %cst_3 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %583 = arith.divf %582, %577 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %584 = arith.subf %575, %576 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %585 = arith.mulf %584, %cst_3 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %586 = arith.divf %585, %578 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %587 = arith.addf %583, %586 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %588 = arith.divf %587, %cst_4 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %589 = arith.subf %573, %575 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %590 = arith.mulf %589, %cst_3 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %591 = arith.divf %590, %579 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %592 = arith.subf %574, %576 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %593 = arith.mulf %592, %cst_3 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %594 = arith.divf %593, %580 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %595 = arith.addf %591, %594 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %596 = arith.negf %595 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %597 = arith.divf %596, %cst_4 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %598 = arith.mulf %588, %588 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %599 = arith.mulf %597, %597 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %600 = arith.addf %598, %599 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %601 = math.sqrt %600 : f64
+// CHECK-NEXT:     %602 = arith.divf %588, %601 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %603 = arith.divf %597, %601 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %604 = arith.mulf %115, %602 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %605 = arith.mulf %172, %603 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %606 = arith.addf %604, %605 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %607 = arith.negf %115 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %608 = arith.mulf %607, %603 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %609 = arith.mulf %172, %602 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     %610 = arith.addf %609, %608 {fastmathFlags = #llvm.fastmath<none>} : f64
+// CHECK-NEXT:     affine.store %606, %arg0[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     affine.store %610, %arg1[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     affine.store %229, %arg2[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     affine.store %343, %arg3[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     affine.store %286, %arg4[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     affine.store %400, %arg5[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     affine.store %457, %arg6[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:     affine.store %572, %arg7[0, %arg22 + 6, %arg23 + 6] : memref<1x99x194xf64, 1>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+

--- a/test/lit_tests/raising/llvm_to_memref_both.mlir
+++ b/test/lit_tests/raising/llvm_to_memref_both.mlir
@@ -1,0 +1,71 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access,canonicalize)" --split-input-file | FileCheck %s
+
+#tbaa_root = #llvm.tbaa_root<id = "custom_tbaa">
+#tbaa_type_desc = #llvm.tbaa_type_desc<id = "custom_tbaa_addrspace(1)", members = {<#tbaa_root, 0>}>
+#tbaa_tag = #llvm.tbaa_tag<base_type = #tbaa_type_desc, access_type = #tbaa_type_desc, offset = 0>
+module {
+
+  func.func @test_conversion(%arg0: memref<100x10xf64, 1>, %arg1: memref<100x10xf64, 1>) -> (f64, f64) {
+    // Convert memrefs to pointers
+    %ptr0 = "enzymexla.memref2pointer"(%arg0) : (memref<100x10xf64, 1>) -> !llvm.ptr<1>
+    %ptr1 = "enzymexla.memref2pointer"(%arg1) : (memref<100x10xf64, 1>) -> !llvm.ptr<1>
+
+    %c0 = arith.constant 0 : index
+    %c100 = arith.constant 100 : index
+    %c1 = arith.constant 1 : index
+
+    %val2_ref = memref.alloca() : memref<f64>
+    %val3_ref = memref.alloca() : memref<f64>
+
+    // Put loads inside affine.parallel
+    affine.parallel (%i) = (0) to (10) {
+      %val1 = affine.load %arg0[%i*10,%i] : memref<100x10xf64,1>
+      %val1_i64 = arith.fptosi %val1 : f64 to i64
+      %i_i64 = arith.index_cast %i : index to i64
+      %index1 = arith.addi %val1_i64, %i_i64 : i64
+      %gep0 = llvm.getelementptr inbounds %ptr0[%index1] : (!llvm.ptr<1>,i64) -> !llvm.ptr<1>, f64
+      %val2 = llvm.load %gep0 {alignment = 8 : i64, tbaa = [#tbaa_tag]} : !llvm.ptr<1> -> f64
+      %c8 = arith.constant 8 : i64
+      %mul = arith.muli %i_i64, %c8 : i64
+      %gep1 = llvm.getelementptr %ptr1[%mul] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+      %val3 = llvm.load %gep1 {alignment = 8 : i64} : !llvm.ptr<1> -> f64
+      %c99 = arith.constant 99 : index
+      %is_last = arith.cmpi eq, %i, %c99 : index
+      scf.if %is_last {
+        memref.store %val2, %val2_ref[] : memref<f64>
+        memref.store %val3, %val3_ref[] : memref<f64>
+      }
+    }
+
+    %result0 = memref.load %val2_ref[] : memref<f64>
+    %result1 = memref.load %val3_ref[] : memref<f64>
+    return %result0, %result1 : f64, f64
+  }
+}
+
+// CHECK-LABEL: test_conversion
+// CHECK-NEXT : %c99 = arith.constant 99 : index
+// CHECK-NEXT : %0 = "enzymexla.memref2pointer"(%arg0) : (memref<100x10xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT : %1 = "enzymexla.memref2pointer"(%arg1) : (memref<100x10xf64, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT : %alloca = memref.alloca() : memref<f64>
+// CHECK-NEXT : %alloca_0 = memref.alloca() : memref<f64>
+// CHECK-NEXT : affine.parallel (%arg2) = (0) to (10) {
+// CHECK-NEXT :   %4 = affine.load %arg0[%arg2 * 10, %arg2] : memref<100x10xf64, 1>
+// CHECK-NEXT :   %5 = arith.fptosi %4 : f64 to i64
+// CHECK-NEXT :   %6 = arith.index_cast %arg2 : index to i64
+// CHECK-NEXT :   %7 = arith.addi %5, %6 : i64
+// CHECK-NEXT :   %8 = arith.index_cast %7 : i64 to index
+// CHECK-NEXT :   %9 = "enzymexla.pointer2memref"(%0) : (!llvm.ptr<1>) -> memref<1000xf64, 1>
+// CHECK-NEXT :   %10 = memref.load %9[%8] {alignment = 8 : i64, ordering = 0 : i64, tbaa = [#tbaa_tag]} : memref<1000xf64, 1>
+// CHECK-NEXT :   %11 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+// CHECK-NEXT :   %12 = affine.load %11[%arg2 * 8] {alignment = 8 : i64, ordering = 0 : i64} : memref<?xf64, 1>
+// CHECK-NEXT :   %13 = arith.cmpi eq, %arg2, %c99 : index
+// CHECK-NEXT :   scf.if %13 {
+// CHECK-NEXT :     memref.store %10, %alloca[] : memref<f64>
+// CHECK-NEXT :     memref.store %12, %alloca_0[] : memref<f64>
+// CHECK-NEXT :   }
+// CHECK-NEXT : }
+// CHECK-NEXT : %2 = memref.load %alloca[] : memref<f64>
+// CHECK-NEXT : %3 = memref.load %alloca_0[] : memref<f64>
+// CHECK-NEXT : return %2, %3 : f64, f64
+// CHECK-NEXT : }


### PR DESCRIPTION
Does this as a fallback in the case:
1. we cannot promote to an affine load/store
2. The defining op for the load/store is a `GEP` whose base is defined by `enzymexla.memref2pointer` (but I believe it is flattened for access) 