### PR TITLE
feat: syrk simplifications and fixes

### DIFF
--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -431,11 +431,11 @@ def SyrkOp: EnzymeXLA_Op<"blas.syrk", [Pure, SameOperandsAndResultElementType]> 
   let summary = "Multiplication involving a symmetric matrix";
 
   let description = [{
-    C := alpha*A*A^T + beta*C, or C := alpha*A^T*A + beta*C, where alpha and beta are
-    scalars. C must be a n x n symmetric matrix.
+    C_out := alpha*A*A^T + beta*C, or C_out := alpha*A^T*A + beta*C, where alpha and beta
+    are scalars. C must be a n x n symmetric matrix.
 
-    If `fill` is present, then both the upper and lower triangles of the matrix are filled.
-    Otherwise the values in the non-uplo part of the matrix are undefined.
+    `output_uplo` determines which part of `C_out` is populated. Accessing the values in
+    the non-`output_uplo` part of the matrix is undefined behavior.
   }];
 
   let arguments = (ins
@@ -444,8 +444,8 @@ def SyrkOp: EnzymeXLA_Op<"blas.syrk", [Pure, SameOperandsAndResultElementType]> 
     TensorFloat:$alpha,
     TensorFloat:$beta,
     EnzymeXLA_LapackUploAttr:$uplo,
-    DefaultValuedAttr<EnzymeXLA_LapackTransposeAttr, "::mlir::enzymexla::LapackTranspose::none">:$transpose,
-    OptionalAttr<UnitAttr>:$fill
+    EnzymeXLA_LapackUploAttr:$output_uplo,
+    DefaultValuedAttr<EnzymeXLA_LapackTransposeAttr, "::mlir::enzymexla::LapackTranspose::none">:$transpose
   );
 
   let results = (outs
@@ -455,6 +455,8 @@ def SyrkOp: EnzymeXLA_Op<"blas.syrk", [Pure, SameOperandsAndResultElementType]> 
   let assemblyFormat = [{
     $A `,` $C `,` $alpha `,` $beta attr-dict `:` functional-type(operands, results)
   }];
+
+  let hasVerifier = 1;
 }
 
 def TrmmOp: EnzymeXLA_Op<"blas.trmm", [Pure, SameOperandsAndResultElementType]> {

--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -436,6 +436,14 @@ def SyrkOp: EnzymeXLA_Op<"blas.syrk", [Pure, SameOperandsAndResultElementType]> 
 
     `output_uplo` determines which part of `C_out` is populated. Accessing the values in
     the non-`output_uplo` part of the matrix is undefined behavior.
+
+    LAPACK/BLAS routines typically require a single `uplo` attribute and it is implicitly
+    assumed that the output `uplo` corresponds to the input `uplo`. This means the burden
+    lies on the user to manually copy data if they need to access the other half of the
+    matrix. By specifying the `output_uplo` we can perform transformations that analyze the
+    entire dataflow, and avoid computing/copying half of the tensor all together. Generally,
+    it is recommended to set this attribute to `enzymexla::LapackUplo::F`, and our passes
+    will automatically refine this to minimize data copies.
   }];
 
   let arguments = (ins

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1104,6 +1104,20 @@ LogicalResult enzymexla::MemcpyOp::verify() {
   return success();
 }
 
+LogicalResult enzymexla::SyrkOp::verify() {
+  auto CType = cast<RankedTensorType>(getC().getType());
+  bool isComplex = false;
+  if (auto complex_type = dyn_cast<ComplexType>(CType.getElementType())) {
+    isComplex = true;
+  }
+
+  if (isComplex && getTranspose() == enzymexla::LapackTranspose::adjoint) {
+    return emitOpError("Complex matrix not supported for complex transpose");
+  }
+
+  return success();
+}
+
 namespace {
 
 /// Erases a common case of copy ops where a destination value is used only by

--- a/src/enzyme_ad/jax/Passes/LinalgUtils.h
+++ b/src/enzyme_ad/jax/Passes/LinalgUtils.h
@@ -2,7 +2,7 @@
 #define ENZYMEXLA_LINALGUTILS_H
 
 #include "mlir/IR/Attributes.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/SmallVector.h"
 
 llvm::SmallVector<int64_t> columnMajorMatrixLayout(int64_t ndim);

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLABLAS.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLABLAS.cpp
@@ -12,6 +12,7 @@
 
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/SmallVector.h"
+#include <mlir/IR/BuiltinAttributes.h>
 
 #define DEBUG_TYPE "lower-enzymexla-blas"
 
@@ -81,30 +82,39 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
 
   LogicalResult matchAndRewrite(enzymexla::SyrkOp op,
                                 PatternRewriter &rewriter) const override {
-    if (backend == "cpu")
-      return matchAndRewriteCPU(op, rewriter);
-    if (backend == "cuda")
-      return matchAndRewriteCUDA(op, rewriter);
+    auto AType = cast<RankedTensorType>(op.getA().getType());
+    auto nBatchDims = AType.getRank() - 2;
+
+    if (nBatchDims == 0) {
+      if (backend == "cpu") {
+        return matchAndRewriteCPU(op, rewriter);
+      } else if (backend == "cuda") {
+        return matchAndRewriteCUDA(op, rewriter);
+      }
+    }
 
     return matchAndRewriteFallback(op, rewriter);
   }
 
+  void resolveUplo(enzymexla::SyrkOp op, enzymexla::LapackUplo &customCallUplo,
+                   bool &needsCopy) const {
+    switch (op.getUplo()) {
+    case enzymexla::LapackUplo::F:
+      customCallUplo = standardizeUplo(op.getOutputUplo());
+      needsCopy = op.getOutputUplo() == enzymexla::LapackUplo::F;
+      break;
+    default:
+      customCallUplo = op.getUplo();
+      needsCopy = op.getOutputUplo() != op.getUplo();
+    }
+  }
+
   LogicalResult matchAndRewriteCPU(enzymexla::SyrkOp op,
                                    PatternRewriter &rewriter) const {
-    auto nBatchDims = cast<RankedTensorType>(op.getA().getType()).getRank() - 2;
-    if (nBatchDims != 0) {
-      return matchAndRewriteFallback(op, rewriter);
-    }
-
     auto ctx = op->getContext();
     LLVMTypeConverter typeConverter(ctx);
 
     auto AType = cast<RankedTensorType>(op.getA().getType());
-
-    bool isComplex = false;
-    if (auto complexType = dyn_cast<ComplexType>(AType.getElementType())) {
-      isComplex = true;
-    }
 
     auto moduleOp = op->getParentOfType<ModuleOp>();
 
@@ -170,36 +180,9 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
       LLVM::ReturnOp::create(rewriter, op.getLoc(), ValueRange{});
     }
 
-    enzymexla::LapackUplo uplo2 = op.getUplo(); // drop `F` uplo attribute
-    char uploValue;
-    switch (op.getUplo()) {
-    case enzymexla::LapackUplo::U:
-      uploValue = 'U';
-      break;
-    case enzymexla::LapackUplo::L:
-      uploValue = 'L';
-      break;
-    case enzymexla::LapackUplo::F:
-      uploValue = 'U';
-      uplo2 = enzymexla::LapackUplo::U;
-      break;
-    }
-
-    char transValue;
-    switch (op.getTranspose()) {
-    case enzymexla::LapackTranspose::none:
-      transValue = 'N';
-      break;
-    case enzymexla::LapackTranspose::adjoint:
-      if (isComplex) {
-        llvm_unreachable("adjoint is not supported for complex matrices");
-      }
-      // adjoint for real matrices is the same as transpose
-      LLVM_FALLTHROUGH;
-    case enzymexla::LapackTranspose::transpose:
-      transValue = 'T';
-      break;
-    }
+    bool needsCopy;
+    enzymexla::LapackUplo customCallUplo;
+    resolveUplo(op, customCallUplo, needsCopy);
 
     // generate the func.funcOp that calls the blas function
     static int64_t fn_counter = 0;
@@ -242,12 +225,14 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
 
       auto nSize = stablehlo::ConvertOp::create(
           rewriter, op.getLoc(), intType,
-          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), A,
-                                                transValue == 'N' ? 0 : 1));
+          stablehlo::GetDimensionSizeOp::create(
+              rewriter, op.getLoc(), A,
+              op.getTranspose() != enzymexla::LapackTranspose::none));
       auto kSize = stablehlo::ConvertOp::create(
           rewriter, op.getLoc(), intType,
-          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), A,
-                                                transValue == 'N' ? 1 : 0));
+          stablehlo::GetDimensionSizeOp::create(
+              rewriter, op.getLoc(), A,
+              op.getTranspose() == enzymexla::LapackTranspose::none));
 
       auto lda = stablehlo::ConvertOp::create(
           rewriter, op.getLoc(), intType,
@@ -258,10 +243,15 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
 
       auto uploConst = stablehlo::ConstantOp::create(
           rewriter, op.getLoc(), uint8Type,
-          cast<ElementsAttr>(makeAttr(uint8Type, uploValue)));
+          cast<ElementsAttr>(makeAttr(
+              uint8Type,
+              customCallUplo == enzymexla::LapackUplo::U ? 'U' : 'L')));
       auto transConst = stablehlo::ConstantOp::create(
           rewriter, op.getLoc(), uint8Type,
-          cast<ElementsAttr>(makeAttr(uint8Type, transValue)));
+          cast<ElementsAttr>(makeAttr(
+              uint8Type, op.getTranspose() == enzymexla::LapackTranspose::none
+                             ? 'N'
+                             : 'T')));
 
       // {uplo, trans, n, k, alpha, A, lda, beta, C, ldc}
       auto jitCall = enzymexla::JITCallOp::create(
@@ -286,8 +276,8 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
         ValueRange{op.getA(), op.getC(), op.getAlpha(), op.getBeta()});
 
     auto result = callOp.getResult(0);
-    if (op.getFill()) {
-      result = stablehlo::copyTriangularPart(rewriter, result, uplo2);
+    if (needsCopy) {
+      result = stablehlo::copyTriangularPart(rewriter, result, customCallUplo);
     }
     rewriter.replaceAllUsesWith(op.getResult(), result);
 
@@ -299,18 +289,6 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
     auto CType = cast<RankedTensorType>(op.getC().getType());
     auto rank = CType.getRank();
 
-    bool isComplex = false;
-    if (auto complex_type = dyn_cast<ComplexType>(CType.getElementType())) {
-      isComplex = true;
-    }
-
-    if (isComplex && op.getTranspose() == enzymexla::LapackTranspose::adjoint) {
-      return rewriter.notifyMatchFailure(
-          op, "Complex matrix not supported for complex transpose");
-    }
-
-    bool transpose = op.getTranspose() != enzymexla::LapackTranspose::none;
-
     // Try to extract alpha and beta as constants
     double alphaReal = 0.0, alphaImag = 0.0;
     double betaReal = 0.0, betaImag = 0.0;
@@ -318,12 +296,17 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
         extractConstantScalar(op.getAlpha(), alphaReal, alphaImag);
     bool useBetaAttr = extractConstantScalar(op.getBeta(), betaReal, betaImag);
 
+    bool needsCopy;
+    enzymexla::LapackUplo customCallUplo;
+    resolveUplo(op, customCallUplo, needsCopy);
+
     // Build operands list - use empty tensors for constant alpha/beta
     SmallVector<Value> operands;
-    operands.push_back(op.getA());
-    operands.push_back(op.getC());
+    SmallVector<int64_t> operandRanks;
+    SmallVector<bool> areColMajor;
 
-    SmallVector<int64_t> operandRanks = {rank, rank};
+    auto A = op.getA();
+    auto C = op.getC();
 
     auto [alphaOperand, alphaRank] =
         createScalarOperand(rewriter, op.getLoc(), op.getAlpha(), useAlphaAttr);
@@ -335,47 +318,71 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
     operands.push_back(betaOperand);
     operandRanks.push_back(betaRank);
 
+    StringAttr customCallTarget;
+    ArrayAttr aliases;
+
+    SmallVector<NamedAttribute> configAttrs = {
+        rewriter.getNamedAttr(
+            "transpose",
+            rewriter.getBoolAttr(op.getTranspose() !=
+                                 enzymexla::LapackTranspose::none)),
+        rewriter.getNamedAttr(
+            "uplo",
+            rewriter.getBoolAttr(customCallUplo == enzymexla::LapackUplo::U)),
+        rewriter.getNamedAttr("use_alpha_attribute",
+                              rewriter.getBoolAttr(useAlphaAttr)),
+        rewriter.getNamedAttr("alpha_real",
+                              rewriter.getF64FloatAttr(alphaReal)),
+        rewriter.getNamedAttr("alpha_imag",
+                              rewriter.getF64FloatAttr(alphaImag))};
+
+    if (matchPattern(betaOperand, m_AnyZeroFloat()) ||
+        matchPattern(betaOperand, m_Zero()) ||
+        matchPattern(op.getC(), m_AnyZeroFloat()) ||
+        matchPattern(op.getC(), m_Zero())) {
+      customCallTarget =
+          rewriter.getStringAttr("reactant_cublas_syrk_no_c_ffi");
+      operands = {A, alphaOperand};
+      operandRanks = {rank, alphaRank};
+      aliases = rewriter.getArrayAttr({});
+      areColMajor = {false, false};
+    } else {
+      customCallTarget = rewriter.getStringAttr("reactant_cublas_syrk_ffi");
+      operands = {A, C, alphaOperand, betaOperand};
+      operandRanks = {rank, rank, alphaRank, betaRank};
+
+      configAttrs.push_back(rewriter.getNamedAttr(
+          "use_beta_attribute", rewriter.getBoolAttr(useBetaAttr)));
+      configAttrs.push_back(rewriter.getNamedAttr(
+          "beta_real", rewriter.getF64FloatAttr(betaReal)));
+      configAttrs.push_back(rewriter.getNamedAttr(
+          "beta_imag", rewriter.getF64FloatAttr(betaImag)));
+
+      aliases = rewriter.getArrayAttr(
+          {stablehlo::OutputOperandAliasAttr::get(op.getContext(), {}, 1, {})});
+      areColMajor = {false, false, true, true};
+    }
+
+    DictionaryAttr backendConfig = rewriter.getDictionaryAttr(configAttrs);
+
     auto customCall = stablehlo::CustomCallOp::create(
-        rewriter, op.getLoc(), TypeRange{CType}, operands,
-        rewriter.getStringAttr("reactant_cublas_syrk_ffi"),
+        rewriter, op.getLoc(), TypeRange{CType}, operands, customCallTarget,
         /*has_side_effect*/ nullptr,
-        /*backend_config*/
-        rewriter.getDictionaryAttr({
-            rewriter.getNamedAttr("transpose", rewriter.getBoolAttr(transpose)),
-            rewriter.getNamedAttr(
-                "uplo",
-                rewriter.getBoolAttr(op.getUplo() == enzymexla::LapackUplo::U)),
-            rewriter.getNamedAttr("use_alpha_attribute",
-                                  rewriter.getBoolAttr(useAlphaAttr)),
-            rewriter.getNamedAttr("use_beta_attribute",
-                                  rewriter.getBoolAttr(useBetaAttr)),
-            rewriter.getNamedAttr("alpha_real",
-                                  rewriter.getF64FloatAttr(alphaReal)),
-            rewriter.getNamedAttr("alpha_imag",
-                                  rewriter.getF64FloatAttr(alphaImag)),
-            rewriter.getNamedAttr("beta_real",
-                                  rewriter.getF64FloatAttr(betaReal)),
-            rewriter.getNamedAttr("beta_imag",
-                                  rewriter.getF64FloatAttr(betaImag)),
-        }),
+        /*backend_config*/ backendConfig,
         /*api_version*/
         stablehlo::CustomCallApiVersionAttr::get(
             rewriter.getContext(),
             mlir::stablehlo::CustomCallApiVersion::API_VERSION_TYPED_FFI),
         /*calledcomputations*/ nullptr,
         /*operand_layouts*/
-        getSHLOLayout(rewriter, operandRanks, SmallVector<bool>(4, true), rank),
+        getSHLOLayout(rewriter, operandRanks, areColMajor, rank),
         /*result_layouts*/
-        getSHLOLayout(rewriter, {rank}, SmallVector<bool>(rank, true), rank),
-        /*output_operand_aliases*/
-        rewriter.getArrayAttr({
-            stablehlo::OutputOperandAliasAttr::get(op.getContext(), {}, 1, {}),
-        }));
+        getSHLOLayout(rewriter, {rank}, SmallVector<bool>(rank, false), rank),
+        /*output_operand_aliases*/ aliases);
 
     auto result = customCall.getResult(0);
-    if (op.getFill() || op.getUplo() == enzymexla::LapackUplo::L) {
-      result = stablehlo::copyTriangularPart(rewriter, result,
-                                             enzymexla::LapackUplo::U);
+    if (needsCopy) {
+      result = stablehlo::copyTriangularPart(rewriter, result, customCallUplo);
     }
     rewriter.replaceAllUsesWith(op.getResult(), result);
 
@@ -390,17 +397,12 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
     std::iota(batchDims.begin(), batchDims.end(), 0);
 
     Value C = op.getC();
-    if (!matchPattern(C, m_Constant())) {
-      // for safety we need to copy the uplo part into the other half of the
-      // matrix
+    if (!stablehlo::IsTensorFilled(C)) {
+      // If the tensor is not filled, we copy to the non-uplo region for safety
       C = stablehlo::copyTriangularPart(rewriter, C, op.getUplo());
-      if (!C)
+      if (!C) {
         return failure();
-    }
-
-    bool isComplex = false;
-    if (auto complexType = dyn_cast<ComplexType>(AType.getElementType())) {
-      isComplex = true;
+      }
     }
 
     // fallback to emitting a stablehlo.dot_general that computes:
@@ -414,10 +416,6 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
           {nBatchDims + 1});
       break;
     case enzymexla::LapackTranspose::adjoint:
-      if (isComplex) {
-        llvm_unreachable("adjoint is not supported for complex matrices");
-      }
-      // adjoint for real matrices is the same as transpose
       LLVM_FALLTHROUGH;
     case enzymexla::LapackTranspose::transpose:
       dotDims = stablehlo::DotDimensionNumbersAttr::get(
@@ -429,18 +427,11 @@ struct SyrkOpLowering : public OpRewritePattern<enzymexla::SyrkOp> {
         rewriter, op.getLoc(), cast<RankedTensorType>(op.getC().getType()),
         op.getA(), op.getA(), dotDims, nullptr, nullptr);
 
-    auto alpha = stablehlo::BroadcastInDimOp::create(
-        rewriter, op.getLoc(), cast<RankedTensorType>(AAT.getType()),
-        op.getAlpha(), rewriter.getDenseI64ArrayAttr({}));
-
-    auto lhs = stablehlo::MulOp::create(rewriter, op.getLoc(), alpha, AAT);
-
-    auto beta = stablehlo::BroadcastInDimOp::create(
-        rewriter, op.getLoc(), cast<RankedTensorType>(op.getC().getType()),
-        op.getBeta(), rewriter.getDenseI64ArrayAttr({}));
-
-    rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
-        op, lhs, stablehlo::MulOp::create(rewriter, op.getLoc(), beta, C));
+    auto res = stablehlo::AddOpCreate(
+        rewriter, op->getLoc(),
+        stablehlo::MulOpCreate(rewriter, op->getLoc(), op.getAlpha(), AAT),
+        stablehlo::MulOpCreate(rewriter, op->getLoc(), op.getBeta(), C));
+    rewriter.replaceOp(op, res);
     return success();
   }
 
@@ -460,6 +451,7 @@ struct LowerEnzymeXLABLASPass
     patterns.add<SyrkOpLowering>(backend, blasIntWidth, context);
 
     GreedyRewriteConfig config;
+    config.setUseTopDownTraversal(true);
     if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
                                             config))) {
       signalPassFailure();

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -2627,6 +2627,11 @@ def ApplyReshapeSliceReshapePatterns : EnzymeHLOPatternOp<
   let patterns = ["ReshapeSliceReshape"];
 }
 
+def ApplySyrkSimplifyOutputUploPatterns : EnzymeHLOPatternOp<
+    "syrk_simplify_output_uplo"> {
+  let patterns = ["SyrkSimplifyOutputUplo"];
+}
+
 def ApplyDotGeneralRemoveBatchDimensionsPatterns : EnzymeHLOPatternOp<
     "dot_general_remove_batch_dimensions"> {
   let patterns = ["DotGeneralRemoveBatchDimensions"];

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -10,6 +10,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include <mlir/IR/Value.h>
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -921,6 +922,13 @@ bool isOnlyUsedInOperation(Operation *operation, Operation *parentOp);
 mlir::RankedTensorType removeBatchedDims(mlir::RankedTensorType Ty,
                                          llvm::ArrayRef<int64_t> dims);
 
+enzymexla::LapackTranspose
+transposeLapackTranspose(enzymexla::LapackTranspose trans, bool canBeComplex);
+
+enzymexla::LapackUplo transposeLapackUplo(enzymexla::LapackUplo uplo);
+
+enzymexla::LapackUplo standardizeUplo(enzymexla::LapackUplo uplo);
+
 } // namespace enzyme
 
 namespace stablehlo {
@@ -1277,6 +1285,20 @@ Value DynamicSliceOpCreate(
     OpBuilder &builder, Location loc, Value input, ArrayRef<Value> sliceStarts,
     ArrayRef<int64_t> sliceSizes,
     std::optional<sdy::TensorShardingPerValueAttr> sharding = std::nullopt);
+
+// allows lhs or rhs to be a scalar in which case it will automatically be
+// broadcasted to the correct shape
+Value AddOpCreate(
+    OpBuilder &builder, Location loc, Value lhs, Value rhs,
+    std::optional<sdy::TensorShardingPerValueAttr> sharding = std::nullopt);
+
+Value MulOpCreate(
+    OpBuilder &builder, Location loc, Value lhs, Value rhs,
+    std::optional<sdy::TensorShardingPerValueAttr> sharding = std::nullopt);
+
+// walk back starting from `input` and track the operations to determine if
+// only part of the matrix is populated.
+bool IsTensorFilled(Value input);
 
 } // namespace stablehlo
 

--- a/src/enzyme_ad/jax/primitives.py
+++ b/src/enzyme_ad/jax/primitives.py
@@ -323,6 +323,7 @@ def optimization_passes(
         "while_dus_ds_simplify",
         "while_dus_dus_simplify",
         "reshape_slice_reshape",
+        "syrk_simplify_output_uplo",
         "dynamic_slice_elementwise",
         "dot_general_remove_batch_dimensions",
         "delete_dims_reduce",

--- a/test/lit_tests/dotgeneral_to_syrk.mlir
+++ b/test/lit_tests/dotgeneral_to_syrk.mlir
@@ -13,7 +13,7 @@ func.func @main1(%arg0: tensor<64x32xf32>) -> tensor<64x64xf32> {
 // CHECK-NEXT:   %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK-NEXT:   %cst_0 = stablehlo.constant {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} dense<5.000000e-01> : tensor<f32>
 // CHECK-NEXT:   %cst_1 = stablehlo.constant dense<3.000000e+00> : tensor<64x64xf32>
-// CHECK-NEXT:   %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst_0, %cst {fill, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+// CHECK-NEXT:   %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst_0, %cst {output_uplo = #enzymexla.uplo<F>, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
 // CHECK-NEXT:   return %0 : tensor<64x64xf32>
 // CHECK-NEXT: }
 
@@ -31,7 +31,7 @@ func.func @main2(%arg0: tensor<64x32xf32>) -> tensor<64x64xf32> {
 // CHECK-NEXT:   %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK-NEXT:   %cst_0 = stablehlo.constant {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} dense<5.000000e-01> : tensor<f32>
 // CHECK-NEXT:   %cst_1 = stablehlo.constant dense<3.000000e+00> : tensor<64x64xf32>
-// CHECK-NEXT:   %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst_0, %cst {fill, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+// CHECK-NEXT:   %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst_0, %cst {output_uplo = #enzymexla.uplo<F>, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
 // CHECK-NEXT:   return %0 : tensor<64x64xf32>
 // CHECK-NEXT: }
 
@@ -49,7 +49,7 @@ func.func @main3(%arg0: tensor<64x32xf32>) -> tensor<64x64xf32> {
 // CHECK-NEXT:   %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK-NEXT:   %cst_0 = stablehlo.constant {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} dense<5.000000e-01> : tensor<f32>
 // CHECK-NEXT:   %cst_1 = stablehlo.constant dense<3.000000e+00> : tensor<64x64xf32>
-// CHECK-NEXT:   %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst_0, %cst {fill, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+// CHECK-NEXT:   %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst_0, %cst {output_uplo = #enzymexla.uplo<F>, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
 // CHECK-NEXT:   return %0 : tensor<64x64xf32>
 // CHECK-NEXT: }
 
@@ -68,7 +68,7 @@ func.func @main4(%arg0: tensor<64x32xf32>) -> tensor<64x64xf32> {
 // CHECK-NEXT:   %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
 // CHECK-NEXT:   %cst_0 = stablehlo.constant {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} dense<5.000000e-01> : tensor<f32>
 // CHECK-NEXT:   %cst_1 = stablehlo.constant dense<3.000000e+00> : tensor<64x64xf32>
-// CHECK-NEXT:   %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst_0, %cst {fill, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+// CHECK-NEXT:   %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst_0, %cst {output_uplo = #enzymexla.uplo<F>, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
 // CHECK-NEXT:   return %0 : tensor<64x64xf32>
 // CHECK-NEXT: }
 

--- a/test/lit_tests/linalg/syrk.mlir
+++ b/test/lit_tests/linalg/syrk.mlir
@@ -12,11 +12,11 @@ module {
 }
 
 // CPU: func.func private @enzymexla_blas_ssyrk_wrapper_[[SYRKID:[0-9]+]](%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> tensor<64x64xf32> {
-// CPU-NEXT:   %c = stablehlo.constant dense<78> : tensor<ui8>
-// CPU-NEXT:   %c_0 = stablehlo.constant dense<85> : tensor<ui8>
+// CPU-NEXT:   %c = stablehlo.constant dense<84> : tensor<ui8>
+// CPU-NEXT:   %c_0 = stablehlo.constant dense<76> : tensor<ui8>
 // CPU-NEXT:   %c_1 = stablehlo.constant dense<64> : tensor<i64>
 // CPU-NEXT:   %c_2 = stablehlo.constant dense<32> : tensor<i64>
-// CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_1, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>) -> tensor<64x64xf32>
+// CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_2, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>) -> tensor<64x64xf32>
 // CPU-NEXT:   return %0 : tensor<64x64xf32>
 // CPU-NEXT: }
 // CPU-NEXT: llvm.func private @enzymexla_blas_ssyrk_wrapper(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr, %arg4: !llvm.ptr, %arg5: !llvm.ptr, %arg6: !llvm.ptr, %arg7: !llvm.ptr, %arg8: !llvm.ptr, %arg9: !llvm.ptr) {
@@ -74,11 +74,11 @@ module {
 }
 
 // CPU: func.func private @enzymexla_blas_ssyrk_wrapper_[[SYRKID:[0-9]+]](%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> tensor<64x64xf32> {
-// CPU-NEXT:   %c = stablehlo.constant dense<78> : tensor<ui8>
-// CPU-NEXT:   %c_0 = stablehlo.constant dense<76> : tensor<ui8>
+// CPU-NEXT:   %c = stablehlo.constant dense<84> : tensor<ui8>
+// CPU-NEXT:   %c_0 = stablehlo.constant dense<85> : tensor<ui8>
 // CPU-NEXT:   %c_1 = stablehlo.constant dense<64> : tensor<i64>
 // CPU-NEXT:   %c_2 = stablehlo.constant dense<32> : tensor<i64>
-// CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_1, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>) -> tensor<64x64xf32>
+// CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_2, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>) -> tensor<64x64xf32>
 // CPU-NEXT:   return %0 : tensor<64x64xf32>
 // CPU-NEXT: }
 // CPU-NEXT: llvm.func private @enzymexla_blas_ssyrk_wrapper(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr, %arg4: !llvm.ptr, %arg5: !llvm.ptr, %arg6: !llvm.ptr, %arg7: !llvm.ptr, %arg8: !llvm.ptr, %arg9: !llvm.ptr) {
@@ -126,11 +126,11 @@ module {
 }
 
 // CPU: func.func private @enzymexla_blas_ssyrk_wrapper_[[SYRKID:[0-9]+]](%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> tensor<64x64xf32> {
-// CPU-NEXT:   %c = stablehlo.constant dense<78> : tensor<ui8>
-// CPU-NEXT:   %c_0 = stablehlo.constant dense<76> : tensor<ui8>
+// CPU-NEXT:   %c = stablehlo.constant dense<84> : tensor<ui8>
+// CPU-NEXT:   %c_0 = stablehlo.constant dense<85> : tensor<ui8>
 // CPU-NEXT:   %c_1 = stablehlo.constant dense<64> : tensor<i64>
 // CPU-NEXT:   %c_2 = stablehlo.constant dense<32> : tensor<i64>
-// CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_1, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>) -> tensor<64x64xf32>
+// CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_2, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>) -> tensor<64x64xf32>
 // CPU-NEXT:   return %0 : tensor<64x64xf32>
 // CPU-NEXT: }
 // CPU-NEXT: llvm.func private @enzymexla_blas_ssyrk_wrapper(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr, %arg4: !llvm.ptr, %arg5: !llvm.ptr, %arg6: !llvm.ptr, %arg7: !llvm.ptr, %arg8: !llvm.ptr, %arg9: !llvm.ptr) {
@@ -177,11 +177,11 @@ module {
 }
 
 // CPU: func.func private @enzymexla_blas_ssyrk_wrapper_[[SYRKID:[0-9]+]](%arg0: tensor<5x4xf32>, %arg1: tensor<4x4xf32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> tensor<4x4xf32> {
-// CPU-NEXT:   %c = stablehlo.constant dense<84> : tensor<ui8>
-// CPU-NEXT:   %c_0 = stablehlo.constant dense<85> : tensor<ui8>
+// CPU-NEXT:   %c = stablehlo.constant dense<78> : tensor<ui8>
+// CPU-NEXT:   %c_0 = stablehlo.constant dense<76> : tensor<ui8>
 // CPU-NEXT:   %c_1 = stablehlo.constant dense<4> : tensor<i64>
 // CPU-NEXT:   %c_2 = stablehlo.constant dense<5> : tensor<i64>
-// CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_2, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<5x4xf32>, tensor<i64>, tensor<f32>, tensor<4x4xf32>, tensor<i64>) -> tensor<4x4xf32>
+// CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_1, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<5x4xf32>, tensor<i64>, tensor<f32>, tensor<4x4xf32>, tensor<i64>) -> tensor<4x4xf32>
 // CPU-NEXT:   return %0 : tensor<4x4xf32>
 // CPU-NEXT: }
 // CPU-NEXT: llvm.func private @enzymexla_blas_ssyrk_wrapper(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr, %arg4: !llvm.ptr, %arg5: !llvm.ptr, %arg6: !llvm.ptr, %arg7: !llvm.ptr, %arg8: !llvm.ptr, %arg9: !llvm.ptr) {
@@ -239,4 +239,17 @@ module {
 // CUDA-NEXT:   %4 = stablehlo.transpose %0, dims = [1, 0] : (tensor<64x64xf32>) -> tensor<64x64xf32>
 // CUDA-NEXT:   %5 = stablehlo.select %3, %0, %4 : tensor<64x64xi1>, tensor<64x64xf32>
 // CUDA-NEXT:   return %5 : tensor<64x64xf32>
+// CUDA-NEXT: }
+
+module {
+    func.func @main(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>, %alpha: tensor<f32>, %beta: tensor<f32>) -> tensor<64x64xf32> {
+        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {output_uplo = #enzymexla.uplo<L>, transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<U>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+        return %0 : tensor<64x64xf32>
+    }
+}
+
+// CUDA: func.func @main(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> tensor<64x64xf32> {
+// CUDA-NEXT:     %0 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %arg2, %arg3) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 0.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 0.000000e+00 : f64, transpose = false, uplo = true, use_alpha_attribute = false, use_beta_attribute = false}, enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>], operand_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+// CUDA-NEXT:     %1 = stablehlo.transpose %0, dims = [1, 0] : (tensor<64x64xf32>) -> tensor<64x64xf32>
+// CUDA-NEXT:     return %1 : tensor<64x64xf32>
 // CUDA-NEXT: }

--- a/test/lit_tests/linalg/syrk.mlir
+++ b/test/lit_tests/linalg/syrk.mlir
@@ -6,7 +6,7 @@ module {
     func.func @main1(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
         %alpha = stablehlo.constant dense<2.0> : tensor<f32>
         %beta = stablehlo.constant dense<3.0> : tensor<f32>
-        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {fill, transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<U>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {output_uplo = #enzymexla.uplo<F>, transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<U>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
         return %0 : tensor<64x64xf32>
     }
 }
@@ -40,7 +40,7 @@ module {
 // CUDA: func.func @main1(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
 // CUDA-NEXT:   %0 = tensor.empty() : tensor<0xf32>
 // CUDA-NEXT:   %1 = tensor.empty() : tensor<0xf32>
-// CUDA-NEXT:   %2 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %0, %1) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 2.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 3.000000e+00 : f64, transpose = false, uplo = true, use_alpha_attribute = true, use_beta_attribute = true}, enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>], operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<0xf32>, tensor<0xf32>) -> tensor<64x64xf32>
+// CUDA-NEXT:   %2 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %0, %1) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 2.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 3.000000e+00 : f64, transpose = false, uplo = true, use_alpha_attribute = true, use_beta_attribute = true}, enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>], operand_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<0xf32>, tensor<0xf32>) -> tensor<64x64xf32>
 // CUDA-NEXT:   %3 = stablehlo.iota dim = 0 : tensor<64x64xi32>
 // CUDA-NEXT:   %4 = stablehlo.iota dim = 1 : tensor<64x64xi32>
 // CUDA-NEXT:   %5 = stablehlo.compare  LT, %3, %4 : (tensor<64x64xi32>, tensor<64x64xi32>) -> tensor<64x64xi1>
@@ -68,7 +68,7 @@ module {
     func.func @main2(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
         %alpha = stablehlo.constant dense<2.0> : tensor<f32>
         %beta = stablehlo.constant dense<3.0> : tensor<f32>
-        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<L>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {output_uplo = #enzymexla.uplo<L>, transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<L>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
         return %0 : tensor<64x64xf32>
     }
 }
@@ -97,13 +97,8 @@ module {
 // CUDA: func.func @main2(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
 // CUDA-NEXT:   %0 = tensor.empty() : tensor<0xf32>
 // CUDA-NEXT:   %1 = tensor.empty() : tensor<0xf32>
-// CUDA-NEXT:   %2 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %0, %1) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 2.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 3.000000e+00 : f64, transpose = false, uplo = false, use_alpha_attribute = true, use_beta_attribute = true}, enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>], operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<0xf32>, tensor<0xf32>) -> tensor<64x64xf32>
-// CUDA-NEXT:   %3 = stablehlo.iota dim = 0 : tensor<64x64xi32>
-// CUDA-NEXT:   %4 = stablehlo.iota dim = 1 : tensor<64x64xi32>
-// CUDA-NEXT:   %5 = stablehlo.compare  LT, %3, %4 : (tensor<64x64xi32>, tensor<64x64xi32>) -> tensor<64x64xi1>
-// CUDA-NEXT:   %6 = stablehlo.transpose %2, dims = [1, 0] : (tensor<64x64xf32>) -> tensor<64x64xf32>
-// CUDA-NEXT:   %7 = stablehlo.select %5, %2, %6 : tensor<64x64xi1>, tensor<64x64xf32>
-// CUDA-NEXT:   return %7 : tensor<64x64xf32>
+// CUDA-NEXT:   %2 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %0, %1) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 2.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 3.000000e+00 : f64, transpose = false, uplo = false, use_alpha_attribute = true, use_beta_attribute = true}, operand_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<0xf32>, tensor<0xf32>) -> tensor<64x64xf32>
+// CUDA-NEXT:   return %2 : tensor<64x64xf32>
 // CUDA-NEXT: }
 
 // TPU: func.func @main2(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
@@ -125,14 +120,14 @@ module {
     func.func @main3(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
         %alpha = stablehlo.constant dense<2.0> : tensor<f32>
         %beta = stablehlo.constant dense<3.0> : tensor<f32>
-        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {output_uplo = #enzymexla.uplo<L>, transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<F>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
         return %0 : tensor<64x64xf32>
     }
 }
 
 // CPU: func.func private @enzymexla_blas_ssyrk_wrapper_[[SYRKID:[0-9]+]](%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> tensor<64x64xf32> {
 // CPU-NEXT:   %c = stablehlo.constant dense<78> : tensor<ui8>
-// CPU-NEXT:   %c_0 = stablehlo.constant dense<85> : tensor<ui8>
+// CPU-NEXT:   %c_0 = stablehlo.constant dense<76> : tensor<ui8>
 // CPU-NEXT:   %c_1 = stablehlo.constant dense<64> : tensor<i64>
 // CPU-NEXT:   %c_2 = stablehlo.constant dense<32> : tensor<i64>
 // CPU-NEXT:   %0 = enzymexla.jit_call @enzymexla_blas_ssyrk_wrapper (%c_0, %c, %c_1, %c_2, %arg2, %arg0, %c_1, %arg3, %arg1, %c_1) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 8, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>) -> tensor<64x64xf32>
@@ -154,7 +149,7 @@ module {
 // CUDA: func.func @main3(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x64xf32> {
 // CUDA-NEXT:   %0 = tensor.empty() : tensor<0xf32>
 // CUDA-NEXT:   %1 = tensor.empty() : tensor<0xf32>
-// CUDA-NEXT:   %2 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %0, %1) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 2.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 3.000000e+00 : f64, transpose = false, uplo = false, use_alpha_attribute = true, use_beta_attribute = true}, operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<0xf32>, tensor<0xf32>) -> tensor<64x64xf32>
+// CUDA-NEXT:   %2 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %0, %1) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 2.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 3.000000e+00 : f64, transpose = false, uplo = false, use_alpha_attribute = true, use_beta_attribute = true}, operand_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<0xf32>, tensor<0xf32>) -> tensor<64x64xf32>
 // CUDA-NEXT:   return %2 : tensor<64x64xf32>
 // CUDA-NEXT: }
 
@@ -174,7 +169,7 @@ module {
         %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<4x4xf32>
         %cst_1 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
         %cst_2 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-        %0 = enzymexla.blas.syrk %arg0, %cst_0, %cst_1, %cst_2 {fill, transpose = #enzymexla.transpose<transpose>, uplo = #enzymexla.uplo<U>} : (tensor<5x4xf32>, tensor<4x4xf32>, tensor<f32>, tensor<f32>) -> tensor<4x4xf32>
+        %0 = enzymexla.blas.syrk %arg0, %cst_0, %cst_1, %cst_2 {output_uplo = #enzymexla.uplo<F>, transpose = #enzymexla.transpose<transpose>, uplo = #enzymexla.uplo<U>} : (tensor<5x4xf32>, tensor<4x4xf32>, tensor<f32>, tensor<f32>) -> tensor<4x4xf32>
         %1 = stablehlo.multiply %cst, %arg1 : tensor<4x4xf32>
         %2 = stablehlo.add %0, %1 : tensor<4x4xf32>
         return %2 : tensor<4x4xf32>
@@ -212,15 +207,13 @@ module {
 // CUDA: func.func @main4(%arg0: tensor<5x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
 // CUDA-NEXT{LITERAL}:   %c = stablehlo.constant dense<[[false, true, true, true], [false, false, true, true], [false, false, false, true], [false, false, false, false]]> : tensor<4x4xi1>
 // CUDA-NEXT:   %cst = stablehlo.constant dense<5.000000e+00> : tensor<4x4xf32>
-// CUDA-NEXT:   %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<4x4xf32>
 // CUDA-NEXT:   %0 = tensor.empty() : tensor<0xf32>
-// CUDA-NEXT:   %1 = tensor.empty() : tensor<0xf32>
-// CUDA-NEXT:   %2 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %cst_0, %0, %1) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 1.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 0.000000e+00 : f64, transpose = true, uplo = true, use_alpha_attribute = true, use_beta_attribute = true}, enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>], operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<[0, 1]> : tensor<2xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>]} : (tensor<5x4xf32>, tensor<4x4xf32>, tensor<0xf32>, tensor<0xf32>) -> tensor<4x4xf32>
-// CUDA-NEXT:   %3 = stablehlo.transpose %2, dims = [1, 0] : (tensor<4x4xf32>) -> tensor<4x4xf32>
-// CUDA-NEXT:   %4 = stablehlo.select %c, %2, %3 : tensor<4x4xi1>, tensor<4x4xf32>
-// CUDA-NEXT:   %5 = stablehlo.multiply %cst, %arg1 : tensor<4x4xf32>
-// CUDA-NEXT:   %6 = stablehlo.add %4, %5 : tensor<4x4xf32>
-// CUDA-NEXT:   return %6 : tensor<4x4xf32>
+// CUDA-NEXT:   %1 = stablehlo.custom_call @reactant_cublas_syrk_no_c_ffi(%arg0, %0) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 1.000000e+00 : f64, transpose = true, uplo = true, use_alpha_attribute = true}, enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>], operand_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<0> : tensor<1xindex>], result_layouts = [dense<[1, 0]> : tensor<2xindex>]} : (tensor<5x4xf32>, tensor<0xf32>) -> tensor<4x4xf32>
+// CUDA-NEXT:   %2 = stablehlo.transpose %1, dims = [1, 0] : (tensor<4x4xf32>) -> tensor<4x4xf32>
+// CUDA-NEXT:   %3 = stablehlo.select %c, %1, %2 : tensor<4x4xi1>, tensor<4x4xf32>
+// CUDA-NEXT:   %4 = stablehlo.multiply %cst, %arg1 : tensor<4x4xf32>
+// CUDA-NEXT:   %5 = stablehlo.add %3, %4 : tensor<4x4xf32>
+// CUDA-NEXT:   return %5 : tensor<4x4xf32>
 // CUDA-NEXT: }
 
 // TPU: func.func @main4(%arg0: tensor<5x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
@@ -233,13 +226,13 @@ module {
 
 module {
     func.func @main(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>, %alpha: tensor<f32>, %beta: tensor<f32>) -> tensor<64x64xf32> {
-        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {fill, transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<U>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+        %0 = enzymexla.blas.syrk %arg0, %arg1, %alpha, %beta {output_uplo = #enzymexla.uplo<F>, transpose = #enzymexla.transpose<none>, uplo = #enzymexla.uplo<U>} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
         return %0 : tensor<64x64xf32>
     }
 }
 
 // CUDA: func.func @main(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> tensor<64x64xf32> {
-// CUDA-NEXT:   %0 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %arg2, %arg3) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 0.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 0.000000e+00 : f64, transpose = false, uplo = true, use_alpha_attribute = false, use_beta_attribute = false}, enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>], operand_layouts = [dense<[0, 1]> : tensor<2xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
+// CUDA-NEXT:   %0 = stablehlo.custom_call @reactant_cublas_syrk_ffi(%arg0, %arg1, %arg2, %arg3) {api_version = 4 : i32, backend_config = {alpha_imag = 0.000000e+00 : f64, alpha_real = 0.000000e+00 : f64, beta_imag = 0.000000e+00 : f64, beta_real = 0.000000e+00 : f64, transpose = false, uplo = true, use_alpha_attribute = false, use_beta_attribute = false}, enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>], operand_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>]} : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<f32>, tensor<f32>) -> tensor<64x64xf32>
 // CUDA-NEXT:   %1 = stablehlo.iota dim = 0 : tensor<64x64xi32>
 // CUDA-NEXT:   %2 = stablehlo.iota dim = 1 : tensor<64x64xi32>
 // CUDA-NEXT:   %3 = stablehlo.compare  LT, %1, %2 : (tensor<64x64xi32>, tensor<64x64xi32>) -> tensor<64x64xi1>

--- a/test/lit_tests/newton_schulz_to_syrksymm.mlir
+++ b/test/lit_tests/newton_schulz_to_syrksymm.mlir
@@ -45,14 +45,13 @@ module {
 // CHECK-NEXT:       stablehlo.return %1 : tensor<i1>
 // CHECK-NEXT:     } do {
 // CHECK-NEXT:       %1 = stablehlo.add %iterArg, %c_5 {enzymexla.bounds = {{.*}}} : tensor<i64>
-// CHECK-NEXT:       %2 = enzymexla.blas.syrk %iterArg_7, %cst_3, %cst_2, %cst_1 {fill, transpose = #enzymexla.transpose<transpose>, uplo = #enzymexla.uplo<F>} : (tensor<5x4xf32>, tensor<4x4xf32>, tensor<f32>, tensor<f32>) -> tensor<4x4xf32>
+// CHECK-NEXT:       %2 = enzymexla.blas.syrk %iterArg_7, %cst_3, %cst_2, %cst_1 {output_uplo = #enzymexla.uplo<F>, transpose = #enzymexla.transpose<transpose>, uplo = #enzymexla.uplo<F>} : (tensor<5x4xf32>, tensor<4x4xf32>, tensor<f32>, tensor<f32>) -> tensor<4x4xf32>
 // CHECK-NEXT:       %3 = stablehlo.multiply %cst_6, %2 {enzymexla.symmetric_matrix = [#enzymexla<guaranteed GUARANTEED>]} : tensor<4x4xf32>
 // CHECK-NEXT:       %4 = stablehlo.add %3, %cst : tensor<4x4xf32>
-// CHECK-NEXT:       %5 = enzymexla.blas.syrk %2, %4, %cst_0, %cst_2 {fill, uplo = #enzymexla.uplo<F>} : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<f32>, tensor<f32>) -> tensor<4x4xf32>
+// CHECK-NEXT:       %5 = enzymexla.blas.syrk %2, %4, %cst_0, %cst_2 {output_uplo = #enzymexla.uplo<F>, uplo = #enzymexla.uplo<F>} : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<f32>, tensor<f32>) -> tensor<4x4xf32>
 // CHECK-NEXT:       %6 = stablehlo.dot_general %iterArg_7, %5, contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<5x4xf32>, tensor<4x4xf32>) -> tensor<5x4xf32>
 // CHECK-NEXT:       stablehlo.return %1, %6 : tensor<i64>, tensor<5x4xf32>
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return %0#1 : tensor<5x4xf32>
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
-

--- a/test/lit_tests/syrk_fill_removal.mlir
+++ b/test/lit_tests/syrk_fill_removal.mlir
@@ -1,0 +1,273 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// Test 1: Basic chain - syrk with output_uplo=F feeds into another syrk with uplo=U
+// Expected: output_uplo should be set to U, child syrk's uplo should also be U
+func.func @test_basic_chain_upper(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xf32>
+
+    // First SYRK with output_uplo=F
+    %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    // Second SYRK with uplo=U requires the input C to have U layout
+    %1 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<U>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    return %1 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @test_basic_chain_upper
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: output_uplo = #enzymexla.uplo<U>
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: uplo = #enzymexla.uplo<U>
+
+
+// Test 2: Chain with lower triangular - syrk feeds into syrk with uplo=L
+// Expected: output_uplo should be set to L
+func.func @test_basic_chain_lower(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xf32>
+
+    %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<none>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    %1 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<L>,
+        transpose = #enzymexla.transpose<none>,
+        uplo = #enzymexla.uplo<L>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    return %1 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @test_basic_chain_lower
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: output_uplo = #enzymexla.uplo<L>
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: uplo = #enzymexla.uplo<L>
+
+
+// Test 3: Chain with elementwise ops in between
+// Expected: Should still propagate through elementwise ops
+func.func @test_elementwise_chain(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %cst = stablehlo.constant dense<3.444500e+00> : tensor<32x32xf32>
+    %cst_0 = stablehlo.constant dense<2.031500e+00> : tensor<f32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %cst_2 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %cst_3 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xf32>
+    %cst_4 = stablehlo.constant dense<-4.775000e+00> : tensor<32x32xf32>
+
+    // First SYRK with output_uplo=F
+    %0 = enzymexla.blas.syrk %arg0, %cst_3, %cst_2, %cst_1 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    // Elementwise operations
+    %1 = stablehlo.add %0, %arg1 : tensor<32x32xf32>
+    %2 = stablehlo.multiply %cst_4, %1 : tensor<32x32xf32>
+
+    // Second SYRK uses %2 as C (derived from %0)
+    %3 = enzymexla.blas.syrk %arg0, %2, %cst_0, %cst_2 {
+        output_uplo = #enzymexla.uplo<F>,
+        uplo = #enzymexla.uplo<U>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    return %3 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @test_elementwise_chain
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: output_uplo = #enzymexla.uplo<U>
+// CHECK: stablehlo.add
+// CHECK: stablehlo.multiply
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: uplo = #enzymexla.uplo<U>
+
+
+// Test 4: Multiple child syrk ops with same uplo
+// Expected: All children get the same uplo propagated
+func.func @test_multiple_children_same_uplo(%arg0: tensor<32x32xf32>) -> (tensor<32x32xf32>, tensor<32x32xf32>) {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xf32>
+
+    // Parent SYRK
+    %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    // Two child SYRKs, both with uplo=L
+    %1 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<L>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<L>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    %2 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<L>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<L>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    return %1, %2 : tensor<32x32xf32>, tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @test_multiple_children_same_uplo
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: output_uplo = #enzymexla.uplo<L>
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: uplo = #enzymexla.uplo<L>
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: uplo = #enzymexla.uplo<L>
+
+
+// Test 5: Conflicting uplos - should NOT transform
+// Expected: No transformation when children have conflicting uplos (U and L)
+func.func @test_conflicting_uplos(%arg0: tensor<32x32xf32>) -> (tensor<32x32xf32>, tensor<32x32xf32>) {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xf32>
+
+    // Parent SYRK
+    %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    // Two child SYRKs with CONFLICTING uplos
+    %1 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<U>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<U>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    %2 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<L>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<L>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    return %1, %2 : tensor<32x32xf32>, tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @test_conflicting_uplos
+// Parent SYRK should still have output_uplo = F due to conflict
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: output_uplo = #enzymexla.uplo<F>
+
+
+// Test 6: Non-elementwise user blocks optimization
+// Expected: No transformation when result is used by non-elementwise op
+func.func @test_non_elementwise_user(%arg0: tensor<32x32xf32>) -> (tensor<32x32xf32>, tensor<32x32xf32>) {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xf32>
+
+    // Parent SYRK
+    %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    // One user is a syrk
+    %1 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<U>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<U>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    // Return the original result - this creates an escape that prevents optimization
+    return %1, %0 : tensor<32x32xf32>, tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @test_non_elementwise_user
+// Parent SYRK should still have output_uplo = F due to non-syrk user
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: output_uplo = #enzymexla.uplo<F>
+
+
+// Test 7: All children have uplo=F, choose based on output_uplo majority (upper wins)
+func.func @test_all_f_children_upper_majority(%arg0: tensor<32x32xf32>) -> (tensor<32x32xf32>, tensor<32x32xf32>) {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xf32>
+
+    // Parent SYRK
+    %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    // Children with uplo=F but different output_uplo preferences
+    %1 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<U>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    %2 = enzymexla.blas.syrk %arg0, %0, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<U>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    return %1, %2 : tensor<32x32xf32>, tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @test_all_f_children_upper_majority
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: output_uplo = #enzymexla.uplo<U>
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: uplo = #enzymexla.uplo<U>
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: uplo = #enzymexla.uplo<U>
+
+
+// Test 8: Syrk used as A operand should not block the optimization
+// The optimization only looks at uses as C operand
+func.func @test_syrk_as_a_operand(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xf32>
+
+    // Parent SYRK
+    %0 = enzymexla.blas.syrk %arg0, %cst_1, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<F>,
+        transpose = #enzymexla.transpose<transpose>,
+        uplo = #enzymexla.uplo<F>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    // Child SYRK uses result as A, not C - should fail the pattern
+    %1 = enzymexla.blas.syrk %0, %cst_1, %cst, %cst_0 {
+        output_uplo = #enzymexla.uplo<U>,
+        transpose = #enzymexla.transpose<none>,
+        uplo = #enzymexla.uplo<U>
+    } : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<f32>, tensor<f32>) -> tensor<32x32xf32>
+
+    return %1 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @test_syrk_as_a_operand
+// Should NOT transform since child syrk uses result as A operand, not C
+// CHECK: enzymexla.blas.syrk
+// CHECK-SAME: output_uplo = #enzymexla.uplo<F>


### PR DESCRIPTION
- updates the syrk op to have an output_uplo attr (replacing the old fill attr)
- simplifies output_uplo to minimize copies
- improves the cuda lowering to allow minimize layout changes