### PR TITLE
Extend of slice becomes slice of extend

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8344,7 +8344,8 @@ struct DUSSliceSimplify final
         });
 
     LLVM_DEBUG(
-        for (auto [idx, operandSize, updateSize] : llvm::zip_equal(
+        for (auto [idx, operandSize, updateSize]
+             : llvm::zip_equal(
                  newDusIndices,
                  preSliceOperand.getType().cast<RankedTensorType>().getShape(),
                  preSliceUpdate.getType()

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -14874,6 +14874,99 @@ bool isAxisFusible(int dimension, ArrayRef<Value> vals) {
   return false;
 }
 
+// Pattern:
+//   %slice = stablehlo.slice %operand [...]
+//   %extend = enzymexla.extend %slice, dim=D, lhs=L, rhs=R
+// Constraint:
+//   - %slice has only %extend as its user.
+//   - The slice operation does not modify dimension D (i.e., it takes the
+//     full extent of dimension D).
+// Rewrite to:
+//   %new_extend = enzymexla.extend %operand, dim=D, lhs=L, rhs=R // Type adjusted
+//   %new_slice = stablehlo.slice %new_extend [...] // Indices adjusted for lhs padding
+struct SliceExtend final : OpRewritePattern<enzymexla::ExtendOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(enzymexla::ExtendOp extendOp,
+                                PatternRewriter &rewriter) const override {
+    Value extendOperand = extendOp.getOperand();
+    auto sliceOp = extendOperand.getDefiningOp<stablehlo::SliceOp>();
+
+    if (!sliceOp) {
+      return rewriter.notifyMatchFailure(extendOp, "Operand is not a SliceOp");
+    }
+
+    if (!sliceOp->hasOneUse()) {
+      return rewriter.notifyMatchFailure(extendOp, "SliceOp has multiple users");
+    }
+
+    auto sliceOperandType =
+        dyn_cast<RankedTensorType>(sliceOp.getOperand().getType());
+    auto sliceResultType = dyn_cast<RankedTensorType>(sliceOp.getType());
+    auto extendResultType = dyn_cast<RankedTensorType>(extendOp.getType());
+
+    if (!sliceOperandType || !sliceResultType || !extendResultType ||
+        !sliceOperandType.hasStaticShape() ||
+        !sliceResultType.hasStaticShape() ||
+        !extendResultType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(
+          extendOp, "Requires static shapes for involved tensors");
+    }
+
+    int64_t extendDim = extendOp.getDimension();
+    int64_t extendLhs = extendOp.getLhs();
+    int64_t extendRhs = extendOp.getRhs();
+
+    // Check if the slice operation affects the extended dimension.
+    if (sliceOp.getStartIndices()[extendDim] != 0 ||
+        sliceOp.getLimitIndices()[extendDim] !=
+            sliceOperandType.getShape()[extendDim] ||
+        sliceOp.getStrides()[extendDim] != 1) {
+      return rewriter.notifyMatchFailure(
+          extendOp, "SliceOp modifies the dimension being extended");
+    }
+
+    // --- Constraints met, proceed with rewrite ---
+
+    Location loc = extendOp.getLoc();
+
+    // Create the new ExtendOp operating on the original slice's operand
+    SmallVector<int64_t> newExtendShape =
+        llvm::to_vector(sliceOperandType.getShape());
+    newExtendShape[extendDim] += (extendLhs + extendRhs);
+    auto newExtendType = RankedTensorType::get(
+        newExtendShape, sliceOperandType.getElementType());
+
+    auto newExtendOp = rewriter.create<enzymexla::ExtendOp>(
+        loc, newExtendType, sliceOp.getOperand(), extendDim, extendLhs,
+        extendRhs);
+
+    // Create the new SliceOp operating on the result of the new ExtendOp
+    SmallVector<int64_t> newSliceStarts =
+        llvm::to_vector(sliceOp.getStartIndices());
+    SmallVector<int64_t> newSliceLimits =
+        llvm::to_vector(sliceOp.getLimitIndices());
+    SmallVector<int64_t> newSliceStrides =
+        llvm::to_vector(sliceOp.getStrides());
+
+    RankedTensorType newExtendResultType = newExtendOp.getResult().getType().cast<RankedTensorType>();
+    newSliceStarts[extendDim] = 0; // Start from the beginning of the padded dim
+    newSliceLimits[extendDim] = newExtendResultType.getDimSize(extendDim); // Go to the end of the padded dim
+    newSliceStrides[extendDim] = 1; // Stride must be 1 for this dim to maintain contiguity assumption
+
+
+    // The result type of the new slice should match the original extend result type
+    auto newSliceOp = rewriter.create<stablehlo::SliceOp>(
+        loc, extendResultType, newExtendOp.getResult(), newSliceStarts,
+        newSliceLimits, newSliceStrides);
+
+    rewriter.replaceOp(extendOp, newSliceOp.getResult());
+
+    return success();
+  }
+};
+
+
 struct ConcatConcatAxisSwap final
     : OpRewritePattern<mlir::stablehlo::ConcatenateOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -15105,6 +15198,8 @@ struct EnzymeHLOOptPass
 
     RewritePatternSet patterns(context);
     mlir::enzyme::populateWithGenerated(patterns);
+
+    patterns.add<SliceExtend>(context); // Add the new SliceExtend pattern
 
     patterns
         .add<AddSimplify, SubSimplify, AndSimplify, MaxSimplify, MinSimplify,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1498,6 +1498,11 @@ def RecognizeExtend : EnzymeHLOPatternOp<
   let patterns = ["RecognizeExtend"];
 }
 
+def SliceExtend : EnzymeHLOPatternOp<
+  "slice_extend"> {
+  let patterns = ["SliceExtend"];
+}
+
 def LowerExtend : EnzymeHLOPatternOp<
     "lower_extend"> {
   let patterns = ["LowerExtend"];

--- a/test/lit_tests/sliceextend.mlir
+++ b/test/lit_tests/sliceextend.mlir
@@ -1,0 +1,23 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=slice_extend" --transform-interpreter --enzyme-hlo-remove-transform %s | FileCheck %s
+
+func.func @extend_operations(%arg28: tensor<1x24x96xf64>, %5290: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
+  %11825 = stablehlo.slice %5290 [0:1, 0:8, 72:80] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
+  %11826 = stablehlo.slice %5290 [0:1, 0:8, 0:8] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
+  %11827 = stablehlo.slice %arg28 [0:1, 17:24, 8:88] : (tensor<1x24x96xf64>) -> tensor<1x7x80xf64>
+  %11828 = "enzymexla.extend"(%5290) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+  %11829 = "enzymexla.extend"(%11826) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
+  %11830 = "enzymexla.extend"(%11825) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
+
+  return %11828, %11829, %11830 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
+}
+
+// CHECK:     module {
+// CHECK-NEXT:   func.func @extend_operations(%arg0: tensor<1x24x96xf64>, %arg1: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
+// CHECK-NEXT:     %0 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+// CHECK-NEXT:     %1 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+// CHECK-NEXT:     %2 = stablehlo.slice %1 [0:1, 0:10, 0:8] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
+// CHECK-NEXT:     %3 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+// CHECK-NEXT:     %4 = stablehlo.slice %3 [0:1, 0:10, 72:80] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
+// CHECK-NEXT:     return %0, %2, %4 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
fixes https://github.com/EnzymeAD/Enzyme-JAX/issues/713

```mlir
// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=slice_extend" --transform-interpreter --enzyme-hlo-remove-transform %s | FileCheck %s

func.func @extend_operations(%arg28: tensor<1x24x96xf64>, %5290: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
  %11825 = stablehlo.slice %5290 [0:1, 0:8, 72:80] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
  %11826 = stablehlo.slice %5290 [0:1, 0:8, 0:8] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
  %11827 = stablehlo.slice %arg28 [0:1, 17:24, 8:88] : (tensor<1x24x96xf64>) -> tensor<1x7x80xf64>
  %11828 = "enzymexla.extend"(%5290) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
  %11829 = "enzymexla.extend"(%11826) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
  %11830 = "enzymexla.extend"(%11825) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>

  return %11828, %11829, %11830 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
}
```
now becomes
```mlir
module {
  func.func @extend_operations(%arg0: tensor<1x24x96xf64>, %arg1: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
    %0 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
    %1 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
    %2 = stablehlo.slice %1 [0:1, 0:10, 0:8] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
    %3 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
    %4 = stablehlo.slice %3 [0:1, 0:10, 72:80] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
    return %0, %2, %4 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
  }
}
```