### PR TITLE
resolve #491: Iota Rewrite

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -3793,7 +3793,6 @@ struct BroadcastIotaSimplify
                                  .getShape()
                                  .size() -
                              1;
-        llvm::errs() << broadcast_dim << "\n";
 
         auto iota = rewriter.create<mlir::stablehlo::IotaOp>(loc, result_type,
                                                              broadcast_dim);

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -3788,9 +3788,15 @@ struct BroadcastIotaSimplify
         auto result_type = broadcast->getResultTypes();
         auto loc = broadcast.getLoc();
         rewriter.setInsertionPointAfter(constant);
+        auto broadcast_dim = result_type.front()
+                                 .template cast<mlir::ShapedType>()
+                                 .getShape()
+                                 .size() -
+                             1;
+        llvm::errs() << broadcast_dim << "\n";
 
-        auto iota =
-            rewriter.create<mlir::stablehlo::IotaOp>(loc, result_type, 0);
+        auto iota = rewriter.create<mlir::stablehlo::IotaOp>(loc, result_type,
+                                                             broadcast_dim);
         auto attr = mlir::DenseElementsAttr::get(
             constant.getType().cloneWith(llvm::ArrayRef<int64_t>{}, elemType),
             rewriter.getIntegerAttr(elemType, diff));

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -3788,11 +3788,24 @@ struct BroadcastIotaSimplify
         auto result_type = broadcast->getResultTypes();
         auto loc = broadcast.getLoc();
         rewriter.setInsertionPointAfter(constant);
-        auto broadcast_dim = result_type.front()
-                                 .template cast<mlir::ShapedType>()
-                                 .getShape()
-                                 .size() -
-                             1;
+        auto broadcast_dim = 0Z;
+        auto max_dims = result_type.front()
+                            .template cast<mlir::ShapedType>()
+                            .getShape()
+                            .size();
+
+        // find the dimension to broadcast in
+        for (broadcast_dim = 0Z; broadcast_dim < max_dims; ++broadcast_dim) {
+          bool found = false;
+          for (auto &elem : broadcast.getBroadcastDimensions()) {
+            if (elem == broadcast_dim) {
+              found = true;
+              break;
+            }
+          }
+          if (!found)
+            break;
+        }
 
         auto iota = rewriter.create<mlir::stablehlo::IotaOp>(loc, result_type,
                                                              broadcast_dim);

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -3779,6 +3779,9 @@ struct BroadcastIotaSimplify
         const auto start = (*curr).getInt();
         const auto diff = (*next).getInt() - (*curr).getInt();
 
+        if (diff == 0)
+          return failure();
+
         while (next != end) {
           auto curr_diff = (*next).getInt() - (*curr).getInt();
           if (curr_diff != diff)
@@ -3794,10 +3797,7 @@ struct BroadcastIotaSimplify
         auto broadcast_dim = 0Z;
         auto result_shape =
             result_type.front().template cast<mlir::ShapedType>().getShape();
-        auto max_dims = result_type.front()
-                            .template cast<mlir::ShapedType>()
-                            .getShape()
-                            .size();
+        auto max_dims = result_shape.size();
 
         for (broadcast_dim = 0Z; broadcast_dim < max_dims; ++broadcast_dim) {
           bool found = false;

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -906,7 +906,7 @@ def ApplyTransposeReduceSimplifyPatterns : EnzymeHLOPatternOp<
 }
 
 def BroadcastIotaSimplifyPatterns : EnzymeHLOPatternOp<
-  "broadcast_iota_simpify"
+  "broadcast_iota_simplify"
 > {
   let patterns = ["BroadcastIotaSimplify"];
 }

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -905,6 +905,12 @@ def ApplyTransposeReduceSimplifyPatterns : EnzymeHLOPatternOp<
   let patterns = ["TransposeReduceSimplify"];
 }
 
+def BroadcastIotaSimplifyPatterns : EnzymeHLOPatternOp<
+  "broadcast_iota_simpify"
+> {
+  let patterns = ["BroadcastIotaSimplify"];
+}
+
 // TODO: better naming for parameters requires a static interface for
 // constructing them in search.
 

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -211,6 +211,7 @@ transpose_simplify<16>;
 reshape_empty_broadcast<1>;
 add_pad_pad_to_concat<1>;
 broadcast_reshape<1>;
+broadcast_iota_simpify;
 
 binary_op_transpose_simplify_add<1>;
 binary_op_transpose_simplify_sub<1>;

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -211,7 +211,7 @@ transpose_simplify<16>;
 reshape_empty_broadcast<1>;
 add_pad_pad_to_concat<1>;
 broadcast_reshape<1>;
-broadcast_iota_simpify;
+broadcast_iota_simplify;
 
 binary_op_transpose_simplify_add<1>;
 binary_op_transpose_simplify_sub<1>;

--- a/test/lit_tests/iotaconstbroadcast.mlir
+++ b/test/lit_tests/iotaconstbroadcast.mlir
@@ -1,0 +1,49 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt  --split-input-file | FileCheck %s
+
+module {
+  func.func @main() -> tensor<20x180xi64 >{
+    %c = stablehlo.constant dense<[0, 20176, 40352, 60528, 80704, 100880, 121056, 141232, 161408, 181584, 201760, 221936, 242112, 262288, 282464, 302640, 322816, 342992, 363168, 383344]> : tensor<20xi64>
+    %0 = stablehlo.broadcast_in_dim %c, dims = [0] : (tensor<20xi64>) -> tensor<20x180xi64>
+    return %0 : tensor<20x180xi64>
+  }
+}
+// CHECK:       func.func @main() -> tensor<20x180xi64> {
+// CHECK-NEXT:    %[[v0:[^ ]*]] = stablehlo.constant dense<20176> : tensor<20x180xi64>
+// CHECK-NEXT:    %[[v1:[^ ]*]] = stablehlo.iota dim = 1 : tensor<20x180xi64>
+// CHECK-NEXT:    %[[v2:[^ ]*]] = stablehlo.multiply %[[v1]], %[[v0]] : tensor<20x180xi64>
+// CHECK-NEXT:    return %[[v2]] : tensor<20x180xi64>
+// CHECK-NEXT:  }
+
+// -----
+
+module {
+  func.func @main() -> tensor<180x20xi64 >{
+    %c_1173 = stablehlo.constant dense<[0, 20176, 40352, 60528, 80704, 100880, 121056, 141232, 161408, 181584, 201760, 221936, 242112, 262288, 282464, 302640, 322816, 342992, 363168, 383344]> : tensor<20xi64>
+    %423 = stablehlo.broadcast_in_dim %c_1173, dims = [1] : (tensor<20xi64>) -> tensor<180x20xi64>
+    return %423 : tensor<180x20xi64>
+  }
+}
+// CHECK:       func.func @main() -> tensor<180x20xi64> {
+// CHECK-NEXT:    %[[v0:[^ ]*]] = stablehlo.constant dense<20176> : tensor<180x20xi64>
+// CHECK-NEXT:    %[[v1:[^ ]*]] = stablehlo.iota dim = 0 : tensor<180x20xi64>
+// CHECK-NEXT:    %[[v2:[^ ]*]] = stablehlo.multiply %[[v1]], %[[v0]] : tensor<180x20xi64>
+// CHECK-NEXT:    return %[[v2]] : tensor<180x20xi64>
+// CHECK-NEXT:  }
+
+// -----
+
+module {
+  func.func @main() -> tensor<20x180xi64 >{
+    %c_1173 = stablehlo.constant dense<[1, 20177, 40353, 60529, 80705, 100881, 121057, 141233, 161409, 181585, 201761, 221937, 242113, 262289, 282465, 302641, 322817, 342993, 363169, 383345]> : tensor<20xi64>
+    %423 = stablehlo.broadcast_in_dim %c_1173, dims = [0] : (tensor<20xi64>) -> tensor<20x180xi64>
+    return %423 : tensor<20x180xi64>
+  }
+}
+// CHECK:       func.func @main() -> tensor<20x180xi64> {
+// CHECK-NEXT:    %[[v0:[^ ]*]] = stablehlo.constant dense<1> : tensor<20x180xi64>
+// CHECK-NEXT:    %[[v1:[^ ]*]] = stablehlo.constant dense<20176> : tensor<20x180xi64>
+// CHECK-NEXT:    %[[v2:[^ ]*]] = stablehlo.iota dim = 1 : tensor<20x180xi64>
+// CHECK-NEXT:    %[[v3:[^ ]*]] = stablehlo.multiply %[[v2]], %[[v1]] : tensor<20x180xi64>
+// CHECK-NEXT:    %[[v4:[^ ]*]] = stablehlo.add %[[v0]], %[[v3]] : tensor<20x180xi64>
+// CHECK-NEXT:    return %[[v4]] : tensor<20x180xi64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
This rewrite pattern searches for constant-stride single-dimensional arrays that are broadcasted to higher dimensions, and condenses them into iota operations.

The following input:
```
module{
    func.func @test() -> tensor<20x180xi64 >{
        %c_1173 = stablehlo.constant dense<[0, 20176, 40352, 60528, 80704, 100880, 121056, 141232, 161408, 181584, 201760, 221936, 242112, 262288, 282464, 302640, 322816, 342992, 363168, 383344]> : tensor<20xi64>
        %423 = stablehlo.broadcast_in_dim %c_1173, dims = [0] : (tensor<20xi64>) -> tensor<20x180xi64>
        return %423 : tensor<20x180xi64>
    }
}
```

Will be transformed into:
```
module {
  func.func @test() -> tensor<20x180xi64> {
    %c = stablehlo.constant dense<20176> : tensor<20x180xi64>
    %0 = stablehlo.iota dim = 1 : tensor<20x180xi64>
    %1 = stablehlo.multiply %0, %c : tensor<20x180xi64>
    return %1 : tensor<20x180xi64>
  }
}
```

I'm wondering if higher dimensional constants will correctly fail to transform, and whether or not I am broadcasting to the right dimension.