### PR TITLE
lookup gpu_error ancestor not parent

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -2082,7 +2082,7 @@ LogicalResult ConvertLaunchFuncOpToGpuRuntimeCallPattern::matchAndRewrite(
 
   Location loc = launchOp.getLoc();
 
-  GPUErrorOp errOp = dyn_cast<GPUErrorOp>(launchOp->getParentOp());
+  GPUErrorOp errOp = launchOp->getParentOfType<GPUErrorOp>();
 
   // Create an LLVM global with CUBIN extracted from the kernel annotation and
   // obtain a pointer to the first byte in it.


### PR DESCRIPTION
Some launches may not be nested immediately in the error handling op and be, e.g., conditional.