### PR TITLE
Explicit check for gpu.alloc async token

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1630,7 +1630,9 @@ struct SimplifyDeadAlloc : public OpRewritePattern<T> {
     }
 
     if constexpr (gpu) {
-      alloc->getResult(1).replaceAllUsesWith(alloc.getAsyncToken());
+      if (alloc.getAsyncToken()) {
+        alloc->getResult(1).replaceAllUsesWith(alloc.getAsyncToken());
+      }
     }
 
     for (Operation *user : llvm::make_early_inc_range(alloc->getUsers()))

--- a/test/lit_tests/gpualloc_deadstore_nonasync.mlir
+++ b/test/lit_tests/gpualloc_deadstore_nonasync.mlir
@@ -1,0 +1,12 @@
+// RUN: enzymexlamlir-opt --llvm-to-affine-access %s | FileCheck %s
+
+func.func @deadstore(%val: i8) {
+    %c0 = arith.constant 0 : index
+    %memref = gpu.alloc() : memref<16xi8, 1>
+    memref.store %val, %memref[%c0] : memref<16xi8, 1>
+    return
+}
+
+// CHECK: func.func @deadstore(%arg0: i8) {
+// CHECK-NEXT:   return
+// CHECK-NEXT: }


### PR DESCRIPTION
This fixes a crash where `gpu.alloc` does not return an async token