### PR TITLE
Add `linalg.qr` op

### DIFF
--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -208,4 +208,22 @@ def LUFactorizationOp: EnzymeXLA_Op<"linalg.lu", [Pure]> {
   }];
 }
 
+def QRFactorizationOp: EnzymeXLA_Op<"linalg.qr", [Pure]> {
+  let summary = "QR factorization operation.";
+
+  let arguments = (ins
+    HLO_Tensor:$input
+  );
+
+  let results = (outs
+    HLO_Tensor:$output,
+    HLO_Tensor:$tau,
+    HLO_Tensor:$info
+  );
+
+  let assemblyFormat = [{
+    $input attr-dict `:` functional-type($input, results)
+  }];
+}
+
 #endif // ENZYMEXLA_OPS

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
@@ -898,8 +898,7 @@ struct QRFactorizationOpLowering
         op.getLoc(), type_info, cast<ElementsAttr>(makeAttr(type_info, -1)));
 
     auto tsize = std::min(inputShape.front(), inputShape.back());
-    auto type_tau =
-        RankedTensorType::get({tsize}, rewriter.getIntegerType(blasIntWidth));
+    auto type_tau = RankedTensorType::get({tsize}, inputElementType);
     auto tau = rewriter.create<stablehlo::ConstantOp>(
         op.getLoc(), type_tau, cast<ElementsAttr>(makeAttr(type_tau, 0)));
 

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
@@ -829,9 +829,9 @@ struct QRFactorizationOpLowering
                                           type_llvm_lapack_int, // matrix_layout
                                           type_llvm_lapack_int, // m
                                           type_llvm_lapack_int, // n
-                                          type_llvm_ptr,   // A
+                                          type_llvm_ptr,        // A
                                           type_llvm_lapack_int, // lda
-                                          type_llvm_ptr    // tau
+                                          type_llvm_ptr         // tau
                                       },
                                       false);
       rewriter.create<LLVM::LLVMFuncOp>(op.getLoc(), bind_fn, func_type,
@@ -874,17 +874,17 @@ struct QRFactorizationOpLowering
       auto lda = m;
 
       // call to `lapacke_*geqrf*`
-      auto res =
-          rewriter.create<LLVM::CallOp>(op.getLoc(), TypeRange{type_llvm_lapack_int},
-                                        SymbolRefAttr::get(ctx, bind_fn),
-                                        ValueRange{
-                                            layout.getResult(),
-                                            m.getResult(),
-                                            n.getResult(),
-                                            func.getArgument(0),
-                                            lda.getResult(),
-                                            func.getArgument(1),
-                                        });
+      auto res = rewriter.create<LLVM::CallOp>(op.getLoc(),
+                                               TypeRange{type_llvm_lapack_int},
+                                               SymbolRefAttr::get(ctx, bind_fn),
+                                               ValueRange{
+                                                   layout.getResult(),
+                                                   m.getResult(),
+                                                   n.getResult(),
+                                                   func.getArgument(0),
+                                                   lda.getResult(),
+                                                   func.getArgument(1),
+                                               });
 
       rewriter.create<LLVM::StoreOp>(op.getLoc(), res.getResult(),
                                      func.getArgument(2));
@@ -985,7 +985,8 @@ struct QRFactorizationOpLowering
     rewriter.replaceAllUsesWith(op.getResult(1), cusolver_call_op.getResult(1));
 
     // Netlib's LAPACK returns `info`, but cuSOLVER doesn't
-    auto type_info = RankedTensorType::get({}, rewriter.getIntegerType(blasIntWidth));
+    auto type_info =
+        RankedTensorType::get({}, rewriter.getIntegerType(blasIntWidth));
     auto info_op = rewriter.create<stablehlo::ConstantOp>(
         op.getLoc(), type_info, cast<ElementsAttr>(makeAttr(type_info, 0)));
     rewriter.replaceAllUsesWith(op.getResult(2), info_op.getResult());
@@ -1032,7 +1033,8 @@ struct QRFactorizationOpLowering
     rewriter.replaceAllUsesWith(op.getResult(1), custom_call_op.getResult(1));
 
     // Netlib's LAPACK returns `info`, but TPU kernel doesn't
-    auto type_info = RankedTensorType::get({}, rewriter.getIntegerType(blasIntWidth));
+    auto type_info =
+        RankedTensorType::get({}, rewriter.getIntegerType(blasIntWidth));
     auto info_op = rewriter.create<stablehlo::ConstantOp>(
         op.getLoc(), type_info, cast<ElementsAttr>(makeAttr(type_info, 0)));
     rewriter.replaceAllUsesWith(op.getResult(2), info_op.getResult());

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
@@ -949,15 +949,15 @@ struct QRFactorizationOpLowering
 
     auto type_tau = cast<RankedTensorType>(op.getResult(1).getType());
     auto rank_tau = type_tau.getRank();
-    
+
     // emit `stablehlo.custom_call` to `@cusolver_geqrf_ffi` kernel from jaxlib
     SmallVector<Attribute> aliases = {stablehlo::OutputOperandAliasAttr::get(
-      ctx, std::vector<int64_t>{0}, 0, std::vector<int64_t>{})};
-      SmallVector<int64_t> ranks_operands = {rank_input};
-      SmallVector<int64_t> ranks_results = {rank_input, rank_tau};
-      SmallVector<bool> isColMajorArrOperands = {true};
-      SmallVector<bool> isColMajorArrOutputs = {true, true};
-      
+        ctx, std::vector<int64_t>{0}, 0, std::vector<int64_t>{})};
+    SmallVector<int64_t> ranks_operands = {rank_input};
+    SmallVector<int64_t> ranks_results = {rank_input, rank_tau};
+    SmallVector<bool> isColMajorArrOperands = {true};
+    SmallVector<bool> isColMajorArrOutputs = {true, true};
+
     auto cusolver_call_op = rewriter.create<stablehlo::CustomCallOp>(
         op.getLoc(), TypeRange{type_input, type_tau}, ValueRange{input},
         rewriter.getStringAttr("cusolver_geqrf_ffi"),

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
@@ -721,6 +721,665 @@ struct LUFactorizationOpLowering
   }
 };
 
+struct QRFactorizationOpLowering
+    : public OpRewritePattern<enzymexla::QRFactorizationOp> {
+
+  std::string backend;
+  int64_t blasIntWidth;
+  QRFactorizationOpLowering(std::string backend, int64_t blasIntWidth,
+                            MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit), backend(backend),
+        blasIntWidth(blasIntWidth) {}
+
+  LogicalResult matchAndRewrite(enzymexla::QRFactorizationOp op,
+                                PatternRewriter &rewriter) const override {
+    auto ctx = op->getContext();
+    LLVMTypeConverter typeConverter(ctx);
+
+    auto input = op.getOperand();
+    auto inputShape = cast<RankedTensorType>(input.getType()).getShape();
+    auto inputRank = static_cast<int64_t>(inputShape.size());
+    auto inputType = cast<RankedTensorType>(input.getType());
+    auto inputElementType = inputType.getElementType();
+
+    const int64_t m = inputShape[inputRank - 2];
+    const int64_t n = inputShape[inputRank - 1];
+    const int64_t numBatchDims = inputRank - 2;
+
+    // auto pivotType = cast<RankedTensorType>(op.getResult(1).getType());
+    // auto pivotRank = pivotType.getRank();
+    // auto permutationType = cast<RankedTensorType>(op.getResult(2).getType());
+    // auto permutationRank = permutationType.getRank();
+    auto infoType = cast<RankedTensorType>(op.getResult(3).getType());
+    auto infoRank = infoType.getRank();
+
+    if (backend == "cpu") {
+      auto moduleOp = op->getParentOfType<ModuleOp>();
+      static int64_t fnNum = 0;
+
+      auto blasIntType = rewriter.getIntegerType(blasIntWidth);
+      auto llvmBlasIntType = typeConverter.convertType(blasIntType);
+      auto llvmPtrType = LLVM::LLVMPointerType::get(ctx);
+      auto llvmVoidPtrType = LLVM::LLVMVoidType::get(ctx);
+
+      std::string lapackFn;
+      if (inputElementType.isF32()) {
+        lapackFn = "sgeqrf_"; // single-precision float
+      } else if (inputElementType.isF64()) {
+        lapackFn = "dgeqrf_"; // double-precision float
+      } else if (auto complexType = dyn_cast<ComplexType>(inputElementType)) {
+        auto elem = complexType.getElementType();
+        if (elem.isF32()) {
+          lapackFn = "cgeqrf_"; // single-precision complex
+        } else if (elem.isF64()) {
+          lapackFn = "zgeqrf_"; // double-precision complex
+        } else {
+          op->emitOpError() << "Unsupported complex element type: " << elem;
+          return rewriter.notifyMatchFailure(
+              op, "unsupported complex element type");
+        }
+      } else {
+        op->emitOpError() << "Unsupported input element type: "
+                          << inputElementType;
+        return rewriter.notifyMatchFailure(op,
+                                           "unsupported input element type");
+      }
+      lapackFn = "enzymexla_lapack_" + lapackFn;
+
+      // Generate the LLVM function body
+      std::string fnName = lapackFn + "wrapper_" + std::to_string(fnNum);
+      fnNum++;
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(moduleOp.getBody());
+
+        auto funcType = LLVM::LLVMFunctionType::get(
+            llvmVoidPtrType, {llvmPtrType, llvmPtrType, llvmPtrType}, false);
+
+        auto func =
+            rewriter.create<LLVM::LLVMFuncOp>(op.getLoc(), fnName, funcType);
+        rewriter.setInsertionPointToStart(func.addEntryBlock(rewriter));
+
+        auto ptrSize = rewriter.create<LLVM::ConstantOp>(
+            op.getLoc(), llvmBlasIntType,
+            rewriter.getIntegerAttr(blasIntType, 1));
+        auto mPtr = rewriter.create<LLVM::AllocaOp>(
+            op.getLoc(), llvmPtrType, llvmBlasIntType, ptrSize, 0);
+        auto nPtr = rewriter.create<LLVM::AllocaOp>(
+            op.getLoc(), llvmPtrType, llvmBlasIntType, ptrSize, 0);
+
+        auto mVal = rewriter.create<LLVM::ConstantOp>(
+            op.getLoc(), llvmBlasIntType,
+            rewriter.getIntegerAttr(blasIntType, m));
+        auto nVal = rewriter.create<LLVM::ConstantOp>(
+            op.getLoc(), llvmBlasIntType,
+            rewriter.getIntegerAttr(blasIntType, n));
+
+        auto mStore = rewriter.create<LLVM::StoreOp>(op.getLoc(), mVal, mPtr);
+        auto nStore = rewriter.create<LLVM::StoreOp>(op.getLoc(), nVal, nPtr);
+
+        rewriter.create<LLVM::CallOp>(op.getLoc(), TypeRange{},
+                                      SymbolRefAttr::get(ctx, lapackFn),
+                                      ValueRange{
+                                          mPtr,
+                                          nPtr,
+                                          func.getArgument(0),
+                                          mPtr,
+                                          func.getArgument(1),
+                                          func.getArgument(2),
+                                      });
+
+        rewriter.create<LLVM::ReturnOp>(op.getLoc(), ValueRange{});
+      }
+
+      // Insert function declaration if not already present
+      if (!moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(lapackFn)) {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(moduleOp.getBody());
+
+        auto funcType =
+            LLVM::LLVMFunctionType::get(llvmVoidPtrType,
+                                        {llvmPtrType, llvmPtrType, llvmPtrType,
+                                         llvmPtrType, llvmPtrType, llvmPtrType},
+                                        false);
+
+        rewriter.create<LLVM::LLVMFuncOp>(op.getLoc(), lapackFn, funcType,
+                                          LLVM::Linkage::External);
+      }
+
+      // Call the LLVM function with enzymexla.jit_call
+      SmallVector<Attribute> aliases;
+      for (int i = 0; i < 3; ++i) {
+        aliases.push_back(stablehlo::OutputOperandAliasAttr::get(
+            ctx, std::vector<int64_t>{i}, i, std::vector<int64_t>{}));
+      }
+
+      auto blasPivotType = RankedTensorType::get(
+          pivotType.getShape(), rewriter.getIntegerType(blasIntWidth));
+      auto blasInfoType = RankedTensorType::get(
+          infoType.getShape(), rewriter.getIntegerType(blasIntWidth));
+
+      SmallVector<bool> isColMajorArr = {true, true, true};
+      SmallVector<int64_t> operandRanks = {2, 1, 0};
+      SmallVector<int64_t> outputRanks = {2, 1, 0};
+      auto operandLayouts =
+          getSHLOLayout(rewriter, operandRanks, isColMajorArr, 2);
+      auto resultLayouts =
+          getSHLOLayout(rewriter, outputRanks, isColMajorArr, 2);
+
+      auto iterType = RankedTensorType::get({}, rewriter.getI32Type());
+      auto iter = rewriter.create<stablehlo::ConstantOp>(
+          op.getLoc(), iterType, cast<ElementsAttr>(makeAttr(iterType, 0)));
+      auto zeroConst = rewriter.create<stablehlo::ConstantOp>(
+          op.getLoc(), iterType, cast<ElementsAttr>(makeAttr(iterType, 0)));
+
+      Value factorizedResult, pivotResult, infoResult;
+
+      if (numBatchDims > 0) {
+        // TODO: Implement batched QR factorizations by directly calling MKL
+        //       https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-dpcpp/2023-1/geqrf-batch-buffer-strided-version.html
+        //       https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-dpcpp/2023-1/geqrf-batch-group-version.html
+        //       https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-dpcpp/2023-1/geqrf-batch-usm-strided-version.html
+
+        int64_t batchSize = 1;
+        for (int i = 0; i < numBatchDims; i++) {
+          batchSize *= inputShape[i];
+        }
+        SmallVector<int64_t> flattenedInput = {batchSize, m, n};
+
+        auto flatInputType =
+            RankedTensorType::get(flattenedInput, inputElementType);
+        auto flatInput = rewriter.create<stablehlo::ReshapeOp>(
+            op.getLoc(), flatInputType, input);
+
+        auto flatPivotType = RankedTensorType::get(
+            {batchSize, pivotType.getShape()[pivotRank - 1]}, blasIntType);
+        auto flatPivot = rewriter.create<stablehlo::ConstantOp>(
+            op.getLoc(), flatPivotType,
+            cast<ElementsAttr>(makeAttr(flatPivotType, -1)));
+
+        auto flatInfoType = RankedTensorType::get({batchSize}, blasIntType);
+        auto flatInfo = rewriter.create<stablehlo::ConstantOp>(
+            op.getLoc(), flatInfoType,
+            cast<ElementsAttr>(makeAttr(flatInfoType, -1)));
+
+        auto whileReturnTypes = {iterType, flatInputType, flatPivotType,
+                                 flatInfoType};
+        auto whileOp = rewriter.create<stablehlo::WhileOp>(
+            op.getLoc(),
+            TypeRange{iterType, flatInputType, flatPivotType, flatInfoType},
+            ValueRange{iter, flatInput, flatPivot, flatInfo});
+
+        {
+          OpBuilder::InsertionGuard guard(rewriter);
+
+          Block *block = rewriter.createBlock(&whileOp.getCond());
+          rewriter.setInsertionPointToStart(block);
+
+          for (auto type : whileReturnTypes) {
+            block->addArgument(type, whileOp.getLoc());
+          }
+
+          auto batchSizeConst = rewriter.create<stablehlo::ConstantOp>(
+              op.getLoc(), iterType,
+              cast<ElementsAttr>(makeAttr(iterType, batchSize)));
+
+          auto comparison = rewriter.create<stablehlo::CompareOp>(
+              op.getLoc(), block->getArgument(0), batchSizeConst,
+              stablehlo::ComparisonDirection::LT);
+
+          rewriter.create<stablehlo::ReturnOp>(
+              op.getLoc(), ValueRange{comparison.getResult()});
+        }
+
+        {
+          OpBuilder::InsertionGuard guard(rewriter);
+
+          Block *block = rewriter.createBlock(&whileOp.getBody());
+          rewriter.setInsertionPointToStart(block);
+
+          for (auto type : whileReturnTypes) {
+            block->addArgument(type, whileOp.getLoc());
+          }
+
+          auto iterArg = block->getArgument(0);
+
+          auto inputSliceType = RankedTensorType::get({m, n}, inputElementType);
+          auto inputSlice = rewriter.create<stablehlo::ReshapeOp>(
+              op.getLoc(), inputSliceType,
+              rewriter.create<stablehlo::DynamicSliceOp>(
+                  op.getLoc(), block->getArgument(1),
+                  ValueRange{iterArg, zeroConst, zeroConst},
+                  rewriter.getDenseI64ArrayAttr({1, m, n})));
+
+          auto pivotSliceType =
+              RankedTensorType::get({std::min(m, n)}, blasIntType);
+          auto pivotSlice = rewriter.create<stablehlo::ConstantOp>(
+              op.getLoc(), pivotSliceType,
+              cast<ElementsAttr>(makeAttr(pivotSliceType, -1)));
+
+          auto infoSliceType = RankedTensorType::get({}, blasIntType);
+          auto infoSlice = rewriter.create<stablehlo::ConstantOp>(
+              op.getLoc(), infoSliceType,
+              cast<ElementsAttr>(makeAttr(infoSliceType, -1)));
+
+          auto jitCall = rewriter.create<enzymexla::JITCallOp>(
+              op.getLoc(),
+              TypeRange{inputSliceType, pivotSliceType, infoSliceType},
+              mlir::FlatSymbolRefAttr::get(ctx, fnName),
+              ValueRange{inputSlice, pivotSlice, infoSlice},
+              rewriter.getStringAttr(""),
+              /*operand_layouts=*/operandLayouts,
+              /*result_layouts=*/resultLayouts,
+              /*output_operand_aliases=*/rewriter.getArrayAttr(aliases),
+              /*xla_side_effect_free=*/rewriter.getUnitAttr());
+
+          auto inputUpdated = rewriter.create<stablehlo::DynamicUpdateSliceOp>(
+              op.getLoc(), block->getArgument(1),
+              rewriter.create<stablehlo::ReshapeOp>(
+                  op.getLoc(),
+                  RankedTensorType::get({1, m, n}, inputElementType),
+                  jitCall.getResult(0)),
+              ValueRange{iterArg, zeroConst, zeroConst});
+          auto pivotUpdated = rewriter.create<stablehlo::DynamicUpdateSliceOp>(
+              op.getLoc(), block->getArgument(2),
+              rewriter.create<stablehlo::ReshapeOp>(
+                  op.getLoc(),
+                  RankedTensorType::get({1, std::min(m, n)}, blasIntType),
+                  jitCall.getResult(1)),
+              ValueRange{iterArg, zeroConst});
+          auto infoUpdated = rewriter.create<stablehlo::DynamicUpdateSliceOp>(
+              op.getLoc(), block->getArgument(3),
+              rewriter.create<stablehlo::ReshapeOp>(
+                  op.getLoc(), RankedTensorType::get({1}, blasIntType),
+                  jitCall.getResult(2)),
+              ValueRange{iterArg});
+
+          auto updatedIter = rewriter.create<stablehlo::AddOp>(
+              op.getLoc(), block->getArgument(0),
+              rewriter.create<stablehlo::ConstantOp>(
+                  op.getLoc(), iterType,
+                  cast<ElementsAttr>(makeAttr(iterType, 1))));
+
+          rewriter.create<stablehlo::ReturnOp>(
+              op.getLoc(),
+              ValueRange{updatedIter, inputUpdated, pivotUpdated, infoUpdated});
+        }
+
+        factorizedResult = rewriter.create<stablehlo::ReshapeOp>(
+            op.getLoc(), inputType, whileOp.getResult(1));
+        pivotResult = rewriter.create<stablehlo::ReshapeOp>(
+            op.getLoc(), blasPivotType, whileOp.getResult(2));
+        infoResult = rewriter.create<stablehlo::ReshapeOp>(
+            op.getLoc(), blasInfoType, whileOp.getResult(3));
+      } else {
+        auto pivot = rewriter.create<stablehlo::ConstantOp>(
+            op.getLoc(), blasPivotType,
+            cast<ElementsAttr>(makeAttr(blasPivotType, -1)));
+        auto info = rewriter.create<stablehlo::ConstantOp>(
+            op.getLoc(), blasInfoType,
+            cast<ElementsAttr>(makeAttr(blasInfoType, -1)));
+
+        auto jitCall = rewriter.create<enzymexla::JITCallOp>(
+            op.getLoc(), TypeRange{inputType, blasPivotType, blasInfoType},
+            mlir::FlatSymbolRefAttr::get(ctx, fnName),
+            ValueRange{input, pivot, info}, rewriter.getStringAttr(""),
+            /*operand_layouts=*/operandLayouts,
+            /*result_layouts=*/resultLayouts,
+            /*output_operand_aliases=*/rewriter.getArrayAttr(aliases),
+            /*xla_side_effect_free=*/rewriter.getUnitAttr());
+
+        factorizedResult = jitCall.getResult(0);
+        pivotResult = jitCall.getResult(1);
+        infoResult = jitCall.getResult(2);
+      }
+
+      auto pivots0indexed = rewriter.create<stablehlo::SubtractOp>(
+          op.getLoc(), pivotResult,
+          rewriter.create<stablehlo::ConstantOp>(
+              op.getLoc(), blasPivotType,
+              cast<ElementsAttr>(makeAttr(blasPivotType, 1))));
+
+      auto permutation = rewriter.create<stablehlo::IotaOp>(
+          op.getLoc(), blasPivotType,
+          rewriter.getI64IntegerAttr(blasPivotType.getRank() - 1));
+
+      auto pivotToPermReturnTypes = {iterType, blasPivotType};
+      auto pivotToPermWhileOp = rewriter.create<stablehlo::WhileOp>(
+          op.getLoc(), TypeRange{iterType, blasPivotType},
+          ValueRange{iter, permutation});
+
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+
+        Block *block = rewriter.createBlock(&pivotToPermWhileOp.getCond());
+        rewriter.setInsertionPointToStart(block);
+
+        for (auto type : pivotToPermReturnTypes)
+          block->addArgument(type, pivotToPermWhileOp.getLoc());
+
+        auto pivotShapeConst = rewriter.create<stablehlo::ConstantOp>(
+            op.getLoc(), iterType,
+            cast<ElementsAttr>(makeAttr(
+                iterType, pivotType.getShape()[pivotType.getRank() - 1])));
+
+        auto comparison = rewriter.create<stablehlo::CompareOp>(
+            op.getLoc(), block->getArgument(0), pivotShapeConst,
+            stablehlo::ComparisonDirection::LT);
+
+        rewriter.create<stablehlo::ReturnOp>(
+            op.getLoc(), ValueRange{comparison.getResult()});
+      }
+
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+
+        Block *block = rewriter.createBlock(&pivotToPermWhileOp.getBody());
+        rewriter.setInsertionPointToStart(block);
+
+        for (auto type : pivotToPermReturnTypes)
+          block->addArgument(type, pivotToPermWhileOp.getLoc());
+
+        auto iterArg = block->getArgument(0);
+
+        auto updatedIter = rewriter.create<stablehlo::AddOp>(
+            op.getLoc(), iterArg,
+            rewriter.create<stablehlo::ConstantOp>(
+                op.getLoc(), iterType,
+                cast<ElementsAttr>(makeAttr(iterType, 1))));
+
+        /*
+        for i in range(pivot.shape[-1]):
+          j = pivot[..., i]        # dynamic slice
+          x = permutation[..., i]  # dynamic slice
+          y = permutation[j]       # gather
+          permutation[..., i] = y  # dynamic update slice
+          permutation[j] = x       # scatter
+        */
+
+        SmallVector<Value> indices;
+        SmallVector<int64_t> sliceShape, batchDims;
+        for (int i = 0; i < numBatchDims; i++) {
+          indices.push_back(zeroConst);
+          sliceShape.push_back(pivotType.getShape()[i]);
+          batchDims.push_back(i);
+        }
+        indices.push_back(iterArg);
+        sliceShape.push_back(1);
+        SmallVector<int64_t> gatherSliceSizes(numBatchDims + 1, 1);
+
+        auto pivotJ = rewriter.create<stablehlo::DynamicSliceOp>(
+            op.getLoc(), pivots0indexed, indices, sliceShape);
+        auto permutationX = rewriter.create<stablehlo::DynamicSliceOp>(
+            op.getLoc(), block->getArgument(1), indices, sliceShape);
+
+        auto gatherDims = stablehlo::GatherDimensionNumbersAttr::get(
+            op.getContext(),
+            /*offsetDims=*/{numBatchDims},
+            /*collapsedSliceDims=*/{},
+            /*operandBatchingDims=*/batchDims,
+            /*startIndicesBatchingDims=*/batchDims,
+            /*startIndexMap=*/{numBatchDims},
+            /*indexVectorDim=*/numBatchDims);
+        auto permutationY = rewriter.create<stablehlo::GatherOp>(
+            op.getLoc(),
+            RankedTensorType::get(
+                sliceShape,
+                cast<RankedTensorType>(block->getArgument(1).getType())
+                    .getElementType()),
+            block->getArgument(1), pivotJ.getResult(), gatherDims,
+            gatherSliceSizes);
+
+        auto permutationUpdate1 =
+            rewriter.create<stablehlo::DynamicUpdateSliceOp>(
+                op.getLoc(), block->getArgument(1), permutationY->getResult(0),
+                indices);
+
+        auto scatterDims = stablehlo::ScatterDimensionNumbersAttr::get(
+            op.getContext(),
+            /*updateWindowDims=*/{},
+            /*insertedWindowDims=*/{numBatchDims},
+            /*inputBatchingDims=*/batchDims,
+            /*scatterIndicesBatchingDims=*/batchDims,
+            /*scatterDimsToOperandDims=*/{numBatchDims},
+            /*indexVectorDim=*/numBatchDims);
+        SmallVector<int64_t> scatterShape(sliceShape.begin(),
+                                          sliceShape.end() - 1);
+        auto permutationUpdate2 = rewriter.create<stablehlo::ScatterOp>(
+            op.getLoc(), TypeRange{permutationUpdate1->getResult(0).getType()},
+            ValueRange(permutationUpdate1->getResult(0)), pivotJ,
+            ValueRange(rewriter.create<stablehlo::ReshapeOp>(
+                op.getLoc(),
+                RankedTensorType::get(scatterShape,
+                                      permutationX.getType().getElementType()),
+                permutationX)),
+            scatterDims);
+
+        {
+          OpBuilder::InsertionGuard guard(rewriter);
+          auto *block =
+              rewriter.createBlock(&permutationUpdate2.getUpdateComputation());
+          block->addArgument(RankedTensorType::get({}, blasIntType),
+                             op.getLoc());
+          block->addArgument(RankedTensorType::get({}, blasIntType),
+                             op.getLoc());
+          rewriter.setInsertionPointToStart(block);
+
+          rewriter.create<stablehlo::ReturnOp>(
+              op.getLoc(), ValueRange{block->getArgument(1)});
+        }
+
+        rewriter.create<stablehlo::ReturnOp>(
+            op.getLoc(),
+            ValueRange{updatedIter, permutationUpdate2->getResult(0)});
+      }
+
+      auto finalPermutation = rewriter.create<stablehlo::AddOp>(
+          op.getLoc(), pivotToPermWhileOp.getResult(1),
+          rewriter.create<stablehlo::ConstantOp>(
+              op.getLoc(), blasPivotType,
+              cast<ElementsAttr>(makeAttr(blasPivotType, 1))));
+
+      rewriter.replaceAllUsesWith(op.getResult(0), factorizedResult);
+      rewriter.replaceAllUsesWith(op.getResult(1),
+                                  rewriter.create<stablehlo::ConvertOp>(
+                                      op.getLoc(), pivotType, pivotResult));
+      rewriter.replaceAllUsesWith(
+          op.getResult(2), rewriter.create<stablehlo::ConvertOp>(
+                               op.getLoc(), pivotType, finalPermutation));
+      rewriter.replaceAllUsesWith(op.getResult(3),
+                                  rewriter.create<stablehlo::ConvertOp>(
+                                      op.getLoc(), infoType, infoResult));
+
+      return success();
+    } else if (backend == "cuda") {
+      SmallVector<Attribute> aliases = {stablehlo::OutputOperandAliasAttr::get(
+          ctx, std::vector<int64_t>{0}, 0, std::vector<int64_t>{})};
+
+      SmallVector<bool> isColMajorArrOperands = {true};
+      SmallVector<int64_t> operandRanks = {inputRank};
+      SmallVector<bool> isColMajorArrOutputs = {true, true, true};
+      SmallVector<int64_t> outputRanks = {inputRank, pivotRank, infoRank};
+
+      auto pivotCuSolverType =
+          RankedTensorType::get(pivotType.getShape(), rewriter.getI32Type());
+      auto infoCuSolverType =
+          RankedTensorType::get(infoType.getShape(), rewriter.getI32Type());
+
+      auto cusolverffi = rewriter.create<stablehlo::CustomCallOp>(
+          op.getLoc(),
+          TypeRange{inputType, pivotCuSolverType, infoCuSolverType},
+          ValueRange{input}, rewriter.getStringAttr("cusolver_geqrf_ffi"),
+          /*has_side_effect*/ nullptr,
+          /*backend_config*/ nullptr,
+          /*api_version*/
+          stablehlo::CustomCallApiVersionAttr::get(
+              rewriter.getContext(),
+              mlir::stablehlo::CustomCallApiVersion::API_VERSION_TYPED_FFI),
+          /*calledcomputations*/ nullptr,
+          /*operand_layouts*/
+          getSHLOLayout(rewriter, operandRanks, isColMajorArrOperands,
+                        inputRank),
+          /*result_layouts*/
+          getSHLOLayout(rewriter, outputRanks, isColMajorArrOutputs, inputRank),
+          /*output_operand_aliases*/ rewriter.getArrayAttr(aliases));
+
+      // unused custom call not getting optimized away. so adding a manual check
+      if (!op.getResult(2).getUses().empty()) {
+        auto pivots0indexed = rewriter.create<stablehlo::SubtractOp>(
+            op.getLoc(), cusolverffi.getResult(1),
+            rewriter.create<stablehlo::ConstantOp>(
+                op.getLoc(), pivotCuSolverType,
+                cast<ElementsAttr>(makeAttr(pivotCuSolverType, 1))));
+
+        SmallVector<bool> isColMajorArrOperandsPermutation = {true};
+        SmallVector<int64_t> operandRanksPermutation = {pivotRank};
+        SmallVector<bool> isColMajorArrOutputsPermutation = {true};
+        SmallVector<int64_t> outputRanksPermutation = {pivotRank};
+
+        auto permutation = rewriter.create<stablehlo::CustomCallOp>(
+            op.getLoc(), TypeRange{pivotCuSolverType},
+            ValueRange{pivots0indexed.getResult()},
+            rewriter.getStringAttr("cu_lu_pivots_to_permutation"),
+            /*has_side_effect*/ nullptr,
+            /*backend_config*/ nullptr,
+            /*api_version*/
+            stablehlo::CustomCallApiVersionAttr::get(
+                rewriter.getContext(),
+                mlir::stablehlo::CustomCallApiVersion::API_VERSION_TYPED_FFI),
+            /*calledcomputations*/ nullptr,
+            /*operand_layouts*/
+            getSHLOLayout(rewriter, operandRanksPermutation,
+                          isColMajorArrOperandsPermutation, inputRank),
+            /*result_layouts*/
+            getSHLOLayout(rewriter, outputRanksPermutation,
+                          isColMajorArrOutputsPermutation, inputRank),
+            /*output_operand_aliases*/ nullptr);
+        auto permutation1Indexed = rewriter.create<stablehlo::AddOp>(
+            op.getLoc(),
+            rewriter.create<stablehlo::ConstantOp>(
+                op.getLoc(), pivotCuSolverType,
+                cast<ElementsAttr>(makeAttr(pivotCuSolverType, 1))),
+            permutation.getResult(0));
+
+        rewriter.replaceAllUsesWith(
+            op.getResult(2), rewriter.create<stablehlo::ConvertOp>(
+                                 op.getLoc(), pivotType, permutation1Indexed));
+      }
+
+      rewriter.replaceAllUsesWith(op.getResult(0), cusolverffi.getResult(0));
+      rewriter.replaceAllUsesWith(
+          op.getResult(1),
+          rewriter.create<stablehlo::ConvertOp>(op.getLoc(), pivotType,
+                                                cusolverffi.getResult(1)));
+      rewriter.replaceAllUsesWith(
+          op.getResult(3),
+          rewriter.create<stablehlo::ConvertOp>(op.getLoc(), infoType,
+                                                cusolverffi.getResult(2)));
+
+      return success();
+    } else if (backend == "tpu") {
+      SmallVector<int64_t> permutationShape;
+      for (int i = 0; i < numBatchDims; i++) {
+        permutationShape.push_back(inputShape[i]);
+      }
+      permutationShape.push_back(m);
+      auto permutationType =
+          RankedTensorType::get(permutationShape, rewriter.getI32Type());
+
+      auto pivotTPUType =
+          RankedTensorType::get(pivotType.getShape(), rewriter.getI32Type());
+
+      // TPU returns (LU, pivots, permutation). info isn't returned. based on
+      // how JAX operates, I am assuming info != 0 when there is a nan in the
+      // output.
+      auto customCall = rewriter.create<stablehlo::CustomCallOp>(
+          op.getLoc(), TypeRange{inputType, pivotTPUType, permutationType},
+          ValueRange{input}, rewriter.getStringAttr("QrFactorization"),
+          /*has_side_effect*/ nullptr,
+          /*backend_config*/ nullptr,
+          /*api_version*/ nullptr,
+          /*calledcomputations*/ nullptr,
+          /*operand_layouts*/ nullptr,
+          /*result_layouts*/ nullptr,
+          /*output_operand_aliases*/ nullptr);
+
+      // LAPACK returns 1-indexed pivots, while XLA returns 0-indexed pivots. We
+      // make it consistent with LAPACK by adding 1 to the pivots.
+      auto pivots1Indexed = rewriter.create<stablehlo::AddOp>(
+          op.getLoc(),
+          rewriter.create<stablehlo::ConstantOp>(
+              op.getLoc(), pivotType,
+              cast<ElementsAttr>(makeAttr(pivotType, 1))),
+          rewriter.create<stablehlo::ConvertOp>(op.getLoc(), pivotType,
+                                                customCall.getResult(1)));
+
+      auto permutation1Indexed = rewriter.create<stablehlo::AddOp>(
+          op.getLoc(),
+          rewriter.create<stablehlo::ConstantOp>(
+              op.getLoc(), permutationType,
+              cast<ElementsAttr>(makeAttr(permutationType, 1))),
+          rewriter.create<stablehlo::ConvertOp>(op.getLoc(), permutationType,
+                                                customCall.getResult(2)));
+
+      auto isFinite = rewriter.create<stablehlo::AndOp>(
+          op.getLoc(),
+          rewriter.create<stablehlo::IsFiniteOp>(
+              op.getLoc(), rewriter.create<stablehlo::RealOp>(
+                               op.getLoc(), customCall.getResult(0))),
+          rewriter.create<stablehlo::IsFiniteOp>(
+              op.getLoc(), rewriter.create<stablehlo::ImagOp>(
+                               op.getLoc(), customCall.getResult(0))));
+
+      SmallVector<int64_t> reductionDims;
+      for (int i = numBatchDims; i < inputRank; i++)
+        reductionDims.push_back(i);
+      auto initValType = RankedTensorType::get({}, rewriter.getI1Type());
+      auto initVal = rewriter.create<stablehlo::ConstantOp>(
+          op.getLoc(), initValType,
+          cast<ElementsAttr>(makeAttr(initValType, 1)));
+
+      auto allFinite = rewriter.create<stablehlo::ReduceOp>(
+          op.getLoc(),
+          RankedTensorType::get(infoType.getShape(), rewriter.getI1Type()),
+          ValueRange{isFinite.getResult()}, ValueRange{initVal},
+          rewriter.getDenseI64ArrayAttr(reductionDims));
+
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        auto &region = allFinite.getBody();
+        auto *block =
+            rewriter.createBlock(&region, {}, {initValType, initValType},
+                                 {op.getLoc(), op.getLoc()});
+
+        rewriter.setInsertionPointToStart(block);
+        auto lhs = block->getArgument(0);
+        auto rhs = block->getArgument(1);
+        auto andOp = rewriter.create<stablehlo::AndOp>(op.getLoc(), lhs, rhs);
+
+        rewriter.create<stablehlo::ReturnOp>(op.getLoc(),
+                                             ValueRange{andOp.getResult()});
+      }
+
+      // info == 0 if all finite (success)
+      auto info = rewriter.create<stablehlo::ConvertOp>(
+          op.getLoc(), infoType,
+          rewriter.create<stablehlo::NotOp>(op.getLoc(),
+                                            allFinite.getResult(0)));
+
+      rewriter.replaceAllUsesWith(op.getResult(0), customCall.getResult(0));
+      rewriter.replaceAllUsesWith(op.getResult(1), pivots1Indexed);
+      rewriter.replaceAllUsesWith(op.getResult(2), permutation1Indexed);
+      rewriter.replaceAllUsesWith(op.getResult(3), info);
+      rewriter.eraseOp(op);
+
+      return success();
+    } else {
+      return rewriter.notifyMatchFailure(op, "Unknown backend " + backend);
+    }
+  }
+};
+
 struct LowerEnzymeXLALinalgPass
     : public enzyme::impl::LowerEnzymeXLALinalgPassBase<
           LowerEnzymeXLALinalgPass> {
@@ -731,6 +1390,7 @@ struct LowerEnzymeXLALinalgPass
     RewritePatternSet patterns(context);
 
     patterns.add<LUFactorizationOpLowering>(backend, blasIntWidth, context);
+    patterns.add<QRFactorizationOpLowering>(backend, blasIntWidth, context);
 
     GreedyRewriteConfig config;
     if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),

--- a/test/lit_tests/linalg/qr.mlir
+++ b/test/lit_tests/linalg/qr.mlir
@@ -1,85 +1,48 @@
 // RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cpu blas_int_width=64},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CPU
-// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cuda},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CUDA
-// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=tpu},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=TPU
+// TODO-RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cuda},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CUDA
+// TODO-RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=tpu},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=TPU
 
 module {
-  func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>) {
-    %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
-    return %0#0, %0#1, %0#2, %0#3 : tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>
+  func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<i64>) {
+    %0:3 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<i64>)
+    return %0#0, %0#1, %0#3 : tensor<64x64xf32>, tensor<64x64xf32>, tensor<i64>
   }
 }
 
-// CPU:  llvm.func @enzymexla_lapack_sgeqrf_(!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
-// CPU-NEXT:  llvm.func @enzymexla_lapack_sgeqrf_wrapper_[[WRAPPER_ID:[0-9]+]](%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
-// CPU-NEXT:    %0 = llvm.mlir.constant(64 : i64) : i64
-// CPU-NEXT:    %1 = llvm.mlir.constant(1 : i64) : i64
-// CPU-NEXT:    %2 = llvm.alloca %1 x i64 : (i64) -> !llvm.ptr
-// CPU-NEXT:    %3 = llvm.alloca %1 x i64 : (i64) -> !llvm.ptr
-// CPU-NEXT:    llvm.store %0, %2 : i64, !llvm.ptr
-// CPU-NEXT:    llvm.store %0, %3 : i64, !llvm.ptr
-// CPU-NEXT:    llvm.call @enzymexla_lapack_sgeqrf_(%2, %3, %arg0, %2, %arg1, %arg2) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CPU-NEXT:    llvm.return
+// CPU:  llvm.func @enzymexla_lapacke_dgeqrf_(i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
+// CPU-NEXT:  func.func @enzymexla_wrapper_lapacke_dgeqrf_[[GEQRF_WRAPPER_ID:[0-9]+]](%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
+// CPU-NEXT:    %0 = llvm.mlir.constant(101 : i64) : i64
+// CPU-NEXT:    %1 = llvm.mlir.constant(64 : i64) : i64
+// CPU-NEXT:    %2 = llvm.mlir.constant(64 : i64) : i64
+// CPU-NEXT:    %3 = llvm.mlir.constant(64 : i64) : i64
+// CPU-NEXT:    %4 = llvm.call @enzymexla_lapacke_dgeqrf_(%0, %1, %2, %arg0, %3, %arg1) : (i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
+// CPU-NEXT:    llvm.store %4, %arg2 : i64, !llvm.ptr
+// CPU-NEXT:    return
 // CPU-NEXT:  }
-// CPU-NEXT:  func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>) {
-// CPU-NEXT:    %c = stablehlo.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]> : tensor<64xi64>
-// CPU-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i32>
-// CPU-NEXT:    %c_1 = stablehlo.constant dense<64> : tensor<i32>
-// CPU-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<64xi64>
-// CPU-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<i32>
-// CPU-NEXT:    %c_4 = stablehlo.constant dense<-1> : tensor<64xi64>
-// CPU-NEXT:    %c_5 = stablehlo.constant dense<-1> : tensor<i64>
-// CPU-NEXT:    %0:3 = enzymexla.jit_call @enzymexla_lapack_sgeqrf_wrapper_[[WRAPPER_ID]] (%arg0, %c_4, %c_5) {operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 1, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [2], operand_index = 2, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>], xla_side_effect_free} : (tensor<64x64xf32>, tensor<64xi64>, tensor<i64>) -> (tensor<64x64xf32>, tensor<64xi64>, tensor<i64>)
-// CPU-NEXT:    %1 = stablehlo.subtract %0#1, %c_2 : tensor<64xi64>
-// CPU-NEXT:    %2:2 = stablehlo.while(%iterArg = %c_3, %iterArg_6 = %c) : tensor<i32>, tensor<64xi64>
-// CPU-NEXT:     cond {
-// CPU-NEXT:      %7 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i32>, tensor<i32>) -> tensor<i1>
-// CPU-NEXT:      stablehlo.return %7 : tensor<i1>
-// CPU-NEXT:    } do {
-// CPU-NEXT:      %7 = stablehlo.add %iterArg, %c_0 : tensor<i32>
-// CPU-NEXT:      %8 = stablehlo.dynamic_slice %1, %iterArg, sizes = [1] : (tensor<64xi64>, tensor<i32>) -> tensor<1xi64>
-// CPU-NEXT:      %9 = stablehlo.dynamic_slice %iterArg_6, %iterArg, sizes = [1] : (tensor<64xi64>, tensor<i32>) -> tensor<1xi64>
-// CPU-NEXT:      %10 = "stablehlo.gather"(%iterArg_6, %8) <{dimension_numbers = #stablehlo.gather<offset_dims = [0], start_index_map = [0]>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<64xi64>, tensor<1xi64>) -> tensor<1xi64>
-// CPU-NEXT:      %11 = stablehlo.dynamic_update_slice %iterArg_6, %10, %iterArg : (tensor<64xi64>, tensor<1xi64>, tensor<i32>) -> tensor<64xi64>
-// CPU-NEXT:      %12 = stablehlo.reshape %9 : (tensor<1xi64>) -> tensor<i64>
-// CPU-NEXT:      %13 = "stablehlo.scatter"(%11, %8, %12) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0]>, unique_indices = false}> ({
-// CPU-NEXT:      ^bb0(%arg1: tensor<i64>, %arg2: tensor<i64>):
-// CPU-NEXT:        stablehlo.return %arg2 : tensor<i64>
-// CPU-NEXT:      }) : (tensor<64xi64>, tensor<1xi64>, tensor<i64>) -> tensor<64xi64>
-// CPU-NEXT:      stablehlo.return %7, %13 : tensor<i32>, tensor<64xi64>
-// CPU-NEXT:    }
-// CPU-NEXT:    %3 = stablehlo.add %2#1, %c_2 : tensor<64xi64>
-// CPU-NEXT:    %4 = stablehlo.convert %0#1 : (tensor<64xi64>) -> tensor<64xi32>
-// CPU-NEXT:    %5 = stablehlo.convert %3 : (tensor<64xi64>) -> tensor<64xi32>
-// CPU-NEXT:    %6 = stablehlo.convert %0#2 : (tensor<i64>) -> tensor<i32>
-// CPU-NEXT:    return %0#0, %4, %5, %6 : tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>
+// CPU-NEXT:  llvm.func @enzymexla_lapacke_dorgqr_(i64, i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
+// CPU-NEXT:  func.func @enzymexla_wrapper_lapacke_dorgqr_[[ORGQR_WRAPPER_ID:[0-9]+]](%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
+// CPU-NEXT:    %0 = llvm.mlir.constant(101 : i64) : i64
+// CPU-NEXT:    %1 = llvm.mlir.constant(64 : i64) : i64
+// CPU-NEXT:    %2 = llvm.mlir.constant(64 : i64) : i64
+// CPU-NEXT:    %3 = llvm.mlir.constant(64 : i64) : i64
+// CPU-NEXT:    %4 = llvm.mlir.constant(64 : i64) : i64
+// CPU-NEXT:    %5 = llvm.call @enzymexla_lapacke_dorgqr_(%0, %1, %2, %3, %arg0, %4, %arg1) : (i64, i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
+// CPU-NEXT:    llvm.store %5, %arg2 : i64, !llvm.ptr
+// CPU-NEXT:    return
 // CPU-NEXT:  }
-
-// CUDA: func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>) {
-// CUDA-NEXT:     %c = stablehlo.constant dense<1> : tensor<64xi32>
-// CUDA-NEXT:     %0:3 = stablehlo.custom_call @cusolver_geqrf_ffi(%arg0) {api_version = 4 : i32, operand_layouts = [dense<[0, 1]> : tensor<2xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>]} : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<i32>)
-// CUDA-NEXT:     %1 = stablehlo.subtract %0#1, %c : tensor<64xi32>
-// CUDA-NEXT:     %2 = stablehlo.custom_call @cu_lu_pivots_to_permutation(%1) {api_version = 4 : i32, operand_layouts = [dense<0> : tensor<1xindex>], result_layouts = [dense<0> : tensor<1xindex>]} : (tensor<64xi32>) -> tensor<64xi32>
-// CUDA-NEXT:     %3 = stablehlo.add %c, %2 : tensor<64xi32>
-// CUDA-NEXT:     return %0#0, %0#1, %3, %0#2 : tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>
-// CUDA-NEXT: }
-
-// TPU: func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>) {
-// TPU-NEXT:     %c = stablehlo.constant dense<true> : tensor<i1>
-// TPU-NEXT:     %c_0 = stablehlo.constant dense<1> : tensor<64xi32>
-// TPU-NEXT:     %0:3 = stablehlo.custom_call @LuDecomposition(%arg0) : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>)
-// TPU-NEXT:     %1 = stablehlo.add %c_0, %0#1 : tensor<64xi32>
-// TPU-NEXT:     %2 = stablehlo.add %c_0, %0#2 : tensor<64xi32>
-// TPU-NEXT:     %3 = stablehlo.is_finite %0#0 : (tensor<64x64xf32>) -> tensor<64x64xi1>
-// TPU-NEXT:     %4 = stablehlo.reduce(%3 init: %c) applies stablehlo.and across dimensions = [0, 1] : (tensor<64x64xi1>, tensor<i1>) -> tensor<i1>
-// TPU-NEXT:     %5 = stablehlo.not %4 : tensor<i1>
-// TPU-NEXT:     %6 = stablehlo.convert %5 : (tensor<i1>) -> tensor<i32>
-// TPU-NEXT:     return %0#0, %1, %2, %6 : tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>
-// TPU-NEXT: }
+// CPU-NEXT:  func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) {
+// CPU-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<64xf64>
+// CPU-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
+// CPU-NEXT:    %0:3 = enzymexla.jit_call @enzymexla_wrapper_lapacke_dgeqrf_[[GEQRF_WRAPPER_ID]] (%arg0, %cst, %c) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 1, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [2], operand_index = 2, operand_tuple_indices = []>]} : (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>)
+// CPU-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<i64>
+// CPU-NEXT:    %1:2 = enzymexla.jit_call @enzymexla_wrapper_lapacke_dorgqr_[[ORGQR_WRAPPER_ID]] (%0#0, %0#1, %c_0) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 2, operand_tuple_indices = []>]} : (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) -> (tensor<64x64xf64>, tensor<i64>)
+// CPU-NEXT:    return %1#0, %0#0 : tensor<64x64xf64>, tensor<64x64xf64>
+// CPU-NEXT:  }
 
 module {
   // CPU: func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<i32>) {
   func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<i32>) {
-    // CPU: enzymexla.jit_call @enzymexla_lapack_dgeqrf_wrapper_[[WRAPPER_ID:[0-9]+]]
+    // CPU: enzymexla.jit_call @enzymexla_wrapper_lapacke_dgeqrf_[[WRAPPER_ID:[0-9]+]]
     %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
     return %0#0, %0#1, %0#3 : tensor<64x64xf64>, tensor<64xi32>, tensor<i32>
   }
@@ -88,7 +51,7 @@ module {
 module {
   // CPU: func.func @main(%arg0: tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>) {
   func.func @main(%arg0: tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>) {
-    // CPU: enzymexla.jit_call @enzymexla_lapack_zgeqrf_wrapper_[[WRAPPER_ID:[0-9]+]]
+    // CPU: enzymexla.jit_call @enzymexla_wrapper_lapacke_zgeqrf_[[WRAPPER_ID:[0-9]+]]
     %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
     return %0#0, %0#1, %0#3 : tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>
   }
@@ -97,7 +60,7 @@ module {
 module {
   // CPU: func.func @main(%arg0: tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>) {
   func.func @main(%arg0: tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>) {
-    // CPU: enzymexla.jit_call @enzymexla_lapack_cgeqrf_wrapper_[[WRAPPER_ID:[0-9]+]]
+    // CPU: enzymexla.jit_call @enzymexla_wrapper_lapacke_cgeqrf_[[WRAPPER_ID:[0-9]+]]
     %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
     return %0#0, %0#1, %0#3 : tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>
   }

--- a/test/lit_tests/linalg/qr.mlir
+++ b/test/lit_tests/linalg/qr.mlir
@@ -1,5 +1,5 @@
 // RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cpu blas_int_width=64},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CPU
-// TODO-RUN enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cuda},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CUDA
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cuda},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CUDA
 // TODO-RUN enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=tpu},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=TPU
 
 module {
@@ -23,6 +23,12 @@ module {
 // CPU-NEXT:    %0:3 = enzymexla.jit_call @enzymexla_wrapper_lapacke_sgeqrf_[[WRAPPER_ID]] (%arg0, %cst, %c) {operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 1, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [2], operand_index = 2, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>], xla_side_effect_free} : (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>) -> (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>)
 // CPU-NEXT:    return %0#0, %0#1, %0#2 : tensor<64x64xf32>, tensor<64xf32>, tensor<i64>
 // CPU-NEXT:  }
+
+// CUDA: func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>) {
+// CUDA-NEXT:   %c = stablehlo.constant dense<0> : tensor<i64>
+// CUDA-NEXT:   %0:2 = stablehlo.custom_call @cusolver_geqrf_ffi(%arg0) {api_version = 4 : i32, operand_layouts = [dense<[0, 1]> : tensor<2xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>]} : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>)
+// CUDA-NEXT:   return %0#0, %0#1, %c : tensor<64x64xf32>, tensor<64xf32>, tensor<i64>
+// CUDA-NEXT: }
 
 module {
   // CPU: func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) {

--- a/test/lit_tests/linalg/qr.mlir
+++ b/test/lit_tests/linalg/qr.mlir
@@ -1,0 +1,104 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cpu blas_int_width=64},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CPU
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cuda},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CUDA
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=tpu},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=TPU
+
+module {
+  func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>) {
+    %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
+    return %0#0, %0#1, %0#2, %0#3 : tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>
+  }
+}
+
+// CPU:  llvm.func @enzymexla_lapack_sgeqrf_(!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+// CPU-NEXT:  llvm.func @enzymexla_lapack_sgeqrf_wrapper_[[WRAPPER_ID:[0-9]+]](%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
+// CPU-NEXT:    %0 = llvm.mlir.constant(64 : i64) : i64
+// CPU-NEXT:    %1 = llvm.mlir.constant(1 : i64) : i64
+// CPU-NEXT:    %2 = llvm.alloca %1 x i64 : (i64) -> !llvm.ptr
+// CPU-NEXT:    %3 = llvm.alloca %1 x i64 : (i64) -> !llvm.ptr
+// CPU-NEXT:    llvm.store %0, %2 : i64, !llvm.ptr
+// CPU-NEXT:    llvm.store %0, %3 : i64, !llvm.ptr
+// CPU-NEXT:    llvm.call @enzymexla_lapack_sgeqrf_(%2, %3, %arg0, %2, %arg1, %arg2) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CPU-NEXT:    llvm.return
+// CPU-NEXT:  }
+// CPU-NEXT:  func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>) {
+// CPU-NEXT:    %c = stablehlo.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]> : tensor<64xi64>
+// CPU-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i32>
+// CPU-NEXT:    %c_1 = stablehlo.constant dense<64> : tensor<i32>
+// CPU-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<64xi64>
+// CPU-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<i32>
+// CPU-NEXT:    %c_4 = stablehlo.constant dense<-1> : tensor<64xi64>
+// CPU-NEXT:    %c_5 = stablehlo.constant dense<-1> : tensor<i64>
+// CPU-NEXT:    %0:3 = enzymexla.jit_call @enzymexla_lapack_sgeqrf_wrapper_[[WRAPPER_ID]] (%arg0, %c_4, %c_5) {operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 1, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [2], operand_index = 2, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>], xla_side_effect_free} : (tensor<64x64xf32>, tensor<64xi64>, tensor<i64>) -> (tensor<64x64xf32>, tensor<64xi64>, tensor<i64>)
+// CPU-NEXT:    %1 = stablehlo.subtract %0#1, %c_2 : tensor<64xi64>
+// CPU-NEXT:    %2:2 = stablehlo.while(%iterArg = %c_3, %iterArg_6 = %c) : tensor<i32>, tensor<64xi64>
+// CPU-NEXT:     cond {
+// CPU-NEXT:      %7 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i32>, tensor<i32>) -> tensor<i1>
+// CPU-NEXT:      stablehlo.return %7 : tensor<i1>
+// CPU-NEXT:    } do {
+// CPU-NEXT:      %7 = stablehlo.add %iterArg, %c_0 : tensor<i32>
+// CPU-NEXT:      %8 = stablehlo.dynamic_slice %1, %iterArg, sizes = [1] : (tensor<64xi64>, tensor<i32>) -> tensor<1xi64>
+// CPU-NEXT:      %9 = stablehlo.dynamic_slice %iterArg_6, %iterArg, sizes = [1] : (tensor<64xi64>, tensor<i32>) -> tensor<1xi64>
+// CPU-NEXT:      %10 = "stablehlo.gather"(%iterArg_6, %8) <{dimension_numbers = #stablehlo.gather<offset_dims = [0], start_index_map = [0]>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<64xi64>, tensor<1xi64>) -> tensor<1xi64>
+// CPU-NEXT:      %11 = stablehlo.dynamic_update_slice %iterArg_6, %10, %iterArg : (tensor<64xi64>, tensor<1xi64>, tensor<i32>) -> tensor<64xi64>
+// CPU-NEXT:      %12 = stablehlo.reshape %9 : (tensor<1xi64>) -> tensor<i64>
+// CPU-NEXT:      %13 = "stablehlo.scatter"(%11, %8, %12) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0]>, unique_indices = false}> ({
+// CPU-NEXT:      ^bb0(%arg1: tensor<i64>, %arg2: tensor<i64>):
+// CPU-NEXT:        stablehlo.return %arg2 : tensor<i64>
+// CPU-NEXT:      }) : (tensor<64xi64>, tensor<1xi64>, tensor<i64>) -> tensor<64xi64>
+// CPU-NEXT:      stablehlo.return %7, %13 : tensor<i32>, tensor<64xi64>
+// CPU-NEXT:    }
+// CPU-NEXT:    %3 = stablehlo.add %2#1, %c_2 : tensor<64xi64>
+// CPU-NEXT:    %4 = stablehlo.convert %0#1 : (tensor<64xi64>) -> tensor<64xi32>
+// CPU-NEXT:    %5 = stablehlo.convert %3 : (tensor<64xi64>) -> tensor<64xi32>
+// CPU-NEXT:    %6 = stablehlo.convert %0#2 : (tensor<i64>) -> tensor<i32>
+// CPU-NEXT:    return %0#0, %4, %5, %6 : tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>
+// CPU-NEXT:  }
+
+// CUDA: func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>) {
+// CUDA-NEXT:     %c = stablehlo.constant dense<1> : tensor<64xi32>
+// CUDA-NEXT:     %0:3 = stablehlo.custom_call @cusolver_geqrf_ffi(%arg0) {api_version = 4 : i32, operand_layouts = [dense<[0, 1]> : tensor<2xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>]} : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<i32>)
+// CUDA-NEXT:     %1 = stablehlo.subtract %0#1, %c : tensor<64xi32>
+// CUDA-NEXT:     %2 = stablehlo.custom_call @cu_lu_pivots_to_permutation(%1) {api_version = 4 : i32, operand_layouts = [dense<0> : tensor<1xindex>], result_layouts = [dense<0> : tensor<1xindex>]} : (tensor<64xi32>) -> tensor<64xi32>
+// CUDA-NEXT:     %3 = stablehlo.add %c, %2 : tensor<64xi32>
+// CUDA-NEXT:     return %0#0, %0#1, %3, %0#2 : tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>
+// CUDA-NEXT: }
+
+// TPU: func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>) {
+// TPU-NEXT:     %c = stablehlo.constant dense<true> : tensor<i1>
+// TPU-NEXT:     %c_0 = stablehlo.constant dense<1> : tensor<64xi32>
+// TPU-NEXT:     %0:3 = stablehlo.custom_call @LuDecomposition(%arg0) : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>)
+// TPU-NEXT:     %1 = stablehlo.add %c_0, %0#1 : tensor<64xi32>
+// TPU-NEXT:     %2 = stablehlo.add %c_0, %0#2 : tensor<64xi32>
+// TPU-NEXT:     %3 = stablehlo.is_finite %0#0 : (tensor<64x64xf32>) -> tensor<64x64xi1>
+// TPU-NEXT:     %4 = stablehlo.reduce(%3 init: %c) applies stablehlo.and across dimensions = [0, 1] : (tensor<64x64xi1>, tensor<i1>) -> tensor<i1>
+// TPU-NEXT:     %5 = stablehlo.not %4 : tensor<i1>
+// TPU-NEXT:     %6 = stablehlo.convert %5 : (tensor<i1>) -> tensor<i32>
+// TPU-NEXT:     return %0#0, %1, %2, %6 : tensor<64x64xf32>, tensor<64xi32>, tensor<64xi32>, tensor<i32>
+// TPU-NEXT: }
+
+module {
+  // CPU: func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<i32>) {
+  func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<i32>) {
+    // CPU: enzymexla.jit_call @enzymexla_lapack_dgeqrf_wrapper_[[WRAPPER_ID:[0-9]+]]
+    %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
+    return %0#0, %0#1, %0#3 : tensor<64x64xf64>, tensor<64xi32>, tensor<i32>
+  }
+}
+
+module {
+  // CPU: func.func @main(%arg0: tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>) {
+  func.func @main(%arg0: tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>) {
+    // CPU: enzymexla.jit_call @enzymexla_lapack_zgeqrf_wrapper_[[WRAPPER_ID:[0-9]+]]
+    %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
+    return %0#0, %0#1, %0#3 : tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>
+  }
+}
+
+module {
+  // CPU: func.func @main(%arg0: tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>) {
+  func.func @main(%arg0: tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>) {
+    // CPU: enzymexla.jit_call @enzymexla_lapack_cgeqrf_wrapper_[[WRAPPER_ID:[0-9]+]]
+    %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
+    return %0#0, %0#1, %0#3 : tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>
+  }
+}

--- a/test/lit_tests/linalg/qr.mlir
+++ b/test/lit_tests/linalg/qr.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cpu blas_int_width=64},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CPU
 // RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cuda},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CUDA
-// TODO-RUN enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=tpu},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=TPU
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=tpu},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=TPU
 
 module {
   func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>) {
@@ -29,6 +29,12 @@ module {
 // CUDA-NEXT:   %0:2 = stablehlo.custom_call @cusolver_geqrf_ffi(%arg0) {api_version = 4 : i32, operand_layouts = [dense<[0, 1]> : tensor<2xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>]} : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>)
 // CUDA-NEXT:   return %0#0, %0#1, %c : tensor<64x64xf32>, tensor<64xf32>, tensor<i64>
 // CUDA-NEXT: }
+
+// TPU: func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>) {
+// TPU-NEXT:   %c = stablehlo.constant dense<0> : tensor<i64>
+// TPU-NEXT:   %0:2 = stablehlo.custom_call @QrDecomposition(%arg0) : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>)
+// TPU-NEXT:   return %0#0, %0#1, %c : tensor<64x64xf32>, tensor<64xf32>, tensor<i64>
+// TPU-NEXT: }
 
 module {
   // CPU: func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) {

--- a/test/lit_tests/linalg/qr.mlir
+++ b/test/lit_tests/linalg/qr.mlir
@@ -1,67 +1,52 @@
 // RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cpu blas_int_width=64},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CPU
-// TODO-RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cuda},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CUDA
-// TODO-RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=tpu},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=TPU
+// TODO-RUN enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cuda},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=CUDA
+// TODO-RUN enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=tpu},enzyme-hlo-opt)" %s | FileCheck %s --check-prefix=TPU
 
 module {
-  func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<i64>) {
-    %0:3 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<i64>)
-    return %0#0, %0#1, %0#3 : tensor<64x64xf32>, tensor<64x64xf32>, tensor<i64>
+  func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>) {
+    %0:3 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>)
+    return %0#0, %0#1, %0#2 : tensor<64x64xf32>, tensor<64xf32>, tensor<i64>
   }
 }
 
-// CPU:  llvm.func @enzymexla_lapacke_dgeqrf_(i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
-// CPU-NEXT:  func.func @enzymexla_wrapper_lapacke_dgeqrf_[[GEQRF_WRAPPER_ID:[0-9]+]](%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
+// CPU:  llvm.func @enzymexla_wrapper_lapacke_sgeqrf_[[WRAPPER_ID:[0-9]+]](%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
 // CPU-NEXT:    %0 = llvm.mlir.constant(101 : i64) : i64
 // CPU-NEXT:    %1 = llvm.mlir.constant(64 : i64) : i64
-// CPU-NEXT:    %2 = llvm.mlir.constant(64 : i64) : i64
-// CPU-NEXT:    %3 = llvm.mlir.constant(64 : i64) : i64
-// CPU-NEXT:    %4 = llvm.call @enzymexla_lapacke_dgeqrf_(%0, %1, %2, %arg0, %3, %arg1) : (i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
-// CPU-NEXT:    llvm.store %4, %arg2 : i64, !llvm.ptr
-// CPU-NEXT:    return
+// CPU-NEXT:    %2 = llvm.call @enzymexla_lapacke_sgeqrf_(%0, %1, %1, %arg0, %1, %arg1) : (i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
+// CPU-NEXT:    llvm.store %2, %arg2 : i64, !llvm.ptr
+// CPU-NEXT:    llvm.return
 // CPU-NEXT:  }
-// CPU-NEXT:  llvm.func @enzymexla_lapacke_dorgqr_(i64, i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
-// CPU-NEXT:  func.func @enzymexla_wrapper_lapacke_dorgqr_[[ORGQR_WRAPPER_ID:[0-9]+]](%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
-// CPU-NEXT:    %0 = llvm.mlir.constant(101 : i64) : i64
-// CPU-NEXT:    %1 = llvm.mlir.constant(64 : i64) : i64
-// CPU-NEXT:    %2 = llvm.mlir.constant(64 : i64) : i64
-// CPU-NEXT:    %3 = llvm.mlir.constant(64 : i64) : i64
-// CPU-NEXT:    %4 = llvm.mlir.constant(64 : i64) : i64
-// CPU-NEXT:    %5 = llvm.call @enzymexla_lapacke_dorgqr_(%0, %1, %2, %3, %arg0, %4, %arg1) : (i64, i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
-// CPU-NEXT:    llvm.store %5, %arg2 : i64, !llvm.ptr
-// CPU-NEXT:    return
-// CPU-NEXT:  }
-// CPU-NEXT:  func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) {
-// CPU-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<64xf64>
-// CPU-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
-// CPU-NEXT:    %0:3 = enzymexla.jit_call @enzymexla_wrapper_lapacke_dgeqrf_[[GEQRF_WRAPPER_ID]] (%arg0, %cst, %c) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 1, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [2], operand_index = 2, operand_tuple_indices = []>]} : (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>)
-// CPU-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<i64>
-// CPU-NEXT:    %1:2 = enzymexla.jit_call @enzymexla_wrapper_lapacke_dorgqr_[[ORGQR_WRAPPER_ID]] (%0#0, %0#1, %c_0) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 2, operand_tuple_indices = []>]} : (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) -> (tensor<64x64xf64>, tensor<i64>)
-// CPU-NEXT:    return %1#0, %0#0 : tensor<64x64xf64>, tensor<64x64xf64>
+// CPU-NEXT:  llvm.func @enzymexla_lapacke_sgeqrf_(i64, i64, i64, !llvm.ptr, i64, !llvm.ptr) -> i64
+// CPU-NEXT:  func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>) {
+// CPU-NEXT:    %c = stablehlo.constant dense<-1> : tensor<i64>
+// CPU-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<64xf32>
+// CPU-NEXT:    %0:3 = enzymexla.jit_call @enzymexla_wrapper_lapacke_sgeqrf_[[WRAPPER_ID]] (%arg0, %cst, %c) {operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 1, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [2], operand_index = 2, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<> : tensor<0xindex>], xla_side_effect_free} : (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>) -> (tensor<64x64xf32>, tensor<64xf32>, tensor<i64>)
+// CPU-NEXT:    return %0#0, %0#1, %0#2 : tensor<64x64xf32>, tensor<64xf32>, tensor<i64>
 // CPU-NEXT:  }
 
 module {
-  // CPU: func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<i32>) {
-  func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<i32>) {
+  // CPU: func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) {
+  func.func @main(%arg0: tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>) {
     // CPU: enzymexla.jit_call @enzymexla_wrapper_lapacke_dgeqrf_[[WRAPPER_ID:[0-9]+]]
-    %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
-    return %0#0, %0#1, %0#3 : tensor<64x64xf64>, tensor<64xi32>, tensor<i32>
+    %0:3 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf64>) -> (tensor<64x64xf64>, tensor<64xf64>, tensor<i64>)
+    return %0#0, %0#1, %0#2 : tensor<64x64xf64>, tensor<64xf64>, tensor<i64>
   }
 }
 
 module {
-  // CPU: func.func @main(%arg0: tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>) {
-  func.func @main(%arg0: tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>) {
-    // CPU: enzymexla.jit_call @enzymexla_wrapper_lapacke_zgeqrf_[[WRAPPER_ID:[0-9]+]]
-    %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
-    return %0#0, %0#1, %0#3 : tensor<64x64xcomplex<f64>>, tensor<64xi32>, tensor<i32>
-  }
-}
-
-module {
-  // CPU: func.func @main(%arg0: tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>) {
-  func.func @main(%arg0: tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>) {
+  // CPU: func.func @main(%arg0: tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xcomplex<f32>>, tensor<i64>) {
+  func.func @main(%arg0: tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xcomplex<f32>>, tensor<i64>) {
     // CPU: enzymexla.jit_call @enzymexla_wrapper_lapacke_cgeqrf_[[WRAPPER_ID:[0-9]+]]
-    %0:4 = enzymexla.linalg.qr %arg0 : (tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<64xi32>, tensor<i32>)
-    return %0#0, %0#1, %0#3 : tensor<64x64xcomplex<f32>>, tensor<64xi32>, tensor<i32>
+    %0:3 = enzymexla.linalg.qr %arg0 : (tensor<64x64xcomplex<f32>>) -> (tensor<64x64xcomplex<f32>>, tensor<64xcomplex<f32>>, tensor<i64>)
+    return %0#0, %0#1, %0#2 : tensor<64x64xcomplex<f32>>, tensor<64xcomplex<f32>>, tensor<i64>
+  }
+}
+
+module {
+  // CPU: func.func @main(%arg0: tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xcomplex<f64>>, tensor<i64>) {
+  func.func @main(%arg0: tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xcomplex<f64>>, tensor<i64>) {
+    // CPU: enzymexla.jit_call @enzymexla_wrapper_lapacke_zgeqrf_[[WRAPPER_ID:[0-9]+]]
+    %0:3 = enzymexla.linalg.qr %arg0 : (tensor<64x64xcomplex<f64>>) -> (tensor<64x64xcomplex<f64>>, tensor<64xcomplex<f64>>, tensor<i64>)
+    return %0#0, %0#1, %0#2 : tensor<64x64xcomplex<f64>>, tensor<64xcomplex<f64>>, tensor<i64>
   }
 }


### PR DESCRIPTION
@avik-pal the StableHLO code after the `jit_call` in the `enzymexla.linalg.lu` code I guess is for reconstructing the L and U matrices from the output of the LAPACK routine right?

Also, in the case of the QR, it needs some workspace memory for storing intermediate computations. @wsmoses should we leave the allocation to XLA / EnzymeXLA or should we allocate it ourselves in the wrapper? I feel like reusing the workspace buffer across multiple LAPACK calls would be something that could be optimized in the future, but don't know how to properly express it.

I might also need to call another LAPACK function, `*ORGQR`/`*UNGQR`, to retrieve the Q matrix.