### PR TITLE
[CI] Use again `Reactant#main` for GB-25 test

### DIFF
--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -53,8 +53,8 @@ jobs:
           - 'main'
           # - '0123456789abcdef0123456789abcdef01234567'
         reactant_commit:
-          # - 'main'
-          - "ap/updated_no_nan"
+          - 'main'
+          # - "ap/updated_no_nan"
 
     steps:
       - name: Check GPUs


### PR DESCRIPTION
`ap/updated_no_nan` doesn't exist anymore.