### PR TITLE
Fix reverse mode derivative for `stablehlo.broadcast_in_dim`

### DIFF
--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -682,7 +682,6 @@ public:
     llvm::SmallVector<int64_t> sorted_bcastDims(bcastDims.begin(),
                                                 bcastDims.end());
     llvm::sort(sorted_bcastDims);
-
     llvm::SmallVector<int64_t, 1> permutation;
     permutation.resize(bcastDims.size());
     for (auto i = 0; i < bcastDims.size(); ++i) {
@@ -690,10 +689,9 @@ public:
       permutation[i] = std::distance(sorted_bcastDims.begin(), permutedIdx);
     }
 
-    // transpose back to original dims (rank == bcastDims.size() according to
-    // spec)
-    if (res.getType() != resTy)
-      res = builder.create<TransposeOp>(op.getLoc(), resTy, res, permutation);
+    // Always transpose back to original dims
+    // The spec guarantees rank == bcastDims.size()
+    res = builder.create<TransposeOp>(op.getLoc(), resTy, res, permutation);
 
     gutils->addToDiffe(op.getOperand(), res, builder);
     return success();

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -26,6 +26,8 @@
 
 #include "src/enzyme_ad/jax/Implementations/WhileLoopInfo.h"
 #include "src/enzyme_ad/jax/Implementations/XLADerivatives.h"
+#include <cstdint>
+#include <iterator>
 
 using namespace mlir;
 using namespace mlir::enzyme;
@@ -676,8 +678,22 @@ public:
 
     Value res = red->getResult(0);
     Type resTy = gutils->getShadowType(op.getOperand().getType());
+
+    llvm::SmallVector<int64_t> sorted_bcastDims(bcastDims.begin(),
+                                                bcastDims.end());
+    llvm::sort(sorted_bcastDims);
+
+    llvm::SmallVector<int64_t, 1> permutation;
+    permutation.resize(bcastDims.size());
+    for (auto i = 0; i < bcastDims.size(); ++i) {
+      auto permutedIdx = llvm::find(sorted_bcastDims, bcastDims[i]);
+      permutation[i] = std::distance(sorted_bcastDims.begin(), permutedIdx);
+    }
+
+    // transpose back to original dims (rank == bcastDims.size() according to
+    // spec)
     if (res.getType() != resTy)
-      res = builder.create<ReshapeOp>(op.getLoc(), resTy, res);
+      res = builder.create<TransposeOp>(op.getLoc(), resTy, res, permutation);
 
     gutils->addToDiffe(op.getOperand(), res, builder);
     return success();

--- a/test/lit_tests/diffrules/stablehlo/broadcastindim.mlir
+++ b/test/lit_tests/diffrules/stablehlo/broadcastindim.mlir
@@ -18,6 +18,7 @@ func.func @main(%arg2: tensor<10xf32>) -> (tensor<10x3xf32>) {
 // REVERSE-NEXT:    %cst_1 = arith.constant dense<0.000000e+00> : tensor<10xf32>
 // REVERSE-NEXT:    %0 = arith.addf %arg1, %cst_0 : tensor<10x3xf32>
 // REVERSE-NEXT:    %1 = stablehlo.reduce(%0 init: %cst) applies stablehlo.add across dimensions = [1] : (tensor<10x3xf32>, tensor<f32>) -> tensor<10xf32>
-// REVERSE-NEXT:    %2 = arith.addf %1, %cst_1 : tensor<10xf32>
-// REVERSE-NEXT:    return %2 : tensor<10xf32>
+// REVERSE-NEXT:    %2 = stablehlo.transpose %1, dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
+// REVERSE-NEXT:    %3 = arith.addf %2, %cst_1 : tensor<10xf32>
+// REVERSE-NEXT:    return %3 : tensor<10xf32>
 // REVERSE-NEXT:  }

--- a/test/lit_tests/diffrules/stablehlo/broadcastindim.mlir
+++ b/test/lit_tests/diffrules/stablehlo/broadcastindim.mlir
@@ -1,24 +1,33 @@
 // RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup mode=ForwardMode" | FileCheck %s --check-prefix=FORWARD
-// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active,enzyme_active argTys=enzyme_active,enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
 
-func.func @main(%arg2: tensor<10xf32>) -> (tensor<10x3xf32>) {
+func.func @main(%arg1: tensor<5x5x3xf32>, %arg2: tensor<10xf32>) -> (tensor<1x3x5x5xf32>, tensor<10x3xf32>) {
   %1 = stablehlo.broadcast_in_dim %arg2, dims = [0] : (tensor<10xf32>) -> tensor<10x3xf32>
-  return %1 : tensor<10x3xf32>
+  %2 = stablehlo.broadcast_in_dim %arg1, dims = [3, 2, 1] : (tensor<5x5x3xf32>) -> tensor<1x3x5x5xf32>
+  return %2, %1 : tensor<1x3x5x5xf32>, tensor<10x3xf32>
 }
 
-// FORWARD:  func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<10xf32>) -> (tensor<10x3xf32>, tensor<10x3xf32>) {
-// FORWARD-NEXT:    %0 = stablehlo.broadcast_in_dim %arg1, dims = [0] : (tensor<10xf32>) -> tensor<10x3xf32>
-// FORWARD-NEXT:    %1 = stablehlo.broadcast_in_dim %arg0, dims = [0] : (tensor<10xf32>) -> tensor<10x3xf32>
-// FORWARD-NEXT:    return %1, %0 : tensor<10x3xf32>, tensor<10x3xf32>
-// FORWARD-NEXT:  }
+// FORWARD: func.func @main(%arg0: tensor<5x5x3xf32>, %arg1: tensor<5x5x3xf32>, %arg2: tensor<10xf32>, %arg3: tensor<10xf32>) -> (tensor<1x3x5x5xf32>, tensor<1x3x5x5xf32>, tensor<10x3xf32>, tensor<10x3xf32>) {
+// FORWARD-NEXT:   %0 = stablehlo.broadcast_in_dim %arg3, dims = [0] : (tensor<10xf32>) -> tensor<10x3xf32>
+// FORWARD-NEXT:   %1 = stablehlo.broadcast_in_dim %arg2, dims = [0] : (tensor<10xf32>) -> tensor<10x3xf32>
+// FORWARD-NEXT:   %2 = stablehlo.broadcast_in_dim %arg1, dims = [3, 2, 1] : (tensor<5x5x3xf32>) -> tensor<1x3x5x5xf32>
+// FORWARD-NEXT:   %3 = stablehlo.broadcast_in_dim %arg0, dims = [3, 2, 1] : (tensor<5x5x3xf32>) -> tensor<1x3x5x5xf32>
+// FORWARD-NEXT:   return %3, %2, %1, %0 : tensor<1x3x5x5xf32>, tensor<1x3x5x5xf32>, tensor<10x3xf32>, tensor<10x3xf32>
+// FORWARD-NEXT: }
 
-// REVERSE:  func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<10x3xf32>) -> tensor<10xf32> {
-// REVERSE-NEXT:    %cst = arith.constant dense<0.000000e+00> : tensor<f32>
-// REVERSE-NEXT:    %cst_0 = arith.constant dense<0.000000e+00> : tensor<10x3xf32>
-// REVERSE-NEXT:    %cst_1 = arith.constant dense<0.000000e+00> : tensor<10xf32>
-// REVERSE-NEXT:    %0 = arith.addf %arg1, %cst_0 : tensor<10x3xf32>
-// REVERSE-NEXT:    %1 = stablehlo.reduce(%0 init: %cst) applies stablehlo.add across dimensions = [1] : (tensor<10x3xf32>, tensor<f32>) -> tensor<10xf32>
-// REVERSE-NEXT:    %2 = stablehlo.transpose %1, dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
-// REVERSE-NEXT:    %3 = arith.addf %2, %cst_1 : tensor<10xf32>
-// REVERSE-NEXT:    return %3 : tensor<10xf32>
-// REVERSE-NEXT:  }
+// REVERSE: func.func @main(%arg0: tensor<5x5x3xf32>, %arg1: tensor<10xf32>, %arg2: tensor<1x3x5x5xf32>, %arg3: tensor<10x3xf32>) -> (tensor<5x5x3xf32>, tensor<10xf32>) {
+// REVERSE-NEXT:   %cst = arith.constant dense<0.000000e+00> : tensor<f32>
+// REVERSE-NEXT:   %cst_0 = arith.constant dense<0.000000e+00> : tensor<1x3x5x5xf32>
+// REVERSE-NEXT:   %cst_1 = arith.constant dense<0.000000e+00> : tensor<10x3xf32>
+// REVERSE-NEXT:   %cst_2 = arith.constant dense<0.000000e+00> : tensor<5x5x3xf32>
+// REVERSE-NEXT:   %cst_3 = arith.constant dense<0.000000e+00> : tensor<10xf32>
+// REVERSE-NEXT:   %0 = arith.addf %arg2, %cst_0 : tensor<1x3x5x5xf32>
+// REVERSE-NEXT:   %1 = arith.addf %arg3, %cst_1 : tensor<10x3xf32>
+// REVERSE-NEXT:   %2 = stablehlo.reduce(%0 init: %cst) applies stablehlo.add across dimensions = [0] : (tensor<1x3x5x5xf32>, tensor<f32>) -> tensor<3x5x5xf32>
+// REVERSE-NEXT:   %3 = stablehlo.transpose %2, dims = [2, 1, 0] : (tensor<3x5x5xf32>) -> tensor<5x5x3xf32>
+// REVERSE-NEXT:   %4 = arith.addf %3, %cst_2 : tensor<5x5x3xf32>
+// REVERSE-NEXT:   %5 = stablehlo.reduce(%1 init: %cst) applies stablehlo.add across dimensions = [1] : (tensor<10x3xf32>, tensor<f32>) -> tensor<10xf32>
+// REVERSE-NEXT:   %6 = stablehlo.transpose %5, dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
+// REVERSE-NEXT:   %7 = arith.addf %6, %cst_3 : tensor<10xf32>
+// REVERSE-NEXT:   return %4, %7 : tensor<5x5x3xf32>, tensor<10xf32>
+// REVERSE-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/broadcastindim.mlir
+++ b/test/lit_tests/diffrules/stablehlo/broadcastindim.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup mode=ForwardMode" | FileCheck %s --check-prefix=FORWARD
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup,enzyme_dup argTys=enzyme_dup,enzyme_dup mode=ForwardMode" | FileCheck %s --check-prefix=FORWARD
 // RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active,enzyme_active argTys=enzyme_active,enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
 
 func.func @main(%arg1: tensor<5x5x3xf32>, %arg2: tensor<10xf32>) -> (tensor<1x3x5x5xf32>, tensor<10x3xf32>) {


### PR DESCRIPTION
Should ideally fix the bug in EnzymeAD/Reactant.jl#1117 