### PR TITLE
feat: fuse dot_general + elem into cudnn fusion

### DIFF
--- a/src/enzyme_ad/jax/Passes/CuDNNHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/CuDNNHLOOpt.cpp
@@ -1,0 +1,165 @@
+#include "mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/enzyme_ad/jax/Dialect/Dialect.h"
+#include "src/enzyme_ad/jax/Dialect/Ops.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "llvm/ADT/DynamicAPInt.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/MathExtras.h"
+#include <algorithm>
+#include <cstdint>
+
+#define DEBUG_TYPE "enzymexla-cudnn-hlo-opt"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_CUDNNHLOOPT
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::enzyme;
+
+constexpr llvm::StringLiteral kCuDNNFusionFuncPrefix =
+    "__cudnn_fused_elementwise_dot_";
+
+// TODO: use template to generalize to other elementwise ops
+// TODO: capture intermediate convert ops as well
+struct DotGeneralElementwiseToCuDNNFusion
+    : public OpRewritePattern<stablehlo::AddOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(stablehlo::AddOp elemOp,
+                                PatternRewriter &rewriter) const override {
+    auto lhs = elemOp.getLhs();
+    auto rhs = elemOp.getRhs();
+
+    func::FuncOp parentFunc = elemOp->getParentOfType<func::FuncOp>();
+    if (!parentFunc)
+      return rewriter.notifyMatchFailure(elemOp, "No parent func found");
+
+    if (parentFunc.getSymName().starts_with(kCuDNNFusionFuncPrefix))
+      return failure();
+
+    auto lhsDotGeneral = lhs.getDefiningOp<stablehlo::DotGeneralOp>();
+    auto rhsDotGeneral = rhs.getDefiningOp<stablehlo::DotGeneralOp>();
+
+    if (!lhsDotGeneral && !rhsDotGeneral)
+      return failure();
+
+    if (lhsDotGeneral && rhsDotGeneral)
+      return failure();
+
+    stablehlo::DotGeneralOp dotGeneral;
+    bool dotGeneralIsLhs;
+    if (lhsDotGeneral) {
+      dotGeneral = lhsDotGeneral;
+      dotGeneralIsLhs = true;
+    } else {
+      dotGeneral = rhsDotGeneral;
+      dotGeneralIsLhs = false;
+    }
+
+    // TODO: does cudnn allow returning intermediate results?
+    if (!dotGeneral->hasOneUse())
+      return failure();
+
+    ModuleOp mod = elemOp->getParentOfType<ModuleOp>();
+    if (!mod)
+      return rewriter.notifyMatchFailure(elemOp, "No module found");
+
+    static int fusionCounter = 0;
+    std::string fnName =
+        (kCuDNNFusionFuncPrefix + std::to_string(fusionCounter)).str();
+    auto fnSym = rewriter.getStringAttr(fnName);
+    fusionCounter++;
+
+    // Input Types
+    auto dotGeneralLhsTy = dotGeneral.getLhs().getType();
+    auto dotGeneralRhsTy = dotGeneral.getRhs().getType();
+    Value elemOther;
+    Type elemOtherTy;
+    if (dotGeneralIsLhs) {
+      elemOther = rhs;
+      elemOtherTy = cast<RankedTensorType>(rhs.getType());
+    } else {
+      elemOther = lhs;
+      elemOtherTy = cast<RankedTensorType>(lhs.getType());
+    }
+
+    auto resultTy = elemOp.getType();
+
+    // Replace with a custom call
+    auto customCall = rewriter.replaceOpWithNewOp<stablehlo::CustomCallOp>(
+        elemOp, TypeRange{resultTy},
+        ValueRange{dotGeneral.getLhs(), dotGeneral.getRhs(), elemOther},
+        rewriter.getStringAttr("__cudnn$fusion"),
+        /*has_side_effect=*/rewriter.getBoolAttr(false),
+        /*backend_config=*/nullptr,
+        /*api_version=*/nullptr,
+        /*called_computations=*/
+        ArrayAttr::get(rewriter.getContext(), {FlatSymbolRefAttr::get(fnSym)}),
+        /*operand_layouts=*/nullptr,
+        /*result_layouts=*/nullptr,
+        /*output_operand_aliases=*/nullptr);
+
+    auto funcTy = rewriter.getFunctionType(
+        {dotGeneralLhsTy, dotGeneralRhsTy, elemOtherTy}, {resultTy});
+
+    // Construct the fusion function
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(mod.getBody());
+
+      auto funcOp =
+          rewriter.create<func::FuncOp>(elemOp.getLoc(), fnSym, funcTy);
+      funcOp.setVisibility(SymbolTable::Visibility::Private);
+      funcOp.setNoInlineAttr(rewriter.getUnitAttr());
+      auto &entryBlock = *funcOp.addEntryBlock();
+      rewriter.setInsertionPointToStart(&entryBlock);
+
+      auto arg0 = entryBlock.getArgument(0);
+      auto arg1 = entryBlock.getArgument(1);
+      auto arg2 = entryBlock.getArgument(2);
+
+      auto newDotGeneral = rewriter.create<stablehlo::DotGeneralOp>(
+          elemOp.getLoc(), dotGeneral.getType(), arg0, arg1,
+          dotGeneral.getDotDimensionNumbersAttr(),
+          dotGeneral.getPrecisionConfigAttr(), dotGeneral.getAlgorithmAttr());
+      Value newElementwise;
+      if (dotGeneralIsLhs) {
+        newElementwise = rewriter.create<stablehlo::AddOp>(elemOp.getLoc(),
+                                                           newDotGeneral, arg2);
+      } else {
+        newElementwise = rewriter.create<stablehlo::AddOp>(elemOp.getLoc(),
+                                                           arg2, newDotGeneral);
+      }
+      rewriter.create<func::ReturnOp>(elemOp.getLoc(), newElementwise);
+    }
+
+    return success();
+  }
+};
+
+struct CuDNNHLOOptPass : public enzyme::impl::CuDNNHLOOptBase<CuDNNHLOOptPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    auto context = getOperation()->getContext();
+    RewritePatternSet patterns(context);
+
+    patterns.add<DotGeneralElementwiseToCuDNNFusion>(context);
+
+    GreedyRewriteConfig config;
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                            config))) {
+      signalPassFailure();
+    }
+  }
+};

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -519,10 +519,18 @@ def AffineCFG : Pass<"affine-cfg"> {
   ];
 }
 
+def CuDNNHLOOpt : Pass<"enzymexla-cudnn-hlo-opt"> {
+  let summary = "Optimize stablehlo to emit cuDNN specific optimizations";
+  let dependentDialects = [
+    "stablehlo::StablehloDialect",
+    "enzymexla::EnzymeXLADialect",
+  ];
+}
+
 def OptimizeCommunication : Pass<"optimize-communication"> {
   let summary = "Optimize communication";
   let dependentDialects = [
-    "stablehlo::StablehloDialect",  
+    "stablehlo::StablehloDialect",
     "sdy::SdyDialect",
   ];
   let options =

--- a/test/lit_tests/cudnn/fusion.mlir
+++ b/test/lit_tests/cudnn/fusion.mlir
@@ -1,0 +1,7 @@
+// RUN: enzymexlamlir-opt --enzymexla-cudnn-hlo-opt %s | FileCheck %s
+
+func.func @dense1(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> (tensor<4x16x16xbf16>) {
+    %1 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+    %2 = stablehlo.add %1, %arg2 : tensor<4x16x16xbf16>
+    return %2 : tensor<4x16x16xbf16>
+}

--- a/test/lit_tests/cudnn/fusion.mlir
+++ b/test/lit_tests/cudnn/fusion.mlir
@@ -1,7 +1,38 @@
 // RUN: enzymexlamlir-opt --enzymexla-cudnn-hlo-opt %s | FileCheck %s
 
-func.func @dense1(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> (tensor<4x16x16xbf16>) {
-    %1 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
-    %2 = stablehlo.add %1, %arg2 : tensor<4x16x16xbf16>
-    return %2 : tensor<4x16x16xbf16>
+module {
+    func.func @dense1(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> (tensor<4x16x16xbf16>) {
+        %1 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+        %2 = stablehlo.add %1, %arg2 : tensor<4x16x16xbf16>
+        return %2 : tensor<4x16x16xbf16>
+    }
 }
+
+// CHECK: func.func private @__cudnn_fused_elementwise_dot_0(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> attributes {no_inline} {
+// CHECK-NEXT:    %0 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %arg2 : tensor<4x16x16xbf16>
+// CHECK-NEXT:    return %1 : tensor<4x16x16xbf16>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @dense1(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> {
+// CHECK-NEXT:    %0 = stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_0]} : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+// CHECK-NEXT:    return %0 : tensor<4x16x16xbf16>
+// CHECK-NEXT:  }
+
+
+module {
+    func.func @dense2(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> (tensor<4x16x16xbf16>) {
+        %1 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+        %2 = stablehlo.subtract %arg2, %1 : tensor<4x16x16xbf16>
+        return %2 : tensor<4x16x16xbf16>
+    }
+}
+
+// CHECK: func.func private @__cudnn_fused_elementwise_dot_0(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> attributes {no_inline} {
+// CHECK-NEXT:    %0 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+// CHECK-NEXT:    %1 = stablehlo.subtract %arg2, %0 : tensor<4x16x16xbf16>
+// CHECK-NEXT:    return %1 : tensor<4x16x16xbf16>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @dense2(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> {
+// CHECK-NEXT:    %0 = stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_0]} : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+// CHECK-NEXT:    return %0 : tensor<4x16x16xbf16>
+// CHECK-NEXT:  }


### PR DESCRIPTION
automates the `@cudnn_fusion` decorator for jax. Rn handles only the most basic cases, but we should be able to extend it to more complicated blocks later.

putting this into a separate pass since we might want to add some other passes for attention later on here