### PR TITLE
feat: various passes to fuse mul chains

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6011,6 +6011,13 @@ struct NoNanDivSimplify final
       return success();
     }
 
+    // x / x -> 1
+    if (op.getLhs() == op.getRhs()) {
+      rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
+          op, op.getType(), cast<ElementsAttr>(makeAttr(op.getType(), 1)));
+      return success();
+    }
+
     return failure();
   }
 
@@ -20008,6 +20015,217 @@ struct CommonAssociativeCommutativeOpReorder final
   }
 };
 
+struct LogSimplify final
+    : public CheckedOpRewritePattern<stablehlo::LogOp, LogSimplify> {
+  using CheckedOpRewritePattern<stablehlo::LogOp,
+                                LogSimplify>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::LogOp op,
+                                    PatternRewriter &rewriter) const {
+    { // log(exp(x)) -> x
+      auto defOp = op.getOperand().getDefiningOp<stablehlo::ExpOp>();
+      if (defOp) {
+        rewriter.replaceAllUsesWith(op.getResult(), defOp.getOperand());
+        return success();
+      }
+    }
+
+    { // log(pow(x, y)) -> y * log(x)
+      auto defOp = op.getOperand().getDefiningOp<stablehlo::PowOp>();
+      if (defOp) {
+        rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
+            op, defOp.getRhs(),
+            rewriter.create<stablehlo::LogOp>(op.getLoc(), defOp.getLhs()));
+        return success();
+      }
+    }
+
+    {
+      auto defOp = op.getOperand().getDefiningOp<stablehlo::MulOp>();
+      if (defOp) {
+        auto lhs = defOp.getLhs();
+        auto rhs = defOp.getRhs();
+        if (lhs == rhs) { // log(mul(a, a)) -> 2 * log(a)
+          rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
+              op,
+              rewriter.create<stablehlo::ConstantOp>(
+                  op.getLoc(), lhs.getType(),
+                  cast<ElementsAttr>(makeAttr(lhs.getType(), 2))),
+              rewriter.create<stablehlo::LogOp>(op.getLoc(), lhs));
+          return success();
+        }
+
+        if (anyOperandIsConstant(defOp) &&
+            !allOperandsAreConstant(defOp)) { // log(mul(a, b)) -> log(a) +
+                                              // log(b) if a or b is constant
+          rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
+              op, rewriter.create<stablehlo::LogOp>(op.getLoc(), lhs),
+              rewriter.create<stablehlo::LogOp>(op.getLoc(), rhs));
+          return success();
+        }
+      }
+    }
+
+    {
+      auto defOp = op.getOperand().getDefiningOp<stablehlo::AddOp>();
+      if (defOp) {
+        auto lhs = defOp.getLhs();
+        auto rhs = defOp.getRhs();
+        if (lhs == rhs) { // log(add(a, a)) -> log(2) + log(a)
+          rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
+              op,
+              rewriter.create<stablehlo::LogOp>(
+                  op.getLoc(),
+                  rewriter.create<stablehlo::ConstantOp>(
+                      op.getLoc(), lhs.getType(),
+                      cast<ElementsAttr>(makeAttr(lhs.getType(), 2)))),
+              rewriter.create<stablehlo::LogOp>(op.getLoc(), lhs));
+          return success();
+        }
+      }
+    }
+
+    {
+      auto defOp = op.getOperand().getDefiningOp<stablehlo::DivOp>();
+      if (defOp) {
+        auto lhs = defOp.getLhs();
+        auto rhs = defOp.getRhs();
+
+        if (anyOperandIsConstant(defOp) &&
+            !allOperandsAreConstant(defOp)) { // log(div(a, b)) -> log(a) -
+                                              // log(b) if a or b is constant
+          rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
+              op, rewriter.create<stablehlo::LogOp>(op.getLoc(), lhs),
+              rewriter.create<stablehlo::LogOp>(op.getLoc(), rhs));
+          return success();
+        }
+      }
+    }
+
+    {
+      auto defOp = op.getOperand().getDefiningOp<stablehlo::SqrtOp>();
+      if (defOp &&
+          isOnlyUsedInOperation(defOp, op)) { // log(sqrt(x)) -> log(x) / 2
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
+            op,
+            rewriter.create<stablehlo::LogOp>(op.getLoc(), defOp.getOperand()),
+            rewriter.create<stablehlo::ConstantOp>(
+                op.getLoc(), defOp.getType(),
+                cast<ElementsAttr>(makeAttr(defOp.getType(), 2))));
+        return success();
+      }
+    }
+
+    {
+      auto defOp = op.getOperand().getDefiningOp<stablehlo::CbrtOp>();
+      if (defOp &&
+          isOnlyUsedInOperation(defOp, op)) { // log(cbrt(x)) -> log(x) / 3
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
+            op,
+            rewriter.create<stablehlo::LogOp>(op.getLoc(), defOp.getOperand()),
+            rewriter.create<stablehlo::ConstantOp>(
+                op.getLoc(), defOp.getType(),
+                cast<ElementsAttr>(makeAttr(defOp.getType(), 3))));
+        return success();
+      }
+    }
+
+    {
+      auto defOp = op.getOperand().getDefiningOp<stablehlo::RsqrtOp>();
+      if (defOp &&
+          isOnlyUsedInOperation(defOp, op)) { // log(rsqrt(x)) -> -log(x) / 2
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
+            op,
+            rewriter.create<stablehlo::LogOp>(op.getLoc(), defOp.getOperand()),
+            rewriter.create<stablehlo::ConstantOp>(
+                op.getLoc(), defOp.getType(),
+                cast<ElementsAttr>(makeAttr(defOp.getType(), -2))));
+        return success();
+      }
+    }
+
+    return failure();
+  }
+};
+
+struct NegMulConstSimplify final
+    : public CheckedOpRewritePattern<stablehlo::NegOp, NegMulConstSimplify> {
+  using CheckedOpRewritePattern<stablehlo::NegOp,
+                                NegMulConstSimplify>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::NegOp op,
+                                    PatternRewriter &rewriter) const {
+    auto mulOp = op.getOperand().getDefiningOp<stablehlo::MulOp>();
+    if (!mulOp)
+      return failure();
+
+    auto lhs = mulOp.getLhs();
+    auto rhs = mulOp.getRhs();
+
+    DenseElementsAttr lhsAttr;
+    bool lhsIsConst = matchPattern(lhs, m_Constant(&lhsAttr));
+
+    DenseElementsAttr rhsAttr;
+    bool rhsIsConst = matchPattern(rhs, m_Constant(&rhsAttr));
+
+    if (lhsIsConst && rhsIsConst)
+      return failure(); // const prop will evaluate this
+
+    if (lhsIsConst) {
+      rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
+          op, rewriter.create<stablehlo::NegOp>(op.getLoc(), lhs), rhs);
+      return success();
+    }
+
+    if (rhsIsConst) {
+      rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
+          op, lhs, rewriter.create<stablehlo::NegOp>(op.getLoc(), rhs));
+      return success();
+    }
+
+    return failure();
+  }
+};
+
+struct NegDivConstSimplify final
+    : public CheckedOpRewritePattern<stablehlo::NegOp, NegDivConstSimplify> {
+  using CheckedOpRewritePattern<stablehlo::NegOp,
+                                NegDivConstSimplify>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::NegOp op,
+                                    PatternRewriter &rewriter) const {
+    auto divOp = op.getOperand().getDefiningOp<stablehlo::DivOp>();
+    if (!divOp)
+      return failure();
+
+    auto lhs = divOp.getLhs();
+    auto rhs = divOp.getRhs();
+
+    DenseElementsAttr lhsAttr;
+    bool lhsIsConst = matchPattern(lhs, m_Constant(&lhsAttr));
+
+    DenseElementsAttr rhsAttr;
+    bool rhsIsConst = matchPattern(rhs, m_Constant(&rhsAttr));
+
+    if (lhsIsConst && rhsIsConst)
+      return failure(); // const prop will evaluate this
+
+    if (lhsIsConst) {
+      rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
+          op, rewriter.create<stablehlo::NegOp>(op.getLoc(), lhs), rhs);
+      return success();
+    }
+
+    if (rhsIsConst) {
+      rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
+          op, lhs, rewriter.create<stablehlo::NegOp>(op.getLoc(), rhs));
+      return success();
+    }
+
+    return failure();
+  }
+};
+
 ///////////////  End Imported from stablehlo
 
 // clang-format off
@@ -20238,16 +20456,17 @@ struct EnzymeHLOOptPass
         AddSimplify, SubSimplify, AndSimplify, MaxSimplify, MinSimplify,
         OrSimplify, XorSimplify, MulSimplify, DivSimplify, RemSimplify,
         PowSimplify, NoopSlice, NoopReverse, SliceSlice, PadSimplify,
-        ShiftRightLogicalSimplify, NegativePadToSlice, SliceSimplify,
-        ConvertSimplify, TransposeSimplify, DotGeneralSimplify,
+        LogSimplify, ShiftRightLogicalSimplify, NegativePadToSlice,
+        SliceSimplify, ConvertSimplify, TransposeSimplify, DotGeneralSimplify,
         DynamicSliceToStatic, DynamicUpdateSliceElim, ReduceToReshape,
         BroadcastToReshape, ReshapeEmptyBroadcast, BroadcastReshape,
         ConstPropThroughBarrier, ReplaceNegAddWithSubtract, SignAbsSimplify,
         AbsPositiveSimplify, SimplifyBoundary<enzymexla::ExtendOp>,
         SimplifyBoundary<enzymexla::WrapOp>,
         SimplifyBoundary<enzymexla::RotateOp>, TransposeReshapeToBroadcast,
-        ReshapeTransposeToBroadcast, SelectBroadcastInDim,
-        PowerMultiplyToPower>(context, PatternBenefit(65000));
+        ReshapeTransposeToBroadcast, SelectBroadcastInDim, PowerMultiplyToPower,
+        NegMulConstSimplify, NegDivConstSimplify>(context,
+                                                  PatternBenefit(65000));
 
     patterns.add<IotaSimplify, BroadcastInDimSimplify, ConcatConstProp,
                  DynamicUpdateSliceConstProp, PadSimplify>(

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -5970,7 +5970,8 @@ struct DivSimplify
         auto rhsTen = stablehlo::constantOp(rhsAttr);
         auto oneTen = stablehlo::constantOp(
             cast<ElementsAttr>(makeAttr(op.getType(), 1)));
-        auto out = fromTensor(stablehlo::divideOp(oneTen, rhsTen, op.getType()));
+        auto out =
+            fromTensor(stablehlo::divideOp(oneTen, rhsTen, op.getType()));
 
         rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
             op, op.getLhs(),

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6114,13 +6114,14 @@ struct PowSimplify
   }
 };
 
-struct NoNanPowSimplify final
-    : public CheckedOpRewritePattern<stablehlo::PowOp, NoNanPowSimplify> {
-  using CheckedOpRewritePattern<stablehlo::PowOp,
-                                NoNanPowSimplify>::CheckedOpRewritePattern;
+struct NoNanZeroBasePowSimplify final
+    : public CheckedOpRewritePattern<stablehlo::PowOp,
+                                     NoNanZeroBasePowSimplify> {
+  using CheckedOpRewritePattern<
+      stablehlo::PowOp, NoNanZeroBasePowSimplify>::CheckedOpRewritePattern;
 
-  NoNanPowSimplify(bool allowOnFloatingPointMath, MLIRContext *context,
-                   PatternBenefit benefit = 1)
+  NoNanZeroBasePowSimplify(bool allowOnFloatingPointMath, MLIRContext *context,
+                           PatternBenefit benefit = 1)
       : CheckedOpRewritePattern(context, benefit),
         allowOnFloatingPointMath(allowOnFloatingPointMath) {}
 
@@ -20396,12 +20397,12 @@ void mlir::transform::addNoNanDivSimplify(RewritePatternSet &patterns,
                                     benefit);
 }
 
-void mlir::transform::addNoNanPowSimplify(RewritePatternSet &patterns,
-                                          bool allowOnFloatingPointMath,
-                                          MLIRContext &context,
-                                          PatternBenefit benefit) {
-  patterns.insert<NoNanPowSimplify>(allowOnFloatingPointMath, &context,
-                                    benefit);
+void mlir::transform::addNoNanZeroBasePowSimplify(RewritePatternSet &patterns,
+                                                  bool allowOnFloatingPointMath,
+                                                  MLIRContext &context,
+                                                  PatternBenefit benefit) {
+  patterns.insert<NoNanZeroBasePowSimplify>(allowOnFloatingPointMath, &context,
+                                            benefit);
 }
 
 void mlir::transform::addBroadcastInDimSimplify(RewritePatternSet &patterns,
@@ -20730,8 +20731,8 @@ struct EnzymeHLOOptPass
       patterns.add<AllFinite>(context);
     if (no_nan || all_finite)
       patterns.add<NoNan, NoNanSelfSubSimplify>(context);
-    patterns.add<NoNanAddSubSimplify, NoNanMulSimplify, NoNanDivSimplify,
-                 NoNanPowSimplify>((no_nan || all_finite), context);
+    patterns.add<NoNanAddSubSimplify, NoNanMulSimplify, NoNanDivSimplify>(
+        (no_nan || all_finite), context);
 
     // clang-format off
     patterns.add<

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOPatterns.h
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOPatterns.h
@@ -30,9 +30,9 @@ void addNoNanMulSimplify(RewritePatternSet &patterns,
 void addNoNanDivSimplify(RewritePatternSet &patterns,
                          bool allowOnFloatingPointMath, MLIRContext &context,
                          PatternBenefit benefit);
-void addNoNanPowSimplify(RewritePatternSet &patterns,
-                         bool allowOnFloatingPointMath, MLIRContext &context,
-                         PatternBenefit benefit);
+void addNoNanZeroBasePowSimplify(RewritePatternSet &patterns,
+                                 bool allowOnFloatingPointMath,
+                                 MLIRContext &context, PatternBenefit benefit);
 void addIotaSimplify(RewritePatternSet &patterns, int64_t maxConstantExpansion,
                      MLIRContext &context, PatternBenefit benefit);
 void addConcatConstProp(RewritePatternSet &patterns,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOPatterns.h
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOPatterns.h
@@ -27,6 +27,12 @@ void addNoNanAddSubSimplify(RewritePatternSet &patterns,
 void addNoNanMulSimplify(RewritePatternSet &patterns,
                          bool allowOnFloatingPointMath, MLIRContext &context,
                          PatternBenefit benefit);
+void addNoNanDivSimplify(RewritePatternSet &patterns,
+                         bool allowOnFloatingPointMath, MLIRContext &context,
+                         PatternBenefit benefit);
+void addNoNanPowSimplify(RewritePatternSet &patterns,
+                         bool allowOnFloatingPointMath, MLIRContext &context,
+                         PatternBenefit benefit);
 void addIotaSimplify(RewritePatternSet &patterns, int64_t maxConstantExpansion,
                      MLIRContext &context, PatternBenefit benefit);
 void addConcatConstProp(RewritePatternSet &patterns,

--- a/src/enzyme_ad/jax/TransformOps/GenerateApplyPatterns.cpp
+++ b/src/enzyme_ad/jax/TransformOps/GenerateApplyPatterns.cpp
@@ -156,7 +156,7 @@ LogicalResult parseTransform(OpBuilder &builder, Location loc,
           opName == "extend_unary_elementwise" ||
           opName == "wrap_unary_elementwise" ||
           opName == "no_nan_mul_simplify" || opName == "no_nan_div_simplify" ||
-          opName == "no_nan_pow_simplify")
+          opName == "no_nan_zero_base_pow_simplify")
         state.addAttribute("parameter", builder.getBoolAttr(parameter));
       else
         state.addAttribute("parameter", builder.getI64IntegerAttr(parameter));

--- a/src/enzyme_ad/jax/TransformOps/GenerateApplyPatterns.cpp
+++ b/src/enzyme_ad/jax/TransformOps/GenerateApplyPatterns.cpp
@@ -154,7 +154,9 @@ LogicalResult parseTransform(OpBuilder &builder, Location loc,
           opName == "transpose_elementwise" ||
           opName == "reshape_elementwise" || opName == "reshape_slice" ||
           opName == "extend_unary_elementwise" ||
-          opName == "wrap_unary_elementwise" || opName == "no_nan_mul_simplify")
+          opName == "wrap_unary_elementwise" ||
+          opName == "no_nan_mul_simplify" || opName == "no_nan_div_simplify" ||
+          opName == "no_nan_pow_simplify")
         state.addAttribute("parameter", builder.getBoolAttr(parameter));
       else
         state.addAttribute("parameter", builder.getI64IntegerAttr(parameter));

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.cpp
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.cpp
@@ -40,9 +40,10 @@ void ApplyNoNanDivSimplify::populatePatterns(RewritePatternSet &patterns) {
   addNoNanDivSimplify(patterns, getParameter(), *getContext(),
                       PatternBenefit(getBenefit().value_or(1)));
 }
-void ApplyNoNanPowSimplify::populatePatterns(RewritePatternSet &patterns) {
-  addNoNanPowSimplify(patterns, getParameter(), *getContext(),
-                      PatternBenefit(getBenefit().value_or(1)));
+void ApplyNoNanZeroBasePowSimplify::populatePatterns(
+    RewritePatternSet &patterns) {
+  addNoNanZeroBasePowSimplify(patterns, getParameter(), *getContext(),
+                              PatternBenefit(getBenefit().value_or(1)));
 }
 void ApplyWhileSimplifyPatterns::populatePatterns(RewritePatternSet &patterns) {
   addWhileSimplify(patterns, getParameter(), *getContext(),

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.cpp
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.cpp
@@ -36,6 +36,14 @@ void ApplyNoNanMulSimplify::populatePatterns(RewritePatternSet &patterns) {
   addNoNanMulSimplify(patterns, getParameter(), *getContext(),
                       PatternBenefit(getBenefit().value_or(1)));
 }
+void ApplyNoNanDivSimplify::populatePatterns(RewritePatternSet &patterns) {
+  addNoNanDivSimplify(patterns, getParameter(), *getContext(),
+                      PatternBenefit(getBenefit().value_or(1)));
+}
+void ApplyNoNanPowSimplify::populatePatterns(RewritePatternSet &patterns) {
+  addNoNanPowSimplify(patterns, getParameter(), *getContext(),
+                      PatternBenefit(getBenefit().value_or(1)));
+}
 void ApplyWhileSimplifyPatterns::populatePatterns(RewritePatternSet &patterns) {
   addWhileSimplify(patterns, getParameter(), *getContext(),
                    PatternBenefit(getBenefit().value_or(0)));

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -528,8 +528,8 @@ def ApplyNoNanDivSimplify : EnzymeHLOParameterizedPatternOp<
   }];
 }
 
-def ApplyNoNanPowSimplify : EnzymeHLOParameterizedPatternOp<
-    "no_nan_pow_simplify"> {
+def ApplyNoNanZeroBasePowSimplify : EnzymeHLOParameterizedPatternOp<
+    "no_nan_zero_base_pow_simplify"> {
   let arguments = (ins OptionalAttr<I64Attr>:$benefit, BoolAttr:$parameter);
   let assemblyFormat = "attr-dict";
   // TODO: this should be made better searchable.

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -513,6 +513,36 @@ def ApplyNoNanMulSimplify : EnzymeHLOParameterizedPatternOp<
   }];
 }
 
+def ApplyNoNanDivSimplify : EnzymeHLOParameterizedPatternOp<
+    "no_nan_div_simplify"> {
+  let arguments = (ins OptionalAttr<I64Attr>:$benefit, BoolAttr:$parameter);
+  let assemblyFormat = "attr-dict";
+  // TODO: this should be made better searchable.
+  let extraClassDeclaration = [{
+    ::llvm::SmallVector<::mlir::DictionaryAttr>
+    static getPossibleAttrCombinations(::mlir::Builder &builder) {
+      return {builder.getDictionaryAttr(
+                  builder.getNamedAttr("parameter",
+                                       builder.getBoolAttr(true)))};
+    }
+  }];
+}
+
+def ApplyNoNanPowSimplify : EnzymeHLOParameterizedPatternOp<
+    "no_nan_pow_simplify"> {
+  let arguments = (ins OptionalAttr<I64Attr>:$benefit, BoolAttr:$parameter);
+  let assemblyFormat = "attr-dict";
+  // TODO: this should be made better searchable.
+  let extraClassDeclaration = [{
+    ::llvm::SmallVector<::mlir::DictionaryAttr>
+    static getPossibleAttrCombinations(::mlir::Builder &builder) {
+      return {builder.getDictionaryAttr(
+                  builder.getNamedAttr("parameter",
+                                       builder.getBoolAttr(true)))};
+    }
+  }];
+}
+
 def ApplyTransposeElementwisePatterns : EnzymeHLOParameterizedPatternOp<
     "transpose_elementwise"> {
   let arguments = (ins OptionalAttr<I64Attr>:$benefit, BoolAttr:$parameter);

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -2083,3 +2083,15 @@ def ApplyChainedMultiplyToPower : EnzymeHLOPatternOp<"chained_multiply_to_power"
 def ApplyPowerMultiplyToPower : EnzymeHLOPatternOp<"power_multiply_to_power"> {
   let patterns = ["PowerMultiplyToPower"];
 }
+
+def ApplyLogSimplify : EnzymeHLOPatternOp<"log_simplify"> {
+  let patterns = ["LogSimplify"];
+}
+
+def ApplyNegMulConstSimplify : EnzymeHLOPatternOp<"neg_mul_const_simplify"> {
+  let patterns = ["NegMulConstSimplify"];
+}
+
+def ApplyNegDivConstSimplify : EnzymeHLOPatternOp<"neg_div_const_simplify"> {
+  let patterns = ["NegDivConstSimplify"];
+}

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -611,7 +611,19 @@ def ApplyAssociativeBinaryOpReorderingPatterns : EnzymeHLOPatternOp<
                   "AssociativeBinaryOpReordering<stablehlo::MinOp>",
                   "AssociativeBinaryOpReordering<stablehlo::MaxOp>",
                   "AssociativeBinaryOpReordering<stablehlo::AndOp>",
-                  "AssociativeBinaryOpReordering<stablehlo::OrOp>"];
+                  "AssociativeBinaryOpReordering<stablehlo::OrOp>",
+                  "AssociativeBinaryOpReordering<stablehlo::XorOp>"];
+}
+
+def ApplyCommonAssociativeCommutativeOpReorderPatterns : EnzymeHLOPatternOp<
+    "common_associative_commutative_op_reorder"> {
+  let patterns = ["CommonAssociativeCommutativeOpReorder<stablehlo::AddOp>",
+                  "CommonAssociativeCommutativeOpReorder<stablehlo::MulOp>",
+                  "CommonAssociativeCommutativeOpReorder<stablehlo::MinOp>",
+                  "CommonAssociativeCommutativeOpReorder<stablehlo::MaxOp>",
+                  "CommonAssociativeCommutativeOpReorder<stablehlo::AndOp>",
+                  "CommonAssociativeCommutativeOpReorder<stablehlo::OrOp>",
+                  "CommonAssociativeCommutativeOpReorder<stablehlo::XorOp>"];
 }
 
 def ApplyTransposeUnaryTransposeAbsPatterns : EnzymeHLOPatternOp<
@@ -2032,4 +2044,12 @@ def ApplyUnaryElementwiseScatterSimplify : EnzymeHLOPatternOp<"unary_elementwise
 
 def ApplyGatherElementwise : EnzymeHLOPatternOp<"gather_elementwise"> {
   let patterns = ["GatherElementwise"];
+}
+
+def ApplyChainedMultiplyToPower : EnzymeHLOPatternOp<"chained_multiply_to_power"> {
+  let patterns = ["ChainedMultiplyToPower"];
+}
+
+def ApplyPowerMultiplyToPower : EnzymeHLOPatternOp<"power_multiply_to_power"> {
+  let patterns = ["PowerMultiplyToPower"];
 }

--- a/src/enzyme_ad/jax/Utils.cpp
+++ b/src/enzyme_ad/jax/Utils.cpp
@@ -566,6 +566,24 @@ bool canApplyNoNanPattern(bool allowOnFloatingPointMath, Type outTy,
   return allowOnFloatingPointMath;
 }
 
+bool anyOperandIsConstant(mlir::Operation *op) {
+  DenseElementsAttr attr;
+  for (auto operand : op->getOperands()) {
+    if (matchPattern(operand, m_Constant(&attr)))
+      return true;
+  }
+  return false;
+}
+
+bool allOperandsAreConstant(mlir::Operation *op) {
+  DenseElementsAttr attr;
+  for (auto operand : op->getOperands()) {
+    if (!matchPattern(operand, m_Constant(&attr)))
+      return false;
+  }
+  return true;
+}
+
 } // namespace enzyme
 
 namespace stablehlo {

--- a/src/enzyme_ad/jax/Utils.cpp
+++ b/src/enzyme_ad/jax/Utils.cpp
@@ -550,6 +550,22 @@ bool mayWriteTo(Operation *op, Value val, bool ignoreBarrier) {
   return true;
 }
 
+bool canApplyNoNanPattern(bool allowOnFloatingPointMath, Type Ty) {
+  Ty = getElementTypeOrSelf(Ty);
+  if (Ty.isInteger())
+    return true;
+  return allowOnFloatingPointMath;
+}
+
+bool canApplyNoNanPattern(bool allowOnFloatingPointMath, Type outTy,
+                          Type inTy) {
+  outTy = getElementTypeOrSelf(outTy);
+  inTy = getElementTypeOrSelf(inTy);
+  if (outTy.isInteger() && inTy.isInteger())
+    return true;
+  return allowOnFloatingPointMath;
+}
+
 } // namespace enzyme
 
 namespace stablehlo {

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -291,6 +291,9 @@ bool mayAlias(mlir::MemoryEffects::EffectInstance a,
 
 bool mayAlias(mlir::MemoryEffects::EffectInstance a, mlir::Value b);
 
+bool canApplyNoNanPattern(bool allowOnFloatingPointMath, Type Ty);
+bool canApplyNoNanPattern(bool allowOnFloatingPointMath, Type outTy, Type inTy);
+
 } // namespace enzyme
 
 namespace stablehlo {

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -294,6 +294,9 @@ bool mayAlias(mlir::MemoryEffects::EffectInstance a, mlir::Value b);
 bool canApplyNoNanPattern(bool allowOnFloatingPointMath, Type Ty);
 bool canApplyNoNanPattern(bool allowOnFloatingPointMath, Type outTy, Type inTy);
 
+bool anyOperandIsConstant(mlir::Operation *op);
+bool allOperandsAreConstant(mlir::Operation *op);
+
 } // namespace enzyme
 
 namespace stablehlo {

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -333,6 +333,9 @@ def optimization_passes(
         # "chained_multiply_to_power", # TODO: make it into an optional pass
         "power_multiply_to_power",
         "common_associative_commutative_op_reorder",
+        "log_simplify",
+        "neg_mul_const_simplify",
+        "neg_div_const_simplify",
     ]
 
     # constant propagation patterns

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -467,13 +467,13 @@ def optimization_passes(
             "no_nan_self_sub_simplify",
             "no_nan_add_sub_simplify(1)",
             "no_nan_div_simplify(1)",
-            "no_nan_pow_simplify(1)",
+            # "no_nan_zero_base_pow_simplify(1)",
         ]
     else:
         transform_passes_list += [
             "no_nan_add_sub_simplify(0)",
             "no_nan_div_simplify(0)",
-            "no_nan_pow_simplify(0)",
+            # "no_nan_zero_base_pow_simplify(0)",
         ]
 
     transform_passes = ",".join(

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -330,7 +330,7 @@ def optimization_passes(
         # "concat_to_onedim_dusslice",
         "scatter_multiply_simplify",
         "unary_elementwise_scatter_simplify",
-        "chained_multiply_to_power",
+        # "chained_multiply_to_power", # TODO: make it into an optional pass
         "power_multiply_to_power",
         "common_associative_commutative_op_reorder",
     ]

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -463,9 +463,15 @@ def optimization_passes(
             "no_nan",
             "no_nan_self_sub_simplify",
             "no_nan_add_sub_simplify(1)",
+            "no_nan_div_simplify(1)",
+            "no_nan_pow_simplify(1)",
         ]
     else:
-        transform_passes_list += ["no_nan_add_sub_simplify(0)"]
+        transform_passes_list += [
+            "no_nan_add_sub_simplify(0)",
+            "no_nan_div_simplify(0)",
+            "no_nan_pow_simplify(0)",
+        ]
 
     transform_passes = ",".join(
         [

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -330,6 +330,9 @@ def optimization_passes(
         # "concat_to_onedim_dusslice",
         "scatter_multiply_simplify",
         "unary_elementwise_scatter_simplify",
+        "chained_multiply_to_power",
+        "power_multiply_to_power",
+        "common_associative_commutative_op_reorder",
     ]
 
     # constant propagation patterns

--- a/test/lit_tests/binop_const_lift_computation.mlir
+++ b/test/lit_tests/binop_const_lift_computation.mlir
@@ -42,8 +42,8 @@ func.func @divmulconst(%arg0: tensor<f64>) -> tensor<f64> {
 // (x / 2) / 4 == x / (2 * 4)
 func.func @divdivconst(%arg0: tensor<f64>) -> tensor<f64> {
   // CHECK-LABEL: func @divdivconst
-  // CHECK:      %[[CST:.*]] = stablehlo.constant dense<8.000000e+00> : tensor<f64>
-  // CHECK-NEXT: %[[RES:.*]] = stablehlo.divide %arg0, %[[CST]] : tensor<f64>
+  // CHECK:      %[[CST:.*]] = stablehlo.constant dense<1.250000e-01> : tensor<f64>
+  // CHECK-NEXT: %[[RES:.*]] = stablehlo.multiply %arg0, %[[CST]] : tensor<f64>
   // CHECK-NEXT: return %[[RES]] : tensor<f64>
   %cst = stablehlo.constant dense<2.0> : tensor<f64>
   %cst_0 = stablehlo.constant dense<4.0> : tensor<f64>

--- a/test/lit_tests/chlo_lgamma_prop.mlir
+++ b/test/lit_tests/chlo_lgamma_prop.mlir
@@ -1,7 +1,7 @@
 // RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(enzyme-hlo-opt)" | FileCheck %s
 
 module {
-  func.func @lgamma_f32() -> tensor<f32> {  
+  func.func @lgamma_f32() -> tensor<f32> {
     %arg = stablehlo.constant dense<1.000000e+00> : tensor<f32>
     %1 = chlo.lgamma %arg : tensor<f32> -> tensor<f32>
     func.return %1 : tensor<f32>

--- a/test/lit_tests/diffrules/stablehlo/convolution_transpose.mlir
+++ b/test/lit_tests/diffrules/stablehlo/convolution_transpose.mlir
@@ -20,14 +20,14 @@ module {
 }
 
 // CHECK:  func.func private @"diffeConst{var\22#35#39\22{typeof(loss)}}(var\22#35#39\22{typeof(loss)}(Main.loss, Core.Box(ConvTranspose((3, 3), 3 => 2, stride=2))))_autodiff"(%arg0: tensor<3x2x3x3xf32>, %arg1: tensor<2xf32>, %arg2: tensor<1x3x5x5xf32>, %arg3: tensor<f32>, %arg4: tensor<1x3x5x5xf32>) -> (tensor<f32>, tensor<3x2x3x3xf32>, tensor<2xf32>, tensor<1x3x5x5xf32>, tensor<1x3x5x5xf32>) {
+// CHECK-NEXT:    %[[cst242:.+]] = stablehlo.constant dense<0.00413223123> : tensor<f32>
 // CHECK-NEXT:    %[[zero:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK-NEXT:    %[[cst242:.+]] = stablehlo.constant dense<2.420000e+02> : tensor<f32>
 // CHECK-NEXT:    %[[v0:.+]] = stablehlo.convolution(%arg2, %arg0) dim_numbers = [b, f, 1, 0]x[i, o, 1, 0]->[0, 1, f, b], window = {pad = {{\[\[}}2, 2], [2, 2]], lhs_dilate = [2, 2], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<1x3x5x5xf32>, tensor<3x2x3x3xf32>) -> tensor<11x11x2x1xf32>
 // CHECK-NEXT:    %[[v1:.+]] = stablehlo.broadcast_in_dim %arg1, dims = [2] : (tensor<2xf32>) -> tensor<11x11x2x1xf32>
 // CHECK-NEXT:    %[[v2:.+]] = stablehlo.add %[[v0]], %[[v1]] : tensor<11x11x2x1xf32>
 // CHECK-NEXT:    %[[v3:.+]] = stablehlo.reduce(%[[v2]] init: %[[zero]]) applies stablehlo.add across dimensions = [0, 1, 2, 3] : (tensor<11x11x2x1xf32>, tensor<f32>) -> tensor<f32>
-// CHECK-NEXT:    %[[v4:.+]] = stablehlo.divide %[[v3]], %[[cst242]] : tensor<f32>
-// CHECK-NEXT:    %[[v5:.+]] = stablehlo.divide %arg3, %[[cst242]] : tensor<f32>
+// CHECK-NEXT:    %[[v4:.+]] = stablehlo.multiply %[[v3]], %[[cst242]] : tensor<f32>
+// CHECK-NEXT:    %[[v5:.+]] = stablehlo.multiply %arg3, %[[cst242]] : tensor<f32>
 // CHECK-NEXT:    %[[v6:.+]] = stablehlo.broadcast_in_dim %[[v5]], dims = [] : (tensor<f32>) -> tensor<11x11x2x1xf32>
 // CHECK-NEXT:    %[[rev:.+]] = stablehlo.reverse %arg0, dims = [3, 2] : tensor<3x2x3x3xf32>
 // CHECK-NEXT:    %[[v7:.+]] = stablehlo.convolution(%[[v6]], %[[rev]]) dim_numbers = [0, 1, f, b]x[o, i, 1, 0]->[b, f, 1, 0], window = {stride = [2, 2], pad = {{\[\[}}0, 0], [0, 0]], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<11x11x2x1xf32>, tensor<3x2x3x3xf32>) -> tensor<1x3x5x5xf32>

--- a/test/lit_tests/div_simplify.mlir
+++ b/test/lit_tests/div_simplify.mlir
@@ -1,4 +1,5 @@
 // RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt="no_nan" | FileCheck %s --check-prefix=NONAN
 
 func.func @main1(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
     %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x4xf32>
@@ -24,3 +25,13 @@ func.func @main2(%arg0: tensor<10x4xi32>) -> tensor<10x4xi32> {
 // CHECK-NEXT:     %0 = stablehlo.divide %arg0, %c : tensor<10x4xi32>
 // CHECK-NEXT:     return %0 : tensor<10x4xi32>
 // CHECK-NEXT: }
+
+func.func @main3(%arg0: tensor<10x4xi32>) -> tensor<10x4xi32> {
+    %0 = stablehlo.divide %arg0, %arg0 : tensor<10x4xi32>
+    return %0 : tensor<10x4xi32>
+}
+
+// NONAN: func.func @main3(%arg0: tensor<10x4xi32>) -> tensor<10x4xi32> {
+// NONAN-NEXT:     %c = stablehlo.constant dense<1> : tensor<10x4xi32>
+// NONAN-NEXT:     return %c : tensor<10x4xi32>
+// NONAN-NEXT: }

--- a/test/lit_tests/div_simplify.mlir
+++ b/test/lit_tests/div_simplify.mlir
@@ -1,0 +1,26 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+func.func @main1(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.divide %arg0, %cst : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK: func.func @main1(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<5.000000e-01> : tensor<10x4xf32>
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %cst : tensor<10x4xf32>
+// CHECK-NEXT:     return %0 : tensor<10x4xf32>
+// CHECK-NEXT: }
+
+// shouldn't apply to integer division
+func.func @main2(%arg0: tensor<10x4xi32>) -> tensor<10x4xi32> {
+    %cst = stablehlo.constant dense<2> : tensor<10x4xi32>
+    %0 = stablehlo.divide %arg0, %cst : tensor<10x4xi32>
+    return %0 : tensor<10x4xi32>
+}
+
+// CHECK: func.func @main2(%arg0: tensor<10x4xi32>) -> tensor<10x4xi32> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<2> : tensor<10x4xi32>
+// CHECK-NEXT:     %0 = stablehlo.divide %arg0, %c : tensor<10x4xi32>
+// CHECK-NEXT:     return %0 : tensor<10x4xi32>
+// CHECK-NEXT: }

--- a/test/lit_tests/logsimplify.mlir
+++ b/test/lit_tests/logsimplify.mlir
@@ -1,0 +1,147 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(enzyme-hlo-generate-td{patterns=log_simplify;log_const_prop},transform-interpreter,enzyme-hlo-remove-transform)" | FileCheck %s
+
+func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.exponential %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     return %arg0 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+    %1 = stablehlo.multiply %0, %0 : tensor<f64>
+    %2 = stablehlo.log %1 : tensor<f64>
+    return %2 : tensor<f64>
+}
+
+// CHECK: func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:    %1 = stablehlo.multiply %cst, %0 : tensor<f64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %cst, %1 : tensor<f64>
+// CHECK-NEXT:    return %2 : tensor<f64>
+// CHECK-NEXT:  }
+
+func.func @main3(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<4.000000e+00> : tensor<f64>
+    %0 = stablehlo.multiply %arg0, %cst : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main3(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.3862943611198906> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.add %0, %cst : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main4(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<4.000000e+00> : tensor<f64>
+    %0 = stablehlo.multiply %cst, %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main4(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.3862943611198906> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.add %cst, %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main5(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.add %arg0, %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main5(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.69314718055994529> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.add %cst, %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main6(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main6(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.multiply %cst, %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main7(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<4.000000e+00> : tensor<f64>
+    %0 = stablehlo.divide %arg0, %cst : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main7(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.3862943611198906> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.subtract %0, %cst : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main8(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<4.000000e+00> : tensor<f64>
+    %0 = stablehlo.divide %cst, %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main8(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.3862943611198906> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.subtract %cst, %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main9(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.sqrt %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main9(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.divide %0, %cst : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main10(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.rsqrt %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main10(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-2.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.divide %0, %cst : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main11(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.cbrt %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main11(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<3.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.divide %0, %cst : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }

--- a/test/lit_tests/mul_reassoc.mlir
+++ b/test/lit_tests/mul_reassoc.mlir
@@ -1,0 +1,31 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=power_multiply_to_power;add_const_prop;common_associative_commutative_op_reorder" --transform-interpreter --enzyme-hlo-remove-transform --canonicalize --cse --enzyme-hlo-generate-td="patterns=power_multiply_to_power;add_const_prop;common_associative_commutative_op_reorder" --enzyme-hlo-remove-transform --canonicalize | FileCheck %s
+
+func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+    %1 = stablehlo.multiply %0, %arg0 : tensor<f64>
+    %2 = stablehlo.multiply %1, %arg0 : tensor<f64>
+    %3 = stablehlo.multiply %2, %arg0 : tensor<f64>
+    return %3 : tensor<f64>
+}
+
+// CHECK: func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<5.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.power %arg0, %cst : tensor<f64>
+// CHECK-NEXT:     return %0 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+    %1 = stablehlo.multiply %0, %arg0 : tensor<f64>
+    %2 = stablehlo.multiply %1, %arg0 : tensor<f64>
+    %3 = stablehlo.multiply %2, %arg0 : tensor<f64>
+    %4 = stablehlo.multiply %arg0, %0 : tensor<f64>
+    %5 = stablehlo.multiply %4, %3 : tensor<f64>
+    return %5 : tensor<f64>
+}
+
+// CHECK: func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<8.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.power %arg0, %cst : tensor<f64>
+// CHECK-NEXT:     return %0 : tensor<f64>
+// CHECK-NEXT: }

--- a/test/lit_tests/mul_reassoc.mlir
+++ b/test/lit_tests/mul_reassoc.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=power_multiply_to_power;add_const_prop;common_associative_commutative_op_reorder" --transform-interpreter --enzyme-hlo-remove-transform --canonicalize --cse --enzyme-hlo-generate-td="patterns=power_multiply_to_power;add_const_prop;common_associative_commutative_op_reorder" --enzyme-hlo-remove-transform --canonicalize | FileCheck %s
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(enzyme-hlo-generate-td{patterns=common_associative_commutative_op_reorder},transform-interpreter,enzyme-hlo-remove-transform,canonicalize,cse,enzyme-hlo-generate-td{patterns=common_associative_commutative_op_reorder},transform-interpreter,enzyme-hlo-remove-transform,cse,canonicalize)" | FileCheck %s
 
 func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
     %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
@@ -9,10 +9,11 @@ func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
 }
 
 // CHECK: func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
-// CHECK-NEXT:     %cst = stablehlo.constant dense<5.000000e+00> : tensor<f64>
-// CHECK-NEXT:     %0 = stablehlo.power %arg0, %cst : tensor<f64>
-// CHECK-NEXT:     return %0 : tensor<f64>
-// CHECK-NEXT: }
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+// CHECK-NEXT:    %1 = stablehlo.multiply %0, %0 : tensor<f64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %arg0 : tensor<f64>
+// CHECK-NEXT:    return %2 : tensor<f64>
+// CHECK-NEXT:  }
 
 func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
     %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
@@ -25,7 +26,8 @@ func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
 }
 
 // CHECK: func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
-// CHECK-NEXT:     %cst = stablehlo.constant dense<8.000000e+00> : tensor<f64>
-// CHECK-NEXT:     %0 = stablehlo.power %arg0, %cst : tensor<f64>
-// CHECK-NEXT:     return %0 : tensor<f64>
-// CHECK-NEXT: }
+// CHECK-NEXT:    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+// CHECK-NEXT:    %1 = stablehlo.multiply %0, %0 : tensor<f64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %1 : tensor<f64>
+// CHECK-NEXT:    return %2 : tensor<f64>
+// CHECK-NEXT:  }

--- a/test/lit_tests/multopow.mlir
+++ b/test/lit_tests/multopow.mlir
@@ -1,0 +1,46 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=chained_multiply_to_power;power_multiply_to_power;add_const_prop;common_associative_commutative_op_reorder" --transform-interpreter --enzyme-hlo-remove-transform --canonicalize --cse --enzyme-hlo-generate-td="patterns=chained_multiply_to_power;power_multiply_to_power;add_const_prop;common_associative_commutative_op_reorder" --enzyme-hlo-remove-transform --canonicalize | FileCheck %s
+
+func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+    %1 = stablehlo.multiply %0, %arg0 : tensor<f64>
+    %2 = stablehlo.multiply %1, %arg0 : tensor<f64>
+    %3 = stablehlo.multiply %2, %arg0 : tensor<f64>
+    return %3 : tensor<f64>
+}
+
+// CHECK: func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<5.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.power %arg0, %cst : tensor<f64>
+// CHECK-NEXT:     return %0 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+    %1 = stablehlo.multiply %0, %arg0 : tensor<f64>
+    %2 = stablehlo.multiply %1, %arg0 : tensor<f64>
+    %3 = stablehlo.multiply %2, %arg0 : tensor<f64>
+    %4 = stablehlo.multiply %arg0, %0 : tensor<f64>
+    %5 = stablehlo.multiply %4, %3 : tensor<f64>
+    return %5 : tensor<f64>
+}
+
+// CHECK: func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<8.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.power %arg0, %cst : tensor<f64>
+// CHECK-NEXT:     return %0 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main3(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<3.000000e+00> : tensor<f64>
+    %cst_2 = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+    %0 = stablehlo.power %arg0, %cst : tensor<f64>
+    %1 = stablehlo.power %arg0, %cst_2 : tensor<f64>
+    %2 = stablehlo.multiply %1, %0 : tensor<f64>
+    return %2 : tensor<f64>
+}
+
+// CHECK: func.func @main3(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<5.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.power %arg0, %cst : tensor<f64>
+// CHECK-NEXT:     return %0 : tensor<f64>
+// CHECK-NEXT: }

--- a/test/lit_tests/negdivsimplify.mlir
+++ b/test/lit_tests/negdivsimplify.mlir
@@ -1,0 +1,27 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+func.func @main(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.divide %arg0, %cst : tensor<10x4xf32>
+    %1 = stablehlo.negate %0 : tensor<10x4xf32>
+    return %1 : tensor<10x4xf32>
+}
+
+// CHECK: func.func @main(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-5.000000e-01> : tensor<10x4xf32>
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %cst : tensor<10x4xf32>
+// CHECK-NEXT:     return %0 : tensor<10x4xf32>
+// CHECK-NEXT: }
+
+func.func @main2(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.divide %cst, %arg0 : tensor<10x4xf32>
+    %1 = stablehlo.negate %0 : tensor<10x4xf32>
+    return %1 : tensor<10x4xf32>
+}
+
+// CHECK: func.func @main2(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-2.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:     %0 = stablehlo.divide %cst, %arg0 : tensor<10x4xf32>
+// CHECK-NEXT:     return %0 : tensor<10x4xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/negmulsimplify.mlir
+++ b/test/lit_tests/negmulsimplify.mlir
@@ -1,0 +1,27 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+func.func @main(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.multiply %arg0, %cst : tensor<10x4xf32>
+    %1 = stablehlo.negate %0 : tensor<10x4xf32>
+    return %1 : tensor<10x4xf32>
+}
+
+// CHECK: func.func @main(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-2.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %cst : tensor<10x4xf32>
+// CHECK-NEXT:     return %0 : tensor<10x4xf32>
+// CHECK-NEXT:   }
+
+func.func @main2(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.multiply %cst, %arg0 : tensor<10x4xf32>
+    %1 = stablehlo.negate %0 : tensor<10x4xf32>
+    return %1 : tensor<10x4xf32>
+}
+
+// CHECK: func.func @main2(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-2.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:     %0 = stablehlo.multiply %cst, %arg0 : tensor<10x4xf32>
+// CHECK-NEXT:     return %0 : tensor<10x4xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/pow_simplify.mlir
+++ b/test/lit_tests/pow_simplify.mlir
@@ -1,0 +1,67 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+func.func @main1(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.power %arg0, %cst : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK: func.func @main1(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %arg0 : tensor<10x4xf32>
+// CHECK-NEXT:     return %0 : tensor<10x4xf32>
+// CHECK-NEXT:   }
+
+func.func @main2(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<-1.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.power %arg0, %cst : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK:  func.func @main2(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<1.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:    %0 = stablehlo.divide %cst, %arg0 : tensor<10x4xf32>
+// CHECK-NEXT:    return %0 : tensor<10x4xf32>
+// CHECK-NEXT:  }
+
+func.func @main3(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.power %arg0, %cst : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK:  func.func @main3(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<1.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:    return %cst : tensor<10x4xf32>
+// CHECK-NEXT:  }
+
+func.func @main4(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.power %arg0, %cst : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK:  func.func @main4(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:    return %arg0 : tensor<10x4xf32>
+// CHECK-NEXT:  }
+
+func.func @main5(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<0.500000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.power %arg0, %cst : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK:  func.func @main5(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:    %0 = stablehlo.sqrt %arg0 : tensor<10x4xf32>
+// CHECK-NEXT:    return %0 : tensor<10x4xf32>
+// CHECK-NEXT:  }
+
+func.func @main6(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<-0.500000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.power %arg0, %cst : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK:  func.func @main6(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:    %0 = stablehlo.rsqrt %arg0 : tensor<10x4xf32>
+// CHECK-NEXT:    return %0 : tensor<10x4xf32>
+// CHECK-NEXT:  }

--- a/test/lit_tests/pow_simplify.mlir
+++ b/test/lit_tests/pow_simplify.mlir
@@ -65,3 +65,20 @@ func.func @main6(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
 // CHECK-NEXT:    %0 = stablehlo.rsqrt %arg0 : tensor<10x4xf32>
 // CHECK-NEXT:    return %0 : tensor<10x4xf32>
 // CHECK-NEXT:  }
+
+func.func @main7(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.power %cst, %arg0 : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK: func.func @main7(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<0x7F800000> : tensor<10x4xf32>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:     %0 = stablehlo.compare  GT, %arg0, %cst_1 : (tensor<10x4xf32>, tensor<10x4xf32>) -> tensor<10x4xi1>
+// CHECK-NEXT:     %1 = stablehlo.select %0, %cst_1, %cst_0 : tensor<10x4xi1>, tensor<10x4xf32>
+// CHECK-NEXT:     %2 = stablehlo.compare  EQ, %arg0, %cst_1 : (tensor<10x4xf32>, tensor<10x4xf32>) -> tensor<10x4xi1>
+// CHECK-NEXT:     %3 = stablehlo.select %2, %cst, %1 : tensor<10x4xi1>, tensor<10x4xf32>
+// CHECK-NEXT:     return %3 : tensor<10x4xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/pow_simplify.mlir
+++ b/test/lit_tests/pow_simplify.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt="no_nan" | FileCheck %s
 
 func.func @main1(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
     %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x4xf32>

--- a/test/lit_tests/pow_simplify.mlir
+++ b/test/lit_tests/pow_simplify.mlir
@@ -65,20 +65,3 @@ func.func @main6(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
 // CHECK-NEXT:    %0 = stablehlo.rsqrt %arg0 : tensor<10x4xf32>
 // CHECK-NEXT:    return %0 : tensor<10x4xf32>
 // CHECK-NEXT:  }
-
-func.func @main7(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
-    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x4xf32>
-    %0 = stablehlo.power %cst, %arg0 : tensor<10x4xf32>
-    return %0 : tensor<10x4xf32>
-}
-
-// CHECK: func.func @main7(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
-// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<10x4xf32>
-// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<0x7F800000> : tensor<10x4xf32>
-// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<10x4xf32>
-// CHECK-NEXT:     %0 = stablehlo.compare  GT, %arg0, %cst_1 : (tensor<10x4xf32>, tensor<10x4xf32>) -> tensor<10x4xi1>
-// CHECK-NEXT:     %1 = stablehlo.select %0, %cst_1, %cst_0 : tensor<10x4xi1>, tensor<10x4xf32>
-// CHECK-NEXT:     %2 = stablehlo.compare  EQ, %arg0, %cst_1 : (tensor<10x4xf32>, tensor<10x4xf32>) -> tensor<10x4xi1>
-// CHECK-NEXT:     %3 = stablehlo.select %2, %cst, %1 : tensor<10x4xi1>, tensor<10x4xf32>
-// CHECK-NEXT:     return %3 : tensor<10x4xf32>
-// CHECK-NEXT: }

--- a/test/lit_tests/raising/affine_to_stablehlo17.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo17.mlir
@@ -33,7 +33,7 @@ module {
 }
 
 // CHECK:  func.func private @kernel_raised(%arg0: tensor<26x1x1xf64>, %arg1: tensor<1x32x48xf64>) -> (tensor<26x1x1xf64>, tensor<1x32x48xf64>) {
-// CHECK-NEXT:    %cst = stablehlo.constant dense<3.100000e+01> : tensor<f64>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.032258064516129031> : tensor<f64>
 // CHECK-NEXT:    %0 = stablehlo.slice %arg1 [0:1, 8:9, 8:9] : (tensor<1x32x48xf64>) -> tensor<1x1x1xf64>
 // CHECK-NEXT:    %1 = stablehlo.reshape %0 : (tensor<1x1x1xf64>) -> tensor<f64>
 // CHECK-NEXT:    %2 = stablehlo.slice %arg1 [0:1, 8:9, 9:10] : (tensor<1x32x48xf64>) -> tensor<1x1x1xf64>
@@ -126,7 +126,7 @@ module {
 // CHECK-NEXT:    %89 = stablehlo.slice %arg1 [0:1, 8:9, 38:39] : (tensor<1x32x48xf64>) -> tensor<1x1x1xf64>
 // CHECK-NEXT:    %90 = stablehlo.reshape %89 : (tensor<1x1x1xf64>) -> tensor<f64>
 // CHECK-NEXT:    %91 = stablehlo.add %88, %90 : tensor<f64>
-// CHECK-NEXT:    %92 = stablehlo.divide %91, %cst : tensor<f64>
+// CHECK-NEXT:    %92 = stablehlo.multiply %91, %cst : tensor<f64>
 // CHECK-NEXT:    %93 = stablehlo.reshape %92 : (tensor<f64>) -> tensor<1x1x1xf64>
 // CHECK-NEXT:    %94 = stablehlo.slice %arg0 [0:18, 0:1, 0:1] : (tensor<26x1x1xf64>) -> tensor<18x1x1xf64>
 // CHECK-NEXT:    %95 = stablehlo.slice %arg0 [19:26, 0:1, 0:1] : (tensor<26x1x1xf64>) -> tensor<7x1x1xf64>

--- a/test/lit_tests/zerobasepowsimplify.mlir
+++ b/test/lit_tests/zerobasepowsimplify.mlir
@@ -1,0 +1,18 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(enzyme-hlo-generate-td{patterns=no_nan_zero_base_pow_simplify(1)},transform-interpreter,enzyme-hlo-remove-transform,canonicalize,cse)" | FileCheck %s
+
+func.func @main1(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x4xf32>
+    %0 = stablehlo.power %cst, %arg0 : tensor<10x4xf32>
+    return %0 : tensor<10x4xf32>
+}
+
+// CHECK: func.func @main1(%arg0: tensor<10x4xf32>) -> tensor<10x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<0x7F800000> : tensor<10x4xf32>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<10x4xf32>
+// CHECK-NEXT:     %0 = stablehlo.compare  GT, %arg0, %cst_1 : (tensor<10x4xf32>, tensor<10x4xf32>) -> tensor<10x4xi1>
+// CHECK-NEXT:     %1 = stablehlo.select %0, %cst_1, %cst_0 : tensor<10x4xi1>, tensor<10x4xf32>
+// CHECK-NEXT:     %2 = stablehlo.compare  EQ, %arg0, %cst_1 : (tensor<10x4xf32>, tensor<10x4xf32>) -> tensor<10x4xi1>
+// CHECK-NEXT:     %3 = stablehlo.select %2, %cst, %1 : tensor<10x4xi1>, tensor<10x4xf32>
+// CHECK-NEXT:     return %3 : tensor<10x4xf32>
+// CHECK-NEXT: }


### PR DESCRIPTION
fixes #1077 

## TODOs

- [x] don't break const prop
- [x] more pow simplify
- [x] div const simplify fixes #1078 
- [x] disable to pow in the default case
- [x] reassoc is not completely working

```
func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
    %1 = stablehlo.multiply %0, %arg0 : tensor<f64>
    %2 = stablehlo.multiply %1, %arg0 : tensor<f64>
    %3 = stablehlo.multiply %2, %arg0 : tensor<f64>
    %4 = stablehlo.multiply %arg0, %0 : tensor<f64>
    %5 = stablehlo.multiply %4, %3 : tensor<f64>
    return %5 : tensor<f64>
}
```

```
func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
    %1 = stablehlo.multiply %0, %0 : tensor<f64>
    %2 = stablehlo.multiply %1, %0 : tensor<f64>
    %3 = stablehlo.multiply %0, %2 : tensor<f64>
    return %3 : tensor<f64>
  }
```