### PR TITLE
feat: generalize existing passes

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -21758,69 +21758,13 @@ struct FactorScalarsInDotGeneral final
     if (!canRewriteOperation(op, lhs, rhs))
       return failure();
 
-    // From v, extract scalar * tensor, and return true if the operation is not
-    // used elsewhere.
-    auto extractMul = [&](Value v, Value &scalar, Value &z) -> bool {
-      auto mulOp = v.getDefiningOp<stablehlo::MulOp>();
-      if (!mulOp) { // set default scalar to 1
-        scalar = nullptr;
-        z = v;
-        return true;
-      }
-      if (!isOnlyUsedInOperation(mulOp, op)) {
-        return false;
-      }
-
-      Value mLhs = mulOp.getLhs();
-      Value mRhs = mulOp.getRhs();
-
-      SplatElementsAttr splatAttr;
-      if (matchPattern(mLhs, m_Constant(&splatAttr))) {
-        auto mLhsType = cast<RankedTensorType>(mLhs.getType());
-        auto scalarType = RankedTensorType::get({}, mLhsType.getElementType());
-        scalar =
-            stablehlo::ConstantOp::create(rewriter, op.getLoc(), scalarType,
-                                          splatAttr.resizeSplat(scalarType));
-        z = mRhs;
-      } else if (matchPattern(mRhs, m_Constant(&splatAttr))) {
-        auto mRhsType = cast<RankedTensorType>(mRhs.getType());
-        auto scalarType = RankedTensorType::get({}, mRhsType.getElementType());
-        scalar =
-            stablehlo::ConstantOp::create(rewriter, op.getLoc(), scalarType,
-                                          splatAttr.resizeSplat(scalarType));
-        z = mLhs;
-      } else if (auto lhsBcast =
-                     mLhs.getDefiningOp<stablehlo::BroadcastInDimOp>()) {
-        if (cast<RankedTensorType>(lhsBcast.getOperand().getType()).getRank() ==
-            0) {
-          scalar = lhsBcast.getOperand();
-          z = mRhs;
-        } else {
-          scalar = nullptr;
-          return false;
-        }
-      } else if (auto rhsBcast =
-                     mRhs.getDefiningOp<stablehlo::BroadcastInDimOp>()) {
-        if (cast<RankedTensorType>(rhsBcast.getOperand().getType()).getRank() ==
-            0) {
-          scalar = rhsBcast.getOperand();
-          z = mLhs;
-        } else {
-          scalar = nullptr;
-          return false;
-        }
-      } else { // If both are non-scalar, treat whole v as Z, no scalar
-        scalar = nullptr;
-        z = v;
-      }
-      return true;
-    };
-
     Value lhsScalar, lhsZ;
     Value rhsScalar, rhsZ;
 
-    auto lhsExtracted = extractMul(lhs, lhsScalar, lhsZ);
-    auto rhsExtracted = extractMul(rhs, rhsScalar, rhsZ);
+    auto lhsExtracted = stablehlo::extractMultiplicationFactor(
+        lhs, lhsScalar, lhsZ, op, rewriter);
+    auto rhsExtracted = stablehlo::extractMultiplicationFactor(
+        rhs, rhsScalar, rhsZ, op, rewriter);
 
     assert(lhsExtracted && rhsExtracted);
 
@@ -21856,27 +21800,16 @@ private:
         (rhsMulOp && !isOnlyUsedInOperation(rhsMulOp, op)))
       return false; // better to not do anything
 
-    auto isScalar = [&](Value v) -> bool {
-      SplatElementsAttr splatAttr;
-      if (matchPattern(v, m_Constant(&splatAttr)))
-        return true;
-
-      auto bcastOp = v.getDefiningOp<stablehlo::BroadcastInDimOp>();
-      if (bcastOp &&
-          cast<RankedTensorType>(bcastOp.getOperand().getType()).getRank() == 0)
-        return true;
-
-      return false;
-    };
-
     bool lhsHasScalar = false;
     if (lhsMulOp) {
-      lhsHasScalar = isScalar(lhsMulOp.getLhs()) || isScalar(lhsMulOp.getRhs());
+      lhsHasScalar =
+          isScalarValue(lhsMulOp.getLhs()) || isScalarValue(lhsMulOp.getRhs());
     }
 
     bool rhsHasScalar = false;
     if (rhsMulOp) {
-      rhsHasScalar = isScalar(rhsMulOp.getLhs()) || isScalar(rhsMulOp.getRhs());
+      rhsHasScalar =
+          isScalarValue(rhsMulOp.getLhs()) || isScalarValue(rhsMulOp.getRhs());
     }
 
     return lhsHasScalar || rhsHasScalar;
@@ -23871,20 +23804,12 @@ private:
 // operations and converts them to dot_general(a, op(b, c)) or
 // dot_general(op(b, c), a)
 template <typename OpTy>
-LogicalResult dotGeneralDistributiveSimplify(OpTy op,
-                                             PatternRewriter &rewriter) {
+LogicalResult
+dotGeneralDistributiveSimplify(OpTy op, stablehlo::DotGeneralOp lhsDotGeneralOp,
+                               stablehlo::DotGeneralOp rhsDotGeneralOp,
+                               PatternRewriter &rewriter) {
   // TODO: generalize this to handle cases where the dot general dim numbers are
   // different but the ops can still be distributed
-  if (op.getNumOperands() != 2)
-    return failure();
-
-  auto lhsDotGeneralOp =
-      op.getLhs().template getDefiningOp<stablehlo::DotGeneralOp>();
-  auto rhsDotGeneralOp =
-      op.getRhs().template getDefiningOp<stablehlo::DotGeneralOp>();
-  if (!lhsDotGeneralOp || !rhsDotGeneralOp)
-    return failure();
-
   if (!OperationEquivalence::isEquivalentTo(
           lhsDotGeneralOp, rhsDotGeneralOp,
           OperationEquivalence::ignoreValueEquivalence, nullptr,
@@ -23916,6 +23841,87 @@ LogicalResult dotGeneralDistributiveSimplify(OpTy op,
         op, TypeRange{op.getType()},
         ValueRange{newDotLhs.getResult(), rhsDotGeneralRhs},
         lhsDotGeneralOp->getAttrs());
+    return success();
+  }
+
+  return failure();
+}
+
+template <typename OpTy>
+LogicalResult dotGeneralDistributiveSimplify(OpTy op,
+                                             PatternRewriter &rewriter) {
+  if (op.getNumOperands() != 2)
+    return failure();
+
+  auto lhs = op.getLhs(), rhs = op.getRhs();
+  auto lhsDotGeneralOp = lhs.template getDefiningOp<stablehlo::DotGeneralOp>();
+  auto rhsDotGeneralOp = rhs.template getDefiningOp<stablehlo::DotGeneralOp>();
+
+  if (lhsDotGeneralOp && !isOnlyUsedInOperation(lhsDotGeneralOp, op))
+    return failure();
+  if (rhsDotGeneralOp && !isOnlyUsedInOperation(rhsDotGeneralOp, op))
+    return failure();
+
+  if (lhsDotGeneralOp && rhsDotGeneralOp)
+    return dotGeneralDistributiveSimplify<OpTy>(op, lhsDotGeneralOp,
+                                                rhsDotGeneralOp, rewriter);
+
+  Value newLhs, newRhs;
+  stablehlo::DotGeneralOp dotGeneralOp;
+
+  auto constructOtherOp = [&](Value other, Value scalar, bool scalarIsLhs) {
+    auto bcastedScalar = stablehlo::BroadcastInDimOp::create(
+        rewriter, op.getLoc(), other.getType(), scalar,
+        rewriter.getDenseI64ArrayAttr({}));
+    auto lhs = scalarIsLhs ? bcastedScalar : other;
+    auto rhs = scalarIsLhs ? other : bcastedScalar;
+    return OpTy::create(rewriter, op.getLoc(), lhs, rhs);
+  };
+
+  if (lhsDotGeneralOp) {
+    Value scalar, other;
+    dotGeneralOp = lhsDotGeneralOp;
+    if (extractMultiplicationFactor(rhs, other, op, rewriter)) {
+      if (other == lhsDotGeneralOp.getLhs()) {
+        extractMultiplicationFactor(rhs, scalar, other, op, rewriter);
+
+        // op(X × Y, a * X) -> X × op(Y, a)
+        newLhs = lhsDotGeneralOp.getLhs();
+        newRhs = constructOtherOp(lhsDotGeneralOp.getRhs(), scalar, false);
+      } else if (other == lhsDotGeneralOp.getRhs()) {
+        extractMultiplicationFactor(rhs, scalar, other, op, rewriter);
+
+        // op(Y × X, a * X) -> op(Y, a) × X
+        newLhs = constructOtherOp(lhsDotGeneralOp.getLhs(), scalar, false);
+        newRhs = lhsDotGeneralOp.getRhs();
+      }
+    }
+  }
+
+  if (rhsDotGeneralOp) {
+    Value scalar, other;
+    dotGeneralOp = rhsDotGeneralOp;
+    if (extractMultiplicationFactor(lhs, other, op, rewriter)) {
+      if (other == rhsDotGeneralOp.getLhs()) {
+        extractMultiplicationFactor(lhs, scalar, other, op, rewriter);
+
+        // op(a * X, X × Y) -> X × op(a, Y)
+        newLhs = rhsDotGeneralOp.getLhs();
+        newRhs = constructOtherOp(rhsDotGeneralOp.getRhs(), scalar, true);
+      } else if (other == rhsDotGeneralOp.getRhs()) {
+        extractMultiplicationFactor(lhs, scalar, other, op, rewriter);
+
+        // op(a * X, Y × X) -> op(a, Y) × X
+        newLhs = constructOtherOp(rhsDotGeneralOp.getLhs(), scalar, true);
+        newRhs = rhsDotGeneralOp.getRhs();
+      }
+    }
+  }
+
+  if (newLhs && newRhs) {
+    rewriter.replaceOpWithNewOp<stablehlo::DotGeneralOp>(
+        op, TypeRange{op.getType()}, ValueRange{newLhs, newRhs},
+        dotGeneralOp->getAttrs());
     return success();
   }
 
@@ -25914,12 +25920,25 @@ struct DotGeneralToSyrk
     Value syrkInput;
     enzymexla::LapackTranspose lapackTranspose;
 
-    if (lhs == rhs && lhsContractingDim == rhsContractingDim) {
-      syrkInput = lhs;
-      if (lhsContractingDim == 1) {
-        lapackTranspose = enzymexla::LapackTranspose::none;
+    if (lhs == rhs) {
+      if (lhsContractingDim == rhsContractingDim) {
+        syrkInput = lhs;
+        if (lhsContractingDim == 1) {
+          lapackTranspose = enzymexla::LapackTranspose::none;
+        } else {
+          lapackTranspose = enzymexla::LapackTranspose::transpose;
+        }
       } else {
-        lapackTranspose = enzymexla::LapackTranspose::transpose;
+        // if lhsContractingDim != rhsContractingDim, then we can fuse iff
+        // lhs/rhs is a symmetric matrix
+        if (canApplySymmetricPattern(lhs, rewriter)) {
+          syrkInput = lhs;
+          if (lhsContractingDim == 1) {
+            lapackTranspose = enzymexla::LapackTranspose::none;
+          } else {
+            lapackTranspose = enzymexla::LapackTranspose::transpose;
+          }
+        }
       }
     }
 
@@ -26034,6 +26053,9 @@ struct FuseMulIntoSyrk
       return failure();
     }
 
+    if (!isOnlyUsedInOperation(syrkOp, op))
+      return failure();
+
     Value scalarVal =
         stablehlo::getScalarValue(other.getDefiningOp(), rewriter);
     if (!scalarVal)
@@ -26074,6 +26096,9 @@ struct FuseAddIntoSyrk
     } else {
       return failure();
     }
+
+    if (!isOnlyUsedInOperation(syrkOp, op))
+      return failure();
 
     // we can fuse this addition iff the other operand is a symmetric matrix
     if (!canApplySymmetricPattern(other, rewriter))

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -948,7 +948,18 @@ bool hasTraitElementwise(Operation *op);
 // currently there are no traits for associative ops
 bool isAssociativeOp(Operation *op);
 
+// this doesn't construct the scalar value and instead returns the
+// other operand
+bool extractMultiplicationFactor(Value v, Value &other, Operation *op,
+                                 OpBuilder &builder);
+bool extractMultiplicationFactor(Value v, Value &scalar, Value &other,
+                                 Operation *op, OpBuilder &builder);
+
+Value getScalarValue(Value val, OpBuilder &builder);
 Value getScalarValue(Operation *op, OpBuilder &builder);
+
+bool isScalarValue(Value val);
+bool isScalarValue(Operation *op);
 
 Value copyTriangularPart(OpBuilder &builder, Value input,
                          enzymexla::LapackUplo uplo);

--- a/test/lit_tests/newton_schulz_to_syrksymm.mlir
+++ b/test/lit_tests/newton_schulz_to_syrksymm.mlir
@@ -1,0 +1,58 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-generate-td{patterns=dot_general_to_syrk;transpose_syrk_to_syrk;fuse_mul_into_syrk;fuse_add_into_syrk},transform-interpreter,enzyme-hlo-remove-transform,enzyme-hlo-opt)" %s | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<5x4xf32>) -> tensor<5x4xf32> {
+    %cst = stablehlo.constant dense<2.031500e+00> : tensor<4x4xf32>
+    %c = stablehlo.constant dense<0> : tensor<i64>
+    %c_0 = stablehlo.constant dense<5> : tensor<i64>
+    %c_1 = stablehlo.constant dense<1> : tensor<i64>
+    %cst_2 = stablehlo.constant dense<-4.775000e+00> : tensor<4x4xf32>
+    %cst_3 = stablehlo.constant dense<3.444500e+00> : tensor<5x4xf32>
+    %0:2 = stablehlo.while(%iterArg = %c, %iterArg_4 = %arg0) : tensor<i64>, tensor<5x4xf32>
+    cond {
+      %1 = stablehlo.compare  LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %1 : tensor<i1>
+    } do {
+      %1 = stablehlo.add %iterArg, %c_1 : tensor<i64>
+      %2 = stablehlo.dot_general %iterArg_4, %iterArg_4, contracting_dims = [0] x [0], precision = [DEFAULT, DEFAULT] : (tensor<5x4xf32>, tensor<5x4xf32>) -> tensor<4x4xf32>
+      %3 = stablehlo.multiply %cst_2, %2 : tensor<4x4xf32>
+      %4 = stablehlo.dot_general %2, %2, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+      %5 = stablehlo.multiply %cst, %4 : tensor<4x4xf32>
+      %6 = stablehlo.add %3, %5 : tensor<4x4xf32>
+      %7 = stablehlo.multiply %cst_3, %iterArg_4 : tensor<5x4xf32>
+      %8 = stablehlo.dot_general %iterArg_4, %6, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<5x4xf32>, tensor<4x4xf32>) -> tensor<5x4xf32>
+      %9 = stablehlo.add %7, %8 : tensor<5x4xf32>
+      stablehlo.return %1, %9 : tensor<i64>, tensor<5x4xf32>
+    }
+    return %0#1 : tensor<5x4xf32>
+  }
+}
+
+// CHECK: module {
+// CHECK-NEXT:   func.func @main(%arg0: tensor<5x4xf32>) -> tensor<5x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant {enzymexla.symmetric_matrix = [#enzymexla<guaranteed GUARANTEED>]} dense<3.444500e+00> : tensor<4x4xf32>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} dense<2.031500e+00> : tensor<f32>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:     %cst_2 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK-NEXT:     %cst_3 = stablehlo.constant dense<0.000000e+00> : tensor<4x4xf32>
+// CHECK-NEXT:     %c = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_4 = stablehlo.constant dense<5> : tensor<i64>
+// CHECK-NEXT:     %c_5 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %cst_6 = stablehlo.constant {enzymexla.symmetric_matrix = [#enzymexla<guaranteed GUARANTEED>]} dense<-4.775000e+00> : tensor<4x4xf32>
+// CHECK-NEXT:     %0:2 = stablehlo.while(%iterArg = %c, %iterArg_7 = %arg0) : tensor<i64>, tensor<5x4xf32>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %1 = stablehlo.compare  LT, %iterArg, %c_4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %1 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %1 = stablehlo.add %iterArg, %c_5 : tensor<i64>
+// CHECK-NEXT:       %2 = enzymexla.blas.syrk %iterArg_7, %cst_3, %cst_2, %cst_1 {fill, transpose = #enzymexla.transpose<transpose>, uplo = #enzymexla.uplo<F>} : (tensor<5x4xf32>, tensor<4x4xf32>, tensor<f32>, tensor<f32>) -> tensor<4x4xf32>
+// CHECK-NEXT:       %3 = stablehlo.multiply %cst_6, %2 {enzymexla.symmetric_matrix = [#enzymexla<guaranteed GUARANTEED>]} : tensor<4x4xf32>
+// CHECK-NEXT:       %4 = stablehlo.add %3, %cst : tensor<4x4xf32>
+// CHECK-NEXT:       %5 = enzymexla.blas.syrk %2, %4, %cst_0, %cst_2 {fill, uplo = #enzymexla.uplo<F>} : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<f32>, tensor<f32>) -> tensor<4x4xf32>
+// CHECK-NEXT:       %6 = stablehlo.dot_general %iterArg_7, %5, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<5x4xf32>, tensor<4x4xf32>) -> tensor<5x4xf32>
+// CHECK-NEXT:       stablehlo.return %1, %6 : tensor<i64>, tensor<5x4xf32>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#1 : tensor<5x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+


### PR DESCRIPTION
- fuse add/mul in syrk checks for no additional usage
- dotgeneral distributive also applies if one of the operands is a scalar multiplication