### PR TITLE
feat: add a debugging pass for removing non-splatted constants

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertAllConstantsToSplattedConstantPass.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertAllConstantsToSplattedConstantPass.cpp
@@ -1,0 +1,58 @@
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "stablehlo/dialect/StablehloOps.h"
+
+#include "src/enzyme_ad/jax/Utils.h"
+
+using namespace mlir;
+using namespace mlir::stablehlo;
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_CONVERTALLCONSTANTSTOSPLATTEDCONSTANTPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+struct ConvertSHLOConstantsToSplat
+    : public OpRewritePattern<stablehlo::ConstantOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(stablehlo::ConstantOp op,
+                                PatternRewriter &rewriter) const override {
+    auto attr = cast<DenseElementsAttr>(op.getValue());
+    if (attr.isSplat()) // already splatted
+      return failure();
+
+    auto elementIt = attr.getValues<Attribute>().begin();
+    Attribute firstVal = *elementIt;
+
+    auto splatAttr = SplatElementsAttr::get(op.getType(), firstVal);
+    rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(op, splatAttr);
+    return success();
+  }
+};
+
+namespace {
+
+struct ConvertAllConstantsToSplattedConstantPass
+    : public enzyme::impl::ConvertAllConstantsToSplattedConstantPassBase<
+          ConvertAllConstantsToSplattedConstantPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    auto context = getOperation()->getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<ConvertSHLOConstantsToSplat>(context);
+
+    GreedyRewriteConfig config;
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                            config))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -1077,4 +1077,11 @@ def EnzymeBatchToStableHLOPass : Pass<"enzyme-batch-to-stablehlo"> {
   ];
 }
 
+def ConvertAllConstantsToSplattedConstantPass : Pass<"convert-all-constants-to-splatted-constant", "ModuleOp"> {
+  let summary = "Convert all constants to splatted constants. This is supposed to be used for debugging purposes when dumping the module.";
+  let dependentDialects = [
+    "stablehlo::StablehloDialect",
+  ];
+}
+
 #endif

--- a/test/lit_tests/convert_to_splatted_constants.mlir
+++ b/test/lit_tests/convert_to_splatted_constants.mlir
@@ -1,0 +1,23 @@
+// RUN: enzymexlamlir-opt --convert-all-constants-to-splatted-constant %s | FileCheck %s
+
+func.func @main() -> tensor<3x4xf32> {
+    %c = stablehlo.constant dense<[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]> : tensor<2x4xf32>
+    %c1 = stablehlo.constant dense<[[9.0, 10.0, 11.0, 12.0], [13.0, 14.0, 15.0, 16.0]]> : tensor<2x4xf32>
+    %0 = stablehlo.add %c, %c1 : tensor<2x4xf32>
+    %1 = stablehlo.slice %0 [0:1, 0:4] : (tensor<2x4xf32>) -> tensor<1x4xf32>
+    %c2 = stablehlo.constant dense<4.0> : tensor<3x4xf32>
+    %2 = stablehlo.concatenate %0, %1, dim = 0 : (tensor<2x4xf32>, tensor<1x4xf32>) -> tensor<3x4xf32>
+    %3 = stablehlo.add %2, %c2 : tensor<3x4xf32>
+    return %3 : tensor<3x4xf32>
+}
+
+// CHECK: func.func @main() -> tensor<3x4xf32> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<4.000000e+00> : tensor<3x4xf32>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<2x4xf32>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<9.000000e+00> : tensor<2x4xf32>
+// CHECK-NEXT:     %0 = stablehlo.add %cst_0, %cst_1 : tensor<2x4xf32>
+// CHECK-NEXT:     %1 = stablehlo.slice %0 [0:1, 0:4] : (tensor<2x4xf32>) -> tensor<1x4xf32>
+// CHECK-NEXT:     %2 = stablehlo.concatenate %0, %1, dim = 0 : (tensor<2x4xf32>, tensor<1x4xf32>) -> tensor<3x4xf32>
+// CHECK-NEXT:     %3 = stablehlo.add %2, %cst : tensor<3x4xf32>
+// CHECK-NEXT:     return %3 : tensor<3x4xf32>
+// CHECK-NEXT: }


### PR DESCRIPTION
- neuralgcm dumps a 500MB mlir file which is extremely frustrating to debug.
- goes without saying not intended for external usage, will obviously yield incorrect results.