### PR TITLE
Gatherinact

### DIFF
--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -3455,6 +3455,15 @@ struct StablehloSubSimplifyMathInterface
   }
 };
 
+struct GatherActivityInterface
+    : public ActivityOpInterface::ExternalModel<GatherActivityInterface,
+                                                GatherOp> {
+  bool isInactive(Operation *op) const { return false; }
+  bool isArgInactive(Operation *op, size_t i) const { 
+    return i != 0;
+  }
+};
+
 } // namespace
 
 void mlir::enzyme::registerStableHLODialectAutoDiffInterface(
@@ -3471,6 +3480,7 @@ void mlir::enzyme::registerStableHLODialectAutoDiffInterface(
     WhileOp::attachInterface<ADDataFlowWhileOp>(*context);
     SortOp::attachInterface<ADDataFlowSortOp>(*context);
     ScatterOp::attachInterface<ADDataFlowScatterOp>(*context);
+    GatherOp::attachInterface<GatherActivityInterface>(*context);
     ReduceOp::attachInterface<ADDataFlowReduceOp>(*context);
 
     CaseOp::attachInterface<RegionBranchCaseOp>(*context);

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -3459,9 +3459,7 @@ struct GatherActivityInterface
     : public ActivityOpInterface::ExternalModel<GatherActivityInterface,
                                                 GatherOp> {
   bool isInactive(Operation *op) const { return false; }
-  bool isArgInactive(Operation *op, size_t i) const { 
-    return i != 0;
-  }
+  bool isArgInactive(Operation *op, size_t i) const { return i != 0; }
 };
 
 } // namespace

--- a/test/jaxmd.py
+++ b/test/jaxmd.py
@@ -115,10 +115,10 @@ class JAXMD(EnzymeJaxTest):
         self.AllPipelines = pipelines()
         # No support for stablehlo.while atm
         # self.revfilter = justjax
-        self.mlirad_rev = False
+        # self.mlirad_rev = False
 
         # TODO: Reduction-region must take 2 parameters, but takes 4 parameter(s)
-        self.mlirad_fwd = False
+        # self.mlirad_fwd = False
 
         self.tol = 5e-4
 
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
     # Deps not available on macos
     # PostRev introduces numerical error -- need to investigate
-    if platform.system() != "Darwin" and False:
+    if platform.system() != "Darwin":
         from test_utils import fix_paths
 
         fix_paths()


### PR DESCRIPTION
Intermediate needed until https://github.com/EnzymeAD/Enzyme/issues/2301 fix is made (since really gather [and select/etc] should have their activities autodeduced from the tablegen)