### PR TITLE
feat: generalize `transpose_all_users_slice`  and `concat_reshape_slice`

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -2973,11 +2973,13 @@ struct TransposeAllUsersSlice final
           continue;
         } else if (auto reshapeOp =
                        dyn_cast<stablehlo::ReshapeOp>(downstreamUser)) {
-          auto inputType = cast<RankedTensorType>(reshapeOp.getOperand().getType());
-          auto outputType = cast<RankedTensorType>(reshapeOp.getResult().getType());
+          auto inputType =
+              cast<RankedTensorType>(reshapeOp.getOperand().getType());
+          auto outputType =
+              cast<RankedTensorType>(reshapeOp.getResult().getType());
 
           auto insertionDims = findReshapeInsertionDims(inputType, outputType);
-          if (!insertionDims.empty())  // fused to a broadcast_in_dim
+          if (!insertionDims.empty()) // fused to a broadcast_in_dim
             continue;
 
           if (reshapeIsTranspose(reshapeOp)) // transpose_tranpose elimination
@@ -19535,9 +19537,11 @@ struct ConcatReshapeSlice
       sliceOps.push_back(slice);
     }
 
-    SmallVector<int64_t> sliceStrides(ndims, 1);
-    SmallVector<int64_t> sliceStarts, sliceLimits;
+    SmallVector<int64_t> sliceStarts, sliceLimits, insertionDims, deletionDims;
+    bool insertions = false, deletions = false;
     int64_t srcSliceDim = -1;
+    auto sourceShape =
+        cast<RankedTensorType>(sourceTensor.getType()).getShape();
 
     for (int i = 0; i < sliceOps.size(); i++) {
       auto sliceOp = sliceOps[i];
@@ -19545,16 +19549,15 @@ struct ConcatReshapeSlice
 
       auto sliceShape =
           cast<RankedTensorType>(sliceOp.getResult().getType()).getShape();
+      auto curSliceStarts = llvm::to_vector(sliceOp.getStartIndices());
+      auto curSliceLimits = llvm::to_vector(sliceOp.getLimitIndices());
       auto reshapeShape =
           cast<RankedTensorType>(reshapeOp.getResult().getType()).getShape();
 
-      if (sliceShape.size() != reshapeShape.size())
-        return failure();
-
-      int64_t singletonSliceDim = -1;
-      int64_t nSingletonSlices = 0;
+      int64_t singletonSliceDim = -1, nSingletonSlices = 0;
       for (int64_t i = 0; i < sliceShape.size(); i++) {
-        if (sliceShape[i] == 1) {
+        if (sliceShape[i] == 1 &&
+            !(curSliceStarts[i] == 0 && curSliceLimits[i] == sourceShape[i])) {
           singletonSliceDim = i;
           nSingletonSlices++;
         }
@@ -19565,8 +19568,8 @@ struct ConcatReshapeSlice
 
       if (srcSliceDim == -1) {
         srcSliceDim = singletonSliceDim;
-        sliceStarts = llvm::to_vector(sliceOp.getStartIndices());
-        sliceLimits = llvm::to_vector(sliceOp.getLimitIndices());
+        sliceStarts = std::move(curSliceStarts);
+        sliceLimits = std::move(curSliceLimits);
       } else {
         if (!canMergeSlicesAlongAxis(srcSliceDim, sliceOps[i - 1], sliceOp))
           return failure();
@@ -19585,10 +19588,45 @@ struct ConcatReshapeSlice
         dstNoSingleton.push_back(reshapeShape[i]);
       }
 
-      if (srcNoSingleton != dstNoSingleton)
-        return failure();
+      if (srcNoSingleton != dstNoSingleton) {
+        auto curInsertionDims =
+            findReshapeInsertionDims(srcNoSingleton, dstNoSingleton);
+        auto curDeletionDims =
+            findReshapeInsertionDims(dstNoSingleton, srcNoSingleton);
+        if (curInsertionDims.empty() && curDeletionDims.empty())
+          return failure();
+
+        if (i > 0) {
+          if (insertions) {
+            if (!curDeletionDims.empty())
+              return failure();
+            if (insertionDims != curInsertionDims)
+              return failure();
+          } else {
+            if (!curInsertionDims.empty())
+              return failure();
+            if (deletionDims != curDeletionDims)
+              return failure();
+          }
+        } else {
+          if (!curInsertionDims.empty()) {
+            insertions = true;
+            insertionDims = std::move(curInsertionDims);
+          } else {
+            deletions = true;
+            deletionDims = std::move(curDeletionDims);
+          }
+        }
+      }
     }
 
+    int64_t ndimsCorrected = ndims;
+    if (insertions)
+      ndimsCorrected -= insertionDims.size();
+    if (deletions)
+      ndimsCorrected += deletionDims.size();
+
+    SmallVector<int64_t> sliceStrides(ndimsCorrected, 1);
     int64_t startIndex = sliceOps[0].getStartIndices()[srcSliceDim];
     int64_t limitIndex =
         sliceOps[sliceOps.size() - 1].getLimitIndices()[srcSliceDim];
@@ -19599,10 +19637,8 @@ struct ConcatReshapeSlice
         concatOp.getLoc(), sourceTensor, sliceStarts, sliceLimits,
         sliceStrides);
 
-    SmallVector<int64_t> mapping(ndims, 0);
-    for (int64_t i = 0; i < ndims; i++) {
-      mapping[i] = i;
-    }
+    SmallVector<int64_t> mapping(ndimsCorrected, 0);
+    std::iota(mapping.begin(), mapping.end(), 0);
     mapping[srcSliceDim] = concatDim;
     if (srcSliceDim > concatDim) {
       for (int64_t i = concatDim; i < srcSliceDim; i++) { // shift right
@@ -19614,13 +19650,20 @@ struct ConcatReshapeSlice
       }
     }
 
-    SmallVector<int64_t> permutation(ndims, 0);
-    for (int64_t i = 0; i < ndims; i++) {
+    SmallVector<int64_t> permutation(mapping.size(), 0);
+    for (int64_t i = 0; i < mapping.size(); i++) {
       permutation[mapping[i]] = i;
     }
 
-    rewriter.replaceOpWithNewOp<stablehlo::TransposeOp>(concatOp, newSlice,
-                                                        permutation);
+    auto transposeOp = rewriter.create<stablehlo::TransposeOp>(
+        concatOp.getLoc(), newSlice, permutation);
+    if (!insertions && !deletions) {
+      rewriter.replaceOp(concatOp, transposeOp.getResult());
+    } else {
+      // restore the original shape due to the insertion dims
+      rewriter.replaceOpWithNewOp<stablehlo::ReshapeOp>(
+          concatOp, concatOp.getResult().getType(), transposeOp);
+    }
     return success();
   }
 };

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -472,6 +472,8 @@ static arith::CmpIPredicate swapPredicate(arith::CmpIPredicate pred) {
 
 SmallVector<int64_t> findReshapeInsertionDims(RankedTensorType inputType,
                                               RankedTensorType outputType);
+SmallVector<int64_t> findReshapeInsertionDims(ArrayRef<int64_t> inputShape,
+                                              ArrayRef<int64_t> outputShape);
 
 bool areValidInsertionDims(RankedTensorType inputType,
                            RankedTensorType outputType,

--- a/test/lit_tests/autobatching/concatreshapedotgeneral.mlir
+++ b/test/lit_tests/autobatching/concatreshapedotgeneral.mlir
@@ -1,5 +1,5 @@
 // RUN: enzymexlamlir-opt --auto-batching %s | FileCheck %s
-// RUN: enzymexlamlir-opt --auto-batching --inline --enzyme-hlo-opt %s | FileCheck %s --check-prefix=FULL
+// RUN: enzymexlamlir-opt --auto-batching --inline --enzyme-hlo-opt="passses=65536" --enzyme-hlo-opt %s | FileCheck %s --check-prefix=FULL
 
 module @reactant_batched... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
   func.func @main(%arg0: tensor<5x4x3xf64>, %arg1: tensor<7x4xf64>) -> tensor<5x7x3xf64> {

--- a/test/lit_tests/autobatching/reactant_regression_3.mlir
+++ b/test/lit_tests/autobatching/reactant_regression_3.mlir
@@ -31,32 +31,31 @@ module @reactant_mapped_sub attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
 
 // CHECK: module @reactant_mapped_sub attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
 // CHECK-NEXT:   func.func @main(%arg0: tensor<3x5x10xf32>, %arg1: tensor<3x5x10xf32>) -> tensor<5x3x10xf32> attributes {enzymexla.memory_effects = []} {
-// CHECK-NEXT:     %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<3x5x10xf32>) -> tensor<10x5x3xf32>
-// CHECK-NEXT:     %1 = stablehlo.slice %0 [0:10, 0:1, 0:3] : (tensor<10x5x3xf32>) -> tensor<10x1x3xf32>
-// CHECK-NEXT:     %2 = stablehlo.slice %0 [0:10, 4:5, 0:3] : (tensor<10x5x3xf32>) -> tensor<10x1x3xf32>
-// CHECK-NEXT:     %3 = stablehlo.slice %0 [0:10, 3:4, 0:3] : (tensor<10x5x3xf32>) -> tensor<10x1x3xf32>
-// CHECK-NEXT:     %4 = stablehlo.slice %0 [0:10, 2:3, 0:3] : (tensor<10x5x3xf32>) -> tensor<10x1x3xf32>
-// CHECK-NEXT:     %5 = stablehlo.slice %0 [0:10, 1:2, 0:3] : (tensor<10x5x3xf32>) -> tensor<10x1x3xf32>
-// CHECK-NEXT:     %6 = stablehlo.reshape %1 : (tensor<10x1x3xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %7 = stablehlo.reshape %5 : (tensor<10x1x3xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %8 = stablehlo.reshape %4 : (tensor<10x1x3xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %9 = stablehlo.reshape %3 : (tensor<10x1x3xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %10 = stablehlo.reshape %2 : (tensor<10x1x3xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %11 = stablehlo.concatenate %6, %7, %8, %9, %10, dim = 0 : (tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>) -> tensor<5x10x1x3xf32>
-// CHECK-NEXT:     %12 = stablehlo.broadcast_in_dim %arg1, dims = [3, 0, 1] : (tensor<3x5x10xf32>) -> tensor<5x10x1x3xf32>
-// CHECK-NEXT:     %13 = stablehlo.subtract %11, %12 : tensor<5x10x1x3xf32>
-// CHECK-NEXT:     %14 = stablehlo.transpose %13, dims = [0, 2, 3, 1] : (tensor<5x10x1x3xf32>) -> tensor<5x1x3x10xf32>
-// CHECK-NEXT:     %15 = stablehlo.slice %14 [0:1, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %16 = stablehlo.reshape %15 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %17 = stablehlo.slice %14 [1:2, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %18 = stablehlo.reshape %17 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %19 = stablehlo.slice %14 [2:3, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %20 = stablehlo.reshape %19 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %21 = stablehlo.slice %14 [3:4, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %22 = stablehlo.reshape %21 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %23 = stablehlo.slice %14 [4:5, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %24 = stablehlo.reshape %23 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %25 = stablehlo.concatenate %16, %18, %20, %22, %24, dim = 0 : (tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>) -> tensor<5x3x10xf32>
-// CHECK-NEXT:     return %25 : tensor<5x3x10xf32>
+// CHECK-NEXT:     %0 = stablehlo.slice %arg0 [0:3, 4:5, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
+// CHECK-NEXT:     %1 = stablehlo.slice %arg0 [0:3, 3:4, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
+// CHECK-NEXT:     %2 = stablehlo.slice %arg0 [0:3, 2:3, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
+// CHECK-NEXT:     %3 = stablehlo.slice %arg0 [0:3, 1:2, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
+// CHECK-NEXT:     %4 = stablehlo.slice %arg0 [0:3, 0:1, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
+// CHECK-NEXT:     %5 = stablehlo.broadcast_in_dim %4, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
+// CHECK-NEXT:     %6 = stablehlo.broadcast_in_dim %3, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
+// CHECK-NEXT:     %7 = stablehlo.broadcast_in_dim %2, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
+// CHECK-NEXT:     %8 = stablehlo.broadcast_in_dim %1, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
+// CHECK-NEXT:     %9 = stablehlo.broadcast_in_dim %0, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
+// CHECK-NEXT:     %10 = stablehlo.concatenate %5, %6, %7, %8, %9, dim = 0 : (tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>) -> tensor<5x10x1x3xf32>
+// CHECK-NEXT:     %11 = stablehlo.broadcast_in_dim %arg1, dims = [3, 0, 1] : (tensor<3x5x10xf32>) -> tensor<5x10x1x3xf32>
+// CHECK-NEXT:     %12 = stablehlo.subtract %10, %11 : tensor<5x10x1x3xf32>
+// CHECK-NEXT:     %13 = stablehlo.transpose %12, dims = [0, 2, 3, 1] : (tensor<5x10x1x3xf32>) -> tensor<5x1x3x10xf32>
+// CHECK-NEXT:     %14 = stablehlo.slice %13 [0:1, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
+// CHECK-NEXT:     %15 = stablehlo.reshape %14 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
+// CHECK-NEXT:     %16 = stablehlo.slice %13 [1:2, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
+// CHECK-NEXT:     %17 = stablehlo.reshape %16 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
+// CHECK-NEXT:     %18 = stablehlo.slice %13 [2:3, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
+// CHECK-NEXT:     %19 = stablehlo.reshape %18 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
+// CHECK-NEXT:     %20 = stablehlo.slice %13 [3:4, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
+// CHECK-NEXT:     %21 = stablehlo.reshape %20 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
+// CHECK-NEXT:     %22 = stablehlo.slice %13 [4:5, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
+// CHECK-NEXT:     %23 = stablehlo.reshape %22 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
+// CHECK-NEXT:     %24 = stablehlo.concatenate %15, %17, %19, %21, %23, dim = 0 : (tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>) -> tensor<5x3x10xf32>
+// CHECK-NEXT:     return %24 : tensor<5x3x10xf32>
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/test/lit_tests/autobatching/reactant_regression_3.mlir
+++ b/test/lit_tests/autobatching/reactant_regression_3.mlir
@@ -31,31 +31,11 @@ module @reactant_mapped_sub attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
 
 // CHECK: module @reactant_mapped_sub attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
 // CHECK-NEXT:   func.func @main(%arg0: tensor<3x5x10xf32>, %arg1: tensor<3x5x10xf32>) -> tensor<5x3x10xf32> attributes {enzymexla.memory_effects = []} {
-// CHECK-NEXT:     %0 = stablehlo.slice %arg0 [0:3, 4:5, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
-// CHECK-NEXT:     %1 = stablehlo.slice %arg0 [0:3, 3:4, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
-// CHECK-NEXT:     %2 = stablehlo.slice %arg0 [0:3, 2:3, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
-// CHECK-NEXT:     %3 = stablehlo.slice %arg0 [0:3, 1:2, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
-// CHECK-NEXT:     %4 = stablehlo.slice %arg0 [0:3, 0:1, 0:10] : (tensor<3x5x10xf32>) -> tensor<3x1x10xf32>
-// CHECK-NEXT:     %5 = stablehlo.broadcast_in_dim %4, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %6 = stablehlo.broadcast_in_dim %3, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %7 = stablehlo.broadcast_in_dim %2, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %8 = stablehlo.broadcast_in_dim %1, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %9 = stablehlo.broadcast_in_dim %0, dims = [3, 2, 1] : (tensor<3x1x10xf32>) -> tensor<1x10x1x3xf32>
-// CHECK-NEXT:     %10 = stablehlo.concatenate %5, %6, %7, %8, %9, dim = 0 : (tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>, tensor<1x10x1x3xf32>) -> tensor<5x10x1x3xf32>
-// CHECK-NEXT:     %11 = stablehlo.broadcast_in_dim %arg1, dims = [3, 0, 1] : (tensor<3x5x10xf32>) -> tensor<5x10x1x3xf32>
-// CHECK-NEXT:     %12 = stablehlo.subtract %10, %11 : tensor<5x10x1x3xf32>
-// CHECK-NEXT:     %13 = stablehlo.transpose %12, dims = [0, 2, 3, 1] : (tensor<5x10x1x3xf32>) -> tensor<5x1x3x10xf32>
-// CHECK-NEXT:     %14 = stablehlo.slice %13 [0:1, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %15 = stablehlo.reshape %14 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %16 = stablehlo.slice %13 [1:2, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %17 = stablehlo.reshape %16 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %18 = stablehlo.slice %13 [2:3, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %19 = stablehlo.reshape %18 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %20 = stablehlo.slice %13 [3:4, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %21 = stablehlo.reshape %20 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %22 = stablehlo.slice %13 [4:5, 0:1, 0:3, 0:10] : (tensor<5x1x3x10xf32>) -> tensor<1x1x3x10xf32>
-// CHECK-NEXT:     %23 = stablehlo.reshape %22 : (tensor<1x1x3x10xf32>) -> tensor<1x3x10xf32>
-// CHECK-NEXT:     %24 = stablehlo.concatenate %15, %17, %19, %21, %23, dim = 0 : (tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>) -> tensor<5x3x10xf32>
-// CHECK-NEXT:     return %24 : tensor<5x3x10xf32>
+// CHECK-NEXT:     %0 = stablehlo.broadcast_in_dim %arg0, dims = [3, 0, 1] : (tensor<3x5x10xf32>) -> tensor<5x10x1x3xf32>
+// CHECK-NEXT:     %1 = stablehlo.broadcast_in_dim %arg1, dims = [3, 0, 1] : (tensor<3x5x10xf32>) -> tensor<5x10x1x3xf32>
+// CHECK-NEXT:     %2 = stablehlo.subtract %0, %1 : tensor<5x10x1x3xf32>
+// CHECK-NEXT:     %3 = stablehlo.transpose %2, dims = [0, 2, 3, 1] : (tensor<5x10x1x3xf32>) -> tensor<5x1x3x10xf32>
+// CHECK-NEXT:     %4 = stablehlo.reshape %3 : (tensor<5x1x3x10xf32>) -> tensor<5x3x10xf32>
+// CHECK-NEXT:     return %4 : tensor<5x3x10xf32>
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/test/lit_tests/concatreduce3.mlir
+++ b/test/lit_tests/concatreduce3.mlir
@@ -44,29 +44,24 @@ module @reactant_Boltz.L... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
 }
 
 // CHECK: func.func @main(%arg0: tensor<3x2xf32>, %arg1: tensor<2xf32>) -> tensor<3x1xf32> {
-// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK-NEXT:     %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<3x2xf32>) -> tensor<2x3xf32>
-// CHECK-NEXT:     %1 = stablehlo.slice %0 [0:2, 0:1] : (tensor<2x3xf32>) -> tensor<2x1xf32>
-// CHECK-NEXT:     %2 = stablehlo.slice %0 [0:2, 1:2] : (tensor<2x3xf32>) -> tensor<2x1xf32>
-// CHECK-NEXT:     %3 = stablehlo.slice %0 [0:2, 2:3] : (tensor<2x3xf32>) -> tensor<2x1xf32>
-// CHECK-NEXT:     %4 = stablehlo.reshape %1 : (tensor<2x1xf32>) -> tensor<1x2x1xf32>
-// CHECK-NEXT:     %5 = stablehlo.reshape %2 : (tensor<2x1xf32>) -> tensor<1x2x1xf32>
-// CHECK-NEXT:     %6 = stablehlo.reshape %3 : (tensor<2x1xf32>) -> tensor<1x2x1xf32>
-// CHECK-NEXT:     %7 = stablehlo.concatenate %4, %5, %6, dim = 0 : (tensor<1x2x1xf32>, tensor<1x2x1xf32>, tensor<1x2x1xf32>) -> tensor<3x2x1xf32>
-// CHECK-NEXT:     %8 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<2xf32>) -> tensor<3x2x1xf32>
-// CHECK-NEXT:     %9 = stablehlo.subtract %7, %8 : tensor<3x2x1xf32>
-// CHECK-NEXT:     %10 = stablehlo.multiply %9, %9 : tensor<3x2x1xf32>
-// CHECK-NEXT:     %11 = stablehlo.reduce(%10 init: %cst) applies stablehlo.add across dimensions = [1, 2] : (tensor<3x2x1xf32>, tensor<f32>) -> tensor<3xf32>
-// CHECK-NEXT:     %12 = stablehlo.reshape %11 : (tensor<3xf32>) -> tensor<3x1xf32>
-// CHECK-NEXT:     %13 = stablehlo.reshape %1 : (tensor<2x1xf32>) -> tensor<1x2xf32>
-// CHECK-NEXT:     %14 = stablehlo.reshape %2 : (tensor<2x1xf32>) -> tensor<1x2xf32>
-// CHECK-NEXT:     %15 = stablehlo.reshape %3 : (tensor<2x1xf32>) -> tensor<1x2xf32>
-// CHECK-NEXT:     %16 = stablehlo.concatenate %13, %14, %15, dim = 0 : (tensor<1x2xf32>, tensor<1x2xf32>, tensor<1x2xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:     %17 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<2xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:     %18 = stablehlo.subtract %16, %17 : tensor<3x2xf32>
-// CHECK-NEXT:     %19 = stablehlo.multiply %18, %18 : tensor<3x2xf32>
-// CHECK-NEXT:     %20 = stablehlo.reduce(%19 init: %cst) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
-// CHECK-NEXT:     %21 = stablehlo.reshape %20 : (tensor<3xf32>) -> tensor<3x1xf32>
-// CHECK-NEXT:     %22 = stablehlo.add %12, %21 : tensor<3x1xf32>
-// CHECK-NEXT:     return %22 : tensor<3x1xf32>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [2:3, 0:2] : (tensor<3x2xf32>) -> tensor<1x2xf32>
+// CHECK-NEXT:    %1 = stablehlo.slice %arg0 [1:2, 0:2] : (tensor<3x2xf32>) -> tensor<1x2xf32>
+// CHECK-NEXT:    %2 = stablehlo.slice %arg0 [0:1, 0:2] : (tensor<3x2xf32>) -> tensor<1x2xf32>
+// CHECK-NEXT:    %3 = stablehlo.reshape %2 : (tensor<1x2xf32>) -> tensor<1x2x1xf32>
+// CHECK-NEXT:    %4 = stablehlo.reshape %1 : (tensor<1x2xf32>) -> tensor<1x2x1xf32>
+// CHECK-NEXT:    %5 = stablehlo.reshape %0 : (tensor<1x2xf32>) -> tensor<1x2x1xf32>
+// CHECK-NEXT:    %6 = stablehlo.concatenate %3, %4, %5, dim = 0 : (tensor<1x2x1xf32>, tensor<1x2x1xf32>, tensor<1x2x1xf32>) -> tensor<3x2x1xf32>
+// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<2xf32>) -> tensor<3x2x1xf32>
+// CHECK-NEXT:    %8 = stablehlo.subtract %6, %7 : tensor<3x2x1xf32>
+// CHECK-NEXT:    %9 = stablehlo.multiply %8, %8 : tensor<3x2x1xf32>
+// CHECK-NEXT:    %10 = stablehlo.reduce(%9 init: %cst) applies stablehlo.add across dimensions = [1, 2] : (tensor<3x2x1xf32>, tensor<f32>) -> tensor<3xf32>
+// CHECK-NEXT:    %11 = stablehlo.reshape %10 : (tensor<3xf32>) -> tensor<3x1xf32>
+// CHECK-NEXT:    %12 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<2xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:    %13 = stablehlo.subtract %arg0, %12 : tensor<3x2xf32>
+// CHECK-NEXT:    %14 = stablehlo.multiply %13, %13 : tensor<3x2xf32>
+// CHECK-NEXT:    %15 = stablehlo.reduce(%14 init: %cst) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
+// CHECK-NEXT:    %16 = stablehlo.reshape %15 : (tensor<3xf32>) -> tensor<3x1xf32>
+// CHECK-NEXT:    %17 = stablehlo.add %11, %16 : tensor<3x1xf32>
+// CHECK-NEXT:    return %17 : tensor<3x1xf32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/concatreduce3.mlir
+++ b/test/lit_tests/concatreduce3.mlir
@@ -45,23 +45,17 @@ module @reactant_Boltz.L... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
 
 // CHECK: func.func @main(%arg0: tensor<3x2xf32>, %arg1: tensor<2xf32>) -> tensor<3x1xf32> {
 // CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [2:3, 0:2] : (tensor<3x2xf32>) -> tensor<1x2xf32>
-// CHECK-NEXT:    %1 = stablehlo.slice %arg0 [1:2, 0:2] : (tensor<3x2xf32>) -> tensor<1x2xf32>
-// CHECK-NEXT:    %2 = stablehlo.slice %arg0 [0:1, 0:2] : (tensor<3x2xf32>) -> tensor<1x2xf32>
-// CHECK-NEXT:    %3 = stablehlo.reshape %2 : (tensor<1x2xf32>) -> tensor<1x2x1xf32>
-// CHECK-NEXT:    %4 = stablehlo.reshape %1 : (tensor<1x2xf32>) -> tensor<1x2x1xf32>
-// CHECK-NEXT:    %5 = stablehlo.reshape %0 : (tensor<1x2xf32>) -> tensor<1x2x1xf32>
-// CHECK-NEXT:    %6 = stablehlo.concatenate %3, %4, %5, dim = 0 : (tensor<1x2x1xf32>, tensor<1x2x1xf32>, tensor<1x2x1xf32>) -> tensor<3x2x1xf32>
-// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<2xf32>) -> tensor<3x2x1xf32>
-// CHECK-NEXT:    %8 = stablehlo.subtract %6, %7 : tensor<3x2x1xf32>
-// CHECK-NEXT:    %9 = stablehlo.multiply %8, %8 : tensor<3x2x1xf32>
-// CHECK-NEXT:    %10 = stablehlo.reduce(%9 init: %cst) applies stablehlo.add across dimensions = [1, 2] : (tensor<3x2x1xf32>, tensor<f32>) -> tensor<3xf32>
-// CHECK-NEXT:    %11 = stablehlo.reshape %10 : (tensor<3xf32>) -> tensor<3x1xf32>
-// CHECK-NEXT:    %12 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<2xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:    %13 = stablehlo.subtract %arg0, %12 : tensor<3x2xf32>
-// CHECK-NEXT:    %14 = stablehlo.multiply %13, %13 : tensor<3x2xf32>
-// CHECK-NEXT:    %15 = stablehlo.reduce(%14 init: %cst) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
-// CHECK-NEXT:    %16 = stablehlo.reshape %15 : (tensor<3xf32>) -> tensor<3x1xf32>
-// CHECK-NEXT:    %17 = stablehlo.add %11, %16 : tensor<3x1xf32>
-// CHECK-NEXT:    return %17 : tensor<3x1xf32>
+// CHECK-NEXT:    %0 = stablehlo.reshape %arg0 : (tensor<3x2xf32>) -> tensor<3x2x1xf32>
+// CHECK-NEXT:    %1 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<2xf32>) -> tensor<3x2x1xf32>
+// CHECK-NEXT:    %2 = stablehlo.subtract %0, %1 : tensor<3x2x1xf32>
+// CHECK-NEXT:    %3 = stablehlo.multiply %2, %2 : tensor<3x2x1xf32>
+// CHECK-NEXT:    %4 = stablehlo.reduce(%3 init: %cst) applies stablehlo.add across dimensions = [1, 2] : (tensor<3x2x1xf32>, tensor<f32>) -> tensor<3xf32>
+// CHECK-NEXT:    %5 = stablehlo.reshape %4 : (tensor<3xf32>) -> tensor<3x1xf32>
+// CHECK-NEXT:    %6 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<2xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:    %7 = stablehlo.subtract %arg0, %6 : tensor<3x2xf32>
+// CHECK-NEXT:    %8 = stablehlo.multiply %7, %7 : tensor<3x2xf32>
+// CHECK-NEXT:    %9 = stablehlo.reduce(%8 init: %cst) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
+// CHECK-NEXT:    %10 = stablehlo.reshape %9 : (tensor<3xf32>) -> tensor<3x1xf32>
+// CHECK-NEXT:    %11 = stablehlo.add %5, %10 : tensor<3x1xf32>
+// CHECK-NEXT:    return %11 : tensor<3x1xf32>
 // CHECK-NEXT:  }


### PR DESCRIPTION
- [x] `transpose_all_users_slice` can now handle reshapes (for cases where other opts exist)
- [x] `concat_reshape_slice` can now handle insertion and deletion dims