### PR TITLE
fix: disable raising scatter

### DIFF
--- a/src/enzyme_ad/jax/Implementations/WhileLoopInfo.cpp
+++ b/src/enzyme_ad/jax/Implementations/WhileLoopInfo.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <optional>
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-braces"
@@ -947,6 +948,9 @@ WhileLoopInfo::computeBounds(Operation *op) {
             if (auto intType =
                     dyn_cast<IntegerType>(tensorType.getElementType())) {
               unsigned outBitWidth = intType.getWidth();
+              if (boundsBitWidth < outBitWidth) {
+                return std::nullopt;
+              }
               APInt outMin =
                   APInt::getSignedMinValue(outBitWidth).sext(boundsBitWidth);
               APInt outMax =

--- a/src/enzyme_ad/jax/Passes/AutoBatching.cpp
+++ b/src/enzyme_ad/jax/Passes/AutoBatching.cpp
@@ -977,7 +977,9 @@ LogicalResult GreedyWhileLoopBatchFission::matchAndRewriteImpl(
     bool avoidBatching =
         llvm::TypeSwitch<Operation *, bool>(op)
             .Case<stablehlo::DynamicSliceOp, stablehlo::ReshapeOp,
-                  stablehlo::SliceOp>([=](auto op) { return true; })
+                  stablehlo::SliceOp,
+                  // TODO: avoid scatter since that lowers to loop right now
+                  stablehlo::ScatterOp>([=](auto op) { return true; })
             .Case<stablehlo::BroadcastInDimOp, stablehlo::TransposeOp>(
                 [=](auto op) { return stablehlo::OpIsReshapeLike(op); })
             .Default([](auto op) { return false; });

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -11720,11 +11720,12 @@ struct SliceReshapeDynamicSlice final
     if (!reshape)
       return failure();
 
-    if (!llvm::hasSingleElement(reshape->getUsers()))
-      return failure();
-
     auto prev = reshape.getOperand().getDefiningOp<stablehlo::DynamicSliceOp>();
     if (!prev)
+      return failure();
+
+    if (!llvm::hasSingleElement(reshape->getUsers()) &&
+        !DSDSSimplificationSingleUserCheckException({reshape, op, prev}))
       return failure();
 
     SmallVector<int64_t> starts, limits, strides;


### PR DESCRIPTION
scatter defines batchopinterface with the fallback looped implementation, which causes an infinite recursion. will re-enable when we have the efficient batchopinterface for scatter