### PR TITLE
Fix typo

### DIFF
--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -1384,7 +1384,7 @@ def hlo_call(
         source=(
             in_tree,
             tuple(in_idx_map.items()),
-            tuple(out_idx_map.iterms()),
+            tuple(out_idx_map.items()),
             mfunc,
             tuple(jit_options.items()),
         ),


### PR DESCRIPTION
This seems to be a typo introduced in #1088, and caught by macOS CI (the only one running all the tests, not just the lit ones). Haven't tested it, but I presume this would fix the test failure
```
FAIL: //test:testffi (see /Users/runner/.bazel/execroot/__main__/bazel-out/darwin_arm64-opt/testlogs/test/testffi/test.log)
==================== Test output for //test:testffi:
INFO: From Testing //test:testffi:
Running tests under Python 3.12.8: /Users/runner/.bazel/sandbox/darwin-sandbox/10473/execroot/__main__/bazel-out/darwin_arm64-opt/bin/test/testffi.runfiles/python_aarch64-apple-darwin/bin/python3
I0630 18:17:54.227752 8523239296 xla_bridge.py:897] Unable to initialize backend 'rocm': module 'jaxlib.xla_extension' has no attribute 'GpuAllocatorConfig'
I0630 18:17:54.228193 8523239296 xla_bridge.py:897] Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: dlopen(libtpu.so, 0x0001): tried: 'libtpu.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibtpu.so' (no such file), '/usr/lib/libtpu.so' (no such file, not in dyld cache), 'libtpu.so' (no such file), '/usr/local/lib/libtpu.so' (no such file), '/usr/lib/libtpu.so' (no such file, not in dyld cache)
[ RUN      ] test_utils.EnzymeJaxTest.test
[       OK ] test_utils.EnzymeJaxTest.test
[ RUN      ] HLOFFI.test
[  FAILED  ] HLOFFI.test
======================================================================
ERROR: test (__main__.HLOFFI.test)
HLOFFI.test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/.bazel/sandbox/darwin-sandbox/10473/execroot/__main__/bazel-out/darwin_arm64-opt/bin/test/testffi.runfiles/__main__/test/test_utils.py", line 595, in test
    self.harness(self.name, self.fn, self.ins, self.dins, self.douts)
  File "/Users/runner/.bazel/sandbox/darwin-sandbox/10473/execroot/__main__/bazel-out/darwin_arm64-opt/bin/test/testffi.runfiles/__main__/test/test_utils.py", line 684, in harness
    ao = rfn_enzyme(*ins_backend)
         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/.bazel/sandbox/darwin-sandbox/10473/execroot/__main__/bazel-out/darwin_arm64-opt/bin/test/testffi.runfiles/__main__/test/testffi.py", line 9, in do_something
    a, b = hlo_call(
           ^^^^^^^^^
  File "/Users/runner/.bazel/sandbox/darwin-sandbox/10473/execroot/__main__/bazel-out/darwin_arm64-opt/bin/test/testffi.runfiles/__main__/src/enzyme_ad/jax/primitives.py", line 1387, in hlo_call
    tuple(out_idx_map.iterms()),
          ^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'iterms'. Did you mean: 'items'?
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.

----------------------------------------------------------------------
Ran 2 tests in 0.058s

FAILED (errors=1)
================================================================================
```