### PR TITLE
Remove unused pybind header

### DIFF
--- a/src/enzyme_ad/jax/enzyme_call.cc
+++ b/src/enzyme_ad/jax/enzyme_call.cc
@@ -43,7 +43,6 @@
 #include "mlir-c/Bindings/Python/Interop.h"
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
-#include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"


### PR DESCRIPTION
This file migrated from pybind11 to nanobind in ab4b1bbcfe414c9e7c2faa6bb4f0bbd295b5bed5, but left in a pybind header from MLIR. It is unused in this file and pending removal in LLVM: https://github.com/llvm/llvm-project/pull/172581.