### PR TITLE
Finish up extend of slice becomes slice of extend

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8344,7 +8344,8 @@ struct DUSSliceSimplify final
         });
 
     LLVM_DEBUG(
-        for (auto [idx, operandSize, updateSize] : llvm::zip_equal(
+        for (auto [idx, operandSize, updateSize]
+             : llvm::zip_equal(
                  newDusIndices,
                  preSliceOperand.getType().cast<RankedTensorType>().getShape(),
                  preSliceUpdate.getType()

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -14874,6 +14874,99 @@ bool isAxisFusible(int dimension, ArrayRef<Value> vals) {
   return false;
 }
 
+// Pattern:
+//   %slice = stablehlo.slice %operand [...]
+//   %extend = enzymexla.extend %slice, dim=D, lhs=L, rhs=R
+// Constraint:
+//   - %slice has only %extend as its user.
+//   - The slice operation does not modify dimension D (i.e., it takes the
+//     full extent of dimension D).
+// Rewrite to:
+//   %new_extend = enzymexla.extend %operand, dim=D, lhs=L, rhs=R // Type adjusted
+//   %new_slice = stablehlo.slice %new_extend [...] // Indices adjusted for lhs padding
+struct SliceExtend final : OpRewritePattern<enzymexla::ExtendOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(enzymexla::ExtendOp extendOp,
+                                PatternRewriter &rewriter) const override {
+    Value extendOperand = extendOp.getOperand();
+    auto sliceOp = extendOperand.getDefiningOp<stablehlo::SliceOp>();
+
+    if (!sliceOp) {
+      return rewriter.notifyMatchFailure(extendOp, "Operand is not a SliceOp");
+    }
+
+    if (!sliceOp->hasOneUse()) {
+      return rewriter.notifyMatchFailure(extendOp, "SliceOp has multiple users");
+    }
+
+    auto sliceOperandType =
+        dyn_cast<RankedTensorType>(sliceOp.getOperand().getType());
+    auto sliceResultType = dyn_cast<RankedTensorType>(sliceOp.getType());
+    auto extendResultType = dyn_cast<RankedTensorType>(extendOp.getType());
+
+    if (!sliceOperandType || !sliceResultType || !extendResultType ||
+        !sliceOperandType.hasStaticShape() ||
+        !sliceResultType.hasStaticShape() ||
+        !extendResultType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(
+          extendOp, "Requires static shapes for involved tensors");
+    }
+
+    int64_t extendDim = extendOp.getDimension();
+    int64_t extendLhs = extendOp.getLhs();
+    int64_t extendRhs = extendOp.getRhs();
+
+    // Check if the slice operation affects the extended dimension.
+    if (sliceOp.getStartIndices()[extendDim] != 0 ||
+        sliceOp.getLimitIndices()[extendDim] !=
+            sliceOperandType.getShape()[extendDim] ||
+        sliceOp.getStrides()[extendDim] != 1) {
+      return rewriter.notifyMatchFailure(
+          extendOp, "SliceOp modifies the dimension being extended");
+    }
+
+    // --- Constraints met, proceed with rewrite ---
+
+    Location loc = extendOp.getLoc();
+
+    // Create the new ExtendOp operating on the original slice's operand
+    SmallVector<int64_t> newExtendShape =
+        llvm::to_vector(sliceOperandType.getShape());
+    newExtendShape[extendDim] += (extendLhs + extendRhs);
+    auto newExtendType = RankedTensorType::get(
+        newExtendShape, sliceOperandType.getElementType());
+
+    auto newExtendOp = rewriter.create<enzymexla::ExtendOp>(
+        loc, newExtendType, sliceOp.getOperand(), extendDim, extendLhs,
+        extendRhs);
+
+    // Create the new SliceOp operating on the result of the new ExtendOp
+    SmallVector<int64_t> newSliceStarts =
+        llvm::to_vector(sliceOp.getStartIndices());
+    SmallVector<int64_t> newSliceLimits =
+        llvm::to_vector(sliceOp.getLimitIndices());
+    SmallVector<int64_t> newSliceStrides =
+        llvm::to_vector(sliceOp.getStrides());
+
+    RankedTensorType newExtendResultType = newExtendOp.getResult().getType().cast<RankedTensorType>();
+    newSliceStarts[extendDim] = 0; // Start from the beginning of the padded dim
+    newSliceLimits[extendDim] = newExtendResultType.getDimSize(extendDim); // Go to the end of the padded dim
+    newSliceStrides[extendDim] = 1; // Stride must be 1 for this dim to maintain contiguity assumption
+
+
+    // The result type of the new slice should match the original extend result type
+    auto newSliceOp = rewriter.create<stablehlo::SliceOp>(
+        loc, extendResultType, newExtendOp.getResult(), newSliceStarts,
+        newSliceLimits, newSliceStrides);
+
+    rewriter.replaceOp(extendOp, newSliceOp.getResult());
+
+    return success();
+  }
+};
+
+
 struct ConcatConcatAxisSwap final
     : OpRewritePattern<mlir::stablehlo::ConcatenateOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -15105,6 +15198,8 @@ struct EnzymeHLOOptPass
 
     RewritePatternSet patterns(context);
     mlir::enzyme::populateWithGenerated(patterns);
+
+    patterns.add<SliceExtend>(context); // Add the new SliceExtend pattern
 
     patterns
         .add<AddSimplify, SubSimplify, AndSimplify, MaxSimplify, MinSimplify,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -15106,26 +15106,6 @@ struct SliceExtend final : OpRewritePattern<enzymexla::ExtendOp> {
             newSliceLimits[targetExtendDim] = newBaseExtendResultType.getDimSize(targetExtendDim);
             newSliceStrides[targetExtendDim] = 1;
 
-            oldExtendOp.dump();
-            oldSliceOp.dump();
-            llvm::outs() << oldExtendOp.getLoc() << "\n";
-            llvm::outs() << newBaseExtendResult << "\n";
-            llvm::outs() << "[";
-            for (auto s : newSliceStarts) {
-                llvm::outs() << s << ", ";
-            }
-            llvm::outs() << "]\n";
-            llvm::outs() << "[";
-            for (auto l : newSliceLimits) {
-                llvm::outs() << l << ", ";
-            }
-            llvm::outs() << "]\n";
-            // llvm::outs() << newSliceStarts << "\n";
-            // llvm::outs() << newSliceLimits << "\n"
-
-
-            llvm::outs() << "creating newSlice\n";
-
             auto newSlice = rewriter.create<stablehlo::SliceOp>(
                 oldExtendOp.getLoc(),
                 oldExtendOp.getResult().getType(), // Use original extend op's result type
@@ -15134,8 +15114,6 @@ struct SliceExtend final : OpRewritePattern<enzymexla::ExtendOp> {
                 newSliceLimits,
                 newSliceStrides);
             rewriter.replaceAllOpUsesWith(oldExtendOp, newSlice.getResult());
-
-            // rewriter.replaceOp(oldExtendOp, newSlice.getResult());
         }
     }
 

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -15014,17 +15014,6 @@ bool isAxisFusible(int dimension, ArrayRef<Value> vals) {
   return false;
 }
 
-// Pattern:
-//   %slice = stablehlo.slice %operand [...]
-//   %extend = enzymexla.extend %slice, dim=D, lhs=L, rhs=R
-// Constraint:
-//   - %slice has only %extend as its user.
-//   - The slice operation does not modify dimension D (i.e., it takes the
-//     full extent of dimension D).
-// Rewrite to:
-//   %new_extend = enzymexla.extend %operand, dim=D, lhs=L, rhs=R // Type
-//   adjusted %new_slice = stablehlo.slice %new_extend [...] // Indices adjusted
-//   for lhs padding
 struct SliceExtend final : OpRewritePattern<enzymexla::ExtendOp> {
   using OpRewritePattern::OpRewritePattern;
 

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -14999,84 +14999,145 @@ bool isAxisFusible(int dimension, ArrayRef<Value> vals) {
 struct SliceExtend final : OpRewritePattern<enzymexla::ExtendOp> {
   using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(enzymexla::ExtendOp extendOp,
+  struct CandidateInfo {
+    enzymexla::ExtendOp extendOp;
+    stablehlo::SliceOp sliceOp; // Null if it's a direct extend user
+  };
+
+  LogicalResult matchAndRewrite(enzymexla::ExtendOp triggerExtendOp,
                                 PatternRewriter &rewriter) const override {
-    Value extendOperand = extendOp.getOperand();
-    auto sliceOp = extendOperand.getDefiningOp<stablehlo::SliceOp>();
 
-    if (!sliceOp) {
-      return rewriter.notifyMatchFailure(extendOp, "Operand is not a SliceOp");
+    Value triggerOperand = triggerExtendOp.getOperand();
+    auto triggerSliceOp = triggerOperand.getDefiningOp<stablehlo::SliceOp>();
+
+    if (!triggerSliceOp) {
+       return failure();
     }
 
-    if (!sliceOp->hasOneUse()) {
-      return rewriter.notifyMatchFailure(extendOp,
-                                         "SliceOp has multiple users");
+    Value baseOperand = triggerSliceOp.getOperand();
+
+    // --- Get Target Extension Parameters ---
+    int64_t targetExtendDim = triggerExtendOp.getDimension();
+    int64_t targetLhs = triggerExtendOp.getLhs();
+    int64_t targetRhs = triggerExtendOp.getRhs();
+    Location loc = triggerExtendOp.getLoc();
+
+    // --- Check Validity of Trigger Slice ---
+    auto baseOperandType = dyn_cast<RankedTensorType>(baseOperand.getType());
+    if (!baseOperandType || !baseOperandType.hasStaticShape()) {
+         return rewriter.notifyMatchFailure(triggerExtendOp, "Base operand requires static shape");
+    }
+    if (triggerSliceOp.getStartIndices()[targetExtendDim] != 0 ||
+        triggerSliceOp.getLimitIndices()[targetExtendDim] !=
+            baseOperandType.getShape()[targetExtendDim] ||
+        triggerSliceOp.getStrides()[targetExtendDim] != 1) {
+       return rewriter.notifyMatchFailure(triggerExtendOp, "Trigger SliceOp modifies the dimension being extended");
     }
 
-    auto sliceOperandType =
-        dyn_cast<RankedTensorType>(sliceOp.getOperand().getType());
-    auto sliceResultType = dyn_cast<RankedTensorType>(sliceOp.getType());
-    auto extendResultType = dyn_cast<RankedTensorType>(extendOp.getType());
+    llvm::SmallVector<CandidateInfo> candidates;
+    candidates.push_back({triggerExtendOp, triggerSliceOp});
 
-    if (!sliceOperandType || !sliceResultType || !extendResultType ||
-        !sliceOperandType.hasStaticShape() ||
-        !sliceResultType.hasStaticShape() ||
-        !extendResultType.hasStaticShape()) {
-      return rewriter.notifyMatchFailure(
-          extendOp, "Requires static shapes for involved tensors");
+    for (auto const& userOp : baseOperand.getUsers()) {
+        // Skip the slice that defines the trigger operand
+        if (userOp == triggerSliceOp.getOperation()) continue;
+
+        // Case 1: Direct Extend
+        if (auto directExtend = dyn_cast<enzymexla::ExtendOp>(userOp)) {
+            if (directExtend.getDimension() == targetExtendDim &&
+                directExtend.getLhs() == targetLhs &&
+                directExtend.getRhs() == targetRhs)
+            {
+                candidates.push_back({directExtend, nullptr});
+            }
+        }
+        // Case 2: Extend of Slice
+        else if (auto sliceUser = dyn_cast<stablehlo::SliceOp>(userOp)) {
+            if (!sliceUser->hasOneUse()) continue;
+            auto extendOfSlice = dyn_cast<enzymexla::ExtendOp>(*sliceUser->user_begin());
+            if (!extendOfSlice) continue;
+
+            if (extendOfSlice.getDimension() == targetExtendDim &&
+                extendOfSlice.getLhs() == targetLhs &&
+                extendOfSlice.getRhs() == targetRhs)
+            {
+                // Check validity: sliceUser must not modify targetExtendDim
+                if (sliceUser.getStartIndices()[targetExtendDim] == 0 &&
+                    sliceUser.getLimitIndices()[targetExtendDim] ==
+                        baseOperandType.getShape()[targetExtendDim] &&
+                    sliceUser.getStrides()[targetExtendDim] == 1)
+                {
+                     candidates.push_back({extendOfSlice, sliceUser});
+                }
+            }
+        }
     }
 
-    int64_t extendDim = extendOp.getDimension();
-    int64_t extendLhs = extendOp.getLhs();
-    int64_t extendRhs = extendOp.getRhs();
-
-    // Check if the slice operation affects the extended dimension.
-    if (sliceOp.getStartIndices()[extendDim] != 0 ||
-        sliceOp.getLimitIndices()[extendDim] !=
-            sliceOperandType.getShape()[extendDim] ||
-        sliceOp.getStrides()[extendDim] != 1) {
-      return rewriter.notifyMatchFailure(
-          extendOp, "SliceOp modifies the dimension being extended");
+    if (candidates.size() <= 1) {
+        return rewriter.notifyMatchFailure(triggerExtendOp, "Rewrite condition not met (only found the trigger candidate)");
     }
 
-    // --- Constraints met, proceed with rewrite ---
+    SmallVector<int64_t> newBaseExtendShape = llvm::to_vector(baseOperandType.getShape());
+    newBaseExtendShape[targetExtendDim] += (targetLhs + targetRhs);
+    auto newBaseExtendType = RankedTensorType::get(newBaseExtendShape, baseOperandType.getElementType());
 
-    Location loc = extendOp.getLoc();
+    auto newBaseExtendOp = rewriter.create<enzymexla::ExtendOp>(
+        loc, newBaseExtendType, baseOperand, targetExtendDim, targetLhs, targetRhs);
+    Value newBaseExtendResult = newBaseExtendOp.getResult();
+    RankedTensorType newBaseExtendResultType = newBaseExtendResult.getType().cast<RankedTensorType>();
 
-    // Create the new ExtendOp operating on the original slice's operand
-    SmallVector<int64_t> newExtendShape =
-        llvm::to_vector(sliceOperandType.getShape());
-    newExtendShape[extendDim] += (extendLhs + extendRhs);
-    auto newExtendType = RankedTensorType::get(
-        newExtendShape, sliceOperandType.getElementType());
+    for (const auto& candidate : candidates) {
+        enzymexla::ExtendOp oldExtendOp = candidate.extendOp;
+        stablehlo::SliceOp oldSliceOp = candidate.sliceOp; // Might be null
 
-    auto newExtendOp = rewriter.create<enzymexla::ExtendOp>(
-        loc, newExtendType, sliceOp.getOperand(), extendDim, extendLhs,
-        extendRhs);
+        if (!oldSliceOp) {
+            // Direct Extend - Replace directly
+             if (oldExtendOp.getResult().getType() == newBaseExtendResult.getType()) {
+                 rewriter.replaceOp(oldExtendOp, newBaseExtendResult);
+            } else {
+                 auto castOp = rewriter.create<tensor::CastOp>(loc, oldExtendOp.getResult().getType(), newBaseExtendResult);
+                 rewriter.replaceOp(oldExtendOp, castOp);
+            }
+        } else {
+            SmallVector<int64_t> newSliceStarts = llvm::to_vector(oldSliceOp.getStartIndices());
+            SmallVector<int64_t> newSliceLimits = llvm::to_vector(oldSliceOp.getLimitIndices());
+            SmallVector<int64_t> newSliceStrides = llvm::to_vector(oldSliceOp.getStrides());
 
-    // Create the new SliceOp operating on the result of the new ExtendOp
-    SmallVector<int64_t> newSliceStarts =
-        llvm::to_vector(sliceOp.getStartIndices());
-    SmallVector<int64_t> newSliceLimits =
-        llvm::to_vector(sliceOp.getLimitIndices());
-    SmallVector<int64_t> newSliceStrides =
-        llvm::to_vector(sliceOp.getStrides());
+            newSliceStarts[targetExtendDim] = 0;
+            newSliceLimits[targetExtendDim] = newBaseExtendResultType.getDimSize(targetExtendDim);
+            newSliceStrides[targetExtendDim] = 1;
 
-    RankedTensorType newExtendResultType =
-        newExtendOp.getResult().getType().cast<RankedTensorType>();
-    newSliceStarts[extendDim] = 0; // Start from the beginning of the padded dim
-    newSliceLimits[extendDim] = newExtendResultType.getDimSize(
-        extendDim); // Go to the end of the padded dim
-    newSliceStrides[extendDim] =
-        1; // Stride must be 1 for this dim to maintain contiguity assumption
+            oldExtendOp.dump();
+            oldSliceOp.dump();
+            llvm::outs() << oldExtendOp.getLoc() << "\n";
+            llvm::outs() << newBaseExtendResult << "\n";
+            llvm::outs() << "[";
+            for (auto s : newSliceStarts) {
+                llvm::outs() << s << ", ";
+            }
+            llvm::outs() << "]\n";
+            llvm::outs() << "[";
+            for (auto l : newSliceLimits) {
+                llvm::outs() << l << ", ";
+            }
+            llvm::outs() << "]\n";
+            // llvm::outs() << newSliceStarts << "\n";
+            // llvm::outs() << newSliceLimits << "\n"
 
-    // The result type of the new slice should match the original extend result
-    // type
-    auto newSliceOp = rewriter.create<stablehlo::SliceOp>(
-        loc, extendResultType, newExtendOp.getResult(), newSliceStarts,
-        newSliceLimits, newSliceStrides);
 
-    rewriter.replaceOp(extendOp, newSliceOp.getResult());
+            llvm::outs() << "creating newSlice\n";
+
+            auto newSlice = rewriter.create<stablehlo::SliceOp>(
+                oldExtendOp.getLoc(),
+                oldExtendOp.getResult().getType(), // Use original extend op's result type
+                newBaseExtendResult,
+                newSliceStarts,
+                newSliceLimits,
+                newSliceStrides);
+            rewriter.replaceAllOpUsesWith(oldExtendOp, newSlice.getResult());
+
+            // rewriter.replaceOp(oldExtendOp, newSlice.getResult());
+        }
+    }
 
     return success();
   }

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8374,7 +8374,8 @@ struct DUSSliceSimplify final
         });
 
     LLVM_DEBUG(
-        for (auto [idx, operandSize, updateSize] : llvm::zip_equal(
+        for (auto [idx, operandSize, updateSize]
+             : llvm::zip_equal(
                  newDusIndices,
                  preSliceOperand.getType().cast<RankedTensorType>().getShape(),
                  preSliceUpdate.getType()

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1498,6 +1498,11 @@ def RecognizeExtend : EnzymeHLOPatternOp<
   let patterns = ["RecognizeExtend"];
 }
 
+def SliceExtend : EnzymeHLOPatternOp<
+  "slice_extend"> {
+  let patterns = ["SliceExtend"];
+}
+
 def LowerExtend : EnzymeHLOPatternOp<
     "lower_extend"> {
   let patterns = ["LowerExtend"];

--- a/test/lit_tests/sliceextend.mlir
+++ b/test/lit_tests/sliceextend.mlir
@@ -1,0 +1,23 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=slice_extend" --transform-interpreter --enzyme-hlo-remove-transform %s | FileCheck %s
+
+func.func @extend_operations(%arg28: tensor<1x24x96xf64>, %5290: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
+  %11825 = stablehlo.slice %5290 [0:1, 0:8, 72:80] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
+  %11826 = stablehlo.slice %5290 [0:1, 0:8, 0:8] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
+  %11827 = stablehlo.slice %arg28 [0:1, 17:24, 8:88] : (tensor<1x24x96xf64>) -> tensor<1x7x80xf64>
+  %11828 = "enzymexla.extend"(%5290) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+  %11829 = "enzymexla.extend"(%11826) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
+  %11830 = "enzymexla.extend"(%11825) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
+
+  return %11828, %11829, %11830 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
+}
+
+// CHECK:     module {
+// CHECK-NEXT:   func.func @extend_operations(%arg0: tensor<1x24x96xf64>, %arg1: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
+// CHECK-NEXT:     %0 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+// CHECK-NEXT:     %1 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+// CHECK-NEXT:     %2 = stablehlo.slice %1 [0:1, 0:10, 0:8] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
+// CHECK-NEXT:     %3 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+// CHECK-NEXT:     %4 = stablehlo.slice %3 [0:1, 0:10, 72:80] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
+// CHECK-NEXT:     return %0, %2, %4 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/sliceextend.mlir
+++ b/test/lit_tests/sliceextend.mlir
@@ -1,23 +1,19 @@
 // RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=slice_extend" --transform-interpreter --enzyme-hlo-remove-transform %s | FileCheck %s
 
-func.func @extend_operations(%arg28: tensor<1x24x96xf64>, %5290: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
-  %11825 = stablehlo.slice %5290 [0:1, 0:8, 72:80] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
-  %11826 = stablehlo.slice %5290 [0:1, 0:8, 0:8] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
-  %11827 = stablehlo.slice %arg28 [0:1, 17:24, 8:88] : (tensor<1x24x96xf64>) -> tensor<1x7x80xf64>
-  %11828 = "enzymexla.extend"(%5290) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
-  %11829 = "enzymexla.extend"(%11826) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
-  %11830 = "enzymexla.extend"(%11825) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
-
-  return %11828, %11829, %11830 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
+func.func @extend_operations(%arg0: tensor<1x24x96xf64>, %arg1: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
+  %0 = stablehlo.slice %arg1 [0:1, 0:8, 72:80] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
+  %1 = stablehlo.slice %arg1 [0:1, 0:8, 0:8] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
+  %2 = stablehlo.slice %arg0 [0:1, 17:24, 8:88] : (tensor<1x24x96xf64>) -> tensor<1x7x80xf64>
+  %3 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+  %4 = "enzymexla.extend"(%1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
+  %5 = "enzymexla.extend"(%0) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
+  return %3, %4, %5 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
 }
 
-// CHECK:     module {
-// CHECK-NEXT:   func.func @extend_operations(%arg0: tensor<1x24x96xf64>, %arg1: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
-// CHECK-NEXT:     %0 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
-// CHECK-NEXT:     %1 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
-// CHECK-NEXT:     %2 = stablehlo.slice %1 [0:1, 0:10, 0:8] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
-// CHECK-NEXT:     %3 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
-// CHECK-NEXT:     %4 = stablehlo.slice %3 [0:1, 0:10, 72:80] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
-// CHECK-NEXT:     return %0, %2, %4 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
-// CHECK-NEXT:   }
+
+// CHECK:      func.func @extend_operations(%arg0: tensor<1x24x96xf64>, %arg1: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
+// CHECK-NEXT:   %0 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
+// CHECK-NEXT:   %1 = stablehlo.slice %0 [0:1, 0:10, 72:80] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
+// CHECK-NEXT:   %2 = stablehlo.slice %0 [0:1, 0:10, 0:8] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
+// CHECK-NEXT:   return %0, %2, %1 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
 // CHECK-NEXT: }


### PR DESCRIPTION
matches `slice(extend(base))` and now collects all uses of the base operand that are either:
* the same extendop as the one previously matched
* a slice op that doesn't alter the extended dimension, followed by the same extendop.
And creates a single extendop at the top.
from:
```mlir
func.func @extend_operations(%arg0: tensor<1x24x96xf64>, %arg1: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
  %0 = stablehlo.slice %arg1 [0:1, 0:8, 72:80] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
  %1 = stablehlo.slice %arg1 [0:1, 0:8, 0:8] : (tensor<1x8x80xf64>) -> tensor<1x8x8xf64>
  %2 = stablehlo.slice %arg0 [0:1, 17:24, 8:88] : (tensor<1x24x96xf64>) -> tensor<1x7x80xf64>
  %3 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
  %4 = "enzymexla.extend"(%1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
  %5 = "enzymexla.extend"(%0) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x8xf64>) -> tensor<1x10x8xf64>
  return %3, %4, %5 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
}
```
to
```mlir
func.func @extend_operations(%arg0: tensor<1x24x96xf64>, %arg1: tensor<1x8x80xf64>) -> (tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>) {
  %0 = "enzymexla.extend"(%arg1) <{dimension = 1 : i64, lhs = 1 : i64, rhs = 1 : i64}> : (tensor<1x8x80xf64>) -> tensor<1x10x80xf64>
  %1 = stablehlo.slice %0 [0:1, 0:10, 72:80] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
  %2 = stablehlo.slice %0 [0:1, 0:10, 0:8] : (tensor<1x10x80xf64>) -> tensor<1x10x8xf64>
  return %0, %2, %1 : tensor<1x10x80xf64>, tensor<1x10x8xf64>, tensor<1x10x8xf64>
}
```