### PR TITLE
fix: ReduceTransposeSimplify

### DIFF
--- a/test/lit_tests/reducetranspose.mlir
+++ b/test/lit_tests/reducetranspose.mlir
@@ -25,3 +25,19 @@ module {
 // CHECK-NEXT:    %[[i3:.+]] = stablehlo.reduce(%[[i2]] init: %[[i0]]) applies stablehlo.add across dimensions = [0, 1] : (tensor<5x4xf32>, tensor<f32>) -> tensor<f32>
 // CHECK-NEXT:    return %[[i3]] : tensor<f32>
 // CHECK-NEXT:  }
+
+module {
+  func.func @main(%arg0: tensor<3x4x5x6xf32>) -> tensor<6x4xf32> {
+    %cst_2 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %0 = stablehlo.transpose %arg0, dims = [0, 3, 1, 2] : (tensor<3x4x5x6xf32>) -> tensor<3x6x4x5xf32>
+    %1 = stablehlo.reduce(%0 init: %cst_2) applies stablehlo.add across dimensions = [0, 3] : (tensor<3x6x4x5xf32>, tensor<f32>) -> tensor<6x4xf32>
+    return %1 : tensor<6x4xf32>
+  }
+}
+
+// CHECK:  func.func @main(%arg0: tensor<3x4x5x6xf32>) -> tensor<6x4xf32> {
+// CHECK-NEXT:    %[[i0:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:    %[[i1:.+]] = stablehlo.reduce(%arg0 init: %[[i0]]) applies stablehlo.add across dimensions = [0, 2] : (tensor<3x4x5x6xf32>, tensor<f32>) -> tensor<4x6xf32>
+// CHECK-NEXT:    %[[i2:.+]] = stablehlo.transpose %[[i1]], dims = [1, 0] : (tensor<4x6xf32>) -> tensor<6x4xf32>
+// CHECK-NEXT:    return %[[i2]] : tensor<6x4xf32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Checking for newDims == oldDims to get the permutation would not be correct for same dims (also it was failing for a larger IR)

```mlir
module {
  func.func @"\E2\88\87sumabs2_enzyme"(%arg0: tensor<5x3x4xf32>, %arg1: tensor<5x3x4xf32>, %arg2: tensor<5x3x4xf32>, %arg3: tensor<4x10xf32>, %arg4: tensor<4x10xf32>, %arg5: tensor<4x10xf32>, %arg6: tensor<10x5xf32>) -> (tensor<5x3x4xf32>, tensor<5x3x4xf32>, tensor<5x3x4xf32>, tensor<4x10xf32>, tensor<4x10xf32>, tensor<4x10xf32>, tensor<10x5xf32>, tensor<5x3x4xf32>, tensor<5x3x4xf32>, tensor<5x3x4xf32>, tensor<4x10xf32>, tensor<4x10xf32>, tensor<4x10xf32>, tensor<10x5xf32>) {
    %cst = stablehlo.constant dense<1.41421354> : tensor<15x10xf32>
    %cst_0 = stablehlo.constant dense<0xFF800000> : tensor<f32>
    %cst_1 = stablehlo.constant dense<1.41421354> : tensor<25x3x2xf32>
    %cst_2 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
    %cst_3 = stablehlo.constant dense<0.000000e+00> : tensor<5x3x5xf32>
    %cst_4 = stablehlo.constant dense<0.000000e+00> : tensor<3x5x5x3xf32>
    %0 = stablehlo.reshape %arg0 : (tensor<5x3x4xf32>) -> tensor<15x4xf32>
    %1 = stablehlo.reshape %arg1 : (tensor<5x3x4xf32>) -> tensor<15x4xf32>
    %2 = stablehlo.reshape %arg2 : (tensor<5x3x4xf32>) -> tensor<15x4xf32>
    %3 = stablehlo.dot_general %1, %arg4, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<15x4xf32>, tensor<4x10xf32>) -> tensor<15x10xf32>
    %4 = stablehlo.reshape %3 : (tensor<15x10xf32>) -> tensor<5x3x5x2xf32>
    %5 = stablehlo.dot_general %0, %arg3, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<15x4xf32>, tensor<4x10xf32>) -> tensor<15x10xf32>
    %6 = stablehlo.reshape %5 : (tensor<15x10xf32>) -> tensor<5x3x5x2xf32>
    %7 = stablehlo.transpose %4, dims = [0, 2, 3, 1] : (tensor<5x3x5x2xf32>) -> tensor<5x5x2x3xf32>
    %8 = stablehlo.reshape %7 : (tensor<5x5x2x3xf32>) -> tensor<25x2x3xf32>
    %9 = stablehlo.transpose %6, dims = [0, 2, 1, 3] : (tensor<5x3x5x2xf32>) -> tensor<5x5x3x2xf32>
    %10 = stablehlo.reshape %9 : (tensor<5x5x3x2xf32>) -> tensor<25x3x2xf32>
    %11 = stablehlo.divide %10, %cst_1 : tensor<25x3x2xf32>
    %12 = stablehlo.dot_general %11, %8, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<25x3x2xf32>, tensor<25x2x3xf32>) -> tensor<25x3x3xf32>
    %13 = stablehlo.reshape %12 : (tensor<25x3x3xf32>) -> tensor<5x5x3x3xf32>
    %14 = stablehlo.transpose %13, dims = [3, 2, 1, 0] : (tensor<5x5x3x3xf32>) -> tensor<3x3x5x5xf32>
    %15 = stablehlo.transpose %13, dims = [3, 0, 1, 2] : (tensor<5x5x3x3xf32>) -> tensor<3x5x5x3xf32>
    %16 = stablehlo.reduce(%15 init: %cst_0) applies stablehlo.maximum across dimensions = [0] : (tensor<3x5x5x3xf32>, tensor<f32>) -> tensor<5x5x3xf32>
    %17 = stablehlo.broadcast_in_dim %16, dims = [3, 2, 1] : (tensor<5x5x3xf32>) -> tensor<3x3x5x5xf32>
    %18 = stablehlo.subtract %14, %17 : tensor<3x3x5x5xf32>
    %19 = stablehlo.exponential %18 : tensor<3x3x5x5xf32>
    %20 = stablehlo.transpose %19, dims = [0, 3, 2, 1] : (tensor<3x3x5x5xf32>) -> tensor<3x5x5x3xf32>
    %21 = stablehlo.reduce(%20 init: %cst_2) applies stablehlo.add across dimensions = [0] : (tensor<3x5x5x3xf32>, tensor<f32>) -> tensor<5x5x3xf32>
    %22 = stablehlo.broadcast_in_dim %21, dims = [3, 2, 1] : (tensor<5x5x3xf32>) -> tensor<3x3x5x5xf32>
    %23 = stablehlo.dot_general %2, %arg5, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<15x4xf32>, tensor<4x10xf32>) -> tensor<15x10xf32>
    %24 = stablehlo.reshape %23 : (tensor<15x10xf32>) -> tensor<5x3x5x2xf32>
    %25 = stablehlo.transpose %24, dims = [0, 2, 1, 3] : (tensor<5x3x5x2xf32>) -> tensor<5x5x3x2xf32>
    %26 = stablehlo.reshape %25 : (tensor<5x5x3x2xf32>) -> tensor<25x3x2xf32>
    %27 = stablehlo.transpose %19, dims = [3, 2, 1, 0] : (tensor<3x3x5x5xf32>) -> tensor<5x5x3x3xf32>
    %28 = stablehlo.transpose %22, dims = [3, 2, 1, 0] : (tensor<3x3x5x5xf32>) -> tensor<5x5x3x3xf32>
    %29 = stablehlo.reshape %27 : (tensor<5x5x3x3xf32>) -> tensor<25x3x3xf32>
    %30 = stablehlo.reshape %28 : (tensor<5x5x3x3xf32>) -> tensor<25x3x3xf32>
    %31 = stablehlo.divide %29, %30 : tensor<25x3x3xf32>
    %32 = stablehlo.dot_general %31, %26, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<25x3x3xf32>, tensor<25x3x2xf32>) -> tensor<25x3x2xf32>
    %33 = stablehlo.reshape %32 : (tensor<25x3x2xf32>) -> tensor<5x5x3x2xf32>
    %34 = stablehlo.transpose %33, dims = [0, 2, 1, 3] : (tensor<5x5x3x2xf32>) -> tensor<5x3x5x2xf32>
    %35 = stablehlo.reshape %34 : (tensor<5x3x5x2xf32>) -> tensor<15x10xf32>
    %36 = stablehlo.dot_general %35, %arg6, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<15x10xf32>, tensor<10x5xf32>) -> tensor<15x5xf32>
    %37 = stablehlo.reshape %36 : (tensor<15x5xf32>) -> tensor<5x3x5xf32>
    %38 = stablehlo.transpose %37, dims = [2, 1, 0] : (tensor<5x3x5xf32>) -> tensor<5x3x5xf32>
    %39 = stablehlo.abs %38 : tensor<5x3x5xf32>
    %40 = stablehlo.add %39, %39 : tensor<5x3x5xf32>
    %41 = stablehlo.compare  GE, %38, %cst_3 : (tensor<5x3x5xf32>, tensor<5x3x5xf32>) -> tensor<5x3x5xi1>
    %42 = stablehlo.negate %40 : tensor<5x3x5xf32>
    %43 = stablehlo.select %41, %40, %42 : tensor<5x3x5xi1>, tensor<5x3x5xf32>
    %44 = stablehlo.transpose %43, dims = [2, 1, 0] : (tensor<5x3x5xf32>) -> tensor<5x3x5xf32>
    %45 = stablehlo.reshape %44 : (tensor<5x3x5xf32>) -> tensor<15x5xf32>
    %46 = stablehlo.dot_general %45, %arg6, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<15x5xf32>, tensor<10x5xf32>) -> tensor<15x10xf32>
    %47 = stablehlo.dot_general %35, %45, contracting_dims = [0] x [0], precision = [DEFAULT, DEFAULT] : (tensor<15x10xf32>, tensor<15x5xf32>) -> tensor<10x5xf32>
    %48 = stablehlo.reshape %46 : (tensor<15x10xf32>) -> tensor<5x3x5x2xf32>
    %49 = stablehlo.transpose %48, dims = [0, 2, 1, 3] : (tensor<5x3x5x2xf32>) -> tensor<5x5x3x2xf32>
    %50 = stablehlo.reshape %49 : (tensor<5x5x3x2xf32>) -> tensor<25x3x2xf32>
    %51 = stablehlo.dot_general %50, %26, batching_dims = [0] x [0], contracting_dims = [2] x [2], precision = [DEFAULT, DEFAULT] : (tensor<25x3x2xf32>, tensor<25x3x2xf32>) -> tensor<25x3x3xf32>
    %52 = stablehlo.dot_general %31, %50, batching_dims = [0] x [0], contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<25x3x3xf32>, tensor<25x3x2xf32>) -> tensor<25x3x2xf32>
    %53 = stablehlo.reshape %51 : (tensor<25x3x3xf32>) -> tensor<5x5x3x3xf32>
    %54 = stablehlo.reshape %31 : (tensor<25x3x3xf32>) -> tensor<5x5x3x3xf32>
    %55 = stablehlo.transpose %53, dims = [3, 2, 1, 0] : (tensor<5x5x3x3xf32>) -> tensor<3x3x5x5xf32>
    %56 = stablehlo.divide %55, %22 : tensor<3x3x5x5xf32>
    %57 = stablehlo.transpose %54, dims = [3, 2, 1, 0] : (tensor<5x5x3x3xf32>) -> tensor<3x3x5x5xf32>
    %58 = stablehlo.multiply %56, %57 : tensor<3x3x5x5xf32>
    %59 = stablehlo.negate %58 : tensor<3x3x5x5xf32>
    %60 = stablehlo.reshape %52 : (tensor<25x3x2xf32>) -> tensor<5x5x3x2xf32>
    %61 = stablehlo.transpose %60, dims = [0, 2, 1, 3] : (tensor<5x5x3x2xf32>) -> tensor<5x3x5x2xf32>
    %62 = stablehlo.reshape %61 : (tensor<5x3x5x2xf32>) -> tensor<15x10xf32>
    %63 = stablehlo.dot_general %62, %arg5, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<15x10xf32>, tensor<4x10xf32>) -> tensor<15x4xf32>
    %64 = stablehlo.dot_general %2, %62, contracting_dims = [0] x [0], precision = [DEFAULT, DEFAULT] : (tensor<15x4xf32>, tensor<15x10xf32>) -> tensor<4x10xf32>
    %65 = stablehlo.reduce(%59 init: %cst_2) applies stablehlo.add across dimensions = [0] : (tensor<3x3x5x5xf32>, tensor<f32>) -> tensor<3x5x5xf32>
    %66 = stablehlo.reshape %65 : (tensor<3x5x5xf32>) -> tensor<5x5x3xf32>
    %67 = stablehlo.broadcast_in_dim %66, dims = [1, 2, 3] : (tensor<5x5x3xf32>) -> tensor<3x5x5x3xf32>
    %68 = stablehlo.transpose %67, dims = [0, 3, 2, 1] : (tensor<3x5x5x3xf32>) -> tensor<3x3x5x5xf32>
    %69 = stablehlo.add %56, %68 : tensor<3x3x5x5xf32>
    %70 = stablehlo.multiply %69, %19 : tensor<3x3x5x5xf32>
    %71 = stablehlo.negate %70 : tensor<3x3x5x5xf32>
    %72 = stablehlo.reduce(%71 init: %cst_2) applies stablehlo.add across dimensions = [0] : (tensor<3x3x5x5xf32>, tensor<f32>) -> tensor<3x5x5xf32>
    %73 = stablehlo.reshape %72 : (tensor<3x5x5xf32>) -> tensor<5x5x3xf32>
    %74 = stablehlo.broadcast_in_dim %16, dims = [1, 2, 3] : (tensor<5x5x3xf32>) -> tensor<3x5x5x3xf32>
    %75 = stablehlo.compare  EQ, %74, %15 : (tensor<3x5x5x3xf32>, tensor<3x5x5x3xf32>) -> tensor<3x5x5x3xi1>
    %76 = stablehlo.broadcast_in_dim %73, dims = [1, 2, 3] : (tensor<5x5x3xf32>) -> tensor<3x5x5x3xf32>
    %77 = stablehlo.select %75, %76, %cst_4 : tensor<3x5x5x3xi1>, tensor<3x5x5x3xf32>
    %78 = stablehlo.transpose %77, dims = [1, 2, 3, 0] : (tensor<3x5x5x3xf32>) -> tensor<5x5x3x3xf32>
    %79 = stablehlo.transpose %70, dims = [3, 2, 1, 0] : (tensor<3x3x5x5xf32>) -> tensor<5x5x3x3xf32>
    %80 = stablehlo.reshape %78 : (tensor<5x5x3x3xf32>) -> tensor<25x3x3xf32>
    %81 = stablehlo.reshape %79 : (tensor<5x5x3x3xf32>) -> tensor<25x3x3xf32>
    %82 = stablehlo.add %80, %81 : tensor<25x3x3xf32>
    %83 = stablehlo.dot_general %82, %8, batching_dims = [0] x [0], contracting_dims = [2] x [2], precision = [DEFAULT, DEFAULT] : (tensor<25x3x3xf32>, tensor<25x2x3xf32>) -> tensor<25x3x2xf32>
    %84 = stablehlo.dot_general %11, %82, batching_dims = [0] x [0], contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<25x3x2xf32>, tensor<25x3x3xf32>) -> tensor<25x2x3xf32>
    %85 = stablehlo.reshape %83 : (tensor<25x3x2xf32>) -> tensor<5x5x3x2xf32>
    %86 = stablehlo.transpose %85, dims = [0, 2, 1, 3] : (tensor<5x5x3x2xf32>) -> tensor<5x3x5x2xf32>
    %87 = stablehlo.reshape %84 : (tensor<25x2x3xf32>) -> tensor<5x5x2x3xf32>
    %88 = stablehlo.transpose %87, dims = [0, 3, 1, 2] : (tensor<5x5x2x3xf32>) -> tensor<5x3x5x2xf32>
    %89 = stablehlo.reshape %86 : (tensor<5x3x5x2xf32>) -> tensor<15x10xf32>
    %90 = stablehlo.divide %89, %cst : tensor<15x10xf32>
    %91 = stablehlo.dot_general %90, %arg3, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<15x10xf32>, tensor<4x10xf32>) -> tensor<15x4xf32>
    %92 = stablehlo.dot_general %0, %90, contracting_dims = [0] x [0], precision = [DEFAULT, DEFAULT] : (tensor<15x4xf32>, tensor<15x10xf32>) -> tensor<4x10xf32>
    %93 = stablehlo.reshape %88 : (tensor<5x3x5x2xf32>) -> tensor<15x10xf32>
    %94 = stablehlo.dot_general %93, %arg4, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<15x10xf32>, tensor<4x10xf32>) -> tensor<15x4xf32>
    %95 = stablehlo.dot_general %1, %93, contracting_dims = [0] x [0], precision = [DEFAULT, DEFAULT] : (tensor<15x4xf32>, tensor<15x10xf32>) -> tensor<4x10xf32>
    %96 = stablehlo.reshape %63 : (tensor<15x4xf32>) -> tensor<5x3x4xf32>
    %97 = stablehlo.reshape %94 : (tensor<15x4xf32>) -> tensor<5x3x4xf32>
    %98 = stablehlo.reshape %91 : (tensor<15x4xf32>) -> tensor<5x3x4xf32>
    return %98, %97, %96, %92, %95, %64, %47, %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6 : tensor<5x3x4xf32>, tensor<5x3x4xf32>, tensor<5x3x4xf32>, tensor<4x10xf32>, tensor<4x10xf32>, tensor<4x10xf32>, tensor<10x5xf32>, tensor<5x3x4xf32>, tensor<5x3x4xf32>, tensor<5x3x4xf32>, tensor<4x10xf32>, tensor<4x10xf32>, tensor<4x10xf32>, tensor<10x5xf32>
  }
}
```