### PR TITLE
do not cache known iter count for whileop

### DIFF
--- a/test/lit_tests/diffrules/stablehlo/while6.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while6.mlir
@@ -1,5 +1,5 @@
 // RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup mode=ForwardMode" --canonicalize --arith-raise --enzyme-hlo-opt --remove-unnecessary-enzyme-ops --enzyme-hlo-opt --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=FORWARD
-// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --arith-raise --enzyme-hlo-opt --remove-unnecessary-enzyme-ops --enzyme-hlo-opt --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --arith-raise --enzyme-hlo-opt --remove-unnecessary-enzyme-ops --enzyme-hlo-opt | FileCheck %s --check-prefix=REVERSE
 
 func.func @main(%arg0: tensor<12x16x4xf32>) -> (tensor<12x4xf32>) {
   %c = stablehlo.constant dense<0> : tensor<i32>
@@ -44,19 +44,19 @@ func.func @main(%arg0: tensor<12x16x4xf32>) -> (tensor<12x4xf32>) {
 // FORWARD-NEXT:  }
 
 // REVERSE: func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x4xf32>) -> tensor<12x16x4xf32> {
-// REVERSE-NEXT:     %c = stablehlo.constant dense<15> : tensor<i64>
-// REVERSE-NEXT:     %c_0 = stablehlo.constant dense<14> : tensor<i64>
-// REVERSE-NEXT:     %cst = arith.constant dense<0> : tensor<15xi32>
+// REVERSE-NEXT:     %[[C14:.+]] = stablehlo.constant dense<14> : tensor<i64>
+// REVERSE-NEXT:     %[[ZERO:.+]] = arith.constant dense<0> : tensor<15xi32>
+// REVERSE-NEXT:     %[[C15:.+]] = stablehlo.constant dense<15> : tensor<i64>
 // REVERSE-NEXT:     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<12x16x4xf32>
 // REVERSE-NEXT:     %c_2 = stablehlo.constant dense<1> : tensor<i64>
 // REVERSE-NEXT:     %c_3 = stablehlo.constant dense<0> : tensor<i64>
 // REVERSE-NEXT:     %c_4 = stablehlo.constant dense<1> : tensor<i32>
-// REVERSE-NEXT:     %c_5 = stablehlo.constant dense<15> : tensor<i32>
+// REVERSE-NEXT:     %[[C15_I32:.+]] = stablehlo.constant dense<15> : tensor<i32>
 // REVERSE-NEXT:     %c_6 = stablehlo.constant dense<0> : tensor<i32>
 // REVERSE-NEXT:     %cst_7 = stablehlo.constant dense<0.000000e+00> : tensor<12x4xf32>
 // REVERSE-NEXT:     %[[a0:.+]]:2 = stablehlo.while(%iterArg = %c_6, %iterArg_8 = %cst) : tensor<i32>, tensor<15xi32>
 // REVERSE-NEXT:      cond {
-// REVERSE-NEXT:       %[[a7:.+]] = stablehlo.compare  LT, %iterArg, %c_5 : (tensor<i32>, tensor<i32>) -> tensor<i1>
+// REVERSE-NEXT:       %[[a7:.+]] = stablehlo.compare  LT, %iterArg, %[[C15_I32]] : (tensor<i32>, tensor<i32>) -> tensor<i1>
 // REVERSE-NEXT:       stablehlo.return %[[a7]] : tensor<i1>
 // REVERSE-NEXT:     } do {
 // REVERSE-NEXT:       %[[a7:.+]] = stablehlo.add %c_4, %iterArg : tensor<i32>
@@ -64,9 +64,9 @@ func.func @main(%arg0: tensor<12x16x4xf32>) -> (tensor<12x4xf32>) {
 // REVERSE-NEXT:       %[[a9:.+]] = stablehlo.dynamic_update_slice %iterArg_8, %[[a8]], %iterArg : (tensor<15xi32>, tensor<1xi32>, tensor<i32>) -> tensor<15xi32>
 // REVERSE-NEXT:       stablehlo.return %[[a7]], %[[a9]] : tensor<i32>, tensor<15xi32>
 // REVERSE-NEXT:     }
-// REVERSE-NEXT:     %[[a1:.+]]:3 = stablehlo.while(%iterArg = %c_3, %iterArg_8 = %c_0, %iterArg_9 = %cst_1) : tensor<i64>, tensor<i64>, tensor<12x16x4xf32>
+// REVERSE-NEXT:     %[[a1:.+]]:3 = stablehlo.while(%iterArg = %c_3, %iterArg_8 = %[[C14]], %iterArg_9 = %cst_1) : tensor<i64>, tensor<i64>, tensor<12x16x4xf32>
 // REVERSE-NEXT:      cond {
-// REVERSE-NEXT:       %[[a7:.+]] = stablehlo.compare  LT, %iterArg, %c_5 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       %[[a7:.+]] = stablehlo.compare  LT, %iterArg, %[[C15]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // REVERSE-NEXT:       stablehlo.return %[[a7]] : tensor<i1>
 // REVERSE-NEXT:     } do {
 // REVERSE-NEXT:       %[[a7:.+]] = stablehlo.compare  EQ, %iterArg, %c_3 : (tensor<i64>, tensor<i64>) -> tensor<i1>


### PR DESCRIPTION
Checking for ConstOp would not work in while6 because it was a pop.