### PR TITLE
[CI] Always build the JLLs on Reactant main

### DIFF
--- a/.github/workflows/build-reactantjll.yml
+++ b/.github/workflows/build-reactantjll.yml
@@ -31,10 +31,30 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
+  get-reactant-commit:
+    name: 'Get Reactant commit'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Get latest Reactant commit
+        id: get-reactant-main
+        shell: bash
+        run: |
+          REACTANT_MAIN="$(git ls-remote https://github.com/EnzymeAD/Reactant.jl.git main | awk '{print $1}')"
+          echo "reactant_main=${REACTANT_MAIN}"
+          echo "reactant_main=${REACTANT_MAIN}" >> "${GITHUB_OUTPUT}"
+    outputs:
+      reactant_main: ${{ steps.get-reactant-main.outputs.reactant_main }}
+
   build-jll:
     name: Build Reactant_jll
     if: github.event.pull_request.draft == false
     uses: EnzymeAD/ReactantBuilder/.github/workflows/build-reactant-reusable.yml@main
+    needs: get-reactant-commit
     with:
       reactantbuilder_ref: 'main'
       enzyme_jax_commit: ${{ github.sha }}
+      # If you want to use a different commit than `main`, put here the sha256
+      # hash, but it must always be a hash, can't use branch name here.
+      reactant_commit: ${{ needs.get-reactant-commit.outputs.reactant_main }}


### PR DESCRIPTION
Untested, but something along these lines should do the trick.  This goes with https://github.com/EnzymeAD/ReactantBuilder/commit/af2c125924b2fe3096ffe2f83f81393488ac01e4.