### PR TITLE
Moving transpose to before whileOp  + broadcast iota error fix

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -3902,7 +3902,7 @@ struct BroadcastIotaSimplify
   LogicalResult matchAndRewrite(mlir::stablehlo::BroadcastInDimOp broadcast,
                                 PatternRewriter &rewriter) const final {
     auto operand = broadcast.getOperand();
-    DenseElementsAttr input;
+    DenseIntElementsAttr input;
     matchPattern(operand, m_Constant(&input));
 
     if (input) {

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7801,32 +7801,11 @@ struct WhileTransposePattern : public OpRewritePattern<stablehlo::WhileOp> {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(&newCondBlock);
       for (auto &op : oldCondBlock.getOperations()) {
-        //if (isa<stablehlo::ReturnOp>(op))
-        //  continue;
+        // if (isa<stablehlo::ReturnOp>(op))
+        //   continue;
         rewriter.clone(op, condMapper);
       }
     }
-
-    //// Create condition terminator
-    //{
-    //  auto oldCondReturn =
-    //      cast<stablehlo::ReturnOp>(oldCondBlock.getTerminator());
-    //  SmallVector<Value> newCondValues;
-
-    //  for (auto oldRetVal : oldCondReturn.getOperands()) {
-    //    Value newRetVal = condMapper.lookupOrNull(oldRetVal);
-    //    if (!newRetVal)
-    //      newRetVal = oldRetVal;
-    //    newCondValues.push_back(newRetVal);
-    //  }
-    //  {
-    //    // Save the current insertion point
-    //    mlir::OpBuilder::InsertionGuard guard(rewriter);
-    //    rewriter.setInsertionPointToEnd(&newCondBlock);
-    //    rewriter.create<stablehlo::ReturnOp>(oldCondReturn.getLoc(),
-    //                                         newCondValues);
-    //  }
-    //}
 
     // Step 4 : Insert the transpose op at the beginning of the body of new
     // WhileOp

--- a/test/lit_tests/while-transpose-test.mlir
+++ b/test/lit_tests/while-transpose-test.mlir
@@ -1,0 +1,30 @@
+// RUN: enzymexlamlir-opt  -allow-unregistered-dialect --enzyme-hlo-opt %s | FileCheck %s
+
+func.func @test_while_transpose_elimination(%arg0: tensor<2x3xf32>, %arg1: tensor<i64>) -> tensor<3x2xf32> {
+  %cond = stablehlo.constant dense<true> : tensor<i1>
+  
+  %0:2 = "stablehlo.while"(%arg0, %arg1) ({
+    ^bb0(%arg2: tensor<2x3xf32>, %arg3: tensor<i64>):
+      stablehlo.return %cond : tensor<i1>
+  }, {
+    ^bb0(%arg2: tensor<2x3xf32>, %arg3: tensor<i64>):
+      // Transpose input inside while body
+      %transposed = "unregistered.custom_transform"(%arg2) {} : (tensor<2x3xf32>) -> tensor<3x2xf32>
+      %transposed_back = stablehlo.transpose %transposed, dims = [1, 0] : (tensor<3x2xf32>) -> tensor<2x3xf32>
+      
+      // Do something with the iteration count
+      %one = stablehlo.constant dense<1> : tensor<i64>
+      %next_iter = stablehlo.add %arg3, %one : tensor<i64>
+      
+      // Yield the transposed value (which becomes a result of the while)
+      stablehlo.return %transposed_back, %next_iter : tensor<2x3xf32>, tensor<i64>
+  }) : (tensor<2x3xf32>, tensor<i64>) -> (tensor<2x3xf32>, tensor<i64>)
+  
+  // Transpose the while result back to the original shape (this should be eliminated by the pattern)
+  %1 = stablehlo.transpose %0#0, dims = [1, 0] : (tensor<2x3xf32>) -> tensor<3x2xf32>
+  
+  // Use the transposed result
+  %2 = stablehlo.add %1, %1 : tensor<3x2xf32>
+  
+  return %2 : tensor<3x2xf32>
+} 

--- a/test/lit_tests/while-transpose-test.mlir
+++ b/test/lit_tests/while-transpose-test.mlir
@@ -23,8 +23,5 @@ func.func @test_while_transpose_elimination(%arg0: tensor<2x3xf32>, %arg1: tenso
   // Transpose the while result back to the original shape (this should be eliminated by the pattern)
   %1 = stablehlo.transpose %0#0, dims = [1, 0] : (tensor<2x3xf32>) -> tensor<3x2xf32>
   
-  // Use the transposed result
-  %2 = stablehlo.add %1, %1 : tensor<3x2xf32>
-  
-  return %2 : tensor<3x2xf32>
+  return %1 : tensor<3x2xf32>
 } 


### PR DESCRIPTION
Transform this:

out = while(in)
{
y = something(in)
....
x =tr(a)  //inner transpose
return x
}
c = tr(out) //outer transpose

to this:

z = tr(in) //Moved to before while
out = while(z)
{
new = tr(z) //Another moved to beginning of while
y=something(new)
...
return a
}

c = out;