### PR TITLE
Fix another off by 1

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -834,6 +834,10 @@ struct WhileToForHelper {
           } else if ((stepInt > 0) && (lbInt < ubInt)) {
             updateCmpNeOp = 2; // update to SLT
             ub = cmpRhs;
+
+            // inclusive range if the cmpiop compares with the indVar, not the
+            // updated value
+            ub_addOne = cmpIOp.getLhs().getDefiningOp() != addIOp;
           } else
             return false;
         } else

--- a/test/lit_tests/canonicalizefor/doWhile.mlir
+++ b/test/lit_tests/canonicalizefor/doWhile.mlir
@@ -214,7 +214,7 @@ module @cmpi_ne_neg{
     %c0 = arith.constant 0 : i32
     %c1 = arith.constant 1 : i32
     %c-5 = arith.constant -5 : i32
-  
+
     %result = scf.while (%i = %c0) : (i32) -> i32 {
       "before.keepalive"(%i) : (i32) -> ()
       %updated = arith.subi %i, %c1 : i32
@@ -313,9 +313,9 @@ module @cmpi_ne_i{
 // CHECK-LABEL:  module @cmpi_ne_i {
 // CHECK:    func.func @do_while2() -> i32 {
 // CHECK-DAG:      %[[ONE:.+]] = arith.constant 1 : i32
-// CHECK-DAG:      %[[C49:.+]] = arith.constant 49 : i32
+// CHECK-DAG:      %[[C50:.+]] = arith.constant 50 : i32
 // CHECK:      %[[UB:.+]] = ub.poison : i32
-// CHECK-NEXT:      %[[i4:.+]] = scf.for %[[IV:.+]] = %[[ONE]] to %[[C49]] step %[[ONE]] iter_args(%[[VAL:.+]] = %[[UB]]) -> (i32)  : i32 {
+// CHECK-NEXT:      %[[i4:.+]] = scf.for %[[IV:.+]] = %[[ONE]] to %[[C50]] step %[[ONE]] iter_args(%[[VAL:.+]] = %[[UB]]) -> (i32)  : i32 {
 // CHECK-NEXT:        "before.keepalive"(%[[IV]]) : (i32) -> ()
 // CHECK-NEXT:        %[[NEW:.+]] = arith.addi %[[IV]], %[[ONE]] : i32
 // CHECK-NEXT:        scf.yield %[[NEW]] : i32


### PR DESCRIPTION
the second added test in #509 was wrong since the range is inclusive in this case. The same logic should be applied for other comp predicates. 