### PR TITLE
fix: scatter reverse mode derivative rules

### DIFF
--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -928,7 +928,53 @@ getGatherDims(mlir::MLIRContext *ctx,
 
 bool isSetindexBlock(mlir::Block *block);
 
-template <typename T> bool isCommutativeOpBlock(mlir::Block *block) {
+// rhs is only considered if commutative is false
+template <typename T, bool commutative, bool rhs>
+bool isOnlyOpBlock(mlir::Block *block) {
+  if (block->getNumArguments() != 2)
+    return false;
+
+  if (!hasSingleElement(block->without_terminator()))
+    return false;
+
+  auto op = dyn_cast<T>(block->front());
+  if (!op)
+    return false;
+
+  if (op.getNumOperands() != 2)
+    return false;
+
+  if constexpr (commutative) {
+    if (!(op->getOperand(0) == block->getArgument(0) &&
+          op->getOperand(1) == block->getArgument(1)) &&
+        !(op->getOperand(0) == block->getArgument(1) &&
+          op->getOperand(1) == block->getArgument(0)))
+      return false;
+  } else {
+    if constexpr (rhs) {
+      if (!(op->getOperand(0) == block->getArgument(0) &&
+            op->getOperand(1) == block->getArgument(1)))
+        return false;
+    } else {
+      if (!(op->getOperand(0) == block->getArgument(1) &&
+            op->getOperand(1) == block->getArgument(0)))
+        return false;
+    }
+  }
+
+  auto returnOp = block->getTerminator();
+  auto stablehloReturnOp = dyn_cast<stablehlo::ReturnOp>(returnOp);
+  if (!stablehloReturnOp)
+    return false;
+
+  if (stablehloReturnOp.getNumOperands() != 1)
+    return false;
+
+  // The returned value should be the result of the addition
+  return stablehloReturnOp.getOperand(0) == op.getResult();
+}
+
+template <typename T> bool isRhsOpBlock(mlir::Block *block) {
   if (block->getNumArguments() != 2)
     return false;
 
@@ -943,9 +989,7 @@ template <typename T> bool isCommutativeOpBlock(mlir::Block *block) {
     return false;
 
   if (!(op->getOperand(0) == block->getArgument(0) &&
-        op->getOperand(1) == block->getArgument(1)) &&
-      !(op->getOperand(0) == block->getArgument(1) &&
-        op->getOperand(1) == block->getArgument(0)))
+        op->getOperand(1) == block->getArgument(1)))
     return false;
 
   auto returnOp = block->getTerminator();
@@ -984,13 +1028,13 @@ public:
     }
 
     auto &block = region.getBlocks().front();
-    isAddReduce = isCommutativeOpBlock<stablehlo::AddOp>(&block);
-    isMinReduce = isCommutativeOpBlock<stablehlo::MinOp>(&block);
-    isMaxReduce = isCommutativeOpBlock<stablehlo::MaxOp>(&block);
-    isMulReduce = isCommutativeOpBlock<stablehlo::MulOp>(&block);
-    isAndReduce = isCommutativeOpBlock<stablehlo::AndOp>(&block);
-    isOrReduce = isCommutativeOpBlock<stablehlo::OrOp>(&block);
-    isXorReduce = isCommutativeOpBlock<stablehlo::XorOp>(&block);
+    isAddReduce = isOnlyOpBlock<stablehlo::AddOp, true, false>(&block);
+    isMinReduce = isOnlyOpBlock<stablehlo::MinOp, true, false>(&block);
+    isMaxReduce = isOnlyOpBlock<stablehlo::MaxOp, true, false>(&block);
+    isMulReduce = isOnlyOpBlock<stablehlo::MulOp, true, false>(&block);
+    isAndReduce = isOnlyOpBlock<stablehlo::AndOp, true, false>(&block);
+    isOrReduce = isOnlyOpBlock<stablehlo::OrOp, true, false>(&block);
+    isXorReduce = isOnlyOpBlock<stablehlo::XorOp, true, false>(&block);
   }
 };
 
@@ -998,6 +1042,13 @@ struct CheckCommonScatterOp {
 public:
   bool isSetindexScatter;
   bool isAddScatter;
+  bool isMinScatter;
+  bool isMaxScatter;
+  bool isMulScatter;
+  bool isAndScatter;
+  bool isOrScatter;
+  bool isXorScatter;
+  bool isSubScatter;
 
   CheckCommonScatterOp(stablehlo::ScatterOp op) {
     auto &updateComputation = op.getUpdateComputation();
@@ -1005,12 +1056,26 @@ public:
     if (!updateComputation.hasOneBlock()) {
       isSetindexScatter = false;
       isAddScatter = false;
+      isMinScatter = false;
+      isMaxScatter = false;
+      isMulScatter = false;
+      isAndScatter = false;
+      isOrScatter = false;
+      isXorScatter = false;
+      isSubScatter = false;
       return;
     }
 
     auto &block = updateComputation.front();
     isSetindexScatter = isSetindexBlock(&block);
-    isAddScatter = isCommutativeOpBlock<stablehlo::AddOp>(&block);
+    isAddScatter = isOnlyOpBlock<stablehlo::AddOp, true, false>(&block);
+    isMulScatter = isOnlyOpBlock<stablehlo::MulOp, true, false>(&block);
+    isMinScatter = isOnlyOpBlock<stablehlo::MinOp, true, false>(&block);
+    isMaxScatter = isOnlyOpBlock<stablehlo::MaxOp, true, false>(&block);
+    isAndScatter = isOnlyOpBlock<stablehlo::AndOp, true, false>(&block);
+    isOrScatter = isOnlyOpBlock<stablehlo::OrOp, true, false>(&block);
+    isXorScatter = isOnlyOpBlock<stablehlo::XorOp, true, false>(&block);
+    isSubScatter = isOnlyOpBlock<stablehlo::SubtractOp, false, true>(&block);
   }
 };
 

--- a/test/bench_vs_xla.py
+++ b/test/bench_vs_xla.py
@@ -234,11 +234,7 @@ class ConstScatter(EnzymeJaxTest):
         N = 1024**2
         self.ins = [jnp.full(N, 2.7)]
         self.dins = [jnp.full(N, 3.1)]
-        self.douts = (self.dins[0],)
-
-        # TODO: support multiply for scatter reverse mode
-        self.revfilter = lambda _: []
-        # self.revfilter = justjax
+        self.douts = (jnp.array(5.0),)
 
 
 class ScatterSum(EnzymeJaxTest):

--- a/test/jaxmd.py
+++ b/test/jaxmd.py
@@ -100,14 +100,7 @@ class JAXMD(EnzymeJaxTest):
         # for i, v in enumerate(self.ins):
         #    print("i=", i, v)
         self.dins = [x.copy() for x in self.ins]
-        self.douts = tuple(x.copy() for x in self.ins)
-
-        # No support for stablehlo.scatter atm
-        # self.revfilter = justjax
-        self.mlirad_rev = False
-
-        # TODO: This is horribly slow for reasons which are unknown.
-        # self.mlirad_fwd = False
+        self.douts = [x.copy() for x in self.ins]
 
         self.atol = 5e-3
         self.rtol = 1e-3

--- a/test/lit_tests/diffrules/stablehlo/scatter2.mlir
+++ b/test/lit_tests/diffrules/stablehlo/scatter2.mlir
@@ -1,0 +1,277 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_active,enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --split-input-file | FileCheck %s
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<460000x1xi32>, %update : tensor<460000x3xf32>) -> tensor<8000x3xf32> {
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.add %arg3, %arg4 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<460000x1xi32>, %arg2: tensor<460000x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>) {
+// CHECK-NEXT:    %cst = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:    %cst_0 = arith.constant dense<0.000000e+00> : tensor<460000x3xf32>
+// CHECK-NEXT:    %cst_1 = arith.constant dense<0> : tensor<460000x1xi32>
+// CHECK-NEXT:    %0 = arith.addf %arg3, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:    %1 = arith.addf %0, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:    %2 = "stablehlo.gather"(%0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 3>}> : (tensor<8000x3xf32>, tensor<460000x1xi32>) -> tensor<460000x3xf32>
+// CHECK-NEXT:    %3 = arith.addf %2, %cst_0 : tensor<460000x3xf32>
+// CHECK-NEXT:    return %1, %cst_1, %3 : tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>
+// CHECK-NEXT:  }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<4600x1xi32>, %update : tensor<4600x3xf32>) -> tensor<8000x3xf32> {
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.multiply %arg3, %arg4 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<4600x1xi32>, %arg2: tensor<4600x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) {
+// CHECK-NEXT:   %cst = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:   %cst_0 = arith.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %cst_1 = arith.constant dense<0> : tensor<4600x1xi32>
+// CHECK-NEXT:   %0 = arith.addf %arg3, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:   %1 = "stablehlo.scatter"(%0, %arg1, %arg2) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:   ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
+// CHECK-NEXT:     %6 = stablehlo.multiply %arg4, %arg5 : tensor<f32>
+// CHECK-NEXT:     stablehlo.return %6 : tensor<f32>
+// CHECK-NEXT:   }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+// CHECK-NEXT:   %2 = arith.addf %1, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:   %3 = stablehlo.multiply %0, %arg0 : tensor<8000x3xf32>
+// CHECK-NEXT:   %4 = "stablehlo.gather"(%3, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 3>}> : (tensor<8000x3xf32>, tensor<4600x1xi32>) -> tensor<4600x3xf32>
+// CHECK-NEXT:   %5 = arith.addf %4, %cst_0 : tensor<4600x3xf32>
+// CHECK-NEXT:   return %2, %cst_1, %5 : tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>
+// CHECK-NEXT: }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<460000x1xi32>, %update : tensor<460000x3xf32>) -> tensor<8000x3xf32> {
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.subtract %arg3, %arg4 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<460000x1xi32>, %arg2: tensor<460000x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>) {
+// CHECK-NEXT:   %cst = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:   %cst_0 = arith.constant dense<0.000000e+00> : tensor<460000x3xf32>
+// CHECK-NEXT:   %cst_1 = arith.constant dense<0> : tensor<460000x1xi32>
+// CHECK-NEXT:   %0 = arith.addf %arg3, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:   %1 = arith.addf %0, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:   %2 = "stablehlo.gather"(%0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 3>}> : (tensor<8000x3xf32>, tensor<460000x1xi32>) -> tensor<460000x3xf32>
+// CHECK-NEXT:   %3 = stablehlo.negate %2 : tensor<460000x3xf32>
+// CHECK-NEXT:   %4 = arith.addf %3, %cst_0 : tensor<460000x3xf32>
+// CHECK-NEXT:   return %1, %cst_1, %4 : tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>
+// CHECK-NEXT: }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<460000x1xi32>, %update : tensor<460000x3xf32>) -> tensor<8000x3xf32> {
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      stablehlo.return %arg4 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<460000x1xi32>, %arg2: tensor<460000x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>) {
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:   %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<460000x3xf32>
+// CHECK-NEXT:   %cst_1 = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:   %cst_2 = arith.constant dense<0.000000e+00> : tensor<460000x3xf32>
+// CHECK-NEXT:   %cst_3 = arith.constant dense<0> : tensor<460000x1xi32>
+// CHECK-NEXT:   %0 = arith.addf %arg3, %cst_1 : tensor<8000x3xf32>
+// CHECK-NEXT:   %1 = "stablehlo.scatter"(%0, %arg1, %cst_0) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:   ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
+// CHECK-NEXT:     stablehlo.return %cst : tensor<f32>
+// CHECK-NEXT:   }) : (tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>) -> tensor<8000x3xf32>
+// CHECK-NEXT:   %2 = arith.addf %1, %cst_1 : tensor<8000x3xf32>
+// CHECK-NEXT:   %3 = "stablehlo.gather"(%0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 3>}> : (tensor<8000x3xf32>, tensor<460000x1xi32>) -> tensor<460000x3xf32>
+// CHECK-NEXT:   %4 = arith.addf %3, %cst_2 : tensor<460000x3xf32>
+// CHECK-NEXT:   return %2, %cst_3, %4 : tensor<8000x3xf32>, tensor<460000x1xi32>, tensor<460000x3xf32>
+// CHECK-NEXT: }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<4600x1xi32>, %update : tensor<4600x3xf32>) -> tensor<8000x3xf32> {
+    %cst = stablehlo.constant dense<5.0> : tensor<f32>
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.multiply %cst, %arg4 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<4600x1xi32>, %arg2: tensor<4600x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<5.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:    %cst_2 = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:    %cst_3 = arith.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:    %cst_4 = arith.constant dense<0> : tensor<4600x1xi32>
+// CHECK-NEXT:    %0 = arith.addf %arg3, %cst_2 : tensor<8000x3xf32>
+// CHECK-NEXT:    %1 = "stablehlo.scatter"(%0, %arg1, %cst_1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:    ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
+// CHECK-NEXT:      stablehlo.return %cst_0 : tensor<f32>
+// CHECK-NEXT:    }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+// CHECK-NEXT:    %2 = arith.addf %1, %cst_2 : tensor<8000x3xf32>
+// CHECK-NEXT:    %3 = stablehlo.multiply %0, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:    %4 = "stablehlo.gather"(%3, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 3>}> : (tensor<8000x3xf32>, tensor<4600x1xi32>) -> tensor<4600x3xf32>
+// CHECK-NEXT:    %5 = arith.addf %4, %cst_3 : tensor<4600x3xf32>
+// CHECK-NEXT:    return %2, %cst_4, %5 : tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>
+// CHECK-NEXT:  }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<4600x1xi32>, %update : tensor<4600x3xf32>) -> tensor<8000x3xf32> {
+    %cst = stablehlo.constant dense<5.0> : tensor<f32>
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.add %cst, %arg3 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<4600x1xi32>, %arg2: tensor<4600x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) {
+// CHECK-NEXT:   %cst = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:   %cst_0 = arith.constant dense<0> : tensor<4600x1xi32>
+// CHECK-NEXT:   %cst_1 = arith.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %0 = arith.addf %arg3, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:   %1 = arith.addf %0, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:   return %1, %cst_0, %cst_1 : tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>
+// CHECK-NEXT: }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<4600x1xi32>, %update : tensor<4600x3xf32>) -> tensor<8000x3xf32> {
+    %cst = stablehlo.constant dense<5.0> : tensor<f32>
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.add %arg3, %cst : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<4600x1xi32>, %arg2: tensor<4600x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) {
+// CHECK-NEXT:   %cst = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:   %cst_0 = arith.constant dense<0> : tensor<4600x1xi32>
+// CHECK-NEXT:   %cst_1 = arith.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %0 = arith.addf %arg3, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:   %1 = arith.addf %0, %cst : tensor<8000x3xf32>
+// CHECK-NEXT:   return %1, %cst_0, %cst_1 : tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>
+// CHECK-NEXT: }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<4600x1xi32>, %update : tensor<4600x3xf32>) -> tensor<8000x3xf32> {
+    %cst = stablehlo.constant dense<5.0> : tensor<f32>
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.add %arg4, %cst : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<4600x1xi32>, %arg2: tensor<4600x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) {
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:   %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %cst_1 = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:   %cst_2 = arith.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %cst_3 = arith.constant dense<0> : tensor<4600x1xi32>
+// CHECK-NEXT:   %0 = arith.addf %arg3, %cst_1 : tensor<8000x3xf32>
+// CHECK-NEXT:   %1 = "stablehlo.scatter"(%0, %arg1, %cst_0) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:     ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
+// CHECK-NEXT:       stablehlo.return %cst : tensor<f32>
+// CHECK-NEXT:     }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+// CHECK-NEXT:   %2 = arith.addf %1, %cst_1 : tensor<8000x3xf32>
+// CHECK-NEXT:   %3 = "stablehlo.gather"(%0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [1], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 3>}> : (tensor<8000x3xf32>, tensor<4600x1xi32>) -> tensor<4600x3xf32>
+// CHECK-NEXT:   %4 = arith.addf %3, %cst_2 : tensor<4600x3xf32>
+// CHECK-NEXT:   return %2, %cst_3, %4 : tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>
+// CHECK-NEXT: }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<4600x1xi32>, %update : tensor<4600x3xf32>) -> tensor<8000x3xf32> {
+    %cst = stablehlo.constant dense<5.0> : tensor<f32>
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.multiply %arg3, %cst : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<4600x1xi32>, %arg2: tensor<4600x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) {
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %cst_0 = stablehlo.constant dense<5.000000e+00> : tensor<f32>
+// CHECK-NEXT:   %cst_1 = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:   %cst_2 = arith.constant dense<0> : tensor<4600x1xi32>
+// CHECK-NEXT:   %cst_3 = arith.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %0 = arith.addf %arg3, %cst_1 : tensor<8000x3xf32>
+// CHECK-NEXT:   %1 = "stablehlo.scatter"(%0, %arg1, %cst) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:   ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
+// CHECK-NEXT:     %3 = stablehlo.multiply %arg4, %cst_0 : tensor<f32>
+// CHECK-NEXT:     stablehlo.return %3 : tensor<f32>
+// CHECK-NEXT:   }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+// CHECK-NEXT:   %2 = arith.addf %1, %cst_1 : tensor<8000x3xf32>
+// CHECK-NEXT:   return %2, %cst_2, %cst_3 : tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>
+// CHECK-NEXT: }
+
+// -----
+
+module {
+  func.func @main(%prev : tensor<8000x3xf32>, %idxs : tensor<4600x1xi32>, %update : tensor<4600x3xf32>) -> tensor<8000x3xf32> {
+    %cst = stablehlo.constant dense<5.0> : tensor<f32>
+    %0 = "stablehlo.scatter"(%prev, %idxs, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
+      %1 = stablehlo.multiply %cst, %arg3 : tensor<f32>
+      stablehlo.return %1 : tensor<f32>
+    }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+    return %0 : tensor<8000x3xf32>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<8000x3xf32>, %arg1: tensor<4600x1xi32>, %arg2: tensor<4600x3xf32>, %arg3: tensor<8000x3xf32>) -> (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) {
+// CHECK-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %cst_0 = stablehlo.constant dense<5.000000e+00> : tensor<f32>
+// CHECK-NEXT:   %cst_1 = arith.constant dense<0.000000e+00> : tensor<8000x3xf32>
+// CHECK-NEXT:   %cst_2 = arith.constant dense<0> : tensor<4600x1xi32>
+// CHECK-NEXT:   %cst_3 = arith.constant dense<0.000000e+00> : tensor<4600x3xf32>
+// CHECK-NEXT:   %0 = arith.addf %arg3, %cst_1 : tensor<8000x3xf32>
+// CHECK-NEXT:   %1 = "stablehlo.scatter"(%0, %arg1, %cst) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:   ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
+// CHECK-NEXT:     %3 = stablehlo.multiply %arg4, %cst_0 : tensor<f32>
+// CHECK-NEXT:     stablehlo.return %3 : tensor<f32>
+// CHECK-NEXT:   }) : (tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>) -> tensor<8000x3xf32>
+// CHECK-NEXT:   %2 = arith.addf %1, %cst_1 : tensor<8000x3xf32>
+// CHECK-NEXT:   return %2, %cst_2, %cst_3 : tensor<8000x3xf32>, tensor<4600x1xi32>, tensor<4600x3xf32>
+// CHECK-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/scatteradd.mlir
+++ b/test/lit_tests/diffrules/stablehlo/scatteradd.mlir
@@ -1,23 +1,25 @@
 // TODO: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup,enzyme_dup mode=ForwardMode" | FileCheck %s --check-prefix=FORWARD
-// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_dup mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
 
 module {
-  func.func public @main(%arg0: tensor<2x5xf32>, %arg1: tensor<2x5xf32>) -> (tensor<2x5xf32>) {
+  func.func public @main(%arg0: tensor<10x5xf32>, %arg1: tensor<2x5xf32>) -> (tensor<10x5xf32>) {
     %c = stablehlo.constant dense<[[3, 1, 0, 4, 2]]> : tensor<1x5xi32>
     %2 = "stablehlo.scatter"(%arg0, %c, %arg1) <{scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0], inserted_window_dims = [1], scatter_dims_to_operand_dims = [1]>, unique_indices = true}> ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>) :
       %5 = stablehlo.add %arg2, %arg3 : tensor<f32>
       stablehlo.return %5 : tensor<f32>
-    }) : (tensor<2x5xf32>, tensor<1x5xi32>, tensor<2x5xf32>) -> tensor<2x5xf32>
-    return %2 : tensor<2x5xf32>
+    }) : (tensor<10x5xf32>, tensor<1x5xi32>, tensor<2x5xf32>) -> tensor<10x5xf32>
+    return %2 : tensor<10x5xf32>
   }
 }
 
-// REVERSE: func.func @main(%arg0: tensor<2x5xf32>, %arg1: tensor<2x5xf32>, %arg2: tensor<2x5xf32>, %arg3: tensor<2x5xf32>) -> tensor<2x5xf32> {
-// REVERSE-NEXT:    %c = stablehlo.constant dense<{{\[\[}}3, 1, 0, 4, 2{{\]\]}}> : tensor<1x5xi32>
-// REVERSE-NEXT:    %cst = arith.constant dense<0.000000e+00> : tensor<2x5xf32>
-// REVERSE-NEXT:    %0 = arith.addf %arg3, %cst : tensor<2x5xf32>
-// REVERSE-NEXT:    %1 = "stablehlo.gather"(%0, %c) <{dimension_numbers = #stablehlo.gather<offset_dims = [0], collapsed_slice_dims = [1], start_index_map = [1]>, slice_sizes = array<i64: 2, 1>}> : (tensor<2x5xf32>, tensor<1x5xi32>) -> tensor<2x5xf32>
-// REVERSE-NEXT:      %2 = arith.addf %1, %cst : tensor<2x5xf32>
-// REVERSE-NEXT:      return %2 : tensor<2x5xf32>
-// REVERSE-NEXT:    }
+// REVERSE: func.func @main(%arg0: tensor<10x5xf32>, %arg1: tensor<2x5xf32>, %arg2: tensor<10x5xf32>) -> (tensor<10x5xf32>, tensor<2x5xf32>) {
+// REVERSE-NEXT{LITERAL}:   %c = stablehlo.constant dense<[[3, 1, 0, 4, 2]]> : tensor<1x5xi32>
+// REVERSE-NEXT:   %cst = arith.constant dense<0.000000e+00> : tensor<10x5xf32>
+// REVERSE-NEXT:   %cst_0 = arith.constant dense<0.000000e+00> : tensor<2x5xf32>
+// REVERSE-NEXT:   %0 = arith.addf %arg2, %cst : tensor<10x5xf32>
+// REVERSE-NEXT:   %1 = arith.addf %0, %cst : tensor<10x5xf32>
+// REVERSE-NEXT:   %2 = "stablehlo.gather"(%0, %c) <{dimension_numbers = #stablehlo.gather<offset_dims = [0], collapsed_slice_dims = [1], start_index_map = [1]>, slice_sizes = array<i64: 2, 1>}> : (tensor<10x5xf32>, tensor<1x5xi32>) -> tensor<2x5xf32>
+// REVERSE-NEXT:   %3 = arith.addf %2, %cst_0 : tensor<2x5xf32>
+// REVERSE-NEXT:   return %1, %3 : tensor<10x5xf32>, tensor<2x5xf32>
+// REVERSE-NEXT: }

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -770,14 +770,17 @@ class EnzymeJaxTest(absltest.TestCase):
 
                         primals, tangents = fwd_enzyme(*(ins_backend + dins_backend))
 
-                        recursive_check(
-                            self,
-                            primals,
-                            primres,
-                            self.atol,
-                            self.rtol,
-                            "Primal " + pname,
-                        )
+                        if primres is None:
+                            primres = primals
+                        else:
+                            recursive_check(
+                                self,
+                                primals,
+                                primres,
+                                self.atol,
+                                self.rtol,
+                                "Primal " + pname,
+                            )
 
                         if fwdres is None:
                             fwdres = tangents


### PR DESCRIPTION
- fixes the slice sizes
- support added for `sub` and `mul` (also a bunch where one of the operands is a constant)