### PR TITLE
ablation tests for jaxmd, neuralgcm

### DIFF
--- a/test/jaxmd.py
+++ b/test/jaxmd.py
@@ -93,6 +93,7 @@ class JAXMD(EnzymeJaxTest):
         self.fn = forward
         self.name = "jaxmd40"
         self.count = 10
+        self.samples = 5
         # self.revprimal = False
         # self.AllPipelines = pipelines
         # self.AllBackends = CurBackends


### PR DESCRIPTION
not sure about the best format, so i'm just fixing the tests and pretty printing the times

## jax-md

I had to increase tolerance (even more) because some pass(es) on `PostRev` introduce numerical errors. Generally, errors seem to be sparse but high, so I've added a flag to skip if the number of erroring numbers is below a threshold. Usually <3% is ok.

```
Created a system of 64000 LJ particles with number density 0.382
Name                    Pipeline                Backend         Key             Time (s)        StdDev (s)     
jaxmd40                 JaXPipe                 cpu             Primal          0.09730578      0.00086500     
jaxmd40                 JaX                     cpu             Primal          0.09752608      0.00054685     
jaxmd40                 HLOOpt                  cpu             Primal          0.09670102      0.00076194     
jaxmd40                 PartOpt                 cpu             Primal          0.09653945      0.00052958     
jaxmd40                 DefOpt                  cpu             Primal          0.09551426      0.00059030     
jaxmd40                 IPartOpt                cpu             Primal          0.09726938      0.00182402     
jaxmd40                 IDefOpt                 cpu             Primal          0.09631212      0.00058779     
jaxmd40                 JaXPipe                 cpu             Forward         0.13624213      0.00097914     
jaxmd40                 JaX                     cpu             Forward         0.15521357      0.00135224     
jaxmd40                 HLOOpt                  cpu             Forward         0.13702734      0.00095580     
jaxmd40                 PartOpt                 cpu             Forward         0.13572360      0.00128039     
jaxmd40                 DefOpt                  cpu             Forward         0.13540525      0.00124451     
jaxmd40                 IPartOpt                cpu             Forward         0.13581601      0.00070531     
jaxmd40                 IDefOpt                 cpu             Forward         0.13631605      0.00080352     
jaxmd40                 JaXPipe                 cpu             PostRev         0.17647669      0.00103687     
jaxmd40                 JaX                     cpu             BothRev         0.17716549      0.00087297     
Warning: There are numbers above the tolerance threshold, but the error percentage 0.002515625 is below threshold 0.003
jaxmd40                 HLOOpt                  cpu             PostRev         0.17731926      0.00098793     
jaxmd40                 PartOpt                 cpu             PostRev         0.17956376      0.00096846     
Warning: There are numbers above the tolerance threshold, but the error percentage 0.002515625 is below threshold 0.003
jaxmd40                 DefOpt                  cpu             PostRev         0.18030027      0.00087811     
jaxmd40                 IPartOpt                cpu             PostRev         0.17913305      0.00100954
```

- `HLOOpt` and `DefOpt` on `PostRev` always have numerical errors but are sparse, so we let them continue
- `IDefOpt` on `PostRev` increases the numerical error to a point where all errors, so we skip it

## neuralgcm

WIP

```
name= JaX  
name= JaX   19.54702745936811
name= JaXPipe
name= JaXPipe 19.64117467403412
name= HLOOpt
name= HLOOpt 14.184140637516975
name= PartOpt
name= PartOpt 19.83721669577062
name= DefOpt
name= DefOpt 17.49880426004529
name= IPartOpt
name= IPartOpt 19.838558081537485
name= IDefOpt
name= IDefOpt 12.991600725799799
```