### PR TITLE
lift memref.load depending on scf.if into that

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -1,3 +1,4 @@
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Passes.h"
@@ -4325,6 +4326,256 @@ struct SinkStoreInIf : public OpRewritePattern<scf::IfOp> {
   }
 };
 
+/// Lift memref read depending on an scf.if into the body of that scf.if. This
+/// proceeds by moving the operations in the backward slide of a `load` that
+/// are dominated by the `if` into both the "then" and the "else" branch, as
+/// long as all operations are pure.
+class LiftMemrefRead : public OpRewritePattern<memref::LoadOp> {
+public:
+  using OpRewritePattern<memref::LoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::LoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    SetVector<Operation *> backwardSlice;
+    DominanceInfo dominance;
+    BackwardSliceOptions options;
+    getBackwardSlice(loadOp.getOperation(), &backwardSlice, options);
+
+    Operation *conditional =
+        llvm::find_singleton<Operation>(backwardSlice, [](Operation *op, bool) {
+          return isa<affine::AffineIfOp, scf::IfOp>(op) ? op : nullptr;
+        });
+    if (!conditional || conditional->getRegion(1).empty() ||
+        conditional->getNumResults() == 0)
+      return rewriter.notifyMatchFailure(
+          loadOp, "not dependent on a conditional result");
+
+    auto toLift = llvm::filter_to_vector(backwardSlice, [&](Operation *op) {
+      return dominance.properlyDominates(conditional, op);
+    });
+    if (llvm::any_of(toLift, [](Operation *op) { return !isPure(op); }))
+      return rewriter.notifyMatchFailure(loadOp,
+                                         "non-pure operation on the path");
+
+    auto cloneIntoBlock = [&](unsigned blockNum) {
+      IRMapping mapping;
+      Block &targetBlock = conditional->getRegion(blockNum).front();
+      mapping.map(conditional->getResults(),
+                  targetBlock.getTerminator()->getOperands());
+      rewriter.setInsertionPoint(targetBlock.getTerminator());
+      for (Operation *op : toLift) {
+        rewriter.clone(*op, mapping);
+      }
+      Operation *clonedLoad = rewriter.clone(*loadOp.getOperation(), mapping);
+      return clonedLoad;
+    };
+
+    Operation *thenLoad = cloneIntoBlock(0);
+    Operation *elseLoad = cloneIntoBlock(1);
+
+    SmallVector<Type> types = llvm::to_vector(conditional->getResultTypes());
+    llvm::append_range(types, thenLoad->getResultTypes());
+    SmallVector<std::unique_ptr<Region>> regions;
+    regions.emplace_back(new Region);
+    regions.emplace_back(new Region);
+    rewriter.setInsertionPoint(conditional);
+    Operation *newConditional = rewriter.create(
+        conditional->getLoc(), conditional->getName().getIdentifier(),
+        conditional->getOperands(), types, conditional->getAttrs(),
+        BlockRange(), regions);
+
+    auto inlineBody = [&](unsigned regionNum, Operation *loadOp) {
+      rewriter.inlineRegionBefore(conditional->getRegion(regionNum),
+                                  newConditional->getRegion(regionNum),
+                                  newConditional->getRegion(regionNum).begin());
+
+      Operation *terminator =
+          newConditional->getRegion(regionNum).front().getTerminator();
+      SmallVector<Value> operands = llvm::to_vector(terminator->getOperands());
+      llvm::append_range(operands, loadOp->getResults());
+      rewriter.setInsertionPoint(terminator);
+      Operation *newTerminator = rewriter.create(
+          terminator->getLoc(), terminator->getName().getIdentifier(), operands,
+          terminator->getResultTypes(), terminator->getAttrs(),
+          terminator->getSuccessors());
+      rewriter.replaceOp(terminator, newTerminator);
+    };
+
+    inlineBody(0, thenLoad);
+    inlineBody(1, elseLoad);
+
+    unsigned numLoadResults = loadOp->getNumResults();
+    rewriter.replaceOp(loadOp,
+                       newConditional->getResults().take_back(numLoadResults));
+    rewriter.replaceOp(conditional,
+                       newConditional->getResults().drop_back(numLoadResults));
+    return success();
+  }
+};
+
+template <typename Derived, typename BinOp>
+struct FoldAffineApplyBase : public OpRewritePattern<BinOp> {
+  using Super = FoldAffineApplyBase<Derived, BinOp>;
+  using OpRewritePattern<BinOp>::OpRewritePattern;
+
+  LogicalResult extractApply(BinOp binOp, affine::AffineApplyOp &apply,
+                             Value &other, PatternRewriter &rewriter) const {
+    apply = binOp.getLhs().template getDefiningOp<affine::AffineApplyOp>();
+    other = binOp.getRhs();
+    if (!apply) {
+      apply = binOp.getRhs().template getDefiningOp<affine::AffineApplyOp>();
+      other = binOp.getLhs();
+    }
+    if (!apply)
+      return rewriter.notifyMatchFailure(binOp,
+                                         "no affine.apply-defined operands");
+    return success();
+  }
+
+  LogicalResult matchAndRewrite(BinOp binOp,
+                                PatternRewriter &rewriter) const override {
+    affine::AffineApplyOp apply;
+    Value other;
+    if (failed(static_cast<const Derived *>(this)->extractApply(
+            binOp, apply, other, rewriter)))
+      return failure();
+
+    AffineExpr expr = apply.getMap().getResult(0);
+    bool otherIsRHS = other == binOp.getRhs();
+    if (affine::isValidSymbol(other)) {
+      auto dimExpr = getAffineSymbolExpr(apply.getMap().getNumSymbols(),
+                                         this->getContext());
+      expr = static_cast<const Derived *>(this)->combineExprs(
+          otherIsRHS ? expr : dimExpr, otherIsRHS ? dimExpr : expr);
+      AffineMap updatedMap =
+          AffineMap::get(apply.getMap().getNumDims(),
+                         apply.getMap().getNumSymbols() + 1, expr);
+      SmallVector<Value> operands = llvm::to_vector(apply->getOperands());
+      operands.push_back(other);
+      rewriter.replaceOpWithNewOp<affine::AffineApplyOp>(binOp, updatedMap,
+                                                         operands);
+      return success();
+    }
+    if (affine::isValidDim(other)) {
+      auto dimExpr =
+          getAffineDimExpr(apply.getMap().getNumDims(), this->getContext());
+      expr = static_cast<const Derived *>(this)->combineExprs(
+          otherIsRHS ? expr : dimExpr, otherIsRHS ? dimExpr : expr);
+      AffineMap updatedMap =
+          AffineMap::get(apply.getMap().getNumDims() + 1,
+                         apply.getMap().getNumSymbols(), expr);
+      SmallVector<Value> operands = llvm::to_vector(apply.getDimOperands());
+      operands.push_back(other);
+      llvm::append_range(operands, apply.getSymbolOperands());
+      rewriter.replaceOpWithNewOp<affine::AffineApplyOp>(binOp, updatedMap,
+                                                         operands);
+      return success();
+    }
+    return failure();
+  }
+};
+
+struct FoldAffineApplyAdd
+    : FoldAffineApplyBase<FoldAffineApplyAdd, arith::AddIOp> {
+  using Super::Super;
+
+  AffineExpr combineExprs(AffineExpr lhs, AffineExpr rhs) const {
+    return lhs + rhs;
+  }
+};
+
+struct FoldAffineApplySub
+    : FoldAffineApplyBase<FoldAffineApplySub, arith::SubIOp> {
+  using Super::Super;
+
+  AffineExpr combineExprs(AffineExpr lhs, AffineExpr rhs) const {
+    return lhs - rhs;
+  }
+};
+
+template <typename Derived, typename BinOp>
+struct FoldAffineApplyConstRHS : public FoldAffineApplyBase<Derived, BinOp> {
+  using FoldAffineApplyBase<Derived, BinOp>::FoldAffineApplyBase;
+  using Super = FoldAffineApplyConstRHS<Derived, BinOp>;
+
+  LogicalResult extractApply(BinOp binOp, affine::AffineApplyOp &apply,
+                             Value &other, PatternRewriter &rewriter) const {
+    apply = binOp.getLhs().template getDefiningOp<affine::AffineApplyOp>();
+    other = binOp.getRhs();
+    llvm::APInt ignore;
+    return success(apply && matchPattern(other, m_ConstantInt(&ignore)));
+  }
+};
+
+struct FoldAffineApplyDiv
+    : FoldAffineApplyConstRHS<FoldAffineApplyDiv, arith::DivUIOp> {
+  using Super::Super;
+
+  AffineExpr combineExprs(AffineExpr lhs, AffineExpr rhs) const {
+    return lhs.floorDiv(rhs);
+  }
+};
+
+struct FoldAffineApplyRem
+    : FoldAffineApplyConstRHS<FoldAffineApplyRem, arith::RemUIOp> {
+  using Super::Super;
+
+  AffineExpr combineExprs(AffineExpr lhs, AffineExpr rhs) const {
+    return lhs % rhs;
+  }
+};
+
+struct FoldAffineApplyMul
+    : FoldAffineApplyBase<FoldAffineApplyMul, arith::MulIOp> {
+  using Super::Super;
+
+  LogicalResult extractApply(arith::MulIOp mulOp, affine::AffineApplyOp &apply,
+                             Value &other, PatternRewriter &rewriter) const {
+    if (failed(Super::extractApply(mulOp, apply, other, rewriter)))
+      return failure();
+    llvm::APInt ignore;
+    return success(matchPattern(other, m_ConstantInt(&ignore)));
+  }
+
+  AffineExpr combineExprs(AffineExpr lhs, AffineExpr rhs) const {
+    return lhs * rhs;
+  }
+};
+
+struct FoldAppliesIntoLoad : public OpRewritePattern<memref::LoadOp> {
+  using OpRewritePattern<memref::LoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::LoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<affine::AffineApplyOp> applies;
+    for (Value index : loadOp.getIndices()) {
+      applies.push_back(index.getDefiningOp<affine::AffineApplyOp>());
+      if (!applies.back())
+        return rewriter.notifyMatchFailure(loadOp,
+                                           "operands is not an affine.apply");
+    }
+
+    SmallVector<Value> loadDimOperands, loadSymOperands;
+    SmallVector<AffineExpr> exprs;
+    for (affine::AffineApplyOp apply : applies) {
+      AffineExpr expr = apply.getMap().getResult(0);
+      expr = expr.shiftDims(apply.getMap().getNumDims(), loadDimOperands.size())
+                 .shiftSymbols(apply.getMap().getNumSymbols(),
+                               loadSymOperands.size());
+      exprs.push_back(expr);
+      llvm::append_range(loadDimOperands, apply.getDimOperands());
+      llvm::append_range(loadSymOperands, apply.getSymbolOperands());
+    }
+
+    AffineMap combinedMap =
+        AffineMap::inferFromExprList({exprs}, getContext())[0];
+    llvm::append_range(loadDimOperands, loadSymOperands);
+    rewriter.replaceOpWithNewOp<affine::AffineLoadOp>(
+        loadOp, loadOp.getMemRef(), combinedMap, loadDimOperands);
+    return success();
+  }
+};
+
 void mlir::enzyme::populateAffineCFGPatterns(RewritePatternSet &rpl) {
   MLIRContext *context = rpl.getContext();
   mlir::enzyme::addSingleIter(rpl, context);
@@ -4338,7 +4589,10 @@ void mlir::enzyme::populateAffineCFGPatterns(RewritePatternSet &rpl) {
           CombineAffineIfs, MergeNestedAffineParallelLoops,
           PrepMergeNestedAffineParallelLoops, MergeNestedAffineParallelIf,
           MergeParallelInductions, OptimizeRem, CanonicalieForBounds,
-          SinkStoreInIf, AddAddCstEnd>(context, 2);
+          SinkStoreInIf, AddAddCstEnd, LiftMemrefRead>(context, 2);
+  rpl.add<FoldAffineApplyAdd, FoldAffineApplySub, FoldAffineApplyRem,
+          FoldAffineApplyDiv, FoldAffineApplyMul, FoldAppliesIntoLoad>(context,
+                                                                       2);
   rpl.add<SplitParallelInductions>(context, 1);
 }
 

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -3063,6 +3063,7 @@ struct OptimizeRem : public OpRewritePattern<arith::RemUIOp> {
         continue;
       rewriter.replaceOpWithNewOp<arith::RemUIOp>(op, sum->getOperand(1 - i),
                                                   op.getRhs());
+      return success();
     }
     return failure();
   }

--- a/test/lit_tests/raising/affinecfg6.mlir
+++ b/test/lit_tests/raising/affinecfg6.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt %s --affine-cfg | FileCheck %s
+// RUN: enzymexlamlir-opt %s --affine-cfg --mlir-print-local-scope | FileCheck %s
 
 #map = affine_map<(d0) -> (d0 mod 5)>
 #map1 = affine_map<(d0) -> (d0 floordiv 5)>
@@ -15,7 +15,7 @@ module {
   }
 // CHECK:  func.func @split_iv(%arg0: memref<10xi64>) {
 // CHECK-NEXT:    affine.parallel (%arg1, %arg2) = (0, 0) to (2, 5) {
-// CHECK-NEXT:      %0 = arith.addi %arg2, %arg1 : index
+// CHECK-NEXT:      %0 = affine.apply affine_map<(d0, d1) -> (d0 + d1)>(%arg1, %arg2)
 // CHECK-NEXT:      %1 = arith.index_cast %0 : index to i64
 // CHECK-NEXT:      affine.store %1, %arg0[%arg2 + %arg1 * 5] : memref<10xi64>
 // CHECK-NEXT:    }

--- a/test/lit_tests/raising/liftintoif.mlir
+++ b/test/lit_tests/raising/liftintoif.mlir
@@ -1,0 +1,141 @@
+// RUN: enzymexlamlir-opt %s --affine-cfg --canonicalize | FileCheck %s
+
+#map1 = affine_map<(d0) -> (-d0 + 18435)>
+#map2 = affine_map<(d0) -> (-d0 + 18241)>
+#map3 = affine_map<(d0) -> (-d0 + 18047)>
+#map4 = affine_map<(d0) -> (-d0 + 17853)>
+#map5 = affine_map<(d0) -> (-d0 + 17659)>
+#map6 = affine_map<(d0) -> (-d0 + 17465)>
+#map7 = affine_map<(d0) -> (-d0 + 17271)>
+#map8 = affine_map<(d0) -> (-d0 + 18629)>
+#map9 = affine_map<(d0) -> (d0 * -194 + 18436)>
+#map10 = affine_map<(d0) -> (d0 * -194 + 18811)>
+#set = affine_set<(d0) : (d0 - 1 >= 0)>
+#set1 = affine_set<(d0) : (-d0 + 89 >= 0)>
+
+func.func private @par6(%arg0: memref<1x104x194xf64, 1>) {
+  %c104 = arith.constant 104 : index
+  %c194 = arith.constant 194 : index
+  %c2_i64 = arith.constant 2 : i64
+  %c182_i64 = arith.constant 182 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c-1_i64 = arith.constant -1 : i64
+  affine.parallel (%arg1) = (0) to (180) {
+    %0 = affine.load %arg0[0, 7, %arg1 + 7] : memref<1x104x194xf64, 1>
+    affine.store %0, %arg0[0, 6, %arg1 + 7] : memref<1x104x194xf64, 1>
+    // CHECK: %[[if:.+]]:10 = affine.if
+    // CHECK: %[[v0:.+]] = affine.load
+    // CHECK: %[[v1:.+]] = affine.load
+    // CHECK: %[[v2:.+]] = affine.load
+    // CHECK: %[[v3:.+]] = affine.load
+    // CHECK: %[[v4:.+]] = affine.load
+    // CHECK: %[[v5:.+]] = affine.load
+    // CHECK: %[[v6:.+]] = affine.load
+    // CHECK: %[[v7:.+]] = affine.load
+    %1:2 = affine.if #set(%arg1) -> (i64, i64) {
+      affine.yield %c-1_i64, %c182_i64 : i64, i64
+    // CHECK: else
+    // CHECK: %[[e0:.+]] = affine.load
+    // CHECK: %[[e1:.+]] = affine.load
+    // CHECK: %[[e2:.+]] = affine.load
+    // CHECK: %[[e3:.+]] = affine.load
+    // CHECK: %[[e4:.+]] = affine.load
+    // CHECK: %[[e5:.+]] = affine.load
+    // CHECK: %[[e6:.+]] = affine.load
+    // CHECK: %[[e7:.+]] = affine.load
+    } else {
+      affine.yield %c1_i64, %c2_i64 : i64, i64
+    }
+    // CHECK-NOT: memref.load
+    // CHECK: arith.mulf %{{.*}}, %[[if]]#9
+    // CHECK: arith.mulf %{{.*}}, %[[if]]#8
+    // CHECK: arith.mulf %{{.*}}, %[[if]]#7
+    // CHECK: arith.mulf %{{.*}}, %[[if]]#6
+    // CHECK: arith.mulf %{{.*}}, %[[if]]#5
+    // CHECK: arith.mulf %{{.*}}, %[[if]]#4
+    // CHECK: arith.mulf %{{.*}}, %[[if]]#3
+    // CHECK: arith.mulf %{{.*}}, %[[if]]#2
+    %2 = arith.sitofp %1#0 : i64 to f64
+    %3 = arith.index_cast %1#1 : i64 to index
+    %4 = affine.apply #map1(%arg1)
+    %5 = arith.addi %4, %3 : index
+    %6 = arith.remui %5, %c194 : index
+    %7 = arith.divui %5, %c194 : index
+    %8 = arith.remui %7, %c104 : index
+    %9 = arith.divui %7, %c104 : index
+    %10 = memref.load %arg0[%9, %8, %6] : memref<1x104x194xf64, 1>
+    %11 = arith.mulf %2, %10 {fastmathFlags = #llvm.fastmath<none>} : f64
+    affine.store %11, %arg0[0, 97, %arg1 + 7] : memref<1x104x194xf64, 1>
+    %12 = affine.apply #map2(%arg1)
+    %13 = arith.addi %12, %3 : index
+    %14 = arith.remui %13, %c194 : index
+    %15 = arith.divui %13, %c194 : index
+    %16 = arith.remui %15, %c104 : index
+    %17 = arith.divui %15, %c104 : index
+    %18 = memref.load %arg0[%17, %16, %14] : memref<1x104x194xf64, 1>
+    %19 = arith.mulf %2, %18 {fastmathFlags = #llvm.fastmath<none>} : f64
+    affine.store %19, %arg0[0, 98, %arg1 + 7] : memref<1x104x194xf64, 1>
+    %20 = affine.apply #map3(%arg1)
+    %21 = arith.addi %20, %3 : index
+    %22 = arith.remui %21, %c194 : index
+    %23 = arith.divui %21, %c194 : index
+    %24 = arith.remui %23, %c104 : index
+    %25 = arith.divui %23, %c104 : index
+    %26 = memref.load %arg0[%25, %24, %22] : memref<1x104x194xf64, 1>
+    %27 = arith.mulf %2, %26 {fastmathFlags = #llvm.fastmath<none>} : f64
+    affine.store %27, %arg0[0, 99, %arg1 + 7] : memref<1x104x194xf64, 1>
+    %28 = affine.apply #map4(%arg1)
+    %29 = arith.addi %28, %3 : index
+    %30 = arith.remui %29, %c194 : index
+    %31 = arith.divui %29, %c194 : index
+    %32 = arith.remui %31, %c104 : index
+    %33 = arith.divui %31, %c104 : index
+    %34 = memref.load %arg0[%33, %32, %30] : memref<1x104x194xf64, 1>
+    %35 = arith.mulf %2, %34 {fastmathFlags = #llvm.fastmath<none>} : f64
+    affine.store %35, %arg0[0, 100, %arg1 + 7] : memref<1x104x194xf64, 1>
+    %36 = affine.apply #map5(%arg1)
+    %37 = arith.addi %36, %3 : index
+    %38 = arith.remui %37, %c194 : index
+    %39 = arith.divui %37, %c194 : index
+    %40 = arith.remui %39, %c104 : index
+    %41 = arith.divui %39, %c104 : index
+    %42 = memref.load %arg0[%41, %40, %38] : memref<1x104x194xf64, 1>
+    %43 = arith.mulf %2, %42 {fastmathFlags = #llvm.fastmath<none>} : f64
+    affine.store %43, %arg0[0, 101, %arg1 + 7] : memref<1x104x194xf64, 1>
+    %44 = affine.apply #map6(%arg1)
+    %45 = arith.addi %44, %3 : index
+    %46 = arith.remui %45, %c194 : index
+    %47 = arith.divui %45, %c194 : index
+    %48 = arith.remui %47, %c104 : index
+    %49 = arith.divui %47, %c104 : index
+    %50 = memref.load %arg0[%49, %48, %46] : memref<1x104x194xf64, 1>
+    %51 = arith.mulf %2, %50 {fastmathFlags = #llvm.fastmath<none>} : f64
+    affine.store %51, %arg0[0, 102, %arg1 + 7] : memref<1x104x194xf64, 1>
+    %52 = affine.apply #map7(%arg1)
+    %53 = arith.addi %52, %3 : index
+    %54 = arith.remui %53, %c194 : index
+    %55 = arith.divui %53, %c194 : index
+    %56 = arith.remui %55, %c104 : index
+    %57 = arith.divui %55, %c104 : index
+    %58 = memref.load %arg0[%57, %56, %54] : memref<1x104x194xf64, 1>
+    %59 = arith.mulf %2, %58 {fastmathFlags = #llvm.fastmath<none>} : f64
+    affine.store %59, %arg0[0, 103, %arg1 + 7] : memref<1x104x194xf64, 1>
+    %60 = arith.index_cast %1#1 : i64 to index
+    %61 = affine.apply #map8(%arg1)
+    %62 = arith.addi %61, %60 : index
+    %63 = arith.remui %62, %c194 : index
+    %64 = arith.divui %62, %c194 : index
+    %65 = arith.remui %64, %c104 : index
+    %66 = arith.divui %64, %c104 : index
+    %67 = memref.load %arg0[%66, %65, %63] : memref<1x104x194xf64, 1>
+    %68 = arith.mulf %2, %67 {fastmathFlags = #llvm.fastmath<none>} : f64
+    %69 = affine.load %arg0[0, 96, %arg1 + 7] : memref<1x104x194xf64, 1>
+    %70 = affine.if #set1(%arg1) -> f64 {
+      affine.yield %69 : f64
+    } else {
+      affine.yield %68 : f64
+    }
+    affine.store %70, %arg0[0, 96, %arg1 + 7] : memref<1x104x194xf64, 1>
+  }
+  return
+}


### PR DESCRIPTION
When a load depends on the conditional value produced by an `scf.if`, lift that load into both conditional branches when possible (no interferring side-effecting operations). This may allow us to turn such loads into affine loads and further raise them.

Additional patterns are needed to fold arithmetic operations into affine forms and further use those to construct and affine load.