### PR TITLE
drop no-longer-supported lifetime annotations

### DIFF
--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -156,6 +156,10 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
   llvm::LLVMContext llvmContext;
   llvmContext.setDiscardValueNames(false);
   auto outModule = translateModuleToLLVMIR(*mod, llvmContext);
+  if (!outModule) {
+    llvm::errs() << "failed to translate MLIR to LLVM IR\n";
+    return "";
+  }
 
   if (auto F = outModule->getFunction("mgpuModuleLoad")) {
     for (auto U : llvm::make_early_inc_range(F->users())) {


### PR DESCRIPTION
LLVM IR dropped support for lifetime intrinsics on everything but allocas and poisons while we still seem to be producing these. Remove them immediately before lowering. This gives us the possibility to rewrite them into something else if we figure out what.