### PR TITLE
feat: generalize loop raising passes to work with affine indexing

### DIFF
--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -2730,8 +2730,7 @@ public:
 
     Value inductionVariable; // [0,..., N - 1] counter from within the loop
 
-    if (matchPattern(info.start, m_Zero()) &&
-        matchPattern(info.step, m_One())) {
+    if (matchPattern(info.getStart(), m_Zero()) && info.isStepOne()) {
       inductionVariable = body->getArgument(0);
     }
 

--- a/src/enzyme_ad/jax/Implementations/WhileLoopInfo.cpp
+++ b/src/enzyme_ad/jax/Implementations/WhileLoopInfo.cpp
@@ -19,6 +19,27 @@ using namespace mlir;
 using namespace mlir::enzyme;
 using namespace mlir::stablehlo;
 
+static bool definedOutside(Value v, Operation *op) {
+  return !op->isAncestor(v.getParentBlock()->getParentOp());
+}
+
+void WhileLoopInfo::computeConstantValues() {
+  constStep = getConstantStepCalculate();
+  constLimit = getConstantLimitCalculate();
+  constStart = getConstantStartCalculate();
+}
+
+Value WhileLoopInfo::getStep(OpBuilder &builder) {
+  if (step)
+    return step;
+
+  auto Ty =
+      RankedTensorType::get({}, builder.getIntegerType(stepInt.getBitWidth()));
+  return stablehlo::ConstantOp::create(
+      builder, op->getLoc(), Ty,
+      cast<ElementsAttr>(makeAttr(Ty, stepInt.getSExtValue())));
+}
+
 LogicalResult WhileLoopInfo::computeInfo() {
   auto &condBlk = op.getCond().front();
   if (condBlk.getOperations().size() != 2)
@@ -38,9 +59,30 @@ LogicalResult WhileLoopInfo::computeInfo() {
   if (cond.getComparisonDirection() != stablehlo::ComparisonDirection::LT)
     return failure();
 
+  start = op->getOperand(induct.getArgNumber());
+  limit = cond.getOperand(1);
+
+  propagateAffineIndexInfo();
+  auto affineIndexInfoMap = getAffineIndexInfo();
+
   auto bodyTerm =
       cast<stablehlo::ReturnOp>(op.getBody().front().getTerminator());
   auto incV = bodyTerm->getOperand(induct.getArgNumber());
+
+  // if part of the index map then exit early
+  if (affineIndexInfoMap.contains(incV)) {
+    auto indexInfo = affineIndexInfoMap[incV];
+    if (indexInfo.scale.isOne()) {
+      stepInt = indexInfo.offset;
+      foundStep = true;
+      computeConstantValues();
+      return success();
+    } else {
+      return failure();
+    }
+  }
+
+  // simpler check
   auto inc = incV.getDefiningOp<stablehlo::AddOp>();
   if (!inc)
     return failure();
@@ -50,48 +92,54 @@ LogicalResult WhileLoopInfo::computeInfo() {
   auto incba0 = dyn_cast<BlockArgument>(inc.getOperand(0));
   auto incba1 = dyn_cast<BlockArgument>(inc.getOperand(1));
 
-  bool found = false;
+  foundStep = false;
 
   if (incba0 && (incba0.getOwner() == loopBodyBlock) &&
       (incba0.getArgNumber() == induct.getArgNumber())) {
     step = inc.getOperand(1);
-    found = true;
+    foundStep = true;
   }
 
-  if (!found && incba1 && (incba1.getOwner() == loopBodyBlock) &&
+  if (!foundStep && incba1 && (incba1.getOwner() == loopBodyBlock) &&
       (incba1.getArgNumber() == induct.getArgNumber())) {
     step = inc.getOperand(0);
-    found = true;
+    foundStep = true;
   }
 
-  if (!found)
+  if (!foundStep)
     return failure();
 
-  start = op->getOperand(induct.getArgNumber());
-  limit = cond.getOperand(1);
-
+  computeConstantValues();
   return success();
 }
 
-std::optional<int64_t> WhileLoopInfo::getConstantStep() {
-  DenseIntElementsAttr stepAttr;
-  if (!matchPattern(step, m_Constant(&stepAttr)))
-    return std::nullopt;
-  return (*stepAttr.begin()).getSExtValue();
+int64_t getBitWidth(Value v) {
+  auto tensorType = cast<RankedTensorType>(v.getType());
+  return tensorType.getElementType().getIntOrFloatBitWidth();
 }
 
-std::optional<int64_t> WhileLoopInfo::getConstantStart() {
-  DenseIntElementsAttr startAttr;
-  if (!matchPattern(start, m_Constant(&startAttr)))
-    return std::nullopt;
-  return (*startAttr.begin()).getSExtValue();
+std::optional<int64_t> WhileLoopInfo::getConstantStepCalculate() {
+  if (!step)
+    return stepInt.getSExtValue();
+
+  llvm::APInt constVal(getBitWidth(step), 0, true);
+  if (isConstantValue(step, constVal))
+    return constVal.getSExtValue();
+  return std::nullopt;
 }
 
-std::optional<int64_t> WhileLoopInfo::getConstantLimit() {
-  DenseIntElementsAttr limitAttr;
-  if (!matchPattern(limit, m_Constant(&limitAttr)))
-    return std::nullopt;
-  return (*limitAttr.begin()).getSExtValue();
+std::optional<int64_t> WhileLoopInfo::getConstantStartCalculate() {
+  llvm::APInt constVal(getBitWidth(start), 0, true);
+  if (isConstantValue(start, constVal))
+    return constVal.getSExtValue();
+  return std::nullopt;
+}
+
+std::optional<int64_t> WhileLoopInfo::getConstantLimitCalculate() {
+  llvm::APInt constVal(getBitWidth(limit), 0, true);
+  if (isConstantValue(limit, constVal))
+    return constVal.getSExtValue();
+  return std::nullopt;
 }
 
 int64_t WhileLoopInfo::getConstantNumIters() {
@@ -104,13 +152,13 @@ int64_t WhileLoopInfo::getConstantNumIters() {
   if (step < 0 && limit > start)
     return 0;
 
-  return (limit - start) / step;
+  return (limit - start + step - 1) / step; // ceil division
 }
 
 Value WhileLoopInfo::getNumIters(mlir::OpBuilder &builder) {
   auto opReg = op->getParentRegion();
   if (!opReg->isAncestor(limit.getParentRegion()) ||
-      !opReg->isAncestor(step.getParentRegion())) {
+      (step && !opReg->isAncestor(step.getParentRegion()))) {
     // Limit or Step are defined in the Condition/Block regions (respectively).
     return {};
   }
@@ -122,17 +170,58 @@ Value WhileLoopInfo::getNumIters(mlir::OpBuilder &builder) {
         cast<ElementsAttr>(makeAttr(start.getType(), getConstantNumIters())));
   } else {
     // numIters = (limit - start) / step;
+    Value stepVal;
+    if (step) {
+      stepVal = step;
+    } else {
+      stepVal = stablehlo::ConstantOp::create(
+          builder, op->getLoc(), start.getType(),
+          cast<ElementsAttr>(
+              makeAttr(start.getType(), stepInt.getSExtValue())));
+    }
     numIters = stablehlo::DivOp::create(
         builder, op->getLoc(),
         stablehlo::SubtractOp::create(builder, op->getLoc(), limit, start),
-        step);
+        stepVal);
   }
 
   return numIters;
 }
 
-void WhileLoopInfo::propagateInductionVarOffsets() {
-  auto inductionVar = op.getBody().front().getArgument(0);
+WhileLoopInfo::AffineIndexInfo
+WhileLoopInfo::updateAffineIndexInfo(AffineIndexInfo curInfo, llvm::APInt scale,
+                                     llvm::APInt offset) {
+  if (curInfo.offset.getBitWidth() != offset.getBitWidth()) {
+    offset = offset.sextOrTrunc(curInfo.offset.getBitWidth());
+  }
+  if (curInfo.scale.getBitWidth() != scale.getBitWidth()) {
+    scale = scale.sextOrTrunc(curInfo.scale.getBitWidth());
+  }
+  return AffineIndexInfo{scale * curInfo.scale,
+                         scale * curInfo.offset + offset};
+}
+
+bool WhileLoopInfo::isStepOne() {
+  if (step) {
+    return matchPattern(step, m_One());
+  }
+
+  return stepInt.isOne();
+}
+
+bool WhileLoopInfo::isConstantValue(Value v, llvm::APInt &constVal) {
+  if (matchPattern(v, m_ConstantInt(&constVal)))
+    return true;
+
+  Value outerValue;
+  if (isConstantAcrossIterations(v, outerValue) &&
+      matchPattern(outerValue, m_ConstantInt(&constVal)))
+    return true;
+  return false;
+}
+
+void WhileLoopInfo::propagateAffineIndexInfo() {
+  auto inductionVar = getInductionVariable();
 
   SmallVector<Value> worklist;
   DenseSet<Value> visited;
@@ -147,7 +236,9 @@ void WhileLoopInfo::propagateInductionVarOffsets() {
     }
   }
 
-  inductionVarOffsets[inductionVar] = APInt(bitWidth, 0, true);
+  llvm::APInt baseScaling(bitWidth, 1, true);
+  llvm::APInt baseOffset(bitWidth, 0, true);
+  affineIndexInfo[inductionVar] = AffineIndexInfo{baseScaling, baseOffset};
 
   while (!worklist.empty()) {
     auto cur = worklist.pop_back_val();
@@ -155,41 +246,329 @@ void WhileLoopInfo::propagateInductionVarOffsets() {
       continue;
     visited.insert(cur);
 
-    APInt curOffset = inductionVarOffsets[cur];
+    AffineIndexInfo curInfo = affineIndexInfo[cur];
 
     for (auto user : cur.getUsers()) {
-      APInt newOffset(bitWidth, 0, true);
+      AffineIndexInfo newInfo;
       Value result;
 
+      APInt constVal(bitWidth, 0, true);
       if (auto addOp = dyn_cast<stablehlo::AddOp>(user)) {
-        Value lhs = addOp.getLhs();
-        Value rhs = addOp.getRhs();
-        APInt constVal(bitWidth, 0, true);
-
-        if (matchPattern(lhs, m_ConstantInt(&constVal))) {
-          newOffset = updateOffset(curOffset, constVal);
+        if (isConstantValue(addOp.getLhs(), constVal)) {
+          newInfo = updateAffineIndexInfo(curInfo, baseScaling, constVal);
           result = addOp.getResult();
-        } else if (matchPattern(rhs, m_ConstantInt(&constVal))) {
-          newOffset = updateOffset(curOffset, constVal);
+        } else if (isConstantValue(addOp.getRhs(), constVal)) {
+          newInfo = updateAffineIndexInfo(curInfo, baseScaling, constVal);
           result = addOp.getResult();
         }
       } else if (auto subOp = dyn_cast<stablehlo::SubtractOp>(user)) {
-        Value rhs = subOp.getRhs();
-        APInt constVal(bitWidth, 0, true);
-
-        if (matchPattern(rhs, m_ConstantInt(&constVal))) {
-          newOffset = updateOffset(curOffset, -constVal);
+        if (isConstantValue(subOp.getRhs(), constVal)) {
+          newInfo = updateAffineIndexInfo(curInfo, baseScaling, -constVal);
+          result = subOp.getResult();
+        } else if (isConstantValue(subOp.getLhs(), constVal)) {
+          newInfo = updateAffineIndexInfo(curInfo, -baseScaling, constVal);
           result = subOp.getResult();
         }
       } else if (auto convertOp = dyn_cast<stablehlo::ConvertOp>(user)) {
-        newOffset = curOffset;
+        newInfo = curInfo;
         result = convertOp.getResult();
+      } else if (auto mulOp = dyn_cast<stablehlo::MulOp>(user)) {
+        if (isConstantValue(mulOp.getRhs(), constVal)) {
+          newInfo = updateAffineIndexInfo(curInfo, constVal, baseOffset);
+          result = mulOp.getResult();
+        } else if (isConstantValue(mulOp.getLhs(), constVal)) {
+          newInfo = updateAffineIndexInfo(curInfo, constVal, baseOffset);
+          result = mulOp.getResult();
+        }
+      } else if (auto negOp = dyn_cast<stablehlo::NegOp>(user)) {
+        newInfo = updateAffineIndexInfo(curInfo, -baseScaling, baseOffset);
+        result = negOp.getResult();
       }
 
-      if (result && !inductionVarOffsets.contains(result)) {
-        inductionVarOffsets[result] = newOffset;
+      if (result && !affineIndexInfo.contains(result)) {
+        affineIndexInfo[result] = newInfo;
         worklist.push_back(result);
       }
     }
   }
+}
+
+bool WhileLoopInfo::isConstantAcrossIterations(Value v) {
+  Value outerValue;
+  return isConstantAcrossIterations(v, outerValue);
+}
+
+bool WhileLoopInfo::isConstantAcrossIterations(Value v, Value &outerValue) {
+  if (auto blockArg = dyn_cast<BlockArgument>(v)) {
+    int64_t blockArgIndex = blockArg.getArgNumber();
+    auto &body = op.getBody().front();
+    auto terminator = body.getTerminator();
+    if (terminator && terminator->getOperand(blockArgIndex) ==
+                          body.getArgument(blockArgIndex)) {
+      outerValue = op->getOperand(blockArgIndex);
+      return true;
+    }
+  }
+
+  if (definedOutside(v, op)) {
+    outerValue = v;
+    return true;
+  }
+  return false;
+}
+
+bool WhileLoopInfo::canHoistOperationFromLoop(
+    mlir::stablehlo::DynamicSliceOp sliceOp, int64_t sliceIndex) {
+  if (!isConstant())
+    return false;
+
+  auto depIndex = sliceOp.getStartIndices()[sliceIndex];
+  if (!affineIndexInfo.contains(depIndex))
+    return false;
+
+  return true;
+}
+
+bool WhileLoopInfo::hoistOperationFromLoop(
+    OpBuilder &builder, Value operand, mlir::stablehlo::DynamicSliceOp sliceOp,
+    int64_t sliceIndex, Value &result) {
+  // for non constant iteration count we will need a dynamic slice
+  if (!isConstant())
+    return false;
+
+  auto totalIterCount = getConstantNumIters();
+
+  auto depIndex = sliceOp.getStartIndices()[sliceIndex];
+  auto indexTy = depIndex.getType();
+
+  // First we emit a DS op that covers the entire sliced region. This
+  // might be converted into a Slice Op if the starts are static.
+  // Next we do a strided slice of this DS op. If starts are static,
+  // these will get fused into a single slice op.
+  if (!affineIndexInfo.contains(depIndex))
+    return false;
+
+  auto indexInfo = affineIndexInfo[depIndex];
+  auto scale = indexInfo.scale.getSExtValue();
+  auto offset = indexInfo.offset.getSExtValue();
+
+  bool negativeScale = scale < 0;
+
+  auto step = getConstantStep().value();
+  auto lb = getConstantStart().value();
+  auto ub = getConstantLimit().value();
+  int64_t N = ub - lb;
+
+  auto rawMin = scale * lb + offset;
+  auto rawMax = scale * (ub - 1) + offset;
+
+  // flip if negative scale
+  auto actualMin = std::min(rawMin, rawMax);
+  auto actualMax = std::max(rawMin, rawMax);
+  auto actualSize = actualMax - actualMin + 1;
+
+  SmallVector<Value> dSliceStarts(sliceOp.getStartIndices().begin(),
+                                  sliceOp.getStartIndices().end());
+  SmallVector<int64_t> dSliceSizes(sliceOp.getSliceSizes().begin(),
+                                   sliceOp.getSliceSizes().end());
+
+  // i in [lb, ub)
+  // idx_min = scale * lb + offset
+  // idx_max = scale * (ub - 1) + offset
+  // size = idx_max - idx_min + 1 = (N - 1) * scale + 1 where N = ub - lb
+  auto idxMinConst = stablehlo::ConstantOp::create(
+      builder, sliceOp.getLoc(), indexTy,
+      cast<ElementsAttr>(makeAttr(indexTy, actualMin)));
+  dSliceStarts[sliceIndex] = idxMinConst;
+  dSliceSizes[sliceIndex] = actualSize;
+
+  auto dSlice = stablehlo::DynamicSliceOp::create(
+      builder, sliceOp.getLoc(), operand, dSliceStarts,
+      builder.getDenseI64ArrayAttr(dSliceSizes));
+  auto dType = dSlice.getResult().getType();
+
+  // j(i) = (scale * i + offset) - idx_min = scale * (i - lb)
+  SmallVector<int64_t> sliceStarts(dSliceStarts.size(), 0);
+  SmallVector<int64_t> sliceStrides(dSliceSizes.size(), 1);
+  sliceStrides[sliceIndex] = std::abs(scale) * step;
+  SmallVector<int64_t> sliceLimits(dType.getShape().begin(),
+                                   dType.getShape().end());
+
+  auto slice =
+      stablehlo::SliceOp::create(builder, sliceOp.getLoc(), dSlice,
+                                 builder.getDenseI64ArrayAttr(sliceStarts),
+                                 builder.getDenseI64ArrayAttr(sliceLimits),
+                                 builder.getDenseI64ArrayAttr(sliceStrides));
+  result = slice.getResult();
+
+  if (negativeScale) {
+    result = stablehlo::ReverseOp::create(
+        builder, sliceOp.getLoc(), result,
+        builder.getDenseI64ArrayAttr({sliceIndex}));
+  }
+
+  return true;
+}
+
+bool WhileLoopInfo::canHoistOperationFromLoop(
+    mlir::stablehlo::DynamicUpdateSliceOp dusOp, int64_t dusIndex) {
+  auto depIndex = dusOp.getStartIndices()[dusIndex];
+  if (!affineIndexInfo.contains(depIndex))
+    return false;
+
+  return true;
+}
+
+bool WhileLoopInfo::hoistOperationFromLoop(
+    OpBuilder &builder, Value operand, Value update,
+    mlir::stablehlo::DynamicUpdateSliceOp dusOp, int64_t dusIndex,
+    Value &result) {
+  auto depIndex = dusOp.getStartIndices()[dusIndex];
+  auto indexTy = depIndex.getType();
+
+  if (!affineIndexInfo.contains(depIndex))
+    return false;
+
+  auto indexInfo = affineIndexInfo[depIndex];
+  auto scale = indexInfo.scale.getSExtValue();
+  auto offset = indexInfo.offset.getSExtValue();
+
+  auto dusType = cast<RankedTensorType>(dusOp.getResult().getType());
+  SmallVector<Value> dusStartIndices(dusOp.getStartIndices().begin(),
+                                     dusOp.getStartIndices().end());
+
+  if (scale == 1) { // avoid scatter if possible
+    auto constOffset = stablehlo::ConstantOp::create(
+        builder, dusOp.getLoc(), indexTy,
+        cast<ElementsAttr>(makeAttr(indexTy, offset)));
+    Value startVal = start;
+    if (start.getType() != indexTy) {
+      startVal =
+          stablehlo::ConvertOp::create(builder, dusOp.getLoc(), indexTy, start);
+    }
+    dusStartIndices[dusIndex] = stablehlo::AddOp::create(
+        builder, dusOp.getLoc(), startVal, constOffset);
+
+    result = stablehlo::DynamicUpdateSliceOp::create(
+                 builder, dusOp.getLoc(), operand, update, dusStartIndices)
+                 .getResult();
+  } else { // emit a scatter
+    auto updateTy = cast<RankedTensorType>(update.getType());
+    auto indexElemTy = cast<ShapedType>(indexTy).getElementType();
+
+    auto bcastIndex = [&](Value val) {
+      if (cast<RankedTensorType>(val.getType()).getElementType() !=
+          indexElemTy) {
+        val = stablehlo::ConvertOp::create(
+            builder, dusOp.getLoc(), RankedTensorType::get({}, indexElemTy),
+            val);
+      }
+
+      return stablehlo::BroadcastInDimOp::create(
+          builder, dusOp.getLoc(),
+          RankedTensorType::get({updateTy.getDimSize(dusIndex), 1},
+                                indexElemTy),
+          val, builder.getDenseI64ArrayAttr({}));
+    };
+
+    SmallVector<Value> leftScatterIndices, rightScatterIndices;
+    for (size_t i = 0; i < dusIndex; i++) {
+      leftScatterIndices.push_back(bcastIndex(dusStartIndices[i]));
+    }
+    for (size_t i = dusIndex + 1; i < dusOp.getStartIndices().size(); i++) {
+      rightScatterIndices.push_back(bcastIndex(dusStartIndices[i]));
+    }
+
+    auto depIndicesTy =
+        RankedTensorType::get({updateTy.getDimSize(dusIndex), 1}, indexElemTy);
+    auto depIndices =
+        stablehlo::IotaOp::create(builder, dusOp.getLoc(), depIndicesTy, 0)
+            .getResult();
+
+    // indices: scale * (idx) + offset -> scale * (lb + i * step) + offset
+    // shift by the lower bound
+    Value startVal = getStart();
+    if (cast<RankedTensorType>(startVal.getType()).getElementType() !=
+        indexElemTy) {
+      startVal = stablehlo::ConvertOp::create(
+          builder, dusOp.getLoc(), RankedTensorType::get({}, indexElemTy),
+          startVal);
+    }
+
+    if (!isStepOne()) {
+      Value stepVal = getStep(builder);
+      if (cast<RankedTensorType>(stepVal.getType()).getElementType() !=
+          indexElemTy) {
+        stepVal = stablehlo::ConvertOp::create(
+            builder, dusOp.getLoc(), RankedTensorType::get({}, indexElemTy),
+            stepVal);
+      }
+      depIndices = stablehlo::MulOp::create(builder, dusOp.getLoc(), depIndices,
+                                            stepVal);
+    }
+
+    depIndices = stablehlo::AddOp::create(
+        builder, dusOp.getLoc(), depIndices,
+        stablehlo::BroadcastInDimOp::create(builder, dusOp.getLoc(),
+                                            depIndicesTy, startVal,
+                                            builder.getDenseI64ArrayAttr({})));
+
+    // apply affine map
+    depIndices = stablehlo::MulOp::create(
+        builder, dusOp.getLoc(), depIndices,
+        stablehlo::ConstantOp::create(
+            builder, dusOp.getLoc(), depIndicesTy,
+            cast<ElementsAttr>(makeAttr(depIndicesTy, scale))));
+    depIndices = stablehlo::AddOp::create(
+        builder, dusOp.getLoc(), depIndices,
+        stablehlo::ConstantOp::create(
+            builder, dusOp.getLoc(), depIndicesTy,
+            cast<ElementsAttr>(makeAttr(depIndicesTy, offset))));
+
+    SmallVector<Value> concatInputs;
+    concatInputs.insert(concatInputs.end(), leftScatterIndices.begin(),
+                        leftScatterIndices.end());
+    concatInputs.push_back(depIndices);
+    concatInputs.insert(concatInputs.end(), rightScatterIndices.begin(),
+                        rightScatterIndices.end());
+
+    Value scatterIndices = stablehlo::ConcatenateOp::create(
+        builder, dusOp.getLoc(), concatInputs, 1);
+
+    SmallVector<int64_t> updateWindowDims(updateTy.getRank() - 1);
+    std::iota(updateWindowDims.begin(), updateWindowDims.begin() + dusIndex, 0);
+    std::iota(updateWindowDims.begin() + dusIndex, updateWindowDims.end(),
+              dusIndex + 1);
+
+    SmallVector<int64_t> scatterDimsToOperandDims(updateTy.getRank());
+    std::iota(scatterDimsToOperandDims.begin(), scatterDimsToOperandDims.end(),
+              0);
+
+    auto scatterOp = stablehlo::ScatterOp::create(
+        builder, dusOp.getLoc(), ValueRange{operand}, scatterIndices,
+        ValueRange{update},
+        stablehlo::ScatterDimensionNumbersAttr::get(
+            dusOp.getContext(),
+            /*updateWindowDims*/ updateWindowDims,
+            /*insertedWindowDims*/ {dusIndex},
+            /*inputBatchingDims*/ {},
+            /*scatterIndicesBatchingDims*/ {},
+            /*scatterDimsToOperandDims*/ scatterDimsToOperandDims,
+            /*indexVectorDim*/ 1),
+        /*indicesAreSorted*/ false, /*uniqueIndices*/ true);
+    result = scatterOp.getResult(0);
+
+    Block *updateBody = new Block();
+    scatterOp.getUpdateComputation().push_back(updateBody);
+
+    {
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPointToStart(updateBody);
+      auto unrankedTy = RankedTensorType::get({}, updateTy.getElementType());
+      updateBody->addArgument(unrankedTy, dusOp.getLoc());
+      Value updateInBody = updateBody->addArgument(unrankedTy, dusOp.getLoc());
+      stablehlo::ReturnOp::create(builder, dusOp.getLoc(), updateInBody);
+    }
+  }
+  return true;
 }

--- a/src/enzyme_ad/jax/Implementations/WhileLoopInfo.h
+++ b/src/enzyme_ad/jax/Implementations/WhileLoopInfo.h
@@ -65,6 +65,7 @@ struct WhileLoopInfo {
 
   bool isConstantAcrossIterations(Value v, bool checkOperands = true);
   bool isConstantAcrossIterations(Value v, Value &outerValue,
+                                  SmallVector<Operation *> &canBeHoisted,
                                   bool checkOperands = true);
 
   bool canHoistOperationFromLoop(mlir::stablehlo::DynamicSliceOp sliceOp,

--- a/src/enzyme_ad/jax/Implementations/WhileLoopInfo.h
+++ b/src/enzyme_ad/jax/Implementations/WhileLoopInfo.h
@@ -11,33 +11,37 @@
 
 #include "stablehlo/dialect/StablehloOps.h"
 
-using namespace mlir;
-using namespace mlir::stablehlo;
-
 namespace mlir {
 
 namespace enzyme {
 
 struct WhileLoopInfo {
-  WhileOp op;
-  llvm::MapVector<Value, APInt> inductionVarOffsets;
-  mlir::Value start; // guaranteed to dominate the while op
-  mlir::Value limit; // not guaranteed to dominate the while op
-  mlir::Value step;  // not guaranteed to dominate the while op
+  struct AffineIndexInfo {
+    llvm::APInt scale;
+    llvm::APInt offset;
+  };
 
-  WhileLoopInfo(WhileOp op_) : op(op_) {}
+  WhileLoopInfo(stablehlo::WhileOp op_) : op(op_) {}
 
   LogicalResult computeInfo();
 
-  bool isValid() { return start && limit && step; }
+  bool isValid() { return start && limit && foundStep; }
+  bool isConstantStart() { return constStart.has_value(); }
+  bool isConstantLimit() { return constLimit.has_value(); }
+  bool isConstantStep() { return constStep.has_value(); }
   bool isConstant() {
-    return getConstantStep().has_value() && getConstantStart().has_value() &&
-           getConstantLimit().has_value();
+    return isConstantStart() && isConstantLimit() && isConstantStep();
   }
 
-  std::optional<int64_t> getConstantStep();
-  std::optional<int64_t> getConstantStart();
-  std::optional<int64_t> getConstantLimit();
+  std::optional<int64_t> getConstantStep() { return constStep; }
+  std::optional<int64_t> getConstantStart() { return constStart; }
+  std::optional<int64_t> getConstantLimit() { return constLimit; }
+
+  bool isStepOne();
+
+  mlir::Value getStart() { return start; }
+
+  mlir::Value getStep(OpBuilder &builder);
 
   // assumes computeInfo() has been called and was successful
   // returns the induction variable in the body of the while op
@@ -54,17 +58,52 @@ struct WhileLoopInfo {
   int64_t getConstantNumIters();
   Value getNumIters(OpBuilder &builder);
 
-  void propagateInductionVarOffsets();
-  llvm::MapVector<Value, APInt> getInductionVarOffsets() {
-    return inductionVarOffsets;
+  void propagateAffineIndexInfo();
+  llvm::MapVector<Value, AffineIndexInfo> getAffineIndexInfo() {
+    return affineIndexInfo;
   }
 
+  bool isConstantAcrossIterations(Value v);
+  bool isConstantAcrossIterations(Value v, Value &outerValue);
+
+  bool canHoistOperationFromLoop(mlir::stablehlo::DynamicSliceOp sliceOp,
+                                 int64_t sliceIndex);
+  bool hoistOperationFromLoop(OpBuilder &builder, Value operand,
+                              mlir::stablehlo::DynamicSliceOp sliceOp,
+                              int64_t sliceIndex, Value &result);
+
+  bool canHoistOperationFromLoop(mlir::stablehlo::DynamicUpdateSliceOp dusOp,
+                                 int64_t dusIndex);
+  bool hoistOperationFromLoop(OpBuilder &builder, Value operand, Value update,
+                              mlir::stablehlo::DynamicUpdateSliceOp dusOp,
+                              int64_t dusIndex, Value &result);
+
 private:
-  APInt updateOffset(APInt curOffset, APInt update) {
-    if (curOffset.getBitWidth() != update.getBitWidth())
-      update = update.sextOrTrunc(curOffset.getBitWidth());
-    return curOffset + update;
-  }
+  stablehlo::WhileOp op;
+
+  mlir::Value start; // guaranteed to dominate the while op
+  std::optional<int64_t> constStart;
+
+  mlir::Value limit; // not guaranteed to dominate the while op
+  std::optional<int64_t> constLimit;
+
+  mlir::Value step; // not guaranteed to dominate the while op
+  APInt stepInt;
+  bool foundStep;
+  std::optional<int64_t> constStep;
+
+  llvm::MapVector<Value, AffineIndexInfo> affineIndexInfo;
+
+  void computeConstantValues();
+
+  bool isConstantValue(Value v, llvm::APInt &constVal);
+
+  std::optional<int64_t> getConstantStepCalculate();
+  std::optional<int64_t> getConstantStartCalculate();
+  std::optional<int64_t> getConstantLimitCalculate();
+
+  AffineIndexInfo updateAffineIndexInfo(AffineIndexInfo curInfo,
+                                        llvm::APInt scale, llvm::APInt offset);
 };
 
 } // end namespace enzyme

--- a/src/enzyme_ad/jax/Implementations/WhileLoopInfo.h
+++ b/src/enzyme_ad/jax/Implementations/WhileLoopInfo.h
@@ -67,16 +67,24 @@ struct WhileLoopInfo {
   bool isConstantAcrossIterations(Value v, Value &outerValue);
 
   bool canHoistOperationFromLoop(mlir::stablehlo::DynamicSliceOp sliceOp,
-                                 int64_t sliceIndex);
+                                 SmallVectorImpl<int64_t> &dimensions);
   bool hoistOperationFromLoop(OpBuilder &builder, Value operand,
                               mlir::stablehlo::DynamicSliceOp sliceOp,
                               int64_t sliceIndex, Value &result);
+  bool hoistOperationFromLoop(OpBuilder &builder, Value operand,
+                              mlir::stablehlo::DynamicSliceOp sliceOp,
+                              SmallVectorImpl<int64_t> &dimensions,
+                              Value &result);
 
   bool canHoistOperationFromLoop(mlir::stablehlo::DynamicUpdateSliceOp dusOp,
-                                 int64_t dusIndex);
+                                 SmallVectorImpl<int64_t> &dimensions);
   bool hoistOperationFromLoop(OpBuilder &builder, Value operand, Value update,
                               mlir::stablehlo::DynamicUpdateSliceOp dusOp,
                               int64_t dusIndex, Value &result);
+  bool hoistOperationFromLoop(OpBuilder &builder, Value operand, Value update,
+                              mlir::stablehlo::DynamicUpdateSliceOp dusOp,
+                              SmallVectorImpl<int64_t> &dimensions,
+                              Value &result);
 
 private:
   stablehlo::WhileOp op;

--- a/src/enzyme_ad/jax/Implementations/WhileLoopInfo.h
+++ b/src/enzyme_ad/jax/Implementations/WhileLoopInfo.h
@@ -63,8 +63,9 @@ struct WhileLoopInfo {
     return affineIndexInfo;
   }
 
-  bool isConstantAcrossIterations(Value v);
-  bool isConstantAcrossIterations(Value v, Value &outerValue);
+  bool isConstantAcrossIterations(Value v, bool checkOperands = true);
+  bool isConstantAcrossIterations(Value v, Value &outerValue,
+                                  bool checkOperands = true);
 
   bool canHoistOperationFromLoop(mlir::stablehlo::DynamicSliceOp sliceOp,
                                  SmallVectorImpl<int64_t> &dimensions);

--- a/src/enzyme_ad/jax/Passes/AutoBatching.cpp
+++ b/src/enzyme_ad/jax/Passes/AutoBatching.cpp
@@ -287,7 +287,7 @@ bool allOpsAreUnique(const SmallVector<Operation *> &ops) {
 
 static SliceInfo<stablehlo::SliceOp>
 defaultUnsupportedSliceInfo(stablehlo::SliceOp sliceOp) {
-  return SliceInfo<stablehlo::SliceOp>(sliceOp, {}, {}, {}, -1, -1, false);
+  return SliceInfo<stablehlo::SliceOp>{sliceOp, {}, {}, {}, -1, -1, false};
 }
 
 SliceInfo<stablehlo::SliceOp> constructSliceInfo(stablehlo::SliceOp sliceOp) {
@@ -330,8 +330,8 @@ SliceInfo<stablehlo::SliceOp> constructSliceInfo(stablehlo::SliceOp sliceOp) {
   if (!supported)
     return defaultUnsupportedSliceInfo(sliceOp);
 
-  return SliceInfo<stablehlo::SliceOp>(sliceOp, {}, startIndices, inputShape,
-                                       sliceDim, sliceStart, true);
+  return SliceInfo<stablehlo::SliceOp>{sliceOp, {}, startIndices, inputShape,
+                                       sliceDim, sliceStart, true};
 }
 
 bool areSlicesContiguous(SmallVector<SliceInfo<stablehlo::SliceOp>> &slices) {
@@ -1344,9 +1344,8 @@ struct AutoBatchingPass
           SliceToBatch<stablehlo::GetDimensionSizeOp>,
           SliceToBatch<stablehlo::ReverseOp>,
           SliceToBatch<stablehlo::ReduceWindowOp>,
-          SliceToBatch<stablehlo::ConvolutionOp>,
-          // SliceToBatchReshape,
-          SliceToBatchElementwise>(context);
+          SliceToBatch<stablehlo::ConvolutionOp>, SliceToBatchElementwise>(
+          context);
     }
 
     if (while_loop_batching_mode == "greedy") {

--- a/src/enzyme_ad/jax/Passes/AutoBatching.cpp
+++ b/src/enzyme_ad/jax/Passes/AutoBatching.cpp
@@ -330,8 +330,8 @@ SliceInfo<stablehlo::SliceOp> constructSliceInfo(stablehlo::SliceOp sliceOp) {
   if (!supported)
     return defaultUnsupportedSliceInfo(sliceOp);
 
-  return SliceInfo<stablehlo::SliceOp>{sliceOp, {}, startIndices, inputShape,
-                                       sliceDim, sliceStart, true};
+  return SliceInfo<stablehlo::SliceOp>{
+      sliceOp, {}, startIndices, inputShape, sliceDim, sliceStart, true};
 }
 
 bool areSlicesContiguous(SmallVector<SliceInfo<stablehlo::SliceOp>> &slices) {

--- a/src/enzyme_ad/jax/Passes/AutoBatching.h
+++ b/src/enzyme_ad/jax/Passes/AutoBatching.h
@@ -213,6 +213,7 @@ private:
     DYNAMIC_SLICE,
     DEFINED_OUTSIDE_WHILE,
     CONSTANT,
+    NEEDS_HOISTING_OUTSIDE_WHILE,
   };
 
   enum class IsValidForBatchingResult {

--- a/src/enzyme_ad/jax/Passes/AutoBatching.h
+++ b/src/enzyme_ad/jax/Passes/AutoBatching.h
@@ -214,6 +214,7 @@ private:
     DEFINED_OUTSIDE_WHILE,
     CONSTANT,
     NEEDS_HOISTING_OUTSIDE_WHILE,
+    AFFINE_INDEX,
   };
 
   enum class IsValidForBatchingResult {
@@ -231,9 +232,8 @@ private:
     mlir::stablehlo::DynamicSliceOp sliceOp;
     llvm::SmallVector<int64_t> dimensions;
     bool intermediateReshape;
-    llvm::SmallVector<int64_t> reshapeShape;
-    mlir::enzyme::WhileLoopInfo::AffineIndexInfo affineIndexInfo;
     bool needsManualReshape;
+    llvm::SmallVector<int64_t> reshapeShape;
   };
 
   struct ValidBatchingInfo {

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -25203,7 +25203,8 @@ private:
     SmallVector<int64_t> inductionVarDimensions;
 
     for (auto [i, startIndex] : llvm::enumerate(startIndices)) {
-      if (info.isConstantAcrossIterations(startIndex))
+      // we could hoist the other dimensions but licm should fix this
+      if (info.isConstantAcrossIterations(startIndex, false))
         continue;
 
       if (!affineIndexInfo.contains(startIndex))

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -66,6 +66,7 @@ namespace enzyme {
 
 using namespace mlir;
 using namespace mlir::enzyme;
+using namespace mlir::stablehlo;
 
 // Check if any of the pad sizes are negative
 bool anyPadSizesNegative(stablehlo::PadOp pad) {
@@ -2207,6 +2208,7 @@ struct DUSPad final
     SmallVector<Value> startIndices = dus.getStartIndices();
     ArrayRef<int64_t> lowPadding = padOp.getEdgePaddingLow();
 
+    SmallVector<int64_t> newDusStartIndexValues;
     SmallVector<Value> newDusStartIndices;
     SmallVector<int64_t> newDusStartIndexValues;
     Location loc = dus.getLoc();
@@ -20846,13 +20848,10 @@ struct ReverseTranspose final
     if (!transposeOp->getResult(0).hasOneUse())
       return failure();
 
-    SmallVector<int64_t> permutation =
-        llvm::to_vector(transposeOp.getPermutation());
-
-    SmallVector<int64_t> newReverseDims(op.getDimensions().size(), 0);
-    for (int64_t i = 0; i < op.getDimensions().size(); i++) {
-      newReverseDims[i] = permutation[op.getDimensions()[i]];
-    }
+    auto permutation = transposeOp.getPermutation();
+    SmallVector<int64_t> newReverseDims(op.getDimensions().size());
+    for (auto [i, dim] : llvm::enumerate(op.getDimensions()))
+      newReverseDims[i] = permutation[dim];
 
     auto newReverseOp = stablehlo::ReverseOp::create(
         rewriter, op.getLoc(), transposeOp.getOperand(), newReverseDims);
@@ -20876,15 +20875,13 @@ struct TransposeReverse final
     if (!reverseOp->getResult(0).hasOneUse())
       return failure();
 
-    SmallVector<int64_t> permutation = llvm::to_vector(op.getPermutation());
-
-    SmallVector<int64_t> newReverseDims(reverseOp.getDimensions().size(), 0);
-    for (int64_t i = 0; i < reverseOp.getDimensions().size(); i++) {
-      newReverseDims[i] = permutation[reverseOp.getDimensions()[i]];
-    }
+    auto invPerm = getInversePermutation(op.getPermutation());
+    SmallVector<int64_t> newReverseDims(reverseOp.getDimensions().size());
+    for (auto [i, dim] : llvm::enumerate(reverseOp.getDimensions()))
+      newReverseDims[i] = invPerm[dim];
 
     auto newTranspose = stablehlo::TransposeOp::create(
-        rewriter, op.getLoc(), reverseOp.getOperand(), permutation);
+        rewriter, op.getLoc(), reverseOp.getOperand(), op.getPermutation());
     rewriter.replaceOpWithNewOp<stablehlo::ReverseOp>(op, newTranspose,
                                                       newReverseDims);
     return success();
@@ -24706,23 +24703,17 @@ struct RemoveNoOpsFromWhileLoop
     // Rewrite ops based on computed bounds
     bool anyOpRewritten = false;
     for (auto op : visited) {
-      if (auto remOp = dyn_cast<stablehlo::RemOp>(op)) {
-        if (rewriteRemOp(rewriter, remOp, boundsMap)) {
-          anyOpRewritten = true;
-        }
-      } else if (auto compareOp = dyn_cast<stablehlo::CompareOp>(op)) {
-        if (rewriteCompareOp(rewriter, compareOp, boundsMap)) {
-          anyOpRewritten = true;
-        }
-      } else if (auto absOp = dyn_cast<stablehlo::AbsOp>(op)) {
-        if (rewriteAbsOp(rewriter, absOp, boundsMap)) {
-          anyOpRewritten = true;
-        }
-      } else if (auto clampOp = dyn_cast<stablehlo::ClampOp>(op)) {
-        if (rewriteClampOp(rewriter, clampOp, boundsMap)) {
-          anyOpRewritten = true;
-        }
-      }
+      bool rewritten =
+          llvm::TypeSwitch<Operation *, bool>(op)
+              .Case<stablehlo::RemOp, stablehlo::CompareOp, stablehlo::AbsOp,
+                    stablehlo::ClampOp>([&](auto op) {
+                auto allBounds = getBoundsOfAllOperands(op, boundsMap);
+                if (!allBounds.has_value())
+                  return false;
+                return rewriteOperation(rewriter, op, allBounds.value());
+              })
+              .Default([&](Operation *op) { return false; });
+      anyOpRewritten |= rewritten;
     }
     return anyOpRewritten ? success() : failure();
   }
@@ -24740,6 +24731,19 @@ private:
   APInt min(APInt a, APInt b) const { return a.slt(b) ? a : b; }
   APInt max(APInt a, APInt b) const { return a.sgt(b) ? a : b; }
   APInt abs(APInt a) const { return a.sgt(0) ? a : -a; }
+
+  std::optional<llvm::DenseMap<Value, Bounds>>
+  getBoundsOfAllOperands(Operation *op,
+                         const DenseMap<Value, Bounds> &boundsMap) const {
+    llvm::DenseMap<Value, Bounds> newBoundsMap;
+    for (auto operand : op->getOperands()) {
+      auto bounds = getBounds(boundsMap, operand);
+      if (!bounds.has_value())
+        return std::nullopt;
+      newBoundsMap[operand] = bounds.value();
+    }
+    return newBoundsMap;
+  }
 
   std::optional<Bounds> getBounds(const DenseMap<Value, Bounds> &boundsMap,
                                   Value value) const {
@@ -24837,16 +24841,10 @@ private:
     return std::nullopt;
   }
 
-  bool rewriteRemOp(PatternRewriter &rewriter, stablehlo::RemOp remOp,
-                    const DenseMap<Value, Bounds> &boundsMap) const {
-    auto optional_lhs_bounds = getBounds(boundsMap, remOp.getLhs());
-    auto optional_rhs_bounds = getBounds(boundsMap, remOp.getRhs());
-
-    if (!optional_lhs_bounds.has_value() || !optional_rhs_bounds.has_value())
-      return false;
-
-    auto lhs_bounds = optional_lhs_bounds.value();
-    auto rhs_bounds = optional_rhs_bounds.value();
+  bool rewriteOperation(PatternRewriter &rewriter, stablehlo::RemOp remOp,
+                        const DenseMap<Value, Bounds> &boundsMap) const {
+    auto lhs_bounds = boundsMap.lookup(remOp.getLhs());
+    auto rhs_bounds = boundsMap.lookup(remOp.getRhs());
 
     auto rhs_abs_min = abs(rhs_bounds.min);
     auto rhs_abs_max = abs(rhs_bounds.max);
@@ -24860,17 +24858,24 @@ private:
     return false;
   };
 
-  bool rewriteCompareOp(PatternRewriter &rewriter,
+  bool rewriteOperation(PatternRewriter &rewriter,
                         stablehlo::CompareOp compareOp,
                         const DenseMap<Value, Bounds> &boundsMap) const {
-    auto optional_lhs_bounds = getBounds(boundsMap, compareOp.getLhs());
-    auto optional_rhs_bounds = getBounds(boundsMap, compareOp.getRhs());
+    auto lhs_bounds = boundsMap.lookup(compareOp.getLhs());
+    auto rhs_bounds = boundsMap.lookup(compareOp.getRhs());
 
-    if (!optional_lhs_bounds.has_value() || !optional_rhs_bounds.has_value())
-      return false;
-
-    auto lhs_bounds = optional_lhs_bounds.value();
-    auto rhs_bounds = optional_rhs_bounds.value();
+    auto replaceWithTrue = [&]() {
+      rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
+          compareOp, compareOp.getType(),
+          cast<ElementsAttr>(makeAttr(compareOp.getType(), true)));
+      return true;
+    };
+    auto replaceWithFalse = [&]() {
+      rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
+          compareOp, compareOp.getType(),
+          cast<ElementsAttr>(makeAttr(compareOp.getType(), false)));
+      return true;
+    };
 
     switch (compareOp.getComparisonDirection()) {
     case stablehlo::ComparisonDirection::EQ: // lhs == rhs
@@ -24878,92 +24883,51 @@ private:
       if (lhs_bounds.min == lhs_bounds.max &&
           rhs_bounds.min == rhs_bounds.max &&
           lhs_bounds.min == rhs_bounds.min) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), true)));
-        return true;
+        return replaceWithTrue();
       }
       // outside of range: lhs_max < rhs_min or rhs_max < lhs_min
       if (lhs_bounds.max.slt(rhs_bounds.min) ||
           rhs_bounds.max.slt(lhs_bounds.min)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), false)));
-        return true;
+        return replaceWithFalse();
       }
       break;
     case stablehlo::ComparisonDirection::NE: // lhs != rhs
       // outside of range: lhs_max < rhs_min or rhs_max < lhs_min
       if (lhs_bounds.max.slt(rhs_bounds.min) ||
           rhs_bounds.max.slt(lhs_bounds.min)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), false)));
-        return true;
+        return replaceWithFalse();
       }
       break;
-    case stablehlo::ComparisonDirection::GE: // lhs >= rhs
-      // lhs_max < rhs_min
-      if (lhs_bounds.max.slt(rhs_bounds.min)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), false)));
-        return true;
+    case stablehlo::ComparisonDirection::GE:    // lhs >= rhs
+      if (lhs_bounds.max.slt(rhs_bounds.min)) { // lhs_max < rhs_min
+        return replaceWithFalse();
       }
-      // lhs_min >= rhs_max
-      if (lhs_bounds.min.sge(rhs_bounds.max)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), true)));
-        return true;
+      if (lhs_bounds.min.sge(rhs_bounds.max)) { // lhs_min >= rhs_max
+        return replaceWithTrue();
       }
       break;
-    case stablehlo::ComparisonDirection::GT: // lhs > rhs
-      // lhs_max <= rhs_min
-      if (lhs_bounds.max.sle(rhs_bounds.min)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), false)));
-        return true;
+    case stablehlo::ComparisonDirection::GT:    // lhs > rhs
+      if (lhs_bounds.max.sle(rhs_bounds.min)) { // lhs_max <= rhs_min
+        return replaceWithFalse();
       }
-      // lhs_min > rhs_max
-      if (lhs_bounds.min.sgt(rhs_bounds.max)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), true)));
-        return true;
+      if (lhs_bounds.min.sgt(rhs_bounds.max)) { // lhs_min > rhs_max
+        return replaceWithTrue();
       }
       break;
-    case stablehlo::ComparisonDirection::LE: // lhs <= rhs
-      // rhs_max < lhs_min
-      if (rhs_bounds.max.slt(lhs_bounds.min)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), false)));
-        return true;
+    case stablehlo::ComparisonDirection::LE:    // lhs <= rhs
+      if (rhs_bounds.max.slt(lhs_bounds.min)) { // rhs_max < lhs_min
+        return replaceWithFalse();
       }
-      // rhs_min >= lhs_max
-      if (rhs_bounds.min.sge(lhs_bounds.max)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), true)));
-        return true;
+      if (rhs_bounds.min.sge(lhs_bounds.max)) { // rhs_min >= lhs_max
+        return replaceWithTrue();
       }
       break;
-    case stablehlo::ComparisonDirection::LT: // lhs < rhs
-      // rhs_max <= lhs_min
-      if (rhs_bounds.max.sle(lhs_bounds.min)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), false)));
-        return true;
+    case stablehlo::ComparisonDirection::LT:    // lhs < rhs
+      if (rhs_bounds.max.sle(lhs_bounds.min)) { // rhs_max <= lhs_min
+        return replaceWithFalse();
       }
-      // rhs_min > lhs_max
-      if (rhs_bounds.min.sgt(lhs_bounds.max)) {
-        rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
-            compareOp, compareOp.getType(),
-            cast<ElementsAttr>(makeAttr(compareOp.getType(), true)));
-        return true;
+      if (rhs_bounds.min.sgt(lhs_bounds.max)) { // rhs_min > lhs_max
+        return replaceWithTrue();
       }
       break;
     }
@@ -24971,13 +24935,10 @@ private:
     return false;
   };
 
-  bool rewriteAbsOp(PatternRewriter &rewriter, stablehlo::AbsOp absOp,
-                    const DenseMap<Value, Bounds> &boundsMap) const {
-    auto optional_bounds = getBounds(boundsMap, absOp.getOperand());
-    if (!optional_bounds.has_value())
-      return false;
+  bool rewriteOperation(PatternRewriter &rewriter, stablehlo::AbsOp absOp,
+                        const DenseMap<Value, Bounds> &boundsMap) const {
+    auto bounds = boundsMap.lookup(absOp.getOperand());
 
-    auto bounds = optional_bounds.value();
     APInt zero(bounds.min.getBitWidth(), 0, true);
     if (bounds.min.sge(zero)) {
       rewriter.replaceOp(absOp, absOp.getOperand());
@@ -24986,18 +24947,11 @@ private:
     return false;
   };
 
-  bool rewriteClampOp(PatternRewriter &rewriter, stablehlo::ClampOp clampOp,
-                      const DenseMap<Value, Bounds> &boundsMap) const {
-    auto optional_min_bounds = getBounds(boundsMap, clampOp.getMin());
-    auto optional_max_bounds = getBounds(boundsMap, clampOp.getMax());
-    auto optional_operand_bounds = getBounds(boundsMap, clampOp.getOperand());
-    if (!optional_min_bounds.has_value() || !optional_max_bounds.has_value() ||
-        !optional_operand_bounds.has_value())
-      return false;
-
-    auto min_bounds = optional_min_bounds.value();
-    auto max_bounds = optional_max_bounds.value();
-    auto operand_bounds = optional_operand_bounds.value();
+  bool rewriteOperation(PatternRewriter &rewriter, stablehlo::ClampOp clampOp,
+                        const DenseMap<Value, Bounds> &boundsMap) const {
+    auto min_bounds = boundsMap.lookup(clampOp.getMin());
+    auto max_bounds = boundsMap.lookup(clampOp.getMax());
+    auto operand_bounds = boundsMap.lookup(clampOp.getOperand());
 
     if (min_bounds.max.sle(operand_bounds.min) &&
         max_bounds.min.sge(operand_bounds.max)) {
@@ -25025,28 +24979,14 @@ struct WhileIsCopySimplify
       return failure();
 
     auto &whileBody = whileOp.getBody().front();
-    auto parentBlock = whileOp->getBlock();
-
-    auto limit = info.getConstantLimit().value();
-    auto start = info.getConstantStart().value();
-    auto step = info.getConstantStep().value();
-    info.propagateInductionVarOffsets();
-
-    if (step != 1)
-      return failure();
-
-    auto parentFunc = whileOp->getParentOp();
-    if (!parentFunc)
-      return failure();
-    DominanceInfo domInfo(parentFunc);
-
-    auto inductionVarOffsets = info.getInductionVarOffsets();
+    auto affineIndexInfo = info.getAffineIndexInfo();
 
     auto returnOp = dyn_cast<stablehlo::ReturnOp>(whileBody.getTerminator());
     if (!returnOp)
       return failure();
 
     bool anyOpRewritten = false;
+    SmallVector<std::tuple<enzyme::BatchOp, func::FuncOp>> batchOps;
 
     for (auto [idx, returnValue] : llvm::enumerate(returnOp.getOperands())) {
       auto dusOp = returnValue.getDefiningOp<stablehlo::DynamicUpdateSliceOp>();
@@ -25060,401 +25000,234 @@ struct WhileIsCopySimplify
         continue;
 
       int32_t dusInductionVarDim =
-          getInductionVariableDimension(dusOp, inductionVarOffsets, whileOp);
+          getInductionVariableDimension(dusOp, affineIndexInfo, whileOp, info);
       if (dusInductionVarDim == -1)
         continue;
 
-      auto [updateChain, trackedDims] = extractValidUpdateChain(
-          rewriter, domInfo, parentBlock, dusOp, dusInductionVarDim, whileOp,
-          inductionVarOffsets);
+      auto updateChainOrNone = extractValidUpdateChain(rewriter, dusOp, whileOp,
+                                                       affineIndexInfo, info);
+      if (!updateChainOrNone.has_value())
+        continue;
+
+      auto updateChain = updateChainOrNone.value();
       if (updateChain.empty())
         continue;
 
-      if (!anyOpRewritten) {
-        anyOpRewritten = true;
-        rewriter.setInsertionPoint(whileOp);
-      }
-
-      // We traverse the reversed chain and map the values based on the
-      // following rules:
-      // 1. Transpose/BroadcastInDim/Convert: mapped as is with updated operand
-      // 2. DynamicSlice: Change the induction dim to start at info.start and
-      //    update the corresponding sliceSize (limit - start). Next transpose
-      //    and move the induction var to the correct position
-      // 3. Reshape: This is a bit more finicky
-      //    1. Move the induction var dim to the front
-      //    2. Reshape the operand to the correct shape
-      //    3. Transpose and move the induction var to the correct position
-      // 4. DynamicUpdateSlice: Copy as is with updated start indices for the
-      //    induction var dimension
       auto dsOp = dyn_cast<stablehlo::DynamicSliceOp>(updateChain.back());
-      assert(dsOp);
-      Value currentOperand = dsOp.getOperand();
-      int32_t curIdx = trackedDims.back();
-      int32_t nextIdx = trackedDims[trackedDims.size() - 2];
+      auto dsInductionVarDim =
+          getInductionVariableDimension(dsOp, affineIndexInfo, whileOp, info);
+      if (dsInductionVarDim == -1)
+        continue;
 
-      SmallVector<Value> dsStartIndices(dsOp.getStartIndices().begin(),
-                                        dsOp.getStartIndices().end());
-      SmallVector<int64_t> dsSliceSizes(dsOp.getSliceSizes().begin(),
-                                        dsOp.getSliceSizes().end());
-      auto oldDSStartIndex = dsOp.getStartIndices()[curIdx];
-      dsStartIndices[curIdx] = stablehlo::ConstantOp::create(
-          rewriter, dsOp.getLoc(), oldDSStartIndex.getType(),
-          cast<ElementsAttr>(
-              makeAttr(oldDSStartIndex.getType(),
-                       start + getInt(inductionVarOffsets[oldDSStartIndex]))));
-      dsSliceSizes[curIdx] = limit - start;
+      if (!info.canHoistOperationFromLoop(dsOp, dsInductionVarDim) ||
+          !info.canHoistOperationFromLoop(dusOp, dusInductionVarDim))
+        continue;
 
-      auto newDS = stablehlo::DynamicSliceOp::create(
-          rewriter, dsOp.getLoc(), currentOperand, dsStartIndices,
-          rewriter.getDenseI64ArrayAttr(dsSliceSizes));
-      currentOperand = newDS.getResult();
+      auto funcOp = createCopyFunction(rewriter, whileOp, updateChain,
+                                       dsInductionVarDim, dusInductionVarDim);
+      if (!funcOp)
+        continue;
 
-      if (nextIdx != curIdx) {
-        SmallVector<int64_t> permutation(dsStartIndices.size());
+      anyOpRewritten = true;
+
+      rewriter.setInsertionPoint(whileOp);
+      Value dsResult;
+      auto successfulHoist = info.hoistOperationFromLoop(
+          rewriter, dsOp.getOperand(), dsOp, dsInductionVarDim, dsResult);
+      assert(successfulHoist && "expected DS hoist to succeed.");
+      auto dsResTy = cast<RankedTensorType>(dsResult.getType());
+
+      // move the induction var to the front
+      if (dsInductionVarDim != 0) {
+        SmallVector<int64_t> permutation(dsResTy.getRank());
         std::iota(permutation.begin(), permutation.end(), 0);
-        if (curIdx > nextIdx) {
-          for (int i = curIdx; i >= nextIdx; i--)
-            permutation[i] = i - 1;
-        } else {
-          for (int i = curIdx; i <= nextIdx; i++)
-            permutation[i] = i + 1;
-        }
-        permutation[nextIdx] = curIdx;
+        permutation[0] = dsInductionVarDim;
+        for (int i = 1; i <= dsInductionVarDim; i++)
+          permutation[i] = i - 1;
 
-        auto transposeOp = stablehlo::TransposeOp::create(
-            rewriter, dsOp.getLoc(), currentOperand,
-            rewriter.getDenseI64ArrayAttr(permutation));
-        currentOperand = transposeOp.getResult();
+        dsResult = stablehlo::TransposeOp::create(
+                       rewriter, whileOp.getLoc(), dsResult,
+                       rewriter.getDenseI64ArrayAttr(permutation))
+                       .getResult();
       }
 
-      for (size_t i = updateChain.size() - 2; i >= 1; i--) {
-        curIdx = trackedDims[i];
-        nextIdx = trackedDims[i - 1];
-        auto curOp = updateChain[i];
+      auto dusOpUpdateTy = cast<RankedTensorType>(dusOp.getUpdate().getType());
+      auto dusOpUpdateShape = dusOpUpdateTy.getShape();
+      SmallVector<int64_t> dusOpUpdateShapePreTranspose;
+      dusOpUpdateShapePreTranspose.push_back(info.getConstantNumIters());
+      for (int i = 0; i < dusInductionVarDim; i++)
+        dusOpUpdateShapePreTranspose.push_back(dusOpUpdateShape[i]);
+      for (int i = dusInductionVarDim + 1; i < dusOpUpdateShape.size(); i++)
+        dusOpUpdateShapePreTranspose.push_back(dusOpUpdateShape[i]);
+      auto batchOpOutTy = RankedTensorType::get(dusOpUpdateShapePreTranspose,
+                                                dusOpUpdateTy.getElementType());
 
-        if (isa<stablehlo::TransposeOp, stablehlo::BroadcastInDimOp,
-                stablehlo::ConvertOp>(curOp)) {
-          auto resTy = cast<RankedTensorType>(curOp->getResult(0).getType());
-          auto resShape = llvm::to_vector(resTy.getShape());
-          resShape[nextIdx] = limit - start;
-          resTy = RankedTensorType::get(resShape, resTy.getElementType());
+      auto batchOp = enzyme::BatchOp::create(
+          rewriter, whileOp.getLoc(), batchOpOutTy, funcOp.getSymName(),
+          ValueRange(dsResult),
+          rewriter.getDenseI64ArrayAttr({info.getConstantNumIters()}));
+      batchOps.push_back({batchOp, funcOp});
 
-          auto tmpIntermediateOp = Operation::create(
-              curOp->getLoc(), curOp->getName(), {resTy}, {currentOperand},
-              curOp->getAttrs(), OpaqueProperties(nullptr),
-              curOp->getSuccessors(), 0);
-          rewriter.insert(tmpIntermediateOp);
-          currentOperand = tmpIntermediateOp->getResult(0);
-        } else if (auto reshapeOp = dyn_cast<stablehlo::ReshapeOp>(curOp)) {
-          auto inTy = cast<RankedTensorType>(reshapeOp.getOperand().getType());
-          auto outTy = cast<RankedTensorType>(reshapeOp.getResult().getType());
+      Value dusUpdateNew = batchOp.getResult(0);
+      if (dusInductionVarDim != 0) {
+        SmallVector<int64_t> permutation(dusOpUpdateShape.size());
+        for (int i = 0; i < dusInductionVarDim; i++)
+          permutation[i] = i + 1;
+        permutation[dusInductionVarDim] = 0;
+        std::iota(permutation.begin() + dusInductionVarDim + 1,
+                  permutation.end(), dusInductionVarDim + 1);
 
-          // move curIdx to 0
-          if (curIdx != 0) {
-            SmallVector<int64_t> permutation(inTy.getRank());
-            std::iota(permutation.begin(), permutation.end(), 0);
-            permutation[0] = curIdx;
-            for (size_t j = 1; j <= curIdx; j++)
-              permutation[j] = j - 1;
-
-            auto tmpTransposeOp = stablehlo::TransposeOp::create(
-                rewriter, dsOp.getLoc(), currentOperand,
-                rewriter.getDenseI64ArrayAttr(permutation));
-            currentOperand = tmpTransposeOp.getResult();
-          }
-
-          auto outShape = llvm::to_vector(outTy.getShape());
-          outShape.erase(outShape.begin() + nextIdx);
-          outShape.insert(outShape.begin(), limit - start);
-          auto newReshapeOp = stablehlo::ReshapeOp::create(
-              rewriter, dsOp.getLoc(),
-              RankedTensorType::get(outShape, outTy.getElementType()),
-              currentOperand);
-          currentOperand = newReshapeOp.getResult();
-
-          // move 0th dim to nextIdx
-          if (nextIdx != 0) {
-            SmallVector<int64_t> permutation(outTy.getRank());
-            std::iota(permutation.begin(), permutation.end(), 0);
-            permutation[nextIdx] = 0;
-            for (size_t j = 1; j <= nextIdx; j++)
-              permutation[j - 1] = j;
-
-            auto tmpTransposeOp = stablehlo::TransposeOp::create(
-                rewriter, dsOp.getLoc(), currentOperand,
-                rewriter.getDenseI64ArrayAttr(permutation));
-            currentOperand = tmpTransposeOp.getResult();
-          }
-        } else {
-          llvm_unreachable("unsupported op");
-        }
+        dusUpdateNew = stablehlo::TransposeOp::create(
+                           rewriter, whileOp.getLoc(), dusUpdateNew,
+                           rewriter.getDenseI64ArrayAttr(permutation))
+                           .getResult();
       }
 
-      auto dusFromChain =
-          dyn_cast<stablehlo::DynamicUpdateSliceOp>(updateChain.front());
-      assert(dusFromChain);
+      Value newDUS;
+      successfulHoist = info.hoistOperationFromLoop(
+          rewriter, whileOp.getOperands()[idx], dusUpdateNew, dusOp,
+          dusInductionVarDim, newDUS);
+      assert(successfulHoist && "Expected DUS hoist to succeed.");
 
-      SmallVector<Value> dusStartIndices(dusFromChain.getStartIndices().begin(),
-                                         dusFromChain.getStartIndices().end());
-      curIdx = trackedDims.front();
-      auto oldDUSStartIndex = dusFromChain.getStartIndices()[curIdx];
-      dusStartIndices[curIdx] = stablehlo::ConstantOp::create(
-          rewriter, dusFromChain.getLoc(), oldDUSStartIndex.getType(),
-          cast<ElementsAttr>(
-              makeAttr(oldDUSStartIndex.getType(),
-                       start + getInt(inductionVarOffsets[oldDUSStartIndex]))));
+      whileOp.getResult(idx).replaceAllUsesWith(newDUS);
+    }
 
-      auto newDUS = stablehlo::DynamicUpdateSliceOp::create(
-          rewriter, dusFromChain.getLoc(), whileOp.getOperands()[idx],
-          currentOperand, dusStartIndices);
-
-      whileOp.getResult(idx).replaceAllUsesWith(newDUS.getResult());
+    if (!batchOps.empty()) {
+      for (auto &[batchOp, funcOp] : batchOps) {
+        enzyme::batchutils::batchOperationInline(
+            rewriter, batchOp,
+            cast<FunctionOpInterface>(funcOp.getOperation()));
+      }
     }
 
     return anyOpRewritten ? success() : failure();
   }
 
 private:
-  struct UpdateChainInfo {
-    SmallVector<Operation *> updateChain;
-    SmallVector<int32_t> trackedDims;
-  };
+  func::FuncOp createCopyFunction(PatternRewriter &rewriter,
+                                  stablehlo::WhileOp whileOp,
+                                  SmallVectorImpl<Operation *> &updateChain,
+                                  int64_t dsInductionVarDimension,
+                                  int64_t dusInductionVarDimension) const {
+    auto dSlice = cast<stablehlo::DynamicSliceOp>(updateChain.back());
+    auto dusOp = cast<stablehlo::DynamicUpdateSliceOp>(updateChain.front());
 
-  UpdateChainInfo extractValidUpdateChain(
-      PatternRewriter &rewriter, DominanceInfo &domInfo, Block *parentBlock,
-      stablehlo::DynamicUpdateSliceOp dusOp, int32_t dusInductionVarDim,
+    auto dSliceResTy = cast<RankedTensorType>(dSlice.getResult().getType());
+    auto dusUpdateTy = cast<RankedTensorType>(dusOp.getUpdate().getType());
+
+    auto funcInType = removeBatchedDims(dSliceResTy, dsInductionVarDimension);
+    auto funcOutType = removeBatchedDims(dusUpdateTy, dusInductionVarDimension);
+
+    static int64_t counter = 0;
+    std::string funcName =
+        "__enzymexla__copy_inside_while_loop_" + std::to_string(counter++);
+
+    auto modOp = whileOp->getParentOfType<ModuleOp>();
+    if (!modOp)
+      return nullptr;
+
+    rewriter.setInsertionPointToStart(modOp.getBody());
+    auto funcOp =
+        func::FuncOp::create(rewriter, whileOp.getLoc(), funcName,
+                             rewriter.getFunctionType(TypeRange{funcInType},
+                                                      TypeRange{funcOutType}));
+    funcOp.setPrivate();
+
+    auto &entryBlock = *funcOp.addEntryBlock();
+    rewriter.setInsertionPointToStart(&entryBlock);
+
+    auto reshapeIn = stablehlo::ReshapeOp::create(
+        rewriter, whileOp.getLoc(), dSliceResTy, entryBlock.getArgument(0));
+
+    IRMapping mapper;
+    mapper.map(dSlice.getResult(), reshapeIn.getResult());
+    for (int i = updateChain.size() - 2; i >= 1; i--) {
+      auto update = updateChain[i];
+      auto clonedOp = rewriter.clone(*update, mapper);
+      mapper.map(update->getResult(0), clonedOp->getResult(0));
+    }
+
+    auto reshapeOut =
+        stablehlo::ReshapeOp::create(rewriter, whileOp.getLoc(), funcOutType,
+                                     mapper.lookup(dusOp.getUpdate()));
+
+    func::ReturnOp::create(rewriter, whileOp.getLoc(), reshapeOut.getResult());
+
+    return funcOp;
+  }
+
+  RankedTensorType removeBatchedDims(RankedTensorType Ty, int64_t dim) const {
+    SmallVector<int64_t> newShape;
+    for (int64_t i = 0; i < Ty.getRank(); i++) {
+      if (i != dim)
+        newShape.push_back(Ty.getDimSize(i));
+    }
+    return RankedTensorType::get(newShape, Ty.getElementType());
+  }
+
+  std::optional<SmallVector<Operation *>> extractValidUpdateChain(
+      PatternRewriter &rewriter, stablehlo::DynamicUpdateSliceOp dusOp,
       stablehlo::WhileOp whileOp,
-      llvm::MapVector<Value, APInt> &inductionVarOffsets) const {
-    SmallVector<SmallVector<int32_t>> indexTracking(1);
-    indexTracking[0] = {dusInductionVarDim};
+      llvm::MapVector<Value, WhileLoopInfo::AffineIndexInfo> &affineIndexInfo,
+      WhileLoopInfo &info) const {
     SmallVector<Operation *> updateChain;
     updateChain.push_back(dusOp);
 
-    extractValidUpdateChain(rewriter, domInfo, parentBlock,
-                            dusOp.getUpdate().getDefiningOp(), indexTracking,
-                            dusOp, whileOp, inductionVarOffsets, updateChain);
+    bool success = extractValidUpdateChainInner(
+        rewriter, dusOp.getUpdate().getDefiningOp(), whileOp, updateChain);
 
-    if (updateChain.empty() ||
-        !isa<stablehlo::DynamicSliceOp>(updateChain[updateChain.size() - 1])) {
-      return UpdateChainInfo{{}, {}};
-    }
-
-    // currently using a very simple logic of minimizing dimension changes for
-    // dynamic slices and reshapes
-    SmallVector<int32_t> costMultiplier(updateChain.size() - 1, 0);
-    for (int32_t i = updateChain.size() - 2; i >= 0; i--) {
-      if (isa<stablehlo::DynamicSliceOp>(updateChain[i + 1])) {
-        costMultiplier[i] = 1;
-      } else if (isa<stablehlo::ReshapeOp>(updateChain[i + 1])) {
-        costMultiplier[i] = 3;
-      }
-    }
-
-    int32_t bestCost = std::numeric_limits<int32_t>::max();
-    int32_t bestChain;
-    for (int32_t i = 0; i < indexTracking.size(); i++) {
-      int32_t curCost = 0;
-      for (size_t j = 1; j < indexTracking[i].size(); j++) {
-        curCost += std::abs(indexTracking[i][j] - indexTracking[i][j - 1]) *
-                   costMultiplier[j - 1];
-      }
-      if (curCost < bestCost) {
-        bestCost = curCost;
-        bestChain = i;
-      }
-    }
-
-    return UpdateChainInfo{updateChain, indexTracking[bestChain]};
+    if (!success)
+      return std::nullopt;
+    return updateChain;
   }
 
-  // each of the indexTracking vectors is a list of valid traversal paths
-  void extractValidUpdateChain(
-      PatternRewriter &rewriter, DominanceInfo &domInfo, Block *parentBlock,
-      Operation *op, SmallVectorImpl<SmallVector<int32_t>> &indexTracking,
-      stablehlo::DynamicUpdateSliceOp dusOp, stablehlo::WhileOp whileOp,
-      llvm::MapVector<Value, APInt> &inductionVarOffsets,
+  bool extractValidUpdateChainInner(
+      PatternRewriter &rewriter, Operation *op, stablehlo::WhileOp whileOp,
       SmallVectorImpl<Operation *> &updateChain) const {
     if (!op)
-      return;
+      return false;
 
     if (auto sliceOp = dyn_cast<stablehlo::DynamicSliceOp>(op)) {
       // base case, we have reached the dynamic slice
-      Value sliceOperand = sliceOp.getOperand();
-
-      if (!isValueAccessibleFromBlock(domInfo, sliceOperand, parentBlock))
-        return;
-
-      auto inductionVarDim =
-          getInductionVariableDimension(sliceOp, inductionVarOffsets, whileOp);
-      if (inductionVarDim == -1)
-        return;
-
       updateChain.push_back(sliceOp);
-      for (auto &idxs : indexTracking) {
-        idxs.push_back(inductionVarDim);
-      }
-      return;
+      return definedOutside(sliceOp.getOperand(), whileOp);
     }
 
-    if (auto transposeOp = dyn_cast<stablehlo::TransposeOp>(op)) {
-      updateChain.push_back(transposeOp);
-      auto tperm = transposeOp.getPermutation();
-      for (auto &idxs : indexTracking) {
-        idxs.push_back(tperm[idxs.back()]);
-      }
-      return extractValidUpdateChain(rewriter, domInfo, parentBlock,
-                                     transposeOp.getOperand().getDefiningOp(),
-                                     indexTracking, dusOp, whileOp,
-                                     inductionVarOffsets, updateChain);
-    }
-
-    if (isa<stablehlo::ConvertOp>(op)) { // pass through ops
+    if (isa<stablehlo::ConvertOp, stablehlo::BroadcastInDimOp,
+            stablehlo::ReshapeOp, stablehlo::TransposeOp>(op)) {
       updateChain.push_back(op);
-      for (auto &idxs : indexTracking) {
-        idxs.push_back(idxs.back());
-      }
-      return extractValidUpdateChain(
-          rewriter, domInfo, parentBlock, op->getOperand(0).getDefiningOp(),
-          indexTracking, dusOp, whileOp, inductionVarOffsets, updateChain);
+      return extractValidUpdateChainInner(
+          rewriter, op->getOperand(0).getDefiningOp(), whileOp, updateChain);
     }
 
-    if (auto bcastOp = dyn_cast<stablehlo::BroadcastInDimOp>(op)) {
-      auto fwdMapping = bcastOp.getBroadcastDimensions();
-      auto bcastShape = cast<ShapedType>(bcastOp.getType()).getShape();
-      DenseMap<int64_t, int64_t> bwdMapping;
-      for (auto [i, j] : llvm::enumerate(fwdMapping)) {
-        if (bcastShape[j] == 1) // not expanding along this dimension
-          bwdMapping[j] = i;
-      }
+    return false;
+  }
 
-      SmallVector<bool> toRemove(indexTracking.size());
-      for (size_t i = 0; i < indexTracking.size(); i++) {
-        auto found = bwdMapping.find(indexTracking[i].back());
-        if (found != bwdMapping.end()) {
-          indexTracking[i].push_back(found->second);
-          toRemove[i] = false;
-        } else {
-          toRemove[i] = true;
-        }
-      }
-
-      size_t writeIdx = 0;
-      for (auto [i, dim] : llvm::enumerate(indexTracking)) {
-        if (toRemove[i])
-          continue;
-        indexTracking[writeIdx++] = dim;
-      }
-      indexTracking.resize(writeIdx);
-
-      if (indexTracking.empty())
-        return;
-
-      updateChain.push_back(bcastOp);
-      return extractValidUpdateChain(
-          rewriter, domInfo, parentBlock, bcastOp.getOperand().getDefiningOp(),
-          indexTracking, dusOp, whileOp, inductionVarOffsets, updateChain);
-    }
-
-    if (auto reshapeOp = dyn_cast<stablehlo::ReshapeOp>(op)) {
-      SmallVector<int32_t> validIndices;
-      for (auto [i, sz] : llvm::enumerate(
-               cast<ShapedType>(reshapeOp.getOperand().getType()).getShape())) {
-        if (sz == 1)
-          validIndices.push_back(i);
-      }
-
-      if (validIndices.empty())
-        return;
-
-      SmallVector<SmallVector<int32_t>> newTracking;
-      newTracking.reserve(indexTracking.size() * validIndices.size());
-
-      for (const auto &idxs : indexTracking) {
-        for (auto v : validIndices) {
-          SmallVector<int32_t> extended(idxs);
-          extended.push_back(v);
-          newTracking.push_back(extended);
-        }
-      }
-      indexTracking.swap(newTracking);
-      updateChain.push_back(reshapeOp);
-      return extractValidUpdateChain(rewriter, domInfo, parentBlock,
-                                     reshapeOp.getOperand().getDefiningOp(),
-                                     indexTracking, dusOp, whileOp,
-                                     inductionVarOffsets, updateChain);
-    }
-
-    return;
+  template <typename OpTy>
+  int32_t getInductionVariableDimension(
+      OpTy op,
+      llvm::MapVector<Value, WhileLoopInfo::AffineIndexInfo> &affineIndexInfo,
+      stablehlo::WhileOp whileOp, WhileLoopInfo &info) const {
+    return getInductionVariableDimension(op.getStartIndices(), affineIndexInfo,
+                                         whileOp, info);
   }
 
   int32_t getInductionVariableDimension(
-      stablehlo::DynamicSliceOp sliceOp,
-      llvm::MapVector<Value, APInt> &inductionVarOffsets,
-      stablehlo::WhileOp whileOp) const {
+      mlir::OperandRange startIndices,
+      llvm::MapVector<Value, WhileLoopInfo::AffineIndexInfo> &affineIndexInfo,
+      stablehlo::WhileOp whileOp, WhileLoopInfo &info) const {
     int32_t inductionVarDimension = -1;
 
-    for (size_t i = 0; i < sliceOp.getStartIndices().size(); i++) {
-      auto dsStartIndex = sliceOp.getStartIndices()[i];
-
-      if (!isConstantAcrossLoopIterations(dsStartIndex, whileOp)) {
+    for (auto [i, startIndex] : llvm::enumerate(startIndices)) {
+      if (!info.isConstantAcrossIterations(startIndex)) {
         if (inductionVarDimension > 0 || // multiple indices with induction var
-            !inductionVarOffsets.contains(dsStartIndex))
+            !affineIndexInfo.contains(startIndex))
           return -1;
 
         inductionVarDimension = i;
       }
     }
-
     return inductionVarDimension;
-  }
-
-  int32_t getInductionVariableDimension(
-      stablehlo::DynamicUpdateSliceOp dusOp,
-      llvm::MapVector<Value, APInt> &inductionVarOffsets,
-      stablehlo::WhileOp whileOp) const {
-    int32_t inductionVarDimension = -1;
-
-    for (size_t i = 0; i < dusOp.getStartIndices().size(); i++) {
-      auto dusStartIndex = dusOp.getStartIndices()[i];
-
-      if (!isConstantAcrossLoopIterations(dusStartIndex, whileOp)) {
-        if (inductionVarDimension > 0 || // multiple indices with induction var
-            !inductionVarOffsets.contains(dusStartIndex))
-          return -1;
-
-        inductionVarDimension = i;
-      }
-    }
-
-    return inductionVarDimension;
-  }
-
-  bool isConstantAcrossLoopIterations(Value value, WhileOp whileOp) const {
-    // defined outside the loop body
-    // even if it is currently not defined outside, licm should move it
-    // outside before we apply this pattern
-    if (value.getParentBlock() != &whileOp.getBody().front())
-      return true;
-
-    return false;
-  }
-
-  bool isValueAccessibleFromBlock(DominanceInfo &domInfo, Value value,
-                                  Block *block) const {
-    if (auto definingOp = value.getDefiningOp()) {
-      return domInfo.dominates(definingOp->getBlock(), block);
-    } else if (auto blockArg = dyn_cast<BlockArgument>(value)) {
-      return domInfo.dominates(blockArg.getOwner(), block);
-    }
-    return false;
-  }
-
-  int64_t getInt(APInt value) const {
-    if (value.getBitWidth() != 64) {
-      value = value.sextOrTrunc(64);
-    }
-    return value.getSExtValue();
   }
 };
 

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -25948,7 +25948,7 @@ void mlir::transform::addEnzymeHLOUnroll(RewritePatternSet &patterns,
                                          int64_t maxNumIterations,
                                          MLIRContext &context,
                                          PatternBenefit benefit) {
-  patterns.insert<WhileUnroll>(maxNumIterations, &context, benefit);
+  patterns.insert<WhileUnroll>(maxNumIterations, 128, &context, benefit);
 }
 
 void mlir::transform::addPadDotGeneral(RewritePatternSet &patterns,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -2210,7 +2210,6 @@ struct DUSPad final
 
     SmallVector<int64_t> newDusStartIndexValues;
     SmallVector<Value> newDusStartIndices;
-    SmallVector<int64_t> newDusStartIndexValues;
     Location loc = dus.getLoc();
     auto indexElementType =
         cast<ShapedType>(startIndices[0].getType()).getElementType();
@@ -24999,6 +24998,9 @@ struct WhileIsCopySimplify
           blockArg.getArgNumber() != idx)
         continue;
 
+      if (whileOp.getResult(idx).getUses().empty())
+        continue;
+
       auto dusInductionVarDims =
           getInductionVariableDimension(dusOp, affineIndexInfo, whileOp, info);
       if (dusInductionVarDims.empty())
@@ -25035,6 +25037,7 @@ struct WhileIsCopySimplify
       auto successfulHoist = info.hoistOperationFromLoop(
           rewriter, dsOp.getOperand(), dsOp, dsInductionVarDims, dsResult);
       assert(successfulHoist && "expected DS hoist to succeed.");
+      (void)successfulHoist;
       auto dsResTy = cast<RankedTensorType>(dsResult.getType());
 
       // move the induction var to the front

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.cpp
@@ -60,8 +60,9 @@ WhileUnroll::matchAndRewriteImpl(mlir::stablehlo::WhileOp op,
     return rewriter.notifyMatchFailure(op,
                                        "max iterations for unrolling exceeded");
 
-  if (iters > 1 && std::distance(loopBodyBlock->begin(), loopBodyBlock->end()) >
-                       maxOperationThreshold)
+  if (iters > 1 && maxOperationThreshold > -1 &&
+      std::distance(loopBodyBlock->begin(), loopBodyBlock->end()) >
+          maxOperationThreshold)
     return rewriter.notifyMatchFailure(op,
                                        "max operations for unrolling exceeded");
 

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.cpp
@@ -60,6 +60,11 @@ WhileUnroll::matchAndRewriteImpl(mlir::stablehlo::WhileOp op,
     return rewriter.notifyMatchFailure(op,
                                        "max iterations for unrolling exceeded");
 
+  if (iters > 1 && std::distance(loopBodyBlock->begin(), loopBodyBlock->end()) >
+                       maxOperationThreshold)
+    return rewriter.notifyMatchFailure(op,
+                                       "max operations for unrolling exceeded");
+
   SmallVector<Value> results(op.getOperands().begin(), op.getOperands().end());
 
   for (size_t iter = 0; iter < iters; iter++) {
@@ -86,7 +91,7 @@ struct EnzymeHLOUnrollPass
   void runOnOperation() override {
     auto context = getOperation()->getContext();
     RewritePatternSet patterns(context);
-    patterns.add<WhileUnroll>(maxNumIterations, context);
+    patterns.add<WhileUnroll>(maxNumIterations, maxOperationThreshold, context);
     GreedyRewriteConfig config;
     if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
                                             config))) {

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.h
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.h
@@ -25,11 +25,13 @@ struct WhileUnroll
                                 WhileUnroll>::CheckedOpRewritePattern;
 
   int64_t maxNumIterations = -1;
+  int64_t maxOperationThreshold = -1;
 
-  WhileUnroll(int64_t maxNumIterations, MLIRContext *ctx,
-              PatternBenefit benefit = 1)
+  WhileUnroll(int64_t maxNumIterations, int64_t maxOperationThreshold,
+              MLIRContext *ctx, PatternBenefit benefit = 1)
       : CheckedOpRewritePattern<stablehlo::WhileOp, WhileUnroll>(ctx, benefit),
-        maxNumIterations(maxNumIterations) {}
+        maxNumIterations(maxNumIterations),
+        maxOperationThreshold(maxOperationThreshold) {}
 
   LogicalResult matchAndRewriteImpl(stablehlo::WhileOp op,
                                     PatternRewriter &rewriter) const;

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -188,6 +188,12 @@ def EnzymeHLOUnrollPass : Pass<"enzyme-hlo-unroll"> {
         /*type=*/"int",
         /*default=*/"-1",
         /*description=*/"Only unroll if total iterations is less than this value. If -1, no limit.">,
+    Option<
+        /*C++ variable name=*/"maxOperationThreshold",
+        /*CLI argument=*/"max-operation-threshold",
+        /*type=*/"int",
+        /*default=*/"-1",
+        /*description=*/"Only unroll if total operations is less than this value. If -1, no limit.">
   ];
 }
 

--- a/src/enzyme_ad/jax/Utils.cpp
+++ b/src/enzyme_ad/jax/Utils.cpp
@@ -1642,6 +1642,49 @@ Value copyTriangularPart(OpBuilder &builder, Value input,
                                      transposedInput);
 }
 
+bool broadcastInDimIsReshape(BroadcastInDimOp op) {
+  auto input = op.getOperand();
+  auto outputType = op.getType();
+  auto inputType = input.getType();
+  auto broadcastDims = op.getBroadcastDimensions();
+
+  size_t inputSize = 1;
+  for (auto sz : inputType.getShape())
+    inputSize *= sz;
+  size_t outputSize = 1;
+  for (auto sz : outputType.getShape())
+    outputSize *= sz;
+
+  if (inputSize != outputSize)
+    return false;
+
+  SmallVector<int64_t> nonSingletonDims;
+
+  for (size_t i = 0; i < broadcastDims.size(); ++i) {
+    int64_t dimIdx = broadcastDims[i];
+    if (inputType.getRank() > i && inputType.getDimSize(i) != 1) {
+      nonSingletonDims.push_back(dimIdx);
+    }
+  }
+
+  for (int i = 1, s = nonSingletonDims.size(); i < s; ++i) {
+    if (nonSingletonDims[i - 1] > nonSingletonDims[i])
+      return false;
+  }
+
+  for (size_t i = 0; i < outputType.getRank(); ++i) {
+    int64_t dimIdx = outputType.getDimSize(i);
+    if (dimIdx == 1)
+      continue;
+    auto it = llvm::find(broadcastDims, dimIdx);
+    if (it == broadcastDims.end()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 } // namespace stablehlo
 
 } // namespace mlir

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -980,6 +980,8 @@ bool isScalarValue(Operation *op);
 Value copyTriangularPart(OpBuilder &builder, Value input,
                          enzymexla::LapackUplo uplo);
 
+bool broadcastInDimIsReshape(BroadcastInDimOp op);
+
 } // namespace stablehlo
 
 } // namespace mlir

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -1041,12 +1041,6 @@ def _enzyme_primal_lowering(
                     pass_pipeline + ",tensor-empty-raise,drop-unsupported-attributes"
                 )
 
-            _, nmod2 = enzyme_call.run_pass_pipeline(
-                fns, source, "convert-all-constants-to-splatted-constant"
-            )
-            filename = _dump_mlir_to_file(str(nmod2), pass_pipeline)
-            logging.warning("Enzyme MLIR dumped to %s", filename)
-
             try:
                 name, nmod = enzyme_call.run_pass_pipeline(fns, source, pass_pipeline)
             except Exception as e:

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -935,7 +935,7 @@ def _dump_mlir_to_file(source, pass_pipeline):
         suffix=".mlir", dir=dump_mlir_dir, delete=False
     )
     with open(tmpfile.name, "w") as f:
-        f.write("# " + pass_pipeline + "\n")
+        f.write("// " + pass_pipeline + "\n")
         f.write(str(source))
 
     return tmpfile.name
@@ -1040,6 +1040,12 @@ def _enzyme_primal_lowering(
                 pass_pipeline = (
                     pass_pipeline + ",tensor-empty-raise,drop-unsupported-attributes"
                 )
+
+            _, nmod2 = enzyme_call.run_pass_pipeline(
+                fns, source, "convert-all-constants-to-splatted-constant"
+            )
+            filename = _dump_mlir_to_file(str(nmod2), pass_pipeline)
+            logging.warning("Enzyme MLIR dumped to %s", filename)
 
             try:
                 name, nmod = enzyme_call.run_pass_pipeline(fns, source, pass_pipeline)

--- a/test/lit_tests/autobatching/dot_general_loop.mlir
+++ b/test/lit_tests/autobatching/dot_general_loop.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt --enzyme-hlo-opt --auto-batching --inline --enzyme-hlo-generate-td="patterns=reshape_dynamic_slice(1);reshape_licm(1);transpose_dynamic_slice;transpose_licm(1);while_is_copy_simplify;reshape_elementwise(1);elementwise_licm(1)" --transform-interpreter --enzyme-hlo-remove-transform --enzyme-hlo-opt %s | FileCheck %s
+// RUN: enzymexlamlir-opt --auto-batching --enzyme-hlo-opt %s | FileCheck %s
 
 module {
   func.func @main(%arg0: tensor<3x5x10xf32> {enzymexla.memory_effects = []}, %arg1: tensor<4x3xf32> {enzymexla.memory_effects = []}) -> tensor<4x5x10xf32> attributes {enzymexla.memory_effects = []} {

--- a/test/lit_tests/autobatching/elementwise_loop.mlir
+++ b/test/lit_tests/autobatching/elementwise_loop.mlir
@@ -79,3 +79,68 @@ module {
 // CHECK-NEXT:   %4 = stablehlo.transpose %3, dims = [0, 2, 1] : (tensor<4x3x5xf32>) -> tensor<4x5x3xf32>
 // CHECK-NEXT:   return %4 : tensor<4x5x3xf32>
 // CHECK-NEXT: }
+
+module {
+  func.func @main(%arg0: tensor<10xf64>) -> tensor<10xf64> {
+    %c = stablehlo.constant dense<1> : tensor<i32>
+    %c_0 = stablehlo.constant dense<0> : tensor<i64>
+    %c_1 = stablehlo.constant dense<10> : tensor<i64>
+    %c_2 = stablehlo.constant dense<3> : tensor<i64>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10xf64>
+    %0:2 = stablehlo.while(%iterArg = %c_0, %iterArg_3 = %cst) : tensor<i64>, tensor<10xf64>
+    cond {
+      %1 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %1 : tensor<i1>
+    } do {
+      %1 = stablehlo.add %c_2, %iterArg : tensor<i64>
+      %2 = stablehlo.convert %1 : (tensor<i64>) -> tensor<i32>
+      %3 = stablehlo.subtract %2, %c : tensor<i32>
+      %4 = stablehlo.dynamic_slice %arg0, %3, sizes = [1] : (tensor<10xf64>, tensor<i32>) -> tensor<1xf64>
+
+      %sin_res = stablehlo.sine %4 : tensor<1xf64>
+      %neg_res = stablehlo.negate %sin_res : tensor<1xf64>
+      %cos_res = stablehlo.cosine %4 : tensor<1xf64>
+      %5 = stablehlo.add %neg_res, %cos_res : tensor<1xf64>
+
+      %6 = stablehlo.remainder %iterArg, %c_1 : tensor<i64>
+      %7 = stablehlo.add %6, %c_2 : tensor<i64>
+      %8 = stablehlo.convert %7 : (tensor<i64>) -> tensor<i32>
+      %9 = stablehlo.subtract %8, %c : tensor<i32>
+      %10 = stablehlo.dynamic_update_slice %iterArg_3, %5, %9 : (tensor<10xf64>, tensor<1xf64>, tensor<i32>) -> tensor<10xf64>
+
+      stablehlo.return %1, %10 : tensor<i64>, tensor<10xf64>
+    }
+    return %0#1 : tensor<10xf64>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<10xf64>) -> tensor<10xf64> {
+// CHECK-NEXT:   %c = stablehlo.constant dense<1> : tensor<i32>
+// CHECK-NEXT:   %c_0 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:   %c_1 = stablehlo.constant dense<10> : tensor<i64>
+// CHECK-NEXT:   %c_2 = stablehlo.constant dense<3> : tensor<i64>
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<10xf64>
+// CHECK-NEXT:   %c_3 = stablehlo.constant dense<2> : tensor<i32>
+// CHECK-NEXT:   %0 = stablehlo.dynamic_slice %arg0, %c_3, sizes = [10] : (tensor<10xf64>, tensor<i32>) -> tensor<10xf64>
+// CHECK-NEXT:   %1 = stablehlo.slice %0 [0:10:3] : (tensor<10xf64>) -> tensor<4xf64>
+// CHECK-NEXT:   %2 = stablehlo.cosine %1 : tensor<4xf64>
+// CHECK-NEXT:   %3 = stablehlo.dynamic_slice %arg0, %c_3, sizes = [10] : (tensor<10xf64>, tensor<i32>) -> tensor<10xf64>
+// CHECK-NEXT:   %4 = stablehlo.slice %3 [0:10:3] : (tensor<10xf64>) -> tensor<4xf64>
+// CHECK-NEXT:   %5 = stablehlo.sine %4 : tensor<4xf64>
+// CHECK-NEXT:   %6:2 = stablehlo.while(%iterArg = %c_0, %iterArg_4 = %cst) : tensor<i64>, tensor<10xf64>
+// CHECK-NEXT:   cond {
+// CHECK-NEXT:     %7 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:     stablehlo.return %7 : tensor<i1>
+// CHECK-NEXT:   } do {
+// CHECK-NEXT:     %7 = stablehlo.add %c_2, %iterArg : tensor<i64>
+// CHECK-NEXT:     %8 = stablehlo.convert %7 : (tensor<i64>) -> tensor<i32>
+// CHECK-NEXT:     %9 = stablehlo.subtract %8, %c : tensor<i32>
+// CHECK-NEXT:     %10 = stablehlo.divide %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:     %11 = stablehlo.dynamic_slice %5, %10, sizes = [1] : (tensor<4xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:     %12 = stablehlo.dynamic_slice %2, %10, sizes = [1] : (tensor<4xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:     %13 = stablehlo.subtract %12, %11 : tensor<1xf64>
+// CHECK-NEXT:     %14 = stablehlo.dynamic_update_slice %iterArg_4, %13, %9 : (tensor<10xf64>, tensor<1xf64>, tensor<i32>) -> tensor<10xf64>
+// CHECK-NEXT:     stablehlo.return %7, %14 : tensor<i64>, tensor<10xf64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return %6#1 : tensor<10xf64>
+// CHECK-NEXT: }

--- a/test/lit_tests/autobatching/elementwise_loop_affine.mlir
+++ b/test/lit_tests/autobatching/elementwise_loop_affine.mlir
@@ -1,0 +1,91 @@
+// RUN: enzymexlamlir-opt --auto-batching --enzyme-hlo-opt %s | FileCheck %s
+
+func.func @main1(%arg0: tensor<25xf32>) -> tensor<13xf32> {
+  %cst = stablehlo.constant dense<3.000000e+00> : tensor<1xf32>
+  %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<1xf32>
+  %c = stablehlo.constant dense<1> : tensor<i32>
+  %c_1 = stablehlo.constant dense<5> : tensor<i64>
+  %c_2 = stablehlo.constant dense<2> : tensor<i64>
+  %c_3 = stablehlo.constant dense<0> : tensor<i64>
+  %c_4 = stablehlo.constant dense<10> : tensor<i64>
+  %c_5 = stablehlo.constant dense<1> : tensor<i64>
+  %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<13xf32>
+  %0:2 = stablehlo.while(%iterArg = %c_3, %iterArg_7 = %cst_6) : tensor<i64>, tensor<13xf32> attributes {enzyme.disable_mincut}
+  cond {
+    %1 = stablehlo.compare  LT, %iterArg, %c_4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  } do {
+    %1 = stablehlo.add %c_5, %iterArg : tensor<i64>
+    %2 = stablehlo.multiply %c_2, %1 : tensor<i64>
+    %3 = stablehlo.add %2, %c_1 : tensor<i64>
+    %4 = stablehlo.convert %3 : (tensor<i64>) -> tensor<i32>
+    %5 = stablehlo.subtract %4, %c : tensor<i32>
+    %6 = stablehlo.dynamic_slice %arg0, %5, sizes = [1] : (tensor<25xf32>, tensor<i32>) -> tensor<1xf32>
+    %7 = stablehlo.multiply %6, %cst : tensor<1xf32>
+    %8 = stablehlo.subtract %7, %cst_0 : tensor<1xf32>
+    %9 = stablehlo.sine %8 : tensor<1xf32>
+    %10 = stablehlo.add %1, %c_2 : tensor<i64>
+    %11 = stablehlo.convert %10 : (tensor<i64>) -> tensor<i32>
+    %12 = stablehlo.subtract %11, %c : tensor<i32>
+    %13 = stablehlo.dynamic_update_slice %iterArg_7, %9, %12 : (tensor<13xf32>, tensor<1xf32>, tensor<i32>) -> tensor<13xf32>
+    stablehlo.return %1, %13 : tensor<i64>, tensor<13xf32>
+  }
+  return %0#1 : tensor<13xf32>
+}
+
+// CHECK: func.func @main1(%arg0: tensor<25xf32>) -> tensor<13xf32> {
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:   %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<10xf32>
+// CHECK-NEXT:   %cst_1 = stablehlo.constant dense<3.000000e+00> : tensor<10xf32>
+// CHECK-NEXT:   %0 = stablehlo.slice %arg0 [6:25:2] : (tensor<25xf32>) -> tensor<10xf32>
+// CHECK-NEXT:   %1 = stablehlo.multiply %0, %cst_1 : tensor<10xf32>
+// CHECK-NEXT:   %2 = stablehlo.subtract %1, %cst_0 : tensor<10xf32>
+// CHECK-NEXT:   %3 = stablehlo.sine %2 : tensor<10xf32>
+// CHECK-NEXT:   %4 = stablehlo.pad %3, %cst, low = [2], high = [1], interior = [0] : (tensor<10xf32>, tensor<f32>) -> tensor<13xf32>
+// CHECK-NEXT:   return %4 : tensor<13xf32>
+// CHECK-NEXT: }
+
+func.func @main2(%arg0: tensor<25xf32>) -> tensor<13xf32> {
+  %cst = stablehlo.constant dense<3.000000e+00> : tensor<1xf32>
+  %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<1xf32>
+  %c = stablehlo.constant dense<1> : tensor<i32>
+  %c_1 = stablehlo.constant dense<5> : tensor<i64>
+  %c_2 = stablehlo.constant dense<2> : tensor<i64>
+  %c_3 = stablehlo.constant dense<0> : tensor<i64>
+  %c_4 = stablehlo.constant dense<10> : tensor<i64>
+  %c_5 = stablehlo.constant dense<1> : tensor<i64>
+  %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<13xf32>
+  %0:10 = stablehlo.while(%iterArg = %c_3, %iterArg_7 = %cst_6, %iterArg_8 = %c_4, %iterArg_9 = %c_5, %iterArg_10 = %c_2, %iterArg_11 = %c_1, %iterArg_12 = %c, %iterArg_13 = %arg0, %iterArg_14 = %cst, %iterArg_15 = %cst_0) : tensor<i64>, tensor<13xf32>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i32>, tensor<25xf32>, tensor<1xf32>, tensor<1xf32>
+  cond {
+    %1 = stablehlo.compare  LT, %iterArg, %iterArg_8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  } do {
+    %1 = stablehlo.add %iterArg_9, %iterArg : tensor<i64>
+    %2 = stablehlo.multiply %iterArg_10, %1 : tensor<i64>
+    %3 = stablehlo.add %2, %iterArg_11 : tensor<i64>
+    %4 = stablehlo.convert %3 : (tensor<i64>) -> tensor<i32>
+    %5 = stablehlo.subtract %4, %iterArg_12 : tensor<i32>
+    %6 = stablehlo.dynamic_slice %iterArg_13, %5, sizes = [1] : (tensor<25xf32>, tensor<i32>) -> tensor<1xf32>
+    %7 = stablehlo.multiply %6, %iterArg_14 : tensor<1xf32>
+    %8 = stablehlo.subtract %7, %iterArg_15 : tensor<1xf32>
+    %9 = stablehlo.sine %8 : tensor<1xf32>
+    %10 = stablehlo.add %1, %iterArg_10 : tensor<i64>
+    %11 = stablehlo.convert %10 : (tensor<i64>) -> tensor<i32>
+    %12 = stablehlo.subtract %11, %iterArg_12 : tensor<i32>
+    %13 = stablehlo.dynamic_update_slice %iterArg_7, %9, %12 : (tensor<13xf32>, tensor<1xf32>, tensor<i32>) -> tensor<13xf32>
+    stablehlo.return %1, %13, %iterArg_8, %iterArg_9, %iterArg_10, %iterArg_11, %iterArg_12, %iterArg_13, %iterArg_14, %iterArg_15 : tensor<i64>, tensor<13xf32>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i32>, tensor<25xf32>, tensor<1xf32>, tensor<1xf32>
+  }
+  return %0#1 : tensor<13xf32>
+}
+
+// CHECK: func.func @main2(%arg0: tensor<25xf32>) -> tensor<13xf32> {
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:   %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<10xf32>
+// CHECK-NEXT:   %cst_1 = stablehlo.constant dense<3.000000e+00> : tensor<10xf32>
+// CHECK-NEXT:   %0 = stablehlo.slice %arg0 [6:25:2] : (tensor<25xf32>) -> tensor<10xf32>
+// CHECK-NEXT:   %1 = stablehlo.multiply %0, %cst_1 : tensor<10xf32>
+// CHECK-NEXT:   %2 = stablehlo.subtract %1, %cst_0 : tensor<10xf32>
+// CHECK-NEXT:   %3 = stablehlo.sine %2 : tensor<10xf32>
+// CHECK-NEXT:   %4 = stablehlo.pad %3, %cst, low = [2], high = [1], interior = [0] : (tensor<10xf32>, tensor<f32>) -> tensor<13xf32>
+// CHECK-NEXT:   return %4 : tensor<13xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/autobatching/elementwise_loop_multiindex.mlir
+++ b/test/lit_tests/autobatching/elementwise_loop_multiindex.mlir
@@ -1,0 +1,100 @@
+// RUN: enzymexlamlir-opt --auto-batching --enzyme-hlo-opt %s | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<22x20x12xf32>) -> tensor<22x20x12xf32> {
+    %c = stablehlo.constant dense<2> : tensor<i32>
+    %c_0 = stablehlo.constant dense<0> : tensor<i32>
+    %c_1 = stablehlo.constant dense<-2> : tensor<i64>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<22x20x12xf32>
+    %c_2 = stablehlo.constant dense<20> : tensor<i64>
+    %c_3 = stablehlo.constant dense<1> : tensor<i32>
+    %c_4 = stablehlo.constant dense<2> : tensor<i64>
+    %c_5 = stablehlo.constant dense<0> : tensor<i64>
+    %c_6 = stablehlo.constant dense<3> : tensor<i64>
+    %c_7 = stablehlo.constant dense<1> : tensor<i64>
+    %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<22x20x12xf32>) -> tensor<12x20x22xf32>
+    %1:2 = stablehlo.while(%iterArg = %c_5, %iterArg_8 = %cst) : tensor<i64>, tensor<22x20x12xf32>
+    cond {
+      %2 = stablehlo.compare  LT, %iterArg, %c_6 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %2 : tensor<i1>
+    } do {
+      %2 = stablehlo.multiply %iterArg, %c_6 : tensor<i64>
+      %3 = stablehlo.add %c_7, %2 : tensor<i64>
+      %4 = stablehlo.add %iterArg, %c_7 : tensor<i64>
+      %5 = stablehlo.multiply %c_4, %3 : tensor<i64>
+      %6 = stablehlo.add %5, %c_7 : tensor<i64>
+      %7 = stablehlo.subtract %5, %c_7 : tensor<i64>
+      %8 = stablehlo.convert %6 : (tensor<i64>) -> tensor<i32>
+      %9 = stablehlo.subtract %8, %c_3 : tensor<i32>
+      %10 = stablehlo.convert %7 : (tensor<i64>) -> tensor<i32>
+      %11 = stablehlo.subtract %10, %c_3 : tensor<i32>
+      %12 = stablehlo.dynamic_slice %0, %c_0, %9, %11, sizes = [5, 1, 1] : (tensor<12x20x22xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<5x1x1xf32>
+      %13 = stablehlo.add %3, %c_6 : tensor<i64>
+      %14 = stablehlo.multiply %c_1, %3 : tensor<i64>
+      %15 = stablehlo.add %c_2, %14 : tensor<i64>
+      %16 = stablehlo.convert %13 : (tensor<i64>) -> tensor<i32>
+      %17 = stablehlo.subtract %16, %c_3 : tensor<i32>
+      %18 = stablehlo.convert %15 : (tensor<i64>) -> tensor<i32>
+      %19 = stablehlo.subtract %18, %c_3 : tensor<i32>
+      %20 = stablehlo.cosine %12 : tensor<5x1x1xf32>
+      %21 = stablehlo.dynamic_update_slice %iterArg_8, %20, %c, %19, %17 : (tensor<22x20x12xf32>, tensor<5x1x1xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<22x20x12xf32>
+      stablehlo.return %4, %21 : tensor<i64>, tensor<22x20x12xf32>
+    }
+    return %1#1 : tensor<22x20x12xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<22x20x12xf32>) -> tensor<22x20x12xf32> {
+// CHECK-NEXT{LITERAL}:   %c = stablehlo.constant dense<[[2, 17, 3], [2, 11, 6], [2, 5, 9]]> : tensor<3x3xi32>
+// CHECK-NEXT{LITERAL}:   %c_0 = stablehlo.constant dense<[[0, 2, 0], [0, 8, 6], [0, 14, 12]]> : tensor<3x3xi32>
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<22x20x12xf32>
+// CHECK-NEXT:   %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<22x20x12xf32>) -> tensor<12x20x22xf32>
+// CHECK-NEXT:   %1 = "stablehlo.gather"(%0, %c_0) <{dimension_numbers = #stablehlo.gather<offset_dims = [0], collapsed_slice_dims = [1, 2], start_index_map = [0, 1, 2], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 5, 1, 1>}> : (tensor<12x20x22xf32>, tensor<3x3xi32>) -> tensor<5x3xf32>
+// CHECK-NEXT:   %2 = stablehlo.cosine %1 : tensor<5x3xf32>
+// CHECK-NEXT:   %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<5x3xf32>) -> tensor<3x5xf32>
+// CHECK-NEXT:   %4 = "stablehlo.scatter"(%cst, %c, %3) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [1, 2], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:   ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+// CHECK-NEXT:     stablehlo.return %arg2 : tensor<f32>
+// CHECK-NEXT:   }) : (tensor<22x20x12xf32>, tensor<3x3xi32>, tensor<3x5xf32>) -> tensor<22x20x12xf32>
+// CHECK-NEXT:   return %4 : tensor<22x20x12xf32>
+// CHECK-NEXT: }
+
+module {
+  func.func @main(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
+    %c = stablehlo.constant dense<10> : tensor<i64>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x10xf32>
+    %c_0 = stablehlo.constant dense<1> : tensor<i32>
+    %c_1 = stablehlo.constant dense<0> : tensor<i64>
+    %c_2 = stablehlo.constant dense<1> : tensor<i64>
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<10x10xf32>) -> tensor<10x10xf32>
+    %1:2 = stablehlo.while(%iterArg = %c_1, %iterArg_3 = %cst) : tensor<i64>, tensor<10x10xf32>
+    cond {
+      %2 = stablehlo.compare  LT, %iterArg, %c : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %2 : tensor<i1>
+    } do {
+      %2 = stablehlo.add %c_2, %iterArg : tensor<i64>
+      %3 = stablehlo.convert %2 : (tensor<i64>) -> tensor<i32>
+      %4 = stablehlo.subtract %3, %c_0 : tensor<i32>
+      %5 = stablehlo.dynamic_slice %0, %4, %4, sizes = [1, 1] : (tensor<10x10xf32>, tensor<i32>, tensor<i32>) -> tensor<1x1xf32>
+      %6 = stablehlo.multiply %5, %5 : tensor<1x1xf32>
+      %7 = stablehlo.dynamic_update_slice %iterArg_3, %6, %4, %4 : (tensor<10x10xf32>, tensor<1x1xf32>, tensor<i32>, tensor<i32>) -> tensor<10x10xf32>
+      stablehlo.return %2, %7 : tensor<i64>, tensor<10x10xf32>
+    }
+    return %1#1 : tensor<10x10xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
+// CHECK-NEXT{LITERAL}:   %c = stablehlo.constant dense<[[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6], [7, 7], [8, 8], [9, 9]]> : tensor<10x2xi32>
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x10xf32>
+// CHECK-NEXT:   %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<10x10xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:   %1 = "stablehlo.gather"(%0, %c) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<10x10xf32>, tensor<10x2xi32>) -> tensor<10xf32>
+// CHECK-NEXT:   %2 = stablehlo.reshape %1 : (tensor<10xf32>) -> tensor<10x1x1xf32>
+// CHECK-NEXT:   %3 = stablehlo.multiply %2, %2 : tensor<10x1x1xf32>
+// CHECK-NEXT:   %4 = stablehlo.reshape %3 : (tensor<10x1x1xf32>) -> tensor<10xf32>
+// CHECK-NEXT:   %5 = "stablehlo.scatter"(%cst, %c, %4) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:   ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+// CHECK-NEXT:     stablehlo.return %arg2 : tensor<f32>
+// CHECK-NEXT:   }) : (tensor<10x10xf32>, tensor<10x2xi32>, tensor<10xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:   return %5 : tensor<10x10xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/autobatching/higher_order_post_diff.mlir
+++ b/test/lit_tests/autobatching/higher_order_post_diff.mlir
@@ -87,39 +87,40 @@ func.func @main(%arg0: tensor<5x5xf32>, %arg1: tensor<5xf32>, %arg2: tensor<3x5x
 // CHECK-NEXT:     %8 = stablehlo.multiply %7, %4 : tensor<15x5x3xf32>
 // CHECK-NEXT:     %9 = stablehlo.multiply %8, %cst : tensor<15x5x3xf32>
 // CHECK-NEXT:     %10 = stablehlo.multiply %cst_4, %6 : tensor<5x3xf32>
-// CHECK-NEXT:     %11 = stablehlo.multiply %6, %6 : tensor<5x3xf32>
-// CHECK-NEXT:     %12 = stablehlo.broadcast_in_dim %10, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
-// CHECK-NEXT:     %13 = stablehlo.multiply %9, %12 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %14 = stablehlo.multiply %11, %cst_3 : tensor<5x3xf32>
+// CHECK-NEXT:     %11 = stablehlo.broadcast_in_dim %10, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
+// CHECK-NEXT:     %12 = stablehlo.multiply %9, %11 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %13 = stablehlo.multiply %6, %6 : tensor<5x3xf32>
+// CHECK-NEXT:     %14 = stablehlo.multiply %13, %cst_3 : tensor<5x3xf32>
 // CHECK-NEXT:     %15 = stablehlo.add %14, %cst_2 : tensor<5x3xf32>
 // CHECK-NEXT:     %16 = stablehlo.broadcast_in_dim %15, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
 // CHECK-NEXT:     %17 = stablehlo.multiply %2, %16 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %18 = stablehlo.add %17, %13 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %18 = stablehlo.add %17, %12 : tensor<15x5x3xf32>
 // CHECK-NEXT:     %19 = stablehlo.multiply %10, %15 : tensor<5x3xf32>
 // CHECK-NEXT:     %20 = stablehlo.logistic %19 : tensor<5x3xf32>
 // CHECK-NEXT:     %21 = stablehlo.broadcast_in_dim %20, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
 // CHECK-NEXT:     %22 = stablehlo.multiply %1, %21 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %23 = stablehlo.subtract %cst_2, %20 : tensor<5x3xf32>
-// CHECK-NEXT:     %24 = stablehlo.multiply %20, %23 : tensor<5x3xf32>
-// CHECK-NEXT:     %25 = stablehlo.broadcast_in_dim %24, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
-// CHECK-NEXT:     %26 = stablehlo.multiply %18, %25 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %27 = stablehlo.multiply %26, %7 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %28 = stablehlo.add %22, %27 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %29:2 = stablehlo.while(%iterArg = %c_7, %iterArg_12 = %cst_9) : tensor<i64>, tensor<3x5xf32>
+// CHECK-NEXT:     %23 = stablehlo.logistic %19 : tensor<5x3xf32>
+// CHECK-NEXT:     %24 = stablehlo.subtract %cst_2, %23 : tensor<5x3xf32>
+// CHECK-NEXT:     %25 = stablehlo.multiply %23, %24 : tensor<5x3xf32>
+// CHECK-NEXT:     %26 = stablehlo.broadcast_in_dim %25, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
+// CHECK-NEXT:     %27 = stablehlo.multiply %18, %26 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %28 = stablehlo.multiply %27, %7 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %29 = stablehlo.add %22, %28 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %30:2 = stablehlo.while(%iterArg = %c_7, %iterArg_12 = %cst_9) : tensor<i64>, tensor<3x5xf32>
 // CHECK-NEXT:     cond {
-// CHECK-NEXT:       %30 = stablehlo.compare  LT, %iterArg, %c_11 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:       stablehlo.return %30 : tensor<i1>
+// CHECK-NEXT:       %31 = stablehlo.compare  LT, %iterArg, %c_11 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %31 : tensor<i1>
 // CHECK-NEXT:     } do {
-// CHECK-NEXT:       %30 = stablehlo.add %c_8, %iterArg : tensor<i64>
-// CHECK-NEXT:       %31 = stablehlo.remainder %iterArg, %c_5 : tensor<i64>
-// CHECK-NEXT:       %32 = stablehlo.add %31, %c_8 : tensor<i64>
-// CHECK-NEXT:       %33 = stablehlo.convert %32 : (tensor<i64>) -> tensor<i32>
-// CHECK-NEXT:       %34 = stablehlo.subtract %33, %c_6 : tensor<i32>
-// CHECK-NEXT:       %35 = stablehlo.convert %34 : (tensor<i32>) -> tensor<i64>
-// CHECK-NEXT:       %36 = stablehlo.dynamic_slice %28, %iterArg, %35, %c_7, sizes = [1, 1, 1] : (tensor<15x5x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x1x1xf32>
-// CHECK-NEXT:       %37 = stablehlo.reshape %36 : (tensor<1x1x1xf32>) -> tensor<1x1xf32>
-// CHECK-NEXT:       %38 = stablehlo.dynamic_update_slice %iterArg_12, %37, %c, %34 : (tensor<3x5xf32>, tensor<1x1xf32>, tensor<i32>, tensor<i32>) -> tensor<3x5xf32>
-// CHECK-NEXT:       stablehlo.return %30, %38 : tensor<i64>, tensor<3x5xf32>
+// CHECK-NEXT:       %31 = stablehlo.add %c_8, %iterArg : tensor<i64>
+// CHECK-NEXT:       %32 = stablehlo.remainder %iterArg, %c_5 : tensor<i64>
+// CHECK-NEXT:       %33 = stablehlo.add %32, %c_8 : tensor<i64>
+// CHECK-NEXT:       %34 = stablehlo.convert %33 : (tensor<i64>) -> tensor<i32>
+// CHECK-NEXT:       %35 = stablehlo.subtract %34, %c_6 : tensor<i32>
+// CHECK-NEXT:       %36 = stablehlo.convert %35 : (tensor<i32>) -> tensor<i64>
+// CHECK-NEXT:       %37 = stablehlo.dynamic_slice %29, %iterArg, %36, %c_7, sizes = [1, 1, 1] : (tensor<15x5x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x1x1xf32>
+// CHECK-NEXT:       %38 = stablehlo.reshape %37 : (tensor<1x1x1xf32>) -> tensor<1x1xf32>
+// CHECK-NEXT:       %39 = stablehlo.dynamic_update_slice %iterArg_12, %38, %c, %35 : (tensor<3x5xf32>, tensor<1x1xf32>, tensor<i32>, tensor<i32>) -> tensor<3x5xf32>
+// CHECK-NEXT:       stablehlo.return %31, %39 : tensor<i64>, tensor<3x5xf32>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %29#1 : tensor<3x5xf32>
-// CHECK-NEXT: }
+// CHECK-NEXT:     return %30#1 : tensor<3x5xf32>
+// CHECK-NEXT:   }

--- a/test/lit_tests/autobatching/higher_order_post_diff.mlir
+++ b/test/lit_tests/autobatching/higher_order_post_diff.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=dot_general_licm(0);elementwise_licm(0);greedy_while_loop_batch_fission;while_is_copy_simplify;remove_no_ops_from_while_loop;dynamic_slice_reshape_dynamic_slice" --transform-interpreter --enzyme-hlo-remove-transform --inline --enzyme-hlo-opt %s | FileCheck %s
+// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=greedy_while_loop_batch_fission;while_is_copy_simplify;remove_no_ops_from_while_loop;dynamic_slice_reshape_dynamic_slice" --transform-interpreter --enzyme-hlo-remove-transform --enzyme-hlo-opt %s | FileCheck %s
 
 func.func @main(%arg0: tensor<5x5xf32>, %arg1: tensor<5xf32>, %arg2: tensor<3x5xf32>) -> tensor<3x5xf32> {
     %cst = stablehlo.constant dense<"0x000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040"> : tensor<15x3x5xf32>
@@ -83,29 +83,29 @@ func.func @main(%arg0: tensor<5x5xf32>, %arg1: tensor<5xf32>, %arg2: tensor<3x5x
 // CHECK-NEXT:     %4 = stablehlo.dot_general %0, %cst_0, batching_dims = [0] x [0], contracting_dims = [1] x [2] : (tensor<15x5x5xf32>, tensor<15x3x5xf32>) -> tensor<15x5x3xf32>
 // CHECK-NEXT:     %5 = stablehlo.dot_general %arg0, %arg2, contracting_dims = [0] x [1] : (tensor<5x5xf32>, tensor<3x5xf32>) -> tensor<5x3xf32>
 // CHECK-NEXT:     %6 = stablehlo.add %5, %3 : tensor<5x3xf32>
-// CHECK-NEXT:     %7 = stablehlo.broadcast_in_dim %6, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
-// CHECK-NEXT:     %8 = stablehlo.multiply %7, %4 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %9 = stablehlo.multiply %8, %cst : tensor<15x5x3xf32>
-// CHECK-NEXT:     %10 = stablehlo.multiply %cst_4, %6 : tensor<5x3xf32>
-// CHECK-NEXT:     %11 = stablehlo.broadcast_in_dim %10, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
-// CHECK-NEXT:     %12 = stablehlo.multiply %9, %11 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %13 = stablehlo.multiply %6, %6 : tensor<5x3xf32>
-// CHECK-NEXT:     %14 = stablehlo.multiply %13, %cst_3 : tensor<5x3xf32>
-// CHECK-NEXT:     %15 = stablehlo.add %14, %cst_2 : tensor<5x3xf32>
-// CHECK-NEXT:     %16 = stablehlo.broadcast_in_dim %15, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
-// CHECK-NEXT:     %17 = stablehlo.multiply %2, %16 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %18 = stablehlo.add %17, %12 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %19 = stablehlo.multiply %10, %15 : tensor<5x3xf32>
-// CHECK-NEXT:     %20 = stablehlo.logistic %19 : tensor<5x3xf32>
-// CHECK-NEXT:     %21 = stablehlo.broadcast_in_dim %20, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
-// CHECK-NEXT:     %22 = stablehlo.multiply %1, %21 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %23 = stablehlo.logistic %19 : tensor<5x3xf32>
+// CHECK-NEXT:     %7 = stablehlo.multiply %6, %6 : tensor<5x3xf32>
+// CHECK-NEXT:     %8 = stablehlo.multiply %7, %cst_3 : tensor<5x3xf32>
+// CHECK-NEXT:     %9 = stablehlo.add %8, %cst_2 : tensor<5x3xf32>
+// CHECK-NEXT:     %10 = stablehlo.broadcast_in_dim %9, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
+// CHECK-NEXT:     %11 = stablehlo.multiply %2, %10 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %12 = stablehlo.broadcast_in_dim %6, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
+// CHECK-NEXT:     %13 = stablehlo.multiply %12, %4 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %14 = stablehlo.multiply %cst_4, %6 : tensor<5x3xf32>
+// CHECK-NEXT:     %15 = stablehlo.multiply %14, %9 : tensor<5x3xf32>
+// CHECK-NEXT:     %16 = stablehlo.logistic %15 : tensor<5x3xf32>
+// CHECK-NEXT:     %17 = stablehlo.broadcast_in_dim %16, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
+// CHECK-NEXT:     %18 = stablehlo.multiply %1, %17 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %19 = stablehlo.multiply %13, %cst : tensor<15x5x3xf32>
+// CHECK-NEXT:     %20 = stablehlo.broadcast_in_dim %14, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
+// CHECK-NEXT:     %21 = stablehlo.multiply %19, %20 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %22 = stablehlo.add %11, %21 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %23 = stablehlo.logistic %15 : tensor<5x3xf32>
 // CHECK-NEXT:     %24 = stablehlo.subtract %cst_2, %23 : tensor<5x3xf32>
 // CHECK-NEXT:     %25 = stablehlo.multiply %23, %24 : tensor<5x3xf32>
 // CHECK-NEXT:     %26 = stablehlo.broadcast_in_dim %25, dims = [1, 2] : (tensor<5x3xf32>) -> tensor<15x5x3xf32>
-// CHECK-NEXT:     %27 = stablehlo.multiply %18, %26 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %28 = stablehlo.multiply %27, %7 : tensor<15x5x3xf32>
-// CHECK-NEXT:     %29 = stablehlo.add %22, %28 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %27 = stablehlo.multiply %22, %26 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %28 = stablehlo.multiply %27, %12 : tensor<15x5x3xf32>
+// CHECK-NEXT:     %29 = stablehlo.add %18, %28 : tensor<15x5x3xf32>
 // CHECK-NEXT:     %30:2 = stablehlo.while(%iterArg = %c_7, %iterArg_12 = %cst_9) : tensor<i64>, tensor<3x5xf32>
 // CHECK-NEXT:     cond {
 // CHECK-NEXT:       %31 = stablehlo.compare  LT, %iterArg, %c_11 : (tensor<i64>, tensor<i64>) -> tensor<i1>

--- a/test/lit_tests/autobatching/indirect_iota_indexing.mlir
+++ b/test/lit_tests/autobatching/indirect_iota_indexing.mlir
@@ -82,14 +82,11 @@ module {
 // CHECK-NEXT{LITERAL}:    %c = stablehlo.constant dense<[[0, 10, 2], [0, 20, 2], [0, 30, 2], [0, 40, 2], [0, 50, 2], [0, 60, 2], [0, 70, 2]]> : tensor<7x3xi32>
 // CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<9x72x6xf32>
 // CHECK-NEXT:    %0 = stablehlo.slice %arg0 [2:6, 0:31:5, 1:4] : (tensor<9x72x6xf32>) -> tensor<4x7x3xf32>
-// CHECK-NEXT:    %1 = stablehlo.broadcast_in_dim %0, dims = [3, 0, 1] : (tensor<4x7x3xf32>) -> tensor<7x3x1x4xf32>
-// CHECK-NEXT:    %2 = stablehlo.sine %1 : tensor<7x3x1x4xf32>
-// CHECK-NEXT:    %3 = stablehlo.transpose %2, dims = [0, 3, 2, 1] : (tensor<7x3x1x4xf32>) -> tensor<7x4x1x3xf32>
-// CHECK-NEXT:    %4 = stablehlo.reshape %3 : (tensor<7x4x1x3xf32>) -> tensor<7x4x3xf32>
-// CHECK-NEXT:    %5 = stablehlo.transpose %4, dims = [1, 0, 2] : (tensor<7x4x3xf32>) -> tensor<4x7x3xf32>
-// CHECK-NEXT:    %6 = "stablehlo.scatter"(%cst, %c, %5) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:    %1 = stablehlo.sine %0 : tensor<4x7x3xf32>
+// CHECK-NEXT:    %2 = stablehlo.transpose %1, dims = [1, 0, 2] : (tensor<4x7x3xf32>) -> tensor<7x4x3xf32>
+// CHECK-NEXT:    %3 = "stablehlo.scatter"(%cst, %c, %2) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
 // CHECK-NEXT:    ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:      stablehlo.return %arg2 : tensor<f32>
-// CHECK-NEXT:    }) : (tensor<9x72x6xf32>, tensor<7x3xi32>, tensor<4x7x3xf32>) -> tensor<9x72x6xf32>
-// CHECK-NEXT:    return %6 : tensor<9x72x6xf32>
+// CHECK-NEXT:    }) : (tensor<9x72x6xf32>, tensor<7x3xi32>, tensor<7x4x3xf32>) -> tensor<9x72x6xf32>
+// CHECK-NEXT:    return %3 : tensor<9x72x6xf32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/autobatching/indirect_iota_indexing.mlir
+++ b/test/lit_tests/autobatching/indirect_iota_indexing.mlir
@@ -38,3 +38,58 @@ module {
 // CHECK-NEXT:     %3 = stablehlo.convert %2 : (tensor<10xf64>) -> tensor<10xf32>
 // CHECK-NEXT:     return %3 : tensor<10xf32>
 // CHECK-NEXT: }
+
+module {
+  func.func @main(%arg0: tensor<9x72x6xf32> {enzymexla.memory_effects = []}) -> tensor<9x72x6xf32> attributes {enzymexla.memory_effects = []} {
+    %c = stablehlo.constant dense<0> : tensor<i32>
+    %c_0 = stablehlo.constant dense<2> : tensor<i32>
+    %c_1 = stablehlo.constant dense<7> : tensor<i64>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<9x72x6xf32>
+    %c_2 = stablehlo.constant dense<[5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37]> : tensor<33xi64>
+    %c_3 = stablehlo.constant dense<2> : tensor<i64>
+    %c_4 = stablehlo.constant dense<1> : tensor<i32>
+    %c_5 = stablehlo.constant dense<0> : tensor<i64>
+    %c_6 = stablehlo.constant dense<5> : tensor<i64>
+    %c_7 = stablehlo.constant dense<1> : tensor<i64>
+    %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<9x72x6xf32>) -> tensor<6x72x9xf32>
+    %1:2 = stablehlo.while(%iterArg = %c_5, %iterArg_8 = %cst) : tensor<i64>, tensor<9x72x6xf32> attributes {enzyme.disable_mincut}
+    cond {
+      %2 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %2 : tensor<i1>
+    } do {
+      %2 = stablehlo.multiply %iterArg, %c_6 : tensor<i64>
+      %3 = stablehlo.add %c_7, %2 : tensor<i64>
+      %4 = stablehlo.add %iterArg, %c_7 : tensor<i64>
+      %5 = stablehlo.convert %3 : (tensor<i64>) -> tensor<i32>
+      %6 = stablehlo.subtract %5, %c_4 : tensor<i32>
+      %7 = stablehlo.dynamic_slice %c_2, %6, sizes = [1] : (tensor<33xi64>, tensor<i32>) -> tensor<1xi64>
+      %8 = stablehlo.reshape %7 : (tensor<1xi64>) -> tensor<i64>
+      %9 = stablehlo.dynamic_slice %0, %c_4, %6, %c_0, sizes = [3, 1, 4] : (tensor<6x72x9xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<3x1x4xf32>
+      %10 = stablehlo.sine %9 : tensor<3x1x4xf32>
+      %11 = stablehlo.multiply %c_3, %8 : tensor<i64>
+      %12 = stablehlo.add %11, %c_7 : tensor<i64>
+      %13 = stablehlo.convert %12 : (tensor<i64>) -> tensor<i32>
+      %14 = stablehlo.subtract %13, %c_4 : tensor<i32>
+      %15 = stablehlo.transpose %10, dims = [2, 1, 0] : (tensor<3x1x4xf32>) -> tensor<4x1x3xf32>
+      %16 = stablehlo.dynamic_update_slice %iterArg_8, %15, %c, %14, %c_0 : (tensor<9x72x6xf32>, tensor<4x1x3xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<9x72x6xf32>
+      stablehlo.return %4, %16 : tensor<i64>, tensor<9x72x6xf32>
+    }
+    return %1#1 : tensor<9x72x6xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<9x72x6xf32> {enzymexla.memory_effects = []}) -> tensor<9x72x6xf32> attributes {enzymexla.memory_effects = []} {
+// CHECK-NEXT{LITERAL}:    %c = stablehlo.constant dense<[[0, 10, 2], [0, 20, 2], [0, 30, 2], [0, 40, 2], [0, 50, 2], [0, 60, 2], [0, 70, 2]]> : tensor<7x3xi32>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<9x72x6xf32>
+// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [2:6, 0:31:5, 1:4] : (tensor<9x72x6xf32>) -> tensor<4x7x3xf32>
+// CHECK-NEXT:    %1 = stablehlo.broadcast_in_dim %0, dims = [3, 0, 1] : (tensor<4x7x3xf32>) -> tensor<7x3x1x4xf32>
+// CHECK-NEXT:    %2 = stablehlo.sine %1 : tensor<7x3x1x4xf32>
+// CHECK-NEXT:    %3 = stablehlo.transpose %2, dims = [0, 3, 2, 1] : (tensor<7x3x1x4xf32>) -> tensor<7x4x1x3xf32>
+// CHECK-NEXT:    %4 = stablehlo.reshape %3 : (tensor<7x4x1x3xf32>) -> tensor<7x4x3xf32>
+// CHECK-NEXT:    %5 = stablehlo.transpose %4, dims = [1, 0, 2] : (tensor<7x4x3xf32>) -> tensor<4x7x3xf32>
+// CHECK-NEXT:    %6 = "stablehlo.scatter"(%cst, %c, %5) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:    ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+// CHECK-NEXT:      stablehlo.return %arg2 : tensor<f32>
+// CHECK-NEXT:    }) : (tensor<9x72x6xf32>, tensor<7x3xi32>, tensor<4x7x3xf32>) -> tensor<9x72x6xf32>
+// CHECK-NEXT:    return %6 : tensor<9x72x6xf32>
+// CHECK-NEXT:  }

--- a/test/lit_tests/autobatching/loop_negmul_affine.mlir
+++ b/test/lit_tests/autobatching/loop_negmul_affine.mlir
@@ -1,0 +1,48 @@
+// RUN: enzymexlamlir-opt --auto-batching --enzyme-hlo-opt %s | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<5x20x6xf32> {enzymexla.memory_effects = []}) -> tensor<5x20x6xf32> attributes {enzymexla.memory_effects = []} {
+    %c = stablehlo.constant dense<-2> : tensor<i64>
+    %c_0 = stablehlo.constant dense<2> : tensor<i32>
+    %c_1 = stablehlo.constant dense<5> : tensor<i64>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<5x20x6xf32>
+    %c_2 = stablehlo.constant dense<20> : tensor<i64>
+    %c_3 = stablehlo.constant dense<1> : tensor<i32>
+    %c_4 = stablehlo.constant dense<0> : tensor<i64>
+    %c_5 = stablehlo.constant dense<2> : tensor<i64>
+    %c_6 = stablehlo.constant dense<1> : tensor<i64>
+    %0 = stablehlo.slice %arg0 [0:2, 2:11:2, 0:4] : (tensor<5x20x6xf32>) -> tensor<2x5x4xf32>
+    %1 = stablehlo.cosine %0 : tensor<2x5x4xf32>
+    %2 = stablehlo.broadcast_in_dim %1, dims = [1, 0, 3] : (tensor<2x5x4xf32>) -> tensor<5x2x1x4xf32>
+    %3:2 = stablehlo.while(%iterArg = %c_4, %iterArg_7 = %cst) : tensor<i64>, tensor<5x20x6xf32> attributes {enzyme.disable_mincut}
+    cond {
+      %4 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %4 : tensor<i1>
+    } do {
+      %4 = stablehlo.multiply %iterArg, %c_5 : tensor<i64>
+      %5 = stablehlo.add %c_6, %4 : tensor<i64>
+      %6 = stablehlo.add %iterArg, %c_6 : tensor<i64>
+      %7 = stablehlo.multiply %c, %5 : tensor<i64>
+      %8 = stablehlo.add %c_2, %7 : tensor<i64>
+      %9 = stablehlo.convert %8 : (tensor<i64>) -> tensor<i32>
+      %10 = stablehlo.subtract %9, %c_3 : tensor<i32>
+      %11 = stablehlo.dynamic_slice %2, %iterArg, %c_4, %c_4, %c_4, sizes = [1, 2, 1, 4] : (tensor<5x2x1x4xf32>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x2x1x4xf32>
+      %12 = stablehlo.reshape %11 : (tensor<1x2x1x4xf32>) -> tensor<2x1x4xf32>
+      %13 = stablehlo.dynamic_update_slice %iterArg_7, %12, %c_0, %10, %c_3 : (tensor<5x20x6xf32>, tensor<2x1x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<5x20x6xf32>
+      stablehlo.return %6, %13 : tensor<i64>, tensor<5x20x6xf32>
+    }
+    return %3#1 : tensor<5x20x6xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<5x20x6xf32> {enzymexla.memory_effects = []}) -> tensor<5x20x6xf32> attributes {enzymexla.memory_effects = []} {
+// CHECK-NEXT{LITERAL}:     %c = stablehlo.constant dense<[[2, 17, 1], [2, 13, 1], [2, 9, 1], [2, 5, 1], [2, 1, 1]]> : tensor<5x3xi32>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<5x20x6xf32>
+// CHECK-NEXT:     %0 = stablehlo.slice %arg0 [0:2, 2:11:2, 0:4] : (tensor<5x20x6xf32>) -> tensor<2x5x4xf32>
+// CHECK-NEXT:     %1 = stablehlo.cosine %0 : tensor<2x5x4xf32>
+// CHECK-NEXT:     %2 = "stablehlo.scatter"(%cst, %c, %1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+// CHECK-NEXT:       stablehlo.return %arg2 : tensor<f32>
+// CHECK-NEXT:     }) : (tensor<5x20x6xf32>, tensor<5x3xi32>, tensor<2x5x4xf32>) -> tensor<5x20x6xf32>
+// CHECK-NEXT:     return %2 : tensor<5x20x6xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/autobatching/loop_negmul_affine.mlir
+++ b/test/lit_tests/autobatching/loop_negmul_affine.mlir
@@ -40,9 +40,10 @@ module {
 // CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<5x20x6xf32>
 // CHECK-NEXT:     %0 = stablehlo.slice %arg0 [0:2, 2:11:2, 0:4] : (tensor<5x20x6xf32>) -> tensor<2x5x4xf32>
 // CHECK-NEXT:     %1 = stablehlo.cosine %0 : tensor<2x5x4xf32>
-// CHECK-NEXT:     %2 = "stablehlo.scatter"(%cst, %c, %1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:     %2 = stablehlo.transpose %1, dims = [1, 0, 2] : (tensor<2x5x4xf32>) -> tensor<5x2x4xf32>
+// CHECK-NEXT:     %3 = "stablehlo.scatter"(%cst, %c, %2) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
 // CHECK-NEXT:     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:       stablehlo.return %arg2 : tensor<f32>
-// CHECK-NEXT:     }) : (tensor<5x20x6xf32>, tensor<5x3xi32>, tensor<2x5x4xf32>) -> tensor<5x20x6xf32>
-// CHECK-NEXT:     return %2 : tensor<5x20x6xf32>
+// CHECK-NEXT:     }) : (tensor<5x20x6xf32>, tensor<5x3xi32>, tensor<5x2x4xf32>) -> tensor<5x20x6xf32>
+// CHECK-NEXT:     return %3 : tensor<5x20x6xf32>
 // CHECK-NEXT: }

--- a/test/lit_tests/autobatching/loop_negmul_affine2.mlir
+++ b/test/lit_tests/autobatching/loop_negmul_affine2.mlir
@@ -1,0 +1,59 @@
+// RUN: enzymexlamlir-opt --auto-batching --enzyme-hlo-opt %s | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<5x20x6xf32>) -> (tensor<5x20x6xf32>) {
+    %c = stablehlo.constant dense<-2> : tensor<i64>
+    %c_0 = stablehlo.constant dense<-3> : tensor<i64>
+    %c_1 = stablehlo.constant dense<2> : tensor<i32>
+    %c_2 = stablehlo.constant dense<1> : tensor<i32>
+    %c_3 = stablehlo.constant dense<0> : tensor<i32>
+    %c_4 = stablehlo.constant dense<20> : tensor<i64>
+    %c_5 = stablehlo.constant dense<3> : tensor<i64>
+    %c_6 = stablehlo.constant dense<0> : tensor<i64>
+    %c_7 = stablehlo.constant dense<2> : tensor<i64>
+    %c_8 = stablehlo.constant dense<1> : tensor<i64>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<6x20x5xf32>
+    %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<5x20x6xf32>) -> tensor<6x20x5xf32>
+    %1:2 = stablehlo.while(%iterArg = %c_6, %iterArg_9 = %cst) : tensor<i64>, tensor<6x20x5xf32>
+    cond {
+      %4 = stablehlo.compare  LT, %iterArg, %c_5 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %4 : tensor<i1>
+    } do {
+      %4 = stablehlo.multiply %iterArg, %c_7 : tensor<i64>
+      %5 = stablehlo.add %c_8, %4 : tensor<i64>
+      %6 = stablehlo.add %iterArg, %c_8 : tensor<i64>
+      %7 = stablehlo.multiply %c_0, %5 : tensor<i64>
+      %8 = stablehlo.add %c_4, %7 : tensor<i64>
+      %9 = stablehlo.convert %8 : (tensor<i64>) -> tensor<i32>
+      %10 = stablehlo.subtract %9, %c_2 : tensor<i32>
+      %11 = stablehlo.dynamic_slice %0, %c_3, %10, %c_3, sizes = [4, 1, 2] : (tensor<6x20x5xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<4x1x2xf32>
+      %12 = stablehlo.multiply %c, %5 : tensor<i64>
+      %13 = stablehlo.add %c_4, %12 : tensor<i64>
+      %14 = stablehlo.cosine %11 : tensor<4x1x2xf32>
+      %15 = stablehlo.convert %13 : (tensor<i64>) -> tensor<i32>
+      %16 = stablehlo.subtract %15, %c_2 : tensor<i32>
+      %17 = stablehlo.dynamic_update_slice %iterArg_9, %14, %c_2, %16, %c_1 : (tensor<6x20x5xf32>, tensor<4x1x2xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<6x20x5xf32>
+      stablehlo.return %6, %17 : tensor<i64>, tensor<6x20x5xf32>
+    }
+    %2 = stablehlo.transpose %1#1, dims = [2, 1, 0] : (tensor<6x20x5xf32>) -> tensor<5x20x6xf32>
+    return %2 : tensor<5x20x6xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<5x20x6xf32>) -> tensor<5x20x6xf32> {
+// CHECK-NEXT{LITERAL}:     %c = stablehlo.constant dense<[[1, 17, 2], [1, 13, 2], [1, 9, 2]]> : tensor<3x3xi32>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<6x20x5xf32>
+// CHECK-NEXT:     %0 = stablehlo.slice %arg0 [0:2, 4:17:6, 0:4] : (tensor<5x20x6xf32>) -> tensor<2x3x4xf32>
+// CHECK-NEXT:     %1 = stablehlo.transpose %0, dims = [2, 1, 0] : (tensor<2x3x4xf32>) -> tensor<4x3x2xf32>
+// CHECK-NEXT:     %2 = stablehlo.reverse %1, dims = [1] : tensor<4x3x2xf32>
+// CHECK-NEXT:     %3 = stablehlo.broadcast_in_dim %2, dims = [1, 0, 3] : (tensor<4x3x2xf32>) -> tensor<3x4x1x2xf32>
+// CHECK-NEXT:     %4 = stablehlo.cosine %3 : tensor<3x4x1x2xf32>
+// CHECK-NEXT:     %5 = stablehlo.reshape %4 : (tensor<3x4x1x2xf32>) -> tensor<3x4x2xf32>
+// CHECK-NEXT:     %6 = stablehlo.transpose %5, dims = [1, 0, 2] : (tensor<3x4x2xf32>) -> tensor<4x3x2xf32>
+// CHECK-NEXT:     %7 = "stablehlo.scatter"(%cst, %c, %6) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+// CHECK-NEXT:       stablehlo.return %arg2 : tensor<f32>
+// CHECK-NEXT:     }) : (tensor<6x20x5xf32>, tensor<3x3xi32>, tensor<4x3x2xf32>) -> tensor<6x20x5xf32>
+// CHECK-NEXT:     %8 = stablehlo.transpose %7, dims = [2, 1, 0] : (tensor<6x20x5xf32>) -> tensor<5x20x6xf32>
+// CHECK-NEXT:     return %8 : tensor<5x20x6xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/autobatching/loop_negmul_affine2.mlir
+++ b/test/lit_tests/autobatching/loop_negmul_affine2.mlir
@@ -46,14 +46,12 @@ module {
 // CHECK-NEXT:     %0 = stablehlo.slice %arg0 [0:2, 4:17:6, 0:4] : (tensor<5x20x6xf32>) -> tensor<2x3x4xf32>
 // CHECK-NEXT:     %1 = stablehlo.transpose %0, dims = [2, 1, 0] : (tensor<2x3x4xf32>) -> tensor<4x3x2xf32>
 // CHECK-NEXT:     %2 = stablehlo.reverse %1, dims = [1] : tensor<4x3x2xf32>
-// CHECK-NEXT:     %3 = stablehlo.broadcast_in_dim %2, dims = [1, 0, 3] : (tensor<4x3x2xf32>) -> tensor<3x4x1x2xf32>
-// CHECK-NEXT:     %4 = stablehlo.cosine %3 : tensor<3x4x1x2xf32>
-// CHECK-NEXT:     %5 = stablehlo.reshape %4 : (tensor<3x4x1x2xf32>) -> tensor<3x4x2xf32>
-// CHECK-NEXT:     %6 = stablehlo.transpose %5, dims = [1, 0, 2] : (tensor<3x4x2xf32>) -> tensor<4x3x2xf32>
-// CHECK-NEXT:     %7 = "stablehlo.scatter"(%cst, %c, %6) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:     %3 = stablehlo.cosine %2 : tensor<4x3x2xf32>
+// CHECK-NEXT:     %4 = stablehlo.transpose %3, dims = [1, 0, 2] : (tensor<4x3x2xf32>) -> tensor<3x4x2xf32>
+// CHECK-NEXT:     %5 = "stablehlo.scatter"(%cst, %c, %4) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1, 2], inserted_window_dims = [1], scatter_dims_to_operand_dims = [0, 1, 2], index_vector_dim = 1>, unique_indices = true}> ({
 // CHECK-NEXT:     ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
 // CHECK-NEXT:       stablehlo.return %arg2 : tensor<f32>
-// CHECK-NEXT:     }) : (tensor<6x20x5xf32>, tensor<3x3xi32>, tensor<4x3x2xf32>) -> tensor<6x20x5xf32>
-// CHECK-NEXT:     %8 = stablehlo.transpose %7, dims = [2, 1, 0] : (tensor<6x20x5xf32>) -> tensor<5x20x6xf32>
-// CHECK-NEXT:     return %8 : tensor<5x20x6xf32>
-// CHECK-NEXT: }
+// CHECK-NEXT:     }) : (tensor<6x20x5xf32>, tensor<3x3xi32>, tensor<3x4x2xf32>) -> tensor<6x20x5xf32>
+// CHECK-NEXT:     %6 = stablehlo.transpose %5, dims = [2, 1, 0] : (tensor<6x20x5xf32>) -> tensor<5x20x6xf32>
+// CHECK-NEXT:     return %6 : tensor<5x20x6xf32>
+// CHECK-NEXT:   }

--- a/test/lit_tests/autobatching/nbody.mlir
+++ b/test/lit_tests/autobatching/nbody.mlir
@@ -1,0 +1,120 @@
+// RUN: enzymexlamlir-opt --auto-batching --enzyme-hlo-opt --auto-batching --enzyme-hlo-opt --auto-batching --enzyme-hlo-opt --auto-batching  --enzyme-hlo-opt %s | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<100x3xf32>, %arg1: tensor<100xf32>) -> tensor<100x100x3xf32> {
+    %c = stablehlo.constant dense<2> : tensor<i32>
+    %c_0 = stablehlo.constant dense<0> : tensor<i32>
+    %c_1 = stablehlo.constant dense<100> : tensor<i64>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<100x100x3xf32>
+    %c_2 = stablehlo.constant dense<1> : tensor<i32>
+    %cst_3 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %c_4 = stablehlo.constant dense<0> : tensor<i64>
+    %c_5 = stablehlo.constant dense<1> : tensor<i64>
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<100x3xf32>) -> tensor<3x100xf32>
+    %1:2 = stablehlo.while(%iterArg = %c_4, %iterArg_6 = %cst) : tensor<i64>, tensor<100x100x3xf32> attributes {enzyme.disable_mincut}
+    cond {
+      %2 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %2 : tensor<i1>
+    } do {
+      %2 = stablehlo.add %c_5, %iterArg : tensor<i64>
+      %3 = stablehlo.convert %2 : (tensor<i64>) -> tensor<i32>
+      %4 = stablehlo.subtract %3, %c_2 : tensor<i32>
+      %5:2 = stablehlo.while(%iterArg_7 = %c_4, %iterArg_8 = %iterArg_6) : tensor<i64>, tensor<100x100x3xf32> attributes {enzyme.disable_mincut}
+      cond {
+        %6 = stablehlo.compare  LT, %iterArg_7, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+        stablehlo.return %6 : tensor<i1>
+      } do {
+        %6 = stablehlo.add %c_5, %iterArg_7 : tensor<i64>
+        %7 = stablehlo.dynamic_slice %0, %c_0, %4, sizes = [1, 1] : (tensor<3x100xf32>, tensor<i32>, tensor<i32>) -> tensor<1x1xf32>
+        %8 = stablehlo.convert %6 : (tensor<i64>) -> tensor<i32>
+        %9 = stablehlo.subtract %8, %c_2 : tensor<i32>
+        %10 = stablehlo.dynamic_slice %0, %c_0, %9, sizes = [1, 1] : (tensor<3x100xf32>, tensor<i32>, tensor<i32>) -> tensor<1x1xf32>
+        %11 = stablehlo.subtract %7, %10 : tensor<1x1xf32>
+        %12 = stablehlo.reshape %11 : (tensor<1x1xf32>) -> tensor<f32>
+        %13 = stablehlo.dynamic_slice %0, %c_2, %4, sizes = [1, 1] : (tensor<3x100xf32>, tensor<i32>, tensor<i32>) -> tensor<1x1xf32>
+        %14 = stablehlo.dynamic_slice %0, %c_2, %9, sizes = [1, 1] : (tensor<3x100xf32>, tensor<i32>, tensor<i32>) -> tensor<1x1xf32>
+        %15 = stablehlo.subtract %13, %14 : tensor<1x1xf32>
+        %16 = stablehlo.dynamic_slice %0, %c, %4, sizes = [1, 1] : (tensor<3x100xf32>, tensor<i32>, tensor<i32>) -> tensor<1x1xf32>
+        %17 = stablehlo.dynamic_slice %0, %c, %9, sizes = [1, 1] : (tensor<3x100xf32>, tensor<i32>, tensor<i32>) -> tensor<1x1xf32>
+        %18 = stablehlo.subtract %16, %17 : tensor<1x1xf32>
+        %19 = stablehlo.compare  EQ, %2, %6 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+        %20 = stablehlo.multiply %12, %12 : tensor<f32>
+        %21 = stablehlo.multiply %15, %15 : tensor<1x1xf32>
+        %22 = stablehlo.reshape %21 : (tensor<1x1xf32>) -> tensor<f32>
+        %23 = stablehlo.multiply %18, %18 : tensor<1x1xf32>
+        %24 = stablehlo.reshape %23 : (tensor<1x1xf32>) -> tensor<f32>
+        %25 = stablehlo.add %20, %22 : tensor<f32>
+        %26 = stablehlo.add %25, %24 : tensor<f32>
+        %27 = stablehlo.divide %cst_3, %26 : tensor<f32>
+        %28 = stablehlo.select %19, %12, %27 : tensor<i1>, tensor<f32>
+        %29 = stablehlo.dynamic_slice %arg1, %4, sizes = [1] : (tensor<100xf32>, tensor<i32>) -> tensor<1xf32>
+        %30 = stablehlo.dynamic_slice %arg1, %9, sizes = [1] : (tensor<100xf32>, tensor<i32>) -> tensor<1xf32>
+        %31 = stablehlo.multiply %29, %30 : tensor<1xf32>
+        %32 = stablehlo.reshape %31 : (tensor<1xf32>) -> tensor<f32>
+        %33 = stablehlo.multiply %32, %28 : tensor<f32>
+        %34 = stablehlo.reshape %33 : (tensor<f32>) -> tensor<1x1x1xf32>
+        %35 = stablehlo.reshape %11 : (tensor<1x1xf32>) -> tensor<1x1x1xf32>
+        %36 = stablehlo.reshape %15 : (tensor<1x1xf32>) -> tensor<1x1x1xf32>
+        %37 = stablehlo.reshape %18 : (tensor<1x1xf32>) -> tensor<1x1x1xf32>
+        %38 = stablehlo.broadcast_in_dim %33, dims = [] : (tensor<f32>) -> tensor<1x1x2xf32>
+        %39 = stablehlo.concatenate %38, %34, dim = 2 : (tensor<1x1x2xf32>, tensor<1x1x1xf32>) -> tensor<1x1x3xf32>
+        %40 = stablehlo.concatenate %35, %36, %37, dim = 2 : (tensor<1x1x1xf32>, tensor<1x1x1xf32>, tensor<1x1x1xf32>) -> tensor<1x1x3xf32>
+        %41 = stablehlo.multiply %39, %40 : tensor<1x1x3xf32>
+        %42 = stablehlo.dynamic_update_slice %iterArg_8, %41, %9, %4, %c_0 : (tensor<100x100x3xf32>, tensor<1x1x3xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<100x100x3xf32>
+        stablehlo.return %6, %42 : tensor<i64>, tensor<100x100x3xf32>
+      }
+      stablehlo.return %2, %5#1 : tensor<i64>, tensor<100x100x3xf32>
+    }
+    return %1#1 : tensor<100x100x3xf32>
+  }
+}
+
+// CHECK: module {
+// CHECK-NEXT:   func.func @main(%arg0: tensor<100x3xf32>, %arg1: tensor<100xf32>) -> tensor<100x100x3xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<100x100xf32>
+// CHECK-NEXT:     %c = stablehlo.constant dense<1> : tensor<100x100xi64>
+// CHECK-NEXT:     %0 = stablehlo.slice %arg0 [0:100, 0:1] : (tensor<100x3xf32>) -> tensor<100x1xf32>
+// CHECK-NEXT:     %1 = stablehlo.slice %arg0 [0:100, 1:2] : (tensor<100x3xf32>) -> tensor<100x1xf32>
+// CHECK-NEXT:     %2 = stablehlo.slice %arg0 [0:100, 2:3] : (tensor<100x3xf32>) -> tensor<100x1xf32>
+// CHECK-NEXT:     %3 = stablehlo.broadcast_in_dim %0, dims = [0, 2] : (tensor<100x1xf32>) -> tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %4 = stablehlo.broadcast_in_dim %1, dims = [0, 2] : (tensor<100x1xf32>) -> tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %5 = stablehlo.broadcast_in_dim %2, dims = [0, 2] : (tensor<100x1xf32>) -> tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %6 = stablehlo.broadcast_in_dim %arg1, dims = [0] : (tensor<100xf32>) -> tensor<100x100x1xf32>
+// CHECK-NEXT:     %7 = stablehlo.iota dim = 1 : tensor<100x100xi64>
+// CHECK-NEXT:     %8 = stablehlo.add %c, %7 : tensor<100x100xi64>
+// CHECK-NEXT:     %9 = stablehlo.iota dim = 0 : tensor<100x100xi64>
+// CHECK-NEXT:     %10 = stablehlo.add %c, %9 : tensor<100x100xi64>
+// CHECK-NEXT:     %11 = stablehlo.compare  EQ, %8, %10 : (tensor<100x100xi64>, tensor<100x100xi64>) -> tensor<100x100xi1>
+// CHECK-NEXT:     %12 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<100xf32>) -> tensor<100x100x1xf32>
+// CHECK-NEXT:     %13 = stablehlo.multiply %6, %12 : tensor<100x100x1xf32>
+// CHECK-NEXT:     %14 = stablehlo.broadcast_in_dim %2, dims = [1, 2] : (tensor<100x1xf32>) -> tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %15 = stablehlo.subtract %5, %14 : tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %16 = stablehlo.broadcast_in_dim %1, dims = [1, 2] : (tensor<100x1xf32>) -> tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %17 = stablehlo.subtract %4, %16 : tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %18 = stablehlo.broadcast_in_dim %0, dims = [1, 2] : (tensor<100x1xf32>) -> tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %19 = stablehlo.subtract %3, %18 : tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %20 = stablehlo.multiply %15, %15 : tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %21 = stablehlo.multiply %17, %17 : tensor<100x100x1x1xf32>
+// CHECK-NEXT:     %22 = stablehlo.reshape %19 : (tensor<100x100x1x1xf32>) -> tensor<100x100x1x1x1xf32>
+// CHECK-NEXT:     %23 = stablehlo.reshape %17 : (tensor<100x100x1x1xf32>) -> tensor<100x100x1x1x1xf32>
+// CHECK-NEXT:     %24 = stablehlo.reshape %15 : (tensor<100x100x1x1xf32>) -> tensor<100x100x1x1x1xf32>
+// CHECK-NEXT:     %25 = stablehlo.concatenate %22, %23, %24, dim = 4 : (tensor<100x100x1x1x1xf32>, tensor<100x100x1x1x1xf32>, tensor<100x100x1x1x1xf32>) -> tensor<100x100x1x1x3xf32>
+// CHECK-NEXT:     %26 = stablehlo.reshape %19 : (tensor<100x100x1x1xf32>) -> tensor<100x100xf32>
+// CHECK-NEXT:     %27 = stablehlo.multiply %26, %26 : tensor<100x100xf32>
+// CHECK-NEXT:     %28 = stablehlo.reshape %21 : (tensor<100x100x1x1xf32>) -> tensor<100x100xf32>
+// CHECK-NEXT:     %29 = stablehlo.add %27, %28 : tensor<100x100xf32>
+// CHECK-NEXT:     %30 = stablehlo.reshape %20 : (tensor<100x100x1x1xf32>) -> tensor<100x100xf32>
+// CHECK-NEXT:     %31 = stablehlo.add %29, %30 : tensor<100x100xf32>
+// CHECK-NEXT:     %32 = stablehlo.divide %cst, %31 : tensor<100x100xf32>
+// CHECK-NEXT:     %33 = stablehlo.select %11, %26, %32 : tensor<100x100xi1>, tensor<100x100xf32>
+// CHECK-NEXT:     %34 = stablehlo.reshape %13 : (tensor<100x100x1xf32>) -> tensor<100x100xf32>
+// CHECK-NEXT:     %35 = stablehlo.multiply %34, %33 : tensor<100x100xf32>
+// CHECK-NEXT:     %36 = stablehlo.broadcast_in_dim %35, dims = [0, 1] : (tensor<100x100xf32>) -> tensor<100x100x1x1x2xf32>
+// CHECK-NEXT:     %37 = stablehlo.reshape %35 : (tensor<100x100xf32>) -> tensor<100x100x1x1x1xf32>
+// CHECK-NEXT:     %38 = stablehlo.concatenate %36, %37, dim = 4 : (tensor<100x100x1x1x2xf32>, tensor<100x100x1x1x1xf32>) -> tensor<100x100x1x1x3xf32>
+// CHECK-NEXT:     %39 = stablehlo.multiply %38, %25 : tensor<100x100x1x1x3xf32>
+// CHECK-NEXT:     %40 = stablehlo.reshape %39 : (tensor<100x100x1x1x3xf32>) -> tensor<100x100x3xf32>
+// CHECK-NEXT:     %41 = stablehlo.transpose %40, dims = [1, 0, 2] : (tensor<100x100x3xf32>) -> tensor<100x100x3xf32>
+// CHECK-NEXT:     return %41 : tensor<100x100x3xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/autobatching/nested_loop_add_no_reshape.mlir
+++ b/test/lit_tests/autobatching/nested_loop_add_no_reshape.mlir
@@ -43,21 +43,19 @@ module {
 // CHECK-NEXT:     %c_0 = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-NEXT:     %c_1 = stablehlo.constant dense<2> : tensor<i64>
 // CHECK-NEXT:     %c_2 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:     %0 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:     %1 = stablehlo.transpose %arg2, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:     %2 = stablehlo.reshape %0 : (tensor<2x3xf64>) -> tensor<2x3x1x1xf64>
-// CHECK-NEXT:     %3 = stablehlo.reshape %1 : (tensor<2x3xf64>) -> tensor<2x3x1x1xf64>
-// CHECK-NEXT:     %4 = stablehlo.add %2, %3 : tensor<2x3x1x1xf64>
-// CHECK-NEXT:     %5 = stablehlo.reshape %4 : (tensor<2x3x1x1xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:     %6 = stablehlo.transpose %5, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
-// CHECK-NEXT:     %7 = stablehlo.while(%iterArg = %c_0) : tensor<i64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:     %0 = stablehlo.broadcast_in_dim %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3x1x1xf64>
+// CHECK-NEXT:     %1 = stablehlo.broadcast_in_dim %arg2, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3x1x1xf64>
+// CHECK-NEXT:     %2 = stablehlo.add %0, %1 : tensor<2x3x1x1xf64>
+// CHECK-NEXT:     %3 = stablehlo.reshape %2 : (tensor<2x3x1x1xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:     %4 = stablehlo.transpose %3, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+// CHECK-NEXT:     %5 = stablehlo.while(%iterArg = %c_0) : tensor<i64> attributes {enzyme.disable_mincut}
 // CHECK-NEXT:     cond {
-// CHECK-NEXT:       %8 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:       stablehlo.return %8 : tensor<i1>
+// CHECK-NEXT:       %6 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %6 : tensor<i1>
 // CHECK-NEXT:     } do {
-// CHECK-NEXT:       %8 = stablehlo.add %c_2, %iterArg : tensor<i64>
-// CHECK-NEXT:       stablehlo.return %8 : tensor<i64>
+// CHECK-NEXT:       %6 = stablehlo.add %c_2, %iterArg : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %6 : tensor<i64>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %7, %c_2, %c_2, %c_1, %c, %6 : tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<3x2xf64>
+// CHECK-NEXT:     return %5, %c_2, %c_2, %c_1, %c, %4 : tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<3x2xf64>
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/test/lit_tests/autobatching/nested_loop_add_no_reshape.mlir
+++ b/test/lit_tests/autobatching/nested_loop_add_no_reshape.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt %s --auto-batching --enzyme-hlo-opt | FileCheck %s
+// RUN: enzymexlamlir-opt %s --auto-batching --enzyme-hlo-opt --auto-batching --enzyme-hlo-opt | FileCheck %s
 
 module {
   func.func @main(%arg0: tensor<3x2xf64>, %arg1: tensor<3x2xf64>, %arg2: tensor<3x2xf64>) -> (tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<i64>, tensor<3x2xf64>) {
@@ -45,9 +45,9 @@ module {
 // CHECK-NEXT:     %c_2 = stablehlo.constant dense<1> : tensor<i64>
 // CHECK-NEXT:     %0 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
 // CHECK-NEXT:     %1 = stablehlo.transpose %arg2, dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:     %2 = stablehlo.reshape %1 : (tensor<2x3xf64>) -> tensor<2x3x1x1xf64>
-// CHECK-NEXT:     %3 = stablehlo.reshape %0 : (tensor<2x3xf64>) -> tensor<2x3x1x1xf64>
-// CHECK-NEXT:     %4 = stablehlo.add %3, %2 : tensor<2x3x1x1xf64>
+// CHECK-NEXT:     %2 = stablehlo.reshape %0 : (tensor<2x3xf64>) -> tensor<2x3x1x1xf64>
+// CHECK-NEXT:     %3 = stablehlo.reshape %1 : (tensor<2x3xf64>) -> tensor<2x3x1x1xf64>
+// CHECK-NEXT:     %4 = stablehlo.add %2, %3 : tensor<2x3x1x1xf64>
 // CHECK-NEXT:     %5 = stablehlo.reshape %4 : (tensor<2x3x1x1xf64>) -> tensor<2x3xf64>
 // CHECK-NEXT:     %6 = stablehlo.transpose %5, dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
 // CHECK-NEXT:     %7 = stablehlo.while(%iterArg = %c_0) : tensor<i64> attributes {enzyme.disable_mincut}

--- a/test/lit_tests/autobatching/nested_loop_conv.mlir
+++ b/test/lit_tests/autobatching/nested_loop_conv.mlir
@@ -50,8 +50,11 @@ module {
 // CHECK-NEXT:     %3 = stablehlo.reshape %2 : (tensor<4x4x5x12x3xf32>) -> tensor<4x4x60x3xf32>
 // CHECK-NEXT{LITERAL}:     %4 = stablehlo.convolution(%3, %cst) dim_numbers = [0, 1, f, b]x[0, 1, i, o]->[0, 1, f, b], window = {stride = [1, 1], pad = [[0, 0], [0, 0]], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 30 : i64, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<4x4x60x3xf32>, tensor<3x3x2x150xf32>) -> tensor<2x2x150x3xf32>
 // CHECK-NEXT:     %5 = stablehlo.reshape %4 : (tensor<2x2x150x3xf32>) -> tensor<2x2x5x30x3xf32>
-// CHECK-NEXT:     %6 = stablehlo.transpose %5, dims = [2, 0, 1, 3, 4] : (tensor<2x2x5x30x3xf32>) -> tensor<5x2x2x30x3xf32>
-// CHECK-NEXT:     %7 = stablehlo.reshape %6 : (tensor<5x2x2x30x3xf32>) -> tensor<5x2x2x6x5x3xf32>
-// CHECK-NEXT:     %8 = stablehlo.transpose %7, dims = [3, 5, 4, 0, 2, 1] : (tensor<5x2x2x6x5x3xf32>) -> tensor<6x3x5x5x2x2xf32>
-// CHECK-NEXT:     return %8 : tensor<6x3x5x5x2x2xf32>
-// CHECK-NEXT: }
+// CHECK-NEXT:     %6 = stablehlo.broadcast_in_dim %5, dims = [2, 3, 0, 4, 5] : (tensor<2x2x5x30x3xf32>) -> tensor<5x1x2x2x30x3xf32>
+// CHECK-NEXT:     %7 = stablehlo.reshape %6 : (tensor<5x1x2x2x30x3xf32>) -> tensor<5x2x2x6x5x3xf32>
+// CHECK-NEXT:     %8 = stablehlo.broadcast_in_dim %7, dims = [0, 3, 4, 1, 5, 6] : (tensor<5x2x2x6x5x3xf32>) -> tensor<5x6x1x2x2x5x3xf32>
+// CHECK-NEXT:     %9 = stablehlo.reshape %8 : (tensor<5x6x1x2x2x5x3xf32>) -> tensor<5x6x2x2x1x5x3x1xf32>
+// CHECK-NEXT:     %10 = stablehlo.transpose %9, dims = [1, 6, 7, 5, 0, 4, 3, 2] : (tensor<5x6x2x2x1x5x3x1xf32>) -> tensor<6x3x1x5x5x1x2x2xf32>
+// CHECK-NEXT:     %11 = stablehlo.reshape %10 : (tensor<6x3x1x5x5x1x2x2xf32>) -> tensor<6x3x5x5x2x2xf32>
+// CHECK-NEXT:     return %11 : tensor<6x3x5x5x2x2xf32>
+// CHECK-NEXT:   }

--- a/test/lit_tests/autobatching/nested_loop_conv.mlir
+++ b/test/lit_tests/autobatching/nested_loop_conv.mlir
@@ -50,10 +50,10 @@ module {
 // CHECK-NEXT:     %3 = stablehlo.reshape %2 : (tensor<4x4x5x12x3xf32>) -> tensor<4x4x60x3xf32>
 // CHECK-NEXT{LITERAL}:     %4 = stablehlo.convolution(%3, %cst) dim_numbers = [0, 1, f, b]x[0, 1, i, o]->[0, 1, f, b], window = {stride = [1, 1], pad = [[0, 0], [0, 0]], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 30 : i64, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<4x4x60x3xf32>, tensor<3x3x2x150xf32>) -> tensor<2x2x150x3xf32>
 // CHECK-NEXT:     %5 = stablehlo.reshape %4 : (tensor<2x2x150x3xf32>) -> tensor<2x2x5x30x3xf32>
-// CHECK-NEXT:     %6 = stablehlo.broadcast_in_dim %5, dims = [2, 3, 0, 4, 5] : (tensor<2x2x5x30x3xf32>) -> tensor<5x1x2x2x30x3xf32>
-// CHECK-NEXT:     %7 = stablehlo.reshape %6 : (tensor<5x1x2x2x30x3xf32>) -> tensor<5x2x2x6x5x3xf32>
-// CHECK-NEXT:     %8 = stablehlo.broadcast_in_dim %7, dims = [0, 3, 4, 1, 5, 6] : (tensor<5x2x2x6x5x3xf32>) -> tensor<5x6x1x2x2x5x3xf32>
-// CHECK-NEXT:     %9 = stablehlo.reshape %8 : (tensor<5x6x1x2x2x5x3xf32>) -> tensor<5x6x2x2x1x5x3x1xf32>
+// CHECK-NEXT:     %6 = stablehlo.transpose %5, dims = [2, 0, 1, 3, 4] : (tensor<2x2x5x30x3xf32>) -> tensor<5x2x2x30x3xf32>
+// CHECK-NEXT:     %7 = stablehlo.reshape %6 : (tensor<5x2x2x30x3xf32>) -> tensor<5x2x2x6x5x3xf32>
+// CHECK-NEXT:     %8 = stablehlo.transpose %7, dims = [0, 3, 1, 2, 4, 5] : (tensor<5x2x2x6x5x3xf32>) -> tensor<5x6x2x2x5x3xf32>
+// CHECK-NEXT:     %9 = stablehlo.reshape %8 : (tensor<5x6x2x2x5x3xf32>) -> tensor<5x6x2x2x1x5x3x1xf32>
 // CHECK-NEXT:     %10 = stablehlo.transpose %9, dims = [1, 6, 7, 5, 0, 4, 3, 2] : (tensor<5x6x2x2x1x5x3x1xf32>) -> tensor<6x3x1x5x5x1x2x2xf32>
 // CHECK-NEXT:     %11 = stablehlo.reshape %10 : (tensor<6x3x1x5x5x1x2x2xf32>) -> tensor<6x3x5x5x2x2xf32>
 // CHECK-NEXT:     return %11 : tensor<6x3x5x5x2x2xf32>

--- a/test/lit_tests/duspadinfcompile.mlir
+++ b/test/lit_tests/duspadinfcompile.mlir
@@ -1,0 +1,53 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=dus_pad;dynamic_pad_to_pad" --transform-interpreter --enzyme-hlo-remove-transform | FileCheck %s
+
+func.func @negative_mul_indexing(%arg0: tensor<5x20x6xf32>) -> (tensor<5x20x6xf32>, tensor<5x20x6xf32>) {
+  %c = stablehlo.constant dense<13> : tensor<i32>
+  %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+  %c_0 = stablehlo.constant dense<2> : tensor<i32>
+  %c_1 = stablehlo.constant dense<1> : tensor<i32>
+  %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<5x20x6xf32>) -> tensor<6x20x5xf32>
+  %1 = stablehlo.slice %0 [0:4, 4:17:6, 0:2] : (tensor<6x20x5xf32>) -> tensor<4x3x2xf32>
+  %2 = stablehlo.reverse %1, dims = [1] : tensor<4x3x2xf32>
+  %3 = stablehlo.broadcast_in_dim %2, dims = [3, 0, 1] : (tensor<4x3x2xf32>) -> tensor<3x2x1x4xf32>
+  %5 = stablehlo.reshape %3 : (tensor<3x2x1x4xf32>) -> tensor<3x2x4xf32>
+  %6 = stablehlo.broadcast_in_dim %5, dims = [0, 2, 1] : (tensor<3x2x4xf32>) -> tensor<3x4x2xf32>
+  %7 = stablehlo.slice %6 [0:3, 0:4, 0:2] : (tensor<3x4x2xf32>) -> tensor<3x4x2xf32>
+  %9 = stablehlo.slice %7 [0:1, 0:4, 0:2] : (tensor<3x4x2xf32>) -> tensor<1x4x2xf32>
+  %10 = stablehlo.reshape %9 : (tensor<1x4x2xf32>) -> tensor<4x2xf32>
+  %11 = stablehlo.cosine %10 : tensor<4x2xf32>
+  %12 = stablehlo.broadcast_in_dim %11, dims = [0, 2] : (tensor<4x2xf32>) -> tensor<4x1x2xf32>
+  %13 = stablehlo.pad %12, %cst, low = [1, 17, 2], high = [1, 2, 1], interior = [0, 0, 0] : (tensor<4x1x2xf32>, tensor<f32>) -> tensor<6x20x5xf32>
+  %14 = stablehlo.slice %6 [1:2, 0:4, 0:2] : (tensor<3x4x2xf32>) -> tensor<1x4x2xf32>
+  %15 = stablehlo.reshape %14 : (tensor<1x4x2xf32>) -> tensor<4x2xf32>
+  %17 = stablehlo.broadcast_in_dim %15, dims = [0, 2] : (tensor<4x2xf32>) -> tensor<4x1x2xf32>
+  %18 = stablehlo.dynamic_update_slice %13, %17, %c_1, %c, %c_0 : (tensor<6x20x5xf32>, tensor<4x1x2xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<6x20x5xf32>
+  %19 = stablehlo.transpose %18, dims = [2, 1, 0] : (tensor<6x20x5xf32>) -> tensor<5x20x6xf32>
+  %20 = stablehlo.transpose %0, dims = [2, 1, 0] : (tensor<6x20x5xf32>) -> tensor<5x20x6xf32>
+  return %19, %20 : tensor<5x20x6xf32>, tensor<5x20x6xf32>
+}
+
+// CHECK: func.func @negative_mul_indexing(%arg0: tensor<5x20x6xf32>) -> (tensor<5x20x6xf32>, tensor<5x20x6xf32>) {
+// CHECK-NEXT:   %c = stablehlo.constant dense<13> : tensor<i32>
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:   %c_0 = stablehlo.constant dense<2> : tensor<i32>
+// CHECK-NEXT:   %c_1 = stablehlo.constant dense<1> : tensor<i32>
+// CHECK-NEXT:   %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<5x20x6xf32>) -> tensor<6x20x5xf32>
+// CHECK-NEXT:   %1 = stablehlo.slice %0 [0:4, 4:17:6, 0:2] : (tensor<6x20x5xf32>) -> tensor<4x3x2xf32>
+// CHECK-NEXT:   %2 = stablehlo.reverse %1, dims = [1] : tensor<4x3x2xf32>
+// CHECK-NEXT:   %3 = stablehlo.broadcast_in_dim %2, dims = [3, 0, 1] : (tensor<4x3x2xf32>) -> tensor<3x2x1x4xf32>
+// CHECK-NEXT:   %4 = stablehlo.reshape %3 : (tensor<3x2x1x4xf32>) -> tensor<3x2x4xf32>
+// CHECK-NEXT:   %5 = stablehlo.broadcast_in_dim %4, dims = [0, 2, 1] : (tensor<3x2x4xf32>) -> tensor<3x4x2xf32>
+// CHECK-NEXT:   %6 = stablehlo.slice %5 [0:3, 0:4, 0:2] : (tensor<3x4x2xf32>) -> tensor<3x4x2xf32>
+// CHECK-NEXT:   %7 = stablehlo.slice %6 [0:1, 0:4, 0:2] : (tensor<3x4x2xf32>) -> tensor<1x4x2xf32>
+// CHECK-NEXT:   %8 = stablehlo.reshape %7 : (tensor<1x4x2xf32>) -> tensor<4x2xf32>
+// CHECK-NEXT:   %9 = stablehlo.cosine %8 : tensor<4x2xf32>
+// CHECK-NEXT:   %10 = stablehlo.broadcast_in_dim %9, dims = [0, 2] : (tensor<4x2xf32>) -> tensor<4x1x2xf32>
+// CHECK-NEXT:   %11 = stablehlo.pad %10, %cst, low = [1, 17, 2], high = [1, 2, 1], interior = [0, 0, 0] : (tensor<4x1x2xf32>, tensor<f32>) -> tensor<6x20x5xf32>
+// CHECK-NEXT:   %12 = stablehlo.slice %5 [1:2, 0:4, 0:2] : (tensor<3x4x2xf32>) -> tensor<1x4x2xf32>
+// CHECK-NEXT:   %13 = stablehlo.reshape %12 : (tensor<1x4x2xf32>) -> tensor<4x2xf32>
+// CHECK-NEXT:   %14 = stablehlo.broadcast_in_dim %13, dims = [0, 2] : (tensor<4x2xf32>) -> tensor<4x1x2xf32>
+// CHECK-NEXT:   %15 = stablehlo.dynamic_update_slice %11, %14, %c_1, %c, %c_0 : (tensor<6x20x5xf32>, tensor<4x1x2xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<6x20x5xf32>
+// CHECK-NEXT:   %16 = stablehlo.transpose %15, dims = [2, 1, 0] : (tensor<6x20x5xf32>) -> tensor<5x20x6xf32>
+// CHECK-NEXT:   %17 = stablehlo.transpose %0, dims = [2, 1, 0] : (tensor<6x20x5xf32>) -> tensor<5x20x6xf32>
+// CHECK-NEXT:   return %16, %17 : tensor<5x20x6xf32>, tensor<5x20x6xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/reversetranspose.mlir
+++ b/test/lit_tests/reversetranspose.mlir
@@ -1,11 +1,11 @@
 // RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=reverse_transpose" --transform-interpreter --enzyme-hlo-remove-transform %s | FileCheck %s
 
 module {
-  func.func @main(%arg0: tensor<2x3x4xf32>) -> tensor<3x2x4xf32> {
-    // CHECK-DAG: %[[REVERSE:.+]] = stablehlo.reverse %arg0, dims = [0, 2] : tensor<2x3x4xf32>
-    %0 = stablehlo.transpose %arg0, dims = [1, 0, 2] : (tensor<2x3x4xf32>) -> tensor<3x2x4xf32>
-    // CHECK-DAG: %[[TRANSPOSE:.+]] = stablehlo.transpose %[[REVERSE]], dims = [1, 0, 2] : (tensor<2x3x4xf32>) -> tensor<3x2x4xf32>
-    %1 = stablehlo.reverse %0, dims = [1, 2] : (tensor<3x2x4xf32>) -> tensor<3x2x4xf32>
-    return %1 : tensor<3x2x4xf32>
+  func.func @main(%arg0: tensor<2x3x4xf32>) -> tensor<3x4x2xf32> {
+    // CHECK-DAG: %[[REVERSE:.+]] = stablehlo.reverse %arg0, dims = [2, 0] : tensor<2x3x4xf32>
+    %0 = stablehlo.transpose %arg0, dims = [1, 2, 0] : (tensor<2x3x4xf32>) -> tensor<3x4x2xf32>
+    // CHECK-DAG: %[[TRANSPOSE:.+]] = stablehlo.transpose %[[REVERSE]], dims = [1, 2, 0] : (tensor<2x3x4xf32>) -> tensor<3x4x2xf32>
+    %1 = stablehlo.reverse %0, dims = [1, 2] : (tensor<3x4x2xf32>) -> tensor<3x4x2xf32>
+    return %1 : tensor<3x4x2xf32>
   }
 }

--- a/test/lit_tests/transposereverse.mlir
+++ b/test/lit_tests/transposereverse.mlir
@@ -1,11 +1,11 @@
 // RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=transpose_reverse" --transform-interpreter --enzyme-hlo-remove-transform %s | FileCheck %s
 
 module {
-  func.func @main(%arg0: tensor<2x3x4xf32>) -> tensor<3x2x4xf32> {
-    // CHECK-DAG: %[[TRANSPOSE:.+]] = stablehlo.transpose %arg0, dims = [1, 0, 2] : (tensor<2x3x4xf32>) -> tensor<3x2x4xf32>
+  func.func @main(%arg0: tensor<2x3x4xf32>) -> tensor<3x4x2xf32> {
+    // CHECK-DAG: %[[TRANSPOSE:.+]] = stablehlo.transpose %arg0, dims = [1, 2, 0] : (tensor<2x3x4xf32>) -> tensor<3x4x2xf32>
     %1 = stablehlo.reverse %arg0, dims = [1, 2] : (tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
-    // CHECK-DAG: %[[REVERSE:.+]] = stablehlo.reverse %[[TRANSPOSE]], dims = [0, 2] : tensor<3x2x4xf32>
-    %2 = stablehlo.transpose %1, dims = [1, 0, 2] : (tensor<2x3x4xf32>) -> tensor<3x2x4xf32>
-    return %2 : tensor<3x2x4xf32>
+    // CHECK-DAG: %[[REVERSE:.+]] = stablehlo.reverse %[[TRANSPOSE]], dims = [0, 1] : tensor<3x4x2xf32>
+    %2 = stablehlo.transpose %1, dims = [1, 2, 0] : (tensor<2x3x4xf32>) -> tensor<3x4x2xf32>
+    return %2 : tensor<3x4x2xf32>
   }
 }

--- a/test/lit_tests/while_is_copy.mlir
+++ b/test/lit_tests/while_is_copy.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=remove_no_ops_from_while_loop;while_is_copy_simplify" --transform-interpreter --enzyme-hlo-remove-transform --enzyme-hlo-opt %s | FileCheck %s
+// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=remove_no_ops_from_while_loop;while_is_copy_simplify" --transform-interpreter --enzyme-hlo-remove-transform --enzyme-hlo-opt="max_constant_expansion=0" %s | FileCheck %s
 
 module {
   func.func @main(%arg0: tensor<10xf32> {tf.aliasing_output = 0 : i32}, %arg1: tensor<10xf32>) -> tensor<10xf32> {
@@ -293,4 +293,43 @@ module {
 // CHECK-NEXT:   %6 = stablehlo.slice %arg0 [0:1, 0:3, 3:4, 0:1, 0:5] : (tensor<1x3x4x1x5xf32>) -> tensor<1x3x1x1x5xf32>
 // CHECK-NEXT:   %7 = stablehlo.concatenate %5, %6, dim = 2 : (tensor<1x3x3x1x5xf32>, tensor<1x3x1x1x5xf32>) -> tensor<1x3x4x1x5xf32>
 // CHECK-NEXT:   return %7 : tensor<1x3x4x1x5xf32>
+// CHECK-NEXT: }
+
+module {
+  func.func @main(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x10xf32>
+    %c = stablehlo.constant dense<1> : tensor<i32>
+    %c_0 = stablehlo.constant dense<0> : tensor<i64>
+    %c_1 = stablehlo.constant dense<10> : tensor<i64>
+    %c_2 = stablehlo.constant dense<1> : tensor<i64>
+    %0 = stablehlo.multiply %arg0, %arg0 : tensor<10x10xf32>
+    %1 = stablehlo.transpose %0, dims = [1, 0] : (tensor<10x10xf32>) -> tensor<10x10xf32>
+    %2:2 = stablehlo.while(%iterArg = %c_0, %iterArg_3 = %cst) : tensor<i64>, tensor<10x10xf32>
+    cond {
+      %3 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %3 : tensor<i1>
+    } do {
+      %3 = stablehlo.add %c_2, %iterArg : tensor<i64>
+      %4 = stablehlo.convert %3 : (tensor<i64>) -> tensor<i32>
+      %5 = stablehlo.subtract %4, %c : tensor<i32>
+      %6 = stablehlo.dynamic_slice %1, %iterArg, %iterArg, sizes = [1, 1] : (tensor<10x10xf32>, tensor<i64>, tensor<i64>) -> tensor<1x1xf32>
+      %7 = stablehlo.dynamic_update_slice %iterArg_3, %6, %5, %5 : (tensor<10x10xf32>, tensor<1x1xf32>, tensor<i32>, tensor<i32>) -> tensor<10x10xf32>
+      stablehlo.return %3, %7 : tensor<i64>, tensor<10x10xf32>
+    }
+    return %2#1 : tensor<10x10xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x10xf32>
+// CHECK-NEXT:   %0 = stablehlo.multiply %arg0, %arg0 {enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<10x10xf32>
+// CHECK-NEXT:   %1 = stablehlo.transpose %0, dims = [1, 0] : (tensor<10x10xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:   %2 = stablehlo.iota dim = 0 : tensor<10x2xi64>
+// CHECK-NEXT:   %3 = "stablehlo.gather"(%1, %2) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<10x10xf32>, tensor<10x2xi64>) -> tensor<10xf32>
+// CHECK-NEXT:   %4 = stablehlo.iota dim = 0 : tensor<10x2xi32>
+// CHECK-NEXT:   %5 = "stablehlo.scatter"(%cst, %4, %3) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:   ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+// CHECK-NEXT:     stablehlo.return %arg2 : tensor<f32>
+// CHECK-NEXT:   }) : (tensor<10x10xf32>, tensor<10x2xi32>, tensor<10xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:   return %5 : tensor<10x10xf32>
 // CHECK-NEXT: }

--- a/test/lit_tests/while_is_copy_nested.mlir
+++ b/test/lit_tests/while_is_copy_nested.mlir
@@ -102,9 +102,12 @@ module {
 // CHECK-NEXT:     %6 = stablehlo.reshape %5 : (tensor<1x4x4x6x2x3xf32>) -> tensor<4x4x12x3xf32>
 // CHECK-NEXT{LITERAL}:     %7 = stablehlo.convolution(%6, %cst) dim_numbers = [0, 1, f, b]x[0, 1, i, o]->[0, 1, f, b], window = {stride = [1, 1], pad = [[0, 0], [0, 0]], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 6 : i64, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<4x4x12x3xf32>, tensor<3x3x2x30xf32>) -> tensor<2x2x30x3xf32>
 // CHECK-NEXT:     %8 = stablehlo.reshape %7 : (tensor<2x2x30x3xf32>) -> tensor<2x2x6x5x3xf32>
-// CHECK-NEXT:     %9 = stablehlo.broadcast_in_dim %8, dims = [5, 4, 0, 2, 1] : (tensor<2x2x6x5x3xf32>) -> tensor<6x3x5x1x2x2xf32>
-// CHECK-NEXT:     %10 = stablehlo.dynamic_update_slice %iterArg_5, %9, %c, %c, %c, %4, %c, %c : (tensor<6x3x5x5x2x2xf32>, tensor<6x3x5x1x2x2xf32>, tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<6x3x5x5x2x2xf32>
-// CHECK-NEXT:     stablehlo.return %2, %10 : tensor<i64>, tensor<6x3x5x5x2x2xf32>
+// CHECK-NEXT:     %9 = stablehlo.transpose %8, dims = [2, 0, 1, 3, 4] : (tensor<2x2x6x5x3xf32>) -> tensor<6x2x2x5x3xf32>
+// CHECK-NEXT:     %10 = stablehlo.reshape %9 : (tensor<6x2x2x5x3xf32>) -> tensor<6x2x2x1x5x3x1xf32>
+// CHECK-NEXT:     %11 = stablehlo.transpose %10, dims = [0, 6, 5, 4, 3, 2, 1] : (tensor<6x2x2x1x5x3x1xf32>) -> tensor<6x1x3x5x1x2x2xf32>
+// CHECK-NEXT:     %12 = stablehlo.reshape %11 : (tensor<6x1x3x5x1x2x2xf32>) -> tensor<6x3x5x1x2x2xf32>
+// CHECK-NEXT:     %13 = stablehlo.dynamic_update_slice %iterArg_5, %12, %c, %c, %c, %4, %c, %c : (tensor<6x3x5x5x2x2xf32>, tensor<6x3x5x1x2x2xf32>, tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<6x3x5x5x2x2xf32>
+// CHECK-NEXT:     stablehlo.return %2, %13 : tensor<i64>, tensor<6x3x5x5x2x2xf32>
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return %1#1 : tensor<6x3x5x5x2x2xf32>
 // CHECK-NEXT: }


### PR DESCRIPTION
fixes #1675 

- loop info
  - [x] affine index propagation
  - [x] remove the loop offset map
- loop to batch
  - [x] general affine indexing support
  - [x] step != 1
  - [x] negative scaling
  - [x] iota indexing with scaled index
  - [x] constant iteration argument
- while is copy simplify
  - [x] support affine indexing
  - [x] step != 1
  - [x] negative scaling
- Miscellaneous issues
  - [x] fix regression in nested_loop_conv test
  - [x] regression in other testing
  - [x] infinite compile time
- Multiple indices depend on ind var