### PR TITLE
Add Select-Compare-Iota optimization (#535)

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6279,7 +6279,8 @@ struct CompareExt final : OpRewritePattern<mlir::stablehlo::CompareOp> {
   }
 };
 
-struct SelectCompIotaConst final : OpRewritePattern<mlir::stablehlo::SelectOp> {
+struct SelectCompIotaConstSimplify final
+    : OpRewritePattern<mlir::stablehlo::SelectOp> {
   struct slice_data {
     Value tensor;
     int64_t count;
@@ -8387,7 +8388,7 @@ struct EnzymeHLOOptPass
         RealOpCanon,
         ReorderElementwiseAndShapeOp,
         ReshapeOpCanon,
-        SelectCompIotaConst,
+        SelectCompIotaConstSimplify,
         SelectOpUsedWithinIf,
         TransposeBroadcastInDimToBroadcastInDim,
         BroadcastInDimTransposeToBroadcastInDim,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6413,7 +6413,9 @@ struct SelectCompIotaConstSimplify final
           startIndices[iotaDim] = start;
           limitIndices[iotaDim] = start + elem.count;
           auto slice = rewriter.create<stablehlo::SliceOp>(
-              loc, elem.tensor, startIndices, limitIndices, strides);
+              loc, elem.tensor, llvm::ArrayRef<int64_t>(startIndices),
+              llvm::ArrayRef<int64_t>(limitIndices),
+              llvm::ArrayRef<int64_t>(strides));
           sliceValues.push_back(slice);
           start += elem.count;
         }

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6401,12 +6401,12 @@ struct SelectCompIotaConstSimplify final
 
     SmallVector<Value, 3> sliceValues;
     {
-      long start = 0;
+      int64_t start = 0;
       const auto elemType = tensorType.getElementType();
       const auto loc = selectOp.getLoc();
-      SmallVector<long> startIndices(shapeLimit.size(), 0);
-      SmallVector<long> limitIndices{shapeLimit};
-      SmallVector<long> strides(shapeLimit.size(), 1);
+      SmallVector<int64_t> startIndices(shapeLimit.size(), 0);
+      SmallVector<int64_t> limitIndices{shapeLimit};
+      SmallVector<int64_t> strides(shapeLimit.size(), 1);
 
       for (const auto &elem : slices) {
         if (elem.count > 0) {

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6389,7 +6389,6 @@ struct SelectCompIotaConst final : OpRewritePattern<mlir::stablehlo::SelectOp> {
       slices.push_back(rewriter.create<stablehlo::SliceOp>(
           selectOp.getLoc(), trueTensor, constValue + 1, endValue, 1));
       break;
-      assert(false && "not implemented");
     }
 
     assert(slices.size() >= 2);

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -770,9 +770,9 @@ def WhileSimplify : EnzymeHLOPatternOp<
   let patterns = ["WhileSimplify"];
 }
 
-def SelectCompIotaConst : EnzymeHLOPatternOp<
-    "select_comp_iota_const"> {
-  let patterns = ["SelectCompIotaConst"];
+def SelectCompIotaConstSimplify : EnzymeHLOPatternOp<
+    "select_comp_iota_const_simplify"> {
+  let patterns = ["SelectCompIotaConstSimplify"];
 }
 
 def SelectOpUsedWithinIf : EnzymeHLOPatternOp<

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -770,6 +770,11 @@ def WhileSimplify : EnzymeHLOPatternOp<
   let patterns = ["WhileSimplify"];
 }
 
+def SelectCompIotaConst : EnzymeHLOPatternOp<
+    "select_comp_iota_const"> {
+  let patterns = ["SelectCompIotaConst"];
+}
+
 def SelectOpUsedWithinIf : EnzymeHLOPatternOp<
     "select_op_used_within_if"> {
   let patterns = ["SelectOpUsedWithinIf"];

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -197,6 +197,7 @@ scatter_to_dynamic_update_slice<1>;
 reduce_concat<1>;
 slice_concat<1>;
 concat_slice<1>;
+select_comp_iota_const_simplify;
 select_op_used_within_if<1>;
 replace_neg_add_with_subtract<16>;
 

--- a/test/lit_tests/raising/affine_to_stablehlo5.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo5.mlir
@@ -15,9 +15,8 @@ module {
 }
 
 // CHECK:  func.func private @main_raised(%arg0: tensor<180xf32>, %arg1: tensor<180xf32>, %arg2: tensor<180xf32>) -> (tensor<180xf32>, tensor<180xf32>, tensor<180xf32>) {
-// CHECK-NEXT:    %c = stablehlo.constant dense<90> : tensor<180xi64>
-// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<180xi64>
-// CHECK-NEXT:    %1 = stablehlo.compare GT, %0, %c, SIGNED : (tensor<180xi64>, tensor<180xi64>) -> tensor<180xi1>
-// CHECK-NEXT:    %2 = stablehlo.select %1, %arg0, %arg1 : tensor<180xi1>, tensor<180xf32>
-// CHECK-NEXT:    return %arg0, %arg1, %2 : tensor<180xf32>, tensor<180xf32>, tensor<180xf32>
+// CHECK-NEXT:    %0 = stablehlo.slice %arg1 [0:91] : (tensor<180xf32>) -> tensor<91xf32> 
+// CHECK-NEXT:    %1 = stablehlo.slice %arg0 [91:180] : (tensor<180xf32>) -> tensor<89xf32>
+// CHECK-NEXT:    %2 = stablehlo.concatenate %0, %1, dim = 0 : (tensor<91xf32>, tensor<89xf32>) -> tensor<180xf32> 
+// CHECK-NEXT:    return %arg0, %arg1, %2 : tensor<180xf32>, tensor<180xf32>, tensor<180xf32> 
 // CHECK-NEXT:  }

--- a/test/lit_tests/selectcompiotaconstsimplify.mlir
+++ b/test/lit_tests/selectcompiotaconstsimplify.mlir
@@ -1,5 +1,7 @@
 // RUN: enzymexlamlir-opt --enzyme-hlo-opt --split-input-file %s | FileCheck %s
 
+// 0 1 2 3 4 5 6 7 8 9 
+// + + + + + - - - - - ... +5/20 
 module {
   func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
@@ -19,36 +21,64 @@ module {
 
 // -----
 
+// 0 1 2 3 4 5 6 7 8 9 
+// - - - - - - + + + + ... -6/20
+
 module {
   func.func @comp_gt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
     %c = stablehlo.constant dense<5> : tensor<20xi64>    
-    %1 = stablehlo.compare GT, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %1 = stablehlo.compare GT, %0, %c : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
     %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
     return %2 : tensor<20xi64>
   }
 }
 
 //CHECK:        func.func @comp_gt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
-//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
-//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg1 [5:20] : (tensor<20xi64>) -> tensor<15xi64>
-//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<5xi64>, tensor<15xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg1 [0:6] : (tensor<20xi64>) -> tensor<6xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg0 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<6xi64>, tensor<14xi64>) -> tensor<20xi64>
 //CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
 //CHECK-NEXT:   }
 
 // -----
 
+// 0 1 2 3 4 5 6 7 8 9 
+// + + + + + + - - - - ... +6/20 
+
 module {
-  func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+  func.func @comp_le(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
     %c = stablehlo.constant dense<5> : tensor<20xi64>    
-    %1 = stablehlo.compare  LT, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %1 = stablehlo.compare LE, %0, %c : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
     %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
     return %2 : tensor<20xi64>
   }
 }
 
-//CHECK:        func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK:        func.func @comp_le(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:6] : (tensor<20xi64>) -> tensor<6xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg1 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<6xi64>, tensor<14xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----
+
+// 0 1 2 3 4 5 6 7 8 9 
+// - - - - - + + + + + ... -5/20
+
+module {
+  func.func @comp_ge(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  GE, %0, %c : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_ge(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
 //CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg1 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
 //CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg0 [5:20] : (tensor<20xi64>) -> tensor<15xi64>
 //CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<5xi64>, tensor<15xi64>) -> tensor<20xi64>
@@ -56,6 +86,9 @@ module {
 //CHECK-NEXT:   }
 
 // -----
+
+// 0 1 2 3 4 5 6 7 8 9 
+// - - - - - + - - - -... -5/20
 
 module {
   func.func @comp_eq(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
@@ -76,3 +109,24 @@ module {
 //CHECK-NEXT:   }
 
 // -----
+
+// 0 1 2 3 4 5 6 7 8 9 
+// + + + + + - + + + + ... +5/20
+
+module {
+  func.func @comp_ne(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  NE, %0, %c : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_ne(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg1 [5:6] : (tensor<20xi64>) -> tensor<1xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.slice %arg0 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
+//CHECK-NEXT:     %[[v3:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], %[[v2]], dim = 0 : (tensor<5xi64>, tensor<1xi64>, tensor<14xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v3]] : tensor<20xi64>
+//CHECK-NEXT:   }

--- a/test/lit_tests/selectcompiotaconstsimplify.mlir
+++ b/test/lit_tests/selectcompiotaconstsimplify.mlir
@@ -1,0 +1,78 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt --split-input-file %s | FileCheck %s
+
+module {
+  func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  LT, %0, %c : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg1 [5:20] : (tensor<20xi64>) -> tensor<15xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<5xi64>, tensor<15xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----
+
+module {
+  func.func @comp_gt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare GT, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_gt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg1 [5:20] : (tensor<20xi64>) -> tensor<15xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<5xi64>, tensor<15xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----
+
+module {
+  func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  LT, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg1 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg0 [5:20] : (tensor<20xi64>) -> tensor<15xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<5xi64>, tensor<15xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----
+
+module {
+  func.func @comp_eq(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  EQ, %0, %c : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_eq(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg1 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg0 [5:6] : (tensor<20xi64>) -> tensor<1xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.slice %arg1 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
+//CHECK-NEXT:     %[[v3:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], %[[v2]], dim = 0 : (tensor<5xi64>, tensor<1xi64>, tensor<14xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v3]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----

--- a/test/lit_tests/selectcompiotaconstsimplify.mlir
+++ b/test/lit_tests/selectcompiotaconstsimplify.mlir
@@ -2,8 +2,6 @@
 
 // iota `op` const
 
-// 0 1 2 3 4 5 6 7 8 9 
-// + + + + + - - - - - ... +5/20 
 module {
   func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
@@ -22,9 +20,6 @@ module {
 //CHECK-NEXT:   }
 
 // -----
-
-// 0 1 2 3 4 5 6 7 8 9 
-// - - - - - - + + + + ... -6/20
 
 module {
   func.func @comp_gt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
@@ -45,9 +40,6 @@ module {
 
 // -----
 
-// 0 1 2 3 4 5 6 7 8 9 
-// + + + + + + - - - - ... +6/20 
-
 module {
   func.func @comp_le(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
@@ -66,9 +58,6 @@ module {
 //CHECK-NEXT:   }
 
 // -----
-
-// 0 1 2 3 4 5 6 7 8 9 
-// - - - - - + + + + + ... -5/20
 
 module {
   func.func @comp_ge(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
@@ -89,9 +78,6 @@ module {
 
 // -----
 
-// 0 1 2 3 4 5 6 7 8 9 
-// - - - - - + - - - -... -5/20
-
 module {
   func.func @comp_eq(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
@@ -111,9 +97,6 @@ module {
 //CHECK-NEXT:   }
 
 // -----
-
-// 0 1 2 3 4 5 6 7 8 9 
-// + + + + + - + + + + ... +5/20
 
 module {
   func.func @comp_ne(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
@@ -137,8 +120,6 @@ module {
 
 // const `op` iota
 
-// 0 1 2 3 4 5 6 7 8 9 
-// - - - - - - + + + + ... -6/20 
 module {
   func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
@@ -158,8 +139,6 @@ module {
 
 // -----
 
-// 0 1 2 3 4 5 6 7 8 9 
-// + + + + + - - - - - ... -6/20
 
 module {
   func.func @comp_gt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
@@ -178,8 +157,6 @@ module {
 //CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
 //CHECK-NEXT:   }
 
-// 0 1 2 3 4 5 6 7 8 9 
-// - - - - - + + + + + ... -5/20 
 module {
   func.func @comp_le(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
@@ -199,9 +176,6 @@ module {
 
 // -----
 
-// 0 1 2 3 4 5 6 7 8 9 
-// + + + + + + - - - - ... +6/20
-
 module {
   func.func @comp_ge(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
     %0 = stablehlo.iota dim = 0 : tensor<20xi64>
@@ -218,3 +192,98 @@ module {
 //CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<6xi64>, tensor<14xi64>) -> tensor<20xi64>
 //CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
 //CHECK-NEXT:   }
+
+// -----
+
+module {
+  func.func @comp_eq(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  EQ, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_eq(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg1 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg0 [5:6] : (tensor<20xi64>) -> tensor<1xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.slice %arg1 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
+//CHECK-NEXT:     %[[v3:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], %[[v2]], dim = 0 : (tensor<5xi64>, tensor<1xi64>, tensor<14xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v3]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----
+
+module {
+  func.func @comp_ne(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  NE, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_ne(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg1 [5:6] : (tensor<20xi64>) -> tensor<1xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.slice %arg0 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
+//CHECK-NEXT:     %[[v3:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], %[[v2]], dim = 0 : (tensor<5xi64>, tensor<1xi64>, tensor<14xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v3]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----
+
+// test in higher dimensions
+
+module {
+  func.func @comp_lt(%arg0: tensor<2x5xi64>, %arg1: tensor<2x5xi64>) -> tensor<2x5xi64>{
+    %0 = stablehlo.iota dim = 1 : tensor<2x5xi64>
+    %c = stablehlo.constant dense<3> : tensor<2x5xi64>    
+    %1 = stablehlo.compare  LT, %0, %c : (tensor<2x5xi64>, tensor<2x5xi64>) -> tensor<2x5xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<2x5xi1>, tensor<2x5xi64>
+    return %2 : tensor<2x5xi64>
+  }
+}
+
+//CHECK:      func.func @comp_lt(%arg0: tensor<2x5xi64>, %arg1: tensor<2x5xi64>) -> tensor<2x5xi64> {
+//CHECK-NEXT:   %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:2, 0:3] : (tensor<2x5xi64>) -> tensor<2x3xi64>
+//CHECK-NEXT:   %[[v1:[^ ]*]] = stablehlo.slice %arg1 [0:2, 3:5] : (tensor<2x5xi64>) -> tensor<2x2xi64>
+//CHECK-NEXT:   %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 1 : (tensor<2x3xi64>, tensor<2x2xi64>) -> tensor<2x5xi64>
+//CHECK-NEXT:   return %[[v2]] : tensor<2x5xi64>
+//CHECK-NEXT: }
+
+// -----
+
+// test for out of range indices
+
+module {
+  func.func @comp_lt(%arg0: tensor<2x5xi64>, %arg1: tensor<2x5xi64>) -> tensor<2x5xi64>{
+    %0 = stablehlo.iota dim = 1 : tensor<2x5xi64>
+    %c = stablehlo.constant dense<-1> : tensor<2x5xi64>    
+    %1 = stablehlo.compare  LT, %0, %c : (tensor<2x5xi64>, tensor<2x5xi64>) -> tensor<2x5xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<2x5xi1>, tensor<2x5xi64>
+    return %2 : tensor<2x5xi64>
+  }
+}
+
+//CHECK:      func.func @comp_lt(%arg0: tensor<2x5xi64>, %arg1: tensor<2x5xi64>) -> tensor<2x5xi64> {
+//CHECK-NEXT:   return %arg1 : tensor<2x5xi64>
+//CHECK-NEXT: }
+
+// -----
+
+module {
+  func.func @comp_lt(%arg0: tensor<2x5xi64>, %arg1: tensor<2x5xi64>) -> tensor<2x5xi64>{
+    %0 = stablehlo.iota dim = 1 : tensor<2x5xi64>
+    %c = stablehlo.constant dense<5> : tensor<2x5xi64>    
+    %1 = stablehlo.compare  LT, %0, %c : (tensor<2x5xi64>, tensor<2x5xi64>) -> tensor<2x5xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<2x5xi1>, tensor<2x5xi64>
+    return %2 : tensor<2x5xi64>
+  }
+}
+
+//CHECK:      func.func @comp_lt(%arg0: tensor<2x5xi64>, %arg1: tensor<2x5xi64>) -> tensor<2x5xi64> {
+//CHECK-NEXT:   return %arg0 : tensor<2x5xi64>
+//CHECK-NEXT: }

--- a/test/lit_tests/selectcompiotaconstsimplify.mlir
+++ b/test/lit_tests/selectcompiotaconstsimplify.mlir
@@ -1,5 +1,7 @@
 // RUN: enzymexlamlir-opt --enzyme-hlo-opt --split-input-file %s | FileCheck %s
 
+// iota `op` const
+
 // 0 1 2 3 4 5 6 7 8 9 
 // + + + + + - - - - - ... +5/20 
 module {
@@ -129,4 +131,90 @@ module {
 //CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.slice %arg0 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
 //CHECK-NEXT:     %[[v3:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], %[[v2]], dim = 0 : (tensor<5xi64>, tensor<1xi64>, tensor<14xi64>) -> tensor<20xi64>
 //CHECK-NEXT:     return %[[v3]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// ----
+
+// const `op` iota
+
+// 0 1 2 3 4 5 6 7 8 9 
+// - - - - - - + + + + ... -6/20 
+module {
+  func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  LT, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_lt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg1 [0:6] : (tensor<20xi64>) -> tensor<6xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg0 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<6xi64>, tensor<14xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----
+
+// 0 1 2 3 4 5 6 7 8 9 
+// + + + + + - - - - - ... -6/20
+
+module {
+  func.func @comp_gt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare GT, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_gt(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg1 [5:20] : (tensor<20xi64>) -> tensor<15xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<5xi64>, tensor<15xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// 0 1 2 3 4 5 6 7 8 9 
+// - - - - - + + + + + ... -5/20 
+module {
+  func.func @comp_le(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64>{
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare  LE, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_le(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg1 [0:5] : (tensor<20xi64>) -> tensor<5xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg0 [5:20] : (tensor<20xi64>) -> tensor<15xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<5xi64>, tensor<15xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
+//CHECK-NEXT:   }
+
+// -----
+
+// 0 1 2 3 4 5 6 7 8 9 
+// + + + + + + - - - - ... +6/20
+
+module {
+  func.func @comp_ge(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+    %0 = stablehlo.iota dim = 0 : tensor<20xi64>
+    %c = stablehlo.constant dense<5> : tensor<20xi64>    
+    %1 = stablehlo.compare GE, %c, %0 : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+    %2 = stablehlo.select %1, %arg0, %arg1: tensor<20xi1>, tensor<20xi64>
+    return %2 : tensor<20xi64>
+  }
+}
+
+//CHECK:        func.func @comp_ge(%arg0: tensor<20xi64>, %arg1: tensor<20xi64>) -> tensor<20xi64> {
+//CHECK-NEXT:     %[[v0:[^ ]*]] = stablehlo.slice %arg0 [0:6] : (tensor<20xi64>) -> tensor<6xi64>
+//CHECK-NEXT:     %[[v1:[^ ]*]] = stablehlo.slice %arg1 [6:20] : (tensor<20xi64>) -> tensor<14xi64>
+//CHECK-NEXT:     %[[v2:[^ ]*]] = stablehlo.concatenate %[[v0]], %[[v1]], dim = 0 : (tensor<6xi64>, tensor<14xi64>) -> tensor<20xi64>
+//CHECK-NEXT:     return %[[v2]] : tensor<20xi64>
 //CHECK-NEXT:   }


### PR DESCRIPTION
Refer to [the unit test i wrote](https://github.com/EnzymeAD/Enzyme-JAX/blob/a6d8cf6c7e107f04f9c98e2e41d8e1929c0c6c5c/test/lit_tests/selectcompiotaconstsimplify.mlir) for everything I tested.

I have tested:
- all six flags
- swapping the const and iota
- higher dimensions (but LT only)
- if the constant is negative or above the iota dimension

I have also changed the `affine_to_stablehlo5.mlir unit` test, because it was further reduced by this optimization.