### PR TITLE
Fix MacOS local builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,15 +16,19 @@ common --action_env=PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb
 common --experimental_repo_remote_exec
 common --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 common --cxxopt=-w --host_cxxopt=-w
-# common --copt=-fbracket-depth=1024 --host_copt=-fbracket-depth=1024
+
 common --define=grpc_no_ares=true
 common --define=tsl_link_protobuf=true
 common --define open_source_build=true
-common
 common --define framework_shared_object=true
 common --define tsl_protobuf_header_only=true
 common --define=allow_oversize_protos=true
 
+common --enable_platform_specific_config
+
+# macos specific config
+build:macos --macos_minimum_os=11.3
+build:macos --define using_clang=true
 
 # Some targets have the same py source file, but use different
 # configurations via `requires-` tags. This results in an action


### PR DESCRIPTION
Currently, MacOS builds of Enzyme-JAX fail without setting these options in bazelrc. Apple clang 17.0.0 defaults to using `-mmacosx-version-min=10.11` , which doesn't play well with `xla` which needs atleast version `10.13`. 

The `using_clang` definition is to increase bracket depth for TransformOps (we have more than 256 patterns, and Apple clang again has a max depth of 256). 
