### PR TITLE
Remove call to deprecated createTargetMachine overload

### DIFF
--- a/src/enzyme_ad/jax/clang_compile.cc
+++ b/src/enzyme_ad/jax/clang_compile.cc
@@ -162,9 +162,8 @@ static TargetMachine *GetTargetMachine(llvm::Triple TheTriple, StringRef CPUStr,
   }
 
   return TheTarget->createTargetMachine(
-      TheTriple.getTriple(), codegen::getCPUStr(), codegen::getFeaturesStr(),
-      Options, codegen::getExplicitRelocModel(),
-      codegen::getExplicitCodeModel(), level);
+      TheTriple, codegen::getCPUStr(), codegen::getFeaturesStr(), Options,
+      codegen::getExplicitRelocModel(), codegen::getExplicitCodeModel(), level);
 }
 
 std::unique_ptr<llvm::Module>


### PR DESCRIPTION
The overloads for many of the TargetRegistry functions using string triples are deprecated and will be removed soon. Migrate Enzyme off them to prevent breakage.