### PR TITLE
fix: remove blocks from tt_call op

### DIFF
--- a/src/enzyme_ad/jax/Dialect/TritonExt/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/TritonExt/Ops.cpp
@@ -17,8 +17,7 @@ triton_ext::TritonCallOp ReadOnlyArg<triton_ext::TritonCallOp>::create(
     ArrayRef<Type> resTys, ArrayAttr outputAliases) const {
   return rewriter.create<triton_ext::TritonCallOp>(
       launchOp.getLoc(), resTys, launchOp.getFn(), launchOp.getGridx(),
-      launchOp.getGridy(), launchOp.getGridz(), launchOp.getBlockx(),
-      launchOp.getBlocky(), launchOp.getBlockz(), launchOp.getClusterx(),
+      launchOp.getGridy(), launchOp.getGridz(), launchOp.getClusterx(),
       launchOp.getClustery(), launchOp.getClusterz(), launchOp.getInputs(),
       launchOp.getBackendConfigAttr(), launchOp.getOperandLayoutsAttr(),
       /*resultLayouts*/ nullptr, launchOp.getArgAttrsAttr(),

--- a/src/enzyme_ad/jax/Dialect/TritonExt/Ops.td
+++ b/src/enzyme_ad/jax/Dialect/TritonExt/Ops.td
@@ -44,9 +44,6 @@ def TritonCallOp : TritonExtOp<"call", [
     TensorI64:$gridx,
     TensorI64:$gridy,
     TensorI64:$gridz,
-    TensorI64:$blockx,
-    TensorI64:$blocky,
-    TensorI64:$blockz,
     TensorI64:$clusterx,
     TensorI64:$clustery,
     TensorI64:$clusterz,
@@ -68,7 +65,6 @@ def TritonCallOp : TritonExtOp<"call", [
     $fn
     `clusters` `in` `(` $clusterx `,` $clustery `,` $clusterz `)`
     `blocks` `in` `(` $gridx `,` $gridy `,` $gridz `)`
-    `threads` `in` `(` $blockx `,` $blocky `,` $blockz `)`
     `(` $inputs `)`
     attr-dict `:` functional-type($inputs, results)
   }];

--- a/src/enzyme_ad/jax/Passes/RaiseTritonCustomCallPass.cpp
+++ b/src/enzyme_ad/jax/Passes/RaiseTritonCustomCallPass.cpp
@@ -108,12 +108,6 @@ struct RaiseTritonCustomCallPattern final
 
     innerMod.setSymName("triton_module_inner");
 
-    // https://github.com/jax-ml/jax/blob/8d21fb89146b7e5864191bf013733d3a638a26d5/jaxlib/gpu/triton_kernels.cc#L323
-    uint64_t kNumThreadsPerWarp = 64;
-
-    uint64_t blockx = kCall.kernel().num_warps() * kNumThreadsPerWarp,
-             blocky = 1, blockz = 1;
-
     uint64_t gridx = kCall.grid_0(), gridy = kCall.grid_1(),
              gridz = kCall.grid_2();
     uint64_t clusterx = kCall.kernel().cluster_dim_0(),
@@ -138,12 +132,9 @@ struct RaiseTritonCustomCallPattern final
     rewriter.setInsertionPoint(callOp);
     rewriter.replaceOpWithNewOp<enzymexla::triton_ext::TritonCallOp>(
         callOp, callOp->getResultTypes(),
-
         fn,
 
         TI64(gridx), TI64(gridy), TI64(gridz),
-
-        TI64(blockx), TI64(blocky), TI64(blockz),
 
         TI64(clusterx), TI64(clustery), TI64(clusterz),
 

--- a/src/enzyme_ad/jax/Passes/RaiseTritonCustomCallPass.cpp
+++ b/src/enzyme_ad/jax/Passes/RaiseTritonCustomCallPass.cpp
@@ -131,8 +131,7 @@ struct RaiseTritonCustomCallPattern final
 
     rewriter.setInsertionPoint(callOp);
     rewriter.replaceOpWithNewOp<enzymexla::triton_ext::TritonCallOp>(
-        callOp, callOp->getResultTypes(),
-        fn,
+        callOp, callOp->getResultTypes(), fn,
 
         TI64(gridx), TI64(gridy), TI64(gridz),
 

--- a/test/lit_tests/triton/add_kernel.mlir
+++ b/test/lit_tests/triton/add_kernel.mlir
@@ -28,11 +28,10 @@ module {
     }
   }
   func.func @main(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>, %arg2: tensor<1024xf32>, %arg3: tensor<i32>) -> (tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>) {
-    %c = stablehlo.constant dense<64> : tensor<i64>
     %c_0 = stablehlo.constant dense<1> : tensor<i64>
     %c_1 = stablehlo.constant dense<16> : tensor<i64>
     // CHECK: enzymexla_tt_ext.call
-    %0:3 = enzymexla_tt_ext.call @add_kernel_tt::@add_kernel_inner::@add_kernel clusters in (%c_0, %c_0, %c_0) blocks in(%c_1, %c_0, %c_0) threads in(%c, %c_0, %c_0) (%arg0, %arg1, %arg2, %arg3) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 1, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [2], operand_index = 2, operand_tuple_indices = []>]} : (tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<i32>) -> (tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>)
+    %0:3 = enzymexla_tt_ext.call @add_kernel_tt::@add_kernel_inner::@add_kernel clusters in (%c_0, %c_0, %c_0) blocks in(%c_1, %c_0, %c_0) (%arg0, %arg1, %arg2, %arg3) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [1], operand_index = 1, operand_tuple_indices = []>, #stablehlo.output_operand_alias<output_tuple_indices = [2], operand_index = 2, operand_tuple_indices = []>]} : (tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>, tensor<i32>) -> (tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>)
     return %0#0, %0#1, %0#2 : tensor<1024xf32>, tensor<1024xf32>, tensor<1024xf32>
   }
 }

--- a/test/lit_tests/triton/tt_custom_call.mlir
+++ b/test/lit_tests/triton/tt_custom_call.mlir
@@ -9,8 +9,7 @@ module @jit_add attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1
 
 // CHECK:  func.func public @main(%arg0: tensor<8xi32>, %arg1: tensor<8xi32>) -> (tensor<8xi32> {jax.result_info = "result"}) {
 // CHECK-NEXT:    %c = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<256> : tensor<i64>
-// CHECK-NEXT:    %0 = enzymexla_tt_ext.call @triton_module::@triton_module_inner::@add_kernel clusters in(%c, %c, %c) blocks in(%c, %c, %c) threads in(%c_0, %c, %c) (%arg0, %arg1) {arg_attrs = [], operand_layouts = [dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], res_attrs = [], result_layouts = [dense<0> : tensor<1xindex>]} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+// CHECK-NEXT:    %0 = enzymexla_tt_ext.call @triton_module::@triton_module_inner::@add_kernel clusters in(%c, %c, %c) blocks in(%c, %c, %c) (%arg0, %arg1) {arg_attrs = [], operand_layouts = [dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], res_attrs = [], result_layouts = [dense<0> : tensor<1xindex>]} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
 // CHECK-NEXT:    return %0 : tensor<8xi32>
 // CHECK-NEXT:  }
 


### PR DESCRIPTION
We can infer that from the module attributes when lowering to kernel_call.

x/ref https://github.com/EnzymeAD/Enzyme-JAX/pull/1604#discussion_r2513364720