### PR TITLE
Add a dialect-specific canonicalization pass

### DIFF
--- a/src/enzyme_ad/jax/Passes/DialectCanonicalize.cpp
+++ b/src/enzyme_ad/jax/Passes/DialectCanonicalize.cpp
@@ -1,0 +1,56 @@
+//===- DialectCanonicalize.cpp - Dialect-restricted canonicalizer pass ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_DIALECTCANONICALIZE
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::enzyme;
+
+namespace {
+struct DialectCanonicalizePass
+    : mlir::enzyme::impl::DialectCanonicalizeBase<DialectCanonicalizePass> {
+  using DialectCanonicalizeBase::DialectCanonicalizeBase;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    for (const std::string &dialectName : dialects) {
+      if (Dialect *dialect = getContext().getLoadedDialect(dialectName)) {
+        dialect->getCanonicalizationPatterns(patterns);
+        continue;
+      }
+
+      // If the dialect is not loaded, ignore it because it means no ops from
+      // this dialect could have been constructed.
+      getOperation()->emitWarning()
+          << "requested canonicalization for an unloaded dialetct '"
+          << dialectName << "'";
+    }
+    LogicalResult result =
+        applyPatternsGreedily(getOperation(), std::move(patterns),
+                              GreedyRewriteConfig()
+                                  .setMaxNumRewrites(maxNumRewrites)
+                                  .setMaxIterations(maxIterations)
+                                  .enableFolding(enableFolding)
+                                  .enableConstantCSE(enableConstantCSE));
+    if (failed(result)) {
+      getOperation()->emitError()
+          << "greedy pattern application failed in this scope";
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -17,6 +17,25 @@ def CanonicalizeLoopsPass : InterfacePass<"canonicalize-loops",
   let dependentDialects = ["affine::AffineDialect"];
 }
 
+def DialectCanonicalize : Pass<"dialect-canonicalize"> {
+  let summary = "Canonicalize specific dialects listed in options";
+  let options = [
+    ListOption<"dialects", "dialects", "std::string",
+               "List of dialects to fetch canonicalization patterns from">,
+    Option<"maxNumRewrites", "max-num-rewrites", "uint64_t",
+           /*default=*/"static_cast<uint64_t>(-1)",
+           "Maximum number of rewrites to apply (default -1: unlimited)">,
+    Option<"maxIterations", "max-iterations", "uint64_t",
+           /*default=*/"static_cast<uint64_t>(-1)",
+           "Maximum number of times a pattern can be applied (default -1: "
+           "inherit from the driver)">,
+    Option<"enableFolding", "enable-folding", "bool", "true",
+           "Perform folding">,
+    Option<"enableConstantCSE", "enable-constant-cse", "bool", "true",
+           "Deduplicate constants">,
+  ];
+}
+
 def RemoveDuplicateFuncDefPass
     : Pass<"remove-duplicate-func-def", "mlir::ModuleOp"> {
   let summary = "Remove duplicate function definitions";


### PR DESCRIPTION
This only applies canonicalization patterns for ops from the dialects listed in pass options. Normally those ops list patterns for themselves, but it is not a strict requirement.

This offers significant performance bump compared to general canonicalization that collects patterns from all loaded dialects, many of which may not be present at certain stages of compilation. This wastes cycles trying to match patterns that would never apply.