### PR TITLE
Fix an assertion in guaranteed nonan

### DIFF
--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -365,6 +365,9 @@ public:
       auto cur = todo.front();
       todo.pop_front();
 
+      if (seen.find(cur) != seen.end())
+        continue;
+
       SmallVector<Operation *, 2> localtodo;
       State status;
 

--- a/test/lit_tests/shared_operand_nonan.mlir
+++ b/test/lit_tests/shared_operand_nonan.mlir
@@ -1,0 +1,21 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{no_nan=false})" %s | FileCheck %s
+
+module {
+  func.func @test(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
+    %1 = stablehlo.multiply %arg1, %arg1 : tensor<f64>
+    %2 = stablehlo.add %0, %1 : tensor<f64>
+    %3 = stablehlo.add %2, %1 : tensor<f64>
+    %4 = stablehlo.subtract %3, %2 : tensor<f64>
+    return %4 : tensor<f64>
+  }
+}
+
+// CHECK:  func.func @test(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:    %0 = stablehlo.add %arg0, %arg1 {enzymexla.guaranteed_finite = false} : tensor<f64>
+// CHECK-NEXT:    %1 = stablehlo.multiply %arg1, %arg1 {enzymexla.guaranteed_finite = false, enzymexla.guaranteed_no_nan = false} : tensor<f64>
+// CHECK-NEXT:    %2 = stablehlo.add %0, %1 {enzymexla.guaranteed_finite = false, enzymexla.guaranteed_no_nan = false} : tensor<f64>
+// CHECK-NEXT:    %3 = stablehlo.add %2, %1 {enzymexla.guaranteed_finite = false, enzymexla.guaranteed_no_nan = false} : tensor<f64>
+// CHECK-NEXT:    %4 = stablehlo.subtract %3, %2 {enzymexla.guaranteed_no_nan = false} : tensor<f64>
+// CHECK-NEXT:    return %4 : tensor<f64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
In debug build the MWE gives

```
enzymexlamlir-opt: src/enzyme_ad/jax/Utils.h:457: bool mlir::enzyme::GuaranteedResultAnalysisBase<Child>::guaranteed(mlir::Operation*, mlir::PatternRewriter&) [with Child = mlir::enzyme::NoNanResultAnalysis]: Assertion `seen.find(cur) == seen.end()' failed.
```