### PR TITLE
[CI] Stop leaving spammy comments for benchmarks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,7 @@ jobs:
           output-file-path: combined_results.json
           benchmark-data-dir-path: "benchmarks"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-always: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          comment-always: false
           summary-always: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           alert-threshold: "150%"
           fail-on-alert: false


### PR DESCRIPTION
I'm quite a lot bothered by the noisy messages posted by the benchmark bot: [they mess up my notifications](https://github.com/EnzymeAD/Enzyme-JAX/pull/1744#issuecomment-3690611629) and clearly no one cares about them anyway, since most PRs are merged before this message is even posted.