### PR TITLE
fix: use single scatter and gather after splitting complex

### DIFF
--- a/test/lit_tests/split_complex_gather.mlir
+++ b/test/lit_tests/split_complex_gather.mlir
@@ -16,22 +16,21 @@ func.func @test_basic_gather(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x
 }
 // CHECK: %[[REAL:.*]] = stablehlo.real %arg0
 // CHECK: %[[IMAG:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_R:.*]] = stablehlo.reshape %[[REAL]] : (tensor<4xf32>) -> tensor<4x1xf32>
-// CHECK: %[[IMAG_R:.*]] = stablehlo.reshape %[[IMAG]] : (tensor<4xf32>) -> tensor<4x1xf32>
-// CHECK: %[[CONCAT:.*]] = stablehlo.concatenate %[[REAL_R]], %[[IMAG_R]], dim = 1 : (tensor<4x1xf32>, tensor<4x1xf32>) -> tensor<4x2xf32>
+// CHECK: %[[CONCAT_RAW:.*]] = stablehlo.concatenate %[[REAL]], %[[IMAG]], dim = 0
+// CHECK: %[[CONCAT:.*]] = stablehlo.reshape %[[CONCAT_RAW]]
 // CHECK: %[[GATHER:.*]] = "stablehlo.gather"(%[[CONCAT]], %arg1)
 // CHECK-SAME: dimension_numbers = #stablehlo.gather<
-// CHECK-SAME:   offset_dims = [1],
-// CHECK-SAME:   collapsed_slice_dims = [0],
-// CHECK-SAME:   start_index_map = [0],
+// CHECK-SAME:   offset_dims = [0],
+// CHECK-SAME:   collapsed_slice_dims = [1],
+// CHECK-SAME:   start_index_map = [1],
 // CHECK-SAME:   index_vector_dim = 1
 // CHECK-SAME: >,
-// CHECK-SAME: slice_sizes = array<i64: 1, 2>
-// CHECK-SAME: (tensor<4x2xf32>, tensor<2x1xi64>) -> tensor<2x2xf32>
-// CHECK: %[[REAL_S:.*]] = stablehlo.slice %[[GATHER]] [0:2, 0:1] : (tensor<2x2xf32>) -> tensor<2x1xf32>
-// CHECK: %[[IMAG_S:.*]] = stablehlo.slice %[[GATHER]] [0:2, 1:2] : (tensor<2x2xf32>) -> tensor<2x1xf32>
-// CHECK: %[[REAL_RES:.*]] = stablehlo.reshape %[[REAL_S]] : (tensor<2x1xf32>) -> tensor<2xf32>
-// CHECK: %[[IMAG_RES:.*]] = stablehlo.reshape %[[IMAG_S]] : (tensor<2x1xf32>) -> tensor<2xf32>
+// CHECK-SAME: slice_sizes = array<i64: 2, 1>
+// CHECK-SAME: (tensor<2x4xf32>, tensor<2x1xi64>) -> tensor<2x2xf32>
+// CHECK: %[[REAL_S:.*]] = stablehlo.slice %[[GATHER]] [0:1, 0:2] : (tensor<2x2xf32>) -> tensor<1x2xf32>
+// CHECK: %[[IMAG_S:.*]] = stablehlo.slice %[[GATHER]] [1:2, 0:2] : (tensor<2x2xf32>) -> tensor<1x2xf32>
+// CHECK: %[[REAL_RES:.*]] = stablehlo.reshape %[[REAL_S]] : (tensor<1x2xf32>) -> tensor<2xf32>
+// CHECK: %[[IMAG_RES:.*]] = stablehlo.reshape %[[IMAG_S]] : (tensor<1x2xf32>) -> tensor<2xf32>
 // CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_RES]], %[[IMAG_RES]]
 // CHECK: return %[[RESULT]]
 
@@ -52,22 +51,21 @@ func.func @test_multidim_gather(%input: tensor<3x4xcomplex<f32>>, %indices: tens
 }
 // CHECK: %[[REAL:.*]] = stablehlo.real %arg0
 // CHECK: %[[IMAG:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_R:.*]] = stablehlo.reshape %[[REAL]] : (tensor<3x4xf32>) -> tensor<3x4x1xf32>
-// CHECK: %[[IMAG_R:.*]] = stablehlo.reshape %[[IMAG]] : (tensor<3x4xf32>) -> tensor<3x4x1xf32>
-// CHECK: %[[CONCAT:.*]] = stablehlo.concatenate %[[REAL_R]], %[[IMAG_R]], dim = 2 : (tensor<3x4x1xf32>, tensor<3x4x1xf32>) -> tensor<3x4x2xf32>
+// CHECK: %[[CONCAT_RAW:.*]] = stablehlo.concatenate %[[REAL]], %[[IMAG]], dim = 0
+// CHECK: %[[CONCAT:.*]] = stablehlo.reshape %[[CONCAT_RAW]]
 // CHECK: %[[GATHER:.*]] = "stablehlo.gather"(%[[CONCAT]], %arg1)
 // CHECK-SAME: dimension_numbers = #stablehlo.gather<
-// CHECK-SAME:   offset_dims = [1, 2],
-// CHECK-SAME:   collapsed_slice_dims = [0],
-// CHECK-SAME:   start_index_map = [0],
+// CHECK-SAME:   offset_dims = [0, 2],
+// CHECK-SAME:   collapsed_slice_dims = [1],
+// CHECK-SAME:   start_index_map = [1],
 // CHECK-SAME:   index_vector_dim = 1
 // CHECK-SAME: >,
-// CHECK-SAME: slice_sizes = array<i64: 1, 4, 2>
-// CHECK-SAME: (tensor<3x4x2xf32>, tensor<2x1xi64>) -> tensor<2x4x2xf32>
-// CHECK: %[[REAL_S:.*]] = stablehlo.slice %[[GATHER]] [0:2, 0:4, 0:1] : (tensor<2x4x2xf32>) -> tensor<2x4x1xf32>
-// CHECK: %[[IMAG_S:.*]] = stablehlo.slice %[[GATHER]] [0:2, 0:4, 1:2] : (tensor<2x4x2xf32>) -> tensor<2x4x1xf32>
-// CHECK: %[[REAL_RES:.*]] = stablehlo.reshape %[[REAL_S]] : (tensor<2x4x1xf32>) -> tensor<2x4xf32>
-// CHECK: %[[IMAG_RES:.*]] = stablehlo.reshape %[[IMAG_S]] : (tensor<2x4x1xf32>) -> tensor<2x4xf32>
+// CHECK-SAME: slice_sizes = array<i64: 2, 1, 4>
+// CHECK-SAME: (tensor<2x3x4xf32>, tensor<2x1xi64>) -> tensor<2x2x4xf32>
+// CHECK: %[[REAL_S:.*]] = stablehlo.slice %[[GATHER]] [0:1, 0:2, 0:4] : (tensor<2x2x4xf32>) -> tensor<1x2x4xf32>
+// CHECK: %[[IMAG_S:.*]] = stablehlo.slice %[[GATHER]] [1:2, 0:2, 0:4] : (tensor<2x2x4xf32>) -> tensor<1x2x4xf32>
+// CHECK: %[[REAL_RES:.*]] = stablehlo.reshape %[[REAL_S]] : (tensor<1x2x4xf32>) -> tensor<2x4xf32>
+// CHECK: %[[IMAG_RES:.*]] = stablehlo.reshape %[[IMAG_S]] : (tensor<1x2x4xf32>) -> tensor<2x4xf32>
 // CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_RES]], %[[IMAG_RES]]
 // CHECK: return %[[RESULT]]
 
@@ -88,18 +86,17 @@ func.func @test_complex_f64(%input: tensor<8xcomplex<f64>>, %indices: tensor<3x1
 }
 // CHECK: %[[REAL:.*]] = stablehlo.real %arg0
 // CHECK: %[[IMAG:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_R:.*]] = stablehlo.reshape %[[REAL]] : (tensor<8xf64>) -> tensor<8x1xf64>
-// CHECK: %[[IMAG_R:.*]] = stablehlo.reshape %[[IMAG]] : (tensor<8xf64>) -> tensor<8x1xf64>
-// CHECK: %[[CONCAT:.*]] = stablehlo.concatenate %[[REAL_R]], %[[IMAG_R]], dim = 1 : (tensor<8x1xf64>, tensor<8x1xf64>) -> tensor<8x2xf64>
+// CHECK: %[[CONCAT_RAW:.*]] = stablehlo.concatenate %[[REAL]], %[[IMAG]], dim = 0
+// CHECK: %[[CONCAT:.*]] = stablehlo.reshape %[[CONCAT_RAW]]
 // CHECK: %[[GATHER:.*]] = "stablehlo.gather"(%[[CONCAT]], %arg1)
-// CHECK-SAME: offset_dims = [1],
-// CHECK-SAME: collapsed_slice_dims = [0],
-// CHECK-SAME: slice_sizes = array<i64: 1, 2>
-// CHECK-SAME: (tensor<8x2xf64>, tensor<3x1xi64>) -> tensor<3x2xf64>
-// CHECK: %[[REAL_S:.*]] = stablehlo.slice %[[GATHER]] [0:3, 0:1] : (tensor<3x2xf64>) -> tensor<3x1xf64>
-// CHECK: %[[IMAG_S:.*]] = stablehlo.slice %[[GATHER]] [0:3, 1:2] : (tensor<3x2xf64>) -> tensor<3x1xf64>
-// CHECK: %[[REAL_RES:.*]] = stablehlo.reshape %[[REAL_S]] : (tensor<3x1xf64>) -> tensor<3xf64>
-// CHECK: %[[IMAG_RES:.*]] = stablehlo.reshape %[[IMAG_S]] : (tensor<3x1xf64>) -> tensor<3xf64>
+// CHECK-SAME: offset_dims = [0],
+// CHECK-SAME: collapsed_slice_dims = [1],
+// CHECK-SAME: slice_sizes = array<i64: 2, 1>
+// CHECK-SAME: (tensor<2x8xf64>, tensor<3x1xi64>) -> tensor<2x3xf64>
+// CHECK: %[[REAL_S:.*]] = stablehlo.slice %[[GATHER]] [0:1, 0:3] : (tensor<2x3xf64>) -> tensor<1x3xf64>
+// CHECK: %[[IMAG_S:.*]] = stablehlo.slice %[[GATHER]] [1:2, 0:3] : (tensor<2x3xf64>) -> tensor<1x3xf64>
+// CHECK: %[[REAL_RES:.*]] = stablehlo.reshape %[[REAL_S]] : (tensor<1x3xf64>) -> tensor<3xf64>
+// CHECK: %[[IMAG_RES:.*]] = stablehlo.reshape %[[IMAG_S]] : (tensor<1x3xf64>) -> tensor<3xf64>
 // CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_RES]], %[[IMAG_RES]]
 // CHECK: return %[[RESULT]]
 

--- a/test/lit_tests/split_complex_scatter.mlir
+++ b/test/lit_tests/split_complex_scatter.mlir
@@ -11,14 +11,12 @@ func.func @test_setindex(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi6
 }
 // CHECK: %[[REAL_INPUT:.*]] = stablehlo.real %arg0
 // CHECK: %[[IMAG_INPUT:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_INPUT_R:.*]] = stablehlo.reshape %[[REAL_INPUT]] : (tensor<4xf32>) -> tensor<4x1xf32>
-// CHECK: %[[IMAG_INPUT_R:.*]] = stablehlo.reshape %[[IMAG_INPUT]] : (tensor<4xf32>) -> tensor<4x1xf32>
-// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate %[[REAL_INPUT_R]], %[[IMAG_INPUT_R]], dim = 1
+// CHECK: %[[CONCAT_INPUT_RAW:.*]] = stablehlo.concatenate %[[REAL_INPUT]], %[[IMAG_INPUT]], dim = 0
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.reshape %[[CONCAT_INPUT_RAW]]
 // CHECK: %[[REAL_UPDATE:.*]] = stablehlo.real %arg2
 // CHECK: %[[IMAG_UPDATE:.*]] = stablehlo.imag %arg2
-// CHECK: %[[REAL_UPDATE_R:.*]] = stablehlo.reshape %[[REAL_UPDATE]] : (tensor<2xf32>) -> tensor<2x1xf32>
-// CHECK: %[[IMAG_UPDATE_R:.*]] = stablehlo.reshape %[[IMAG_UPDATE]] : (tensor<2xf32>) -> tensor<2x1xf32>
-// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.concatenate %[[REAL_UPDATE_R]], %[[IMAG_UPDATE_R]], dim = 1
+// CHECK: %[[CONCAT_UPDATE_RAW:.*]] = stablehlo.concatenate %[[REAL_UPDATE]], %[[IMAG_UPDATE]], dim = 0
+// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.reshape %[[CONCAT_UPDATE_RAW]]
 // CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CONCAT_UPDATE]])
 // CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   stablehlo.return %[[ARG1]] : tensor<f32>
@@ -38,10 +36,11 @@ func.func @test_constant_setindex(%input: tensor<4xcomplex<f32>>, %indices: tens
   return %0 : tensor<4xcomplex<f32>>
 }
 // The constant real/imag parts get folded into a single constant tensor
-// CHECK: %[[CST:.*]] = stablehlo.constant dense<{{\[}}[3.000000e+00, 4.000000e+00], [3.000000e+00, 4.000000e+00]]> : tensor<2x2xf32>
+// CHECK: %[[CST:.*]] = stablehlo.constant dense<{{\[}}[3.000000e+00, 3.000000e+00], [4.000000e+00, 4.000000e+00]]> : tensor<2x2xf32>
 // CHECK: %[[REAL_INPUT:.*]] = stablehlo.real %arg0
 // CHECK: %[[IMAG_INPUT:.*]] = stablehlo.imag %arg0
-// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_INPUT_RAW:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.reshape %[[CONCAT_INPUT_RAW]]
 // CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CST]])
 // CHECK: ^bb0(%{{.*}}: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   stablehlo.return %[[ARG1]] : tensor<f32>
@@ -60,8 +59,10 @@ func.func @test_add(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi64>, %
   }) : (tensor<4xcomplex<f32>>, tensor<2x1xi64>, tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>>
   return %0 : tensor<4xcomplex<f32>>
 }
-// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
-// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_INPUT_RAW:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.reshape %[[CONCAT_INPUT_RAW]]
+// CHECK: %[[CONCAT_UPDATE_RAW:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.reshape %[[CONCAT_UPDATE_RAW]]
 // CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CONCAT_UPDATE]])
 // CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   %[[ADD:.*]] = stablehlo.add %[[ARG0]], %[[ARG1]] : tensor<f32>
@@ -81,8 +82,10 @@ func.func @test_sub(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi64>, %
   }) : (tensor<4xcomplex<f32>>, tensor<2x1xi64>, tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>>
   return %0 : tensor<4xcomplex<f32>>
 }
-// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
-// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_INPUT_RAW:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.reshape %[[CONCAT_INPUT_RAW]]
+// CHECK: %[[CONCAT_UPDATE_RAW:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.reshape %[[CONCAT_UPDATE_RAW]]
 // CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CONCAT_UPDATE]])
 // CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   %[[SUB:.*]] = stablehlo.subtract %[[ARG0]], %[[ARG1]] : tensor<f32>
@@ -103,8 +106,9 @@ func.func @test_add_constant_update(%input: tensor<4xcomplex<f32>>, %indices: te
   }) : (tensor<4xcomplex<f32>>, tensor<2x1xi64>, tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>>
   return %0 : tensor<4xcomplex<f32>>
 }
-// CHECK: %[[CST:.*]] = stablehlo.constant dense<{{\[}}[2.000000e+00, 5.000000e+00], [2.000000e+00, 5.000000e+00]]> : tensor<2x2xf32>
-// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
+// CHECK: %[[CST:.*]] = stablehlo.constant dense<{{\[}}[2.000000e+00, 2.000000e+00], [5.000000e+00, 5.000000e+00]]> : tensor<2x2xf32>
+// CHECK: %[[CONCAT_INPUT_RAW:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.reshape %[[CONCAT_INPUT_RAW]]
 // CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CST]])
 // CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   %[[ADD:.*]] = stablehlo.add %[[ARG0]], %[[ARG1]] : tensor<f32>
@@ -126,10 +130,12 @@ func.func @test_add_constant_input(%input: tensor<4xcomplex<f32>>, %indices: ten
   return %0 : tensor<4xcomplex<f32>>
 }
 // The constant + update gets precomputed and folded
-// CHECK: %[[CST:.*]] = stablehlo.constant dense<{{\[}}[1.500000e+00, 2.500000e+00], [1.500000e+00, 2.500000e+00]]> : tensor<2x2xf32>
-// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
-// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.concatenate
-// CHECK: %[[ADD:.*]] = stablehlo.add %[[CST]], %[[CONCAT_UPDATE]]
+// CHECK: %[[CST:.*]] = stablehlo.constant dense<[1.500000e+00, 1.500000e+00, 2.500000e+00, 2.500000e+00]> : tensor<4xf32>
+// CHECK: %[[CONCAT_INPUT_RAW:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.reshape %[[CONCAT_INPUT_RAW]]
+// CHECK: %[[CONCAT_UPDATE_RAW:.*]] = stablehlo.concatenate
+// CHECK: %[[ADD_RAW:.*]] = stablehlo.add %[[CST]], %[[CONCAT_UPDATE_RAW]]
+// CHECK: %[[ADD:.*]] = stablehlo.reshape %[[ADD_RAW]]
 // CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[ADD]])
 // CHECK: ^bb0(%{{.*}}: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   stablehlo.return %[[ARG1]] : tensor<f32>

--- a/test/lit_tests/split_complex_scatter.mlir
+++ b/test/lit_tests/split_complex_scatter.mlir
@@ -11,18 +11,24 @@ func.func @test_setindex(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi6
 }
 // CHECK: %[[REAL_INPUT:.*]] = stablehlo.real %arg0
 // CHECK: %[[IMAG_INPUT:.*]] = stablehlo.imag %arg0
+// CHECK: %[[REAL_INPUT_R:.*]] = stablehlo.reshape %[[REAL_INPUT]] : (tensor<4xf32>) -> tensor<4x1xf32>
+// CHECK: %[[IMAG_INPUT_R:.*]] = stablehlo.reshape %[[IMAG_INPUT]] : (tensor<4xf32>) -> tensor<4x1xf32>
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate %[[REAL_INPUT_R]], %[[IMAG_INPUT_R]], dim = 1
 // CHECK: %[[REAL_UPDATE:.*]] = stablehlo.real %arg2
 // CHECK: %[[IMAG_UPDATE:.*]] = stablehlo.imag %arg2
-// CHECK: %[[REAL_SCATTER:.*]] = "stablehlo.scatter"(%[[REAL_INPUT]], %arg1, %[[REAL_UPDATE]])
+// CHECK: %[[REAL_UPDATE_R:.*]] = stablehlo.reshape %[[REAL_UPDATE]] : (tensor<2xf32>) -> tensor<2x1xf32>
+// CHECK: %[[IMAG_UPDATE_R:.*]] = stablehlo.reshape %[[IMAG_UPDATE]] : (tensor<2xf32>) -> tensor<2x1xf32>
+// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.concatenate %[[REAL_UPDATE_R]], %[[IMAG_UPDATE_R]], dim = 1
+// CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CONCAT_UPDATE]])
 // CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   stablehlo.return %[[ARG1]] : tensor<f32>
-// CHECK: %[[IMAG_SCATTER:.*]] = "stablehlo.scatter"(%[[IMAG_INPUT]], %arg1, %[[IMAG_UPDATE]])
-// CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
-// CHECK:   stablehlo.return %[[ARG1]] : tensor<f32>
-// CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_SCATTER]], %[[IMAG_SCATTER]]
+// CHECK: stablehlo.slice
+// CHECK: stablehlo.slice
+// CHECK: %[[RESULT:.*]] = stablehlo.complex
 // CHECK: return %[[RESULT]]
 
 // Test: ConstantSetindex scatter on complex tensors
+// CHECK-LABEL: @test_constant_setindex
 func.func @test_constant_setindex(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi64>, %updates: tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>> {
   %cst = stablehlo.constant dense<(3.0, 4.0)> : tensor<complex<f32>>
   %0 = "stablehlo.scatter"(%input, %indices, %updates) <{scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>}> ({
@@ -31,20 +37,17 @@ func.func @test_constant_setindex(%input: tensor<4xcomplex<f32>>, %indices: tens
   }) : (tensor<4xcomplex<f32>>, tensor<2x1xi64>, tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>>
   return %0 : tensor<4xcomplex<f32>>
 }
-// CHECK-LABEL: @test_constant_setindex
-// CHECK-DAG: %[[IMAG_CST:.*]] = stablehlo.constant dense<4.000000e+00> : tensor<f32>
-// CHECK-DAG: %[[REAL_CST:.*]] = stablehlo.constant dense<3.000000e+00> : tensor<f32>
+// The constant real/imag parts get folded into a single constant tensor
+// CHECK: %[[CST:.*]] = stablehlo.constant dense<{{\[}}[3.000000e+00, 4.000000e+00], [3.000000e+00, 4.000000e+00]]> : tensor<2x2xf32>
 // CHECK: %[[REAL_INPUT:.*]] = stablehlo.real %arg0
 // CHECK: %[[IMAG_INPUT:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_UPDATE:.*]] = stablehlo.real %arg2
-// CHECK: %[[IMAG_UPDATE:.*]] = stablehlo.imag %arg2
-// CHECK: %[[REAL_SCATTER:.*]] = "stablehlo.scatter"(%[[REAL_INPUT]], %arg1, %[[REAL_UPDATE]])
-// CHECK: ^bb0(%{{.*}}: tensor<f32>, %{{.*}}: tensor<f32>):
-// CHECK:   stablehlo.return %[[REAL_CST]] : tensor<f32>
-// CHECK: %[[IMAG_SCATTER:.*]] = "stablehlo.scatter"(%[[IMAG_INPUT]], %arg1, %[[IMAG_UPDATE]])
-// CHECK: ^bb0(%{{.*}}: tensor<f32>, %{{.*}}: tensor<f32>):
-// CHECK:   stablehlo.return %[[IMAG_CST]] : tensor<f32>
-// CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_SCATTER]], %[[IMAG_SCATTER]]
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
+// CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CST]])
+// CHECK: ^bb0(%{{.*}}: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
+// CHECK:   stablehlo.return %[[ARG1]] : tensor<f32>
+// CHECK: stablehlo.slice
+// CHECK: stablehlo.slice
+// CHECK: %[[RESULT:.*]] = stablehlo.complex
 // CHECK: return %[[RESULT]]
 
 // Test: Add scatter on complex tensors
@@ -57,19 +60,15 @@ func.func @test_add(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi64>, %
   }) : (tensor<4xcomplex<f32>>, tensor<2x1xi64>, tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>>
   return %0 : tensor<4xcomplex<f32>>
 }
-// CHECK: %[[REAL_INPUT:.*]] = stablehlo.real %arg0
-// CHECK: %[[IMAG_INPUT:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_UPDATE:.*]] = stablehlo.real %arg2
-// CHECK: %[[IMAG_UPDATE:.*]] = stablehlo.imag %arg2
-// CHECK: %[[REAL_SCATTER:.*]] = "stablehlo.scatter"(%[[REAL_INPUT]], %arg1, %[[REAL_UPDATE]])
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.concatenate
+// CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CONCAT_UPDATE]])
 // CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   %[[ADD:.*]] = stablehlo.add %[[ARG0]], %[[ARG1]] : tensor<f32>
 // CHECK:   stablehlo.return %[[ADD]] : tensor<f32>
-// CHECK: %[[IMAG_SCATTER:.*]] = "stablehlo.scatter"(%[[IMAG_INPUT]], %arg1, %[[IMAG_UPDATE]])
-// CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
-// CHECK:   %[[ADD:.*]] = stablehlo.add %[[ARG0]], %[[ARG1]] : tensor<f32>
-// CHECK:   stablehlo.return %[[ADD]] : tensor<f32>
-// CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_SCATTER]], %[[IMAG_SCATTER]]
+// CHECK: stablehlo.slice
+// CHECK: stablehlo.slice
+// CHECK: %[[RESULT:.*]] = stablehlo.complex
 // CHECK: return %[[RESULT]]
 
 // Test: Sub scatter on complex tensors
@@ -82,22 +81,19 @@ func.func @test_sub(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi64>, %
   }) : (tensor<4xcomplex<f32>>, tensor<2x1xi64>, tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>>
   return %0 : tensor<4xcomplex<f32>>
 }
-// CHECK: %[[REAL_INPUT:.*]] = stablehlo.real %arg0
-// CHECK: %[[IMAG_INPUT:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_UPDATE:.*]] = stablehlo.real %arg2
-// CHECK: %[[IMAG_UPDATE:.*]] = stablehlo.imag %arg2
-// CHECK: %[[REAL_SCATTER:.*]] = "stablehlo.scatter"(%[[REAL_INPUT]], %arg1, %[[REAL_UPDATE]])
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.concatenate
+// CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CONCAT_UPDATE]])
 // CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
 // CHECK:   %[[SUB:.*]] = stablehlo.subtract %[[ARG0]], %[[ARG1]] : tensor<f32>
 // CHECK:   stablehlo.return %[[SUB]] : tensor<f32>
-// CHECK: %[[IMAG_SCATTER:.*]] = "stablehlo.scatter"(%[[IMAG_INPUT]], %arg1, %[[IMAG_UPDATE]])
-// CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
-// CHECK:   %[[SUB:.*]] = stablehlo.subtract %[[ARG0]], %[[ARG1]] : tensor<f32>
-// CHECK:   stablehlo.return %[[SUB]] : tensor<f32>
-// CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_SCATTER]], %[[IMAG_SCATTER]]
+// CHECK: stablehlo.slice
+// CHECK: stablehlo.slice
+// CHECK: %[[RESULT:.*]] = stablehlo.complex
 // CHECK: return %[[RESULT]]
 
 // Test: AddConstantUpdate scatter on complex tensors
+// CHECK-LABEL: @test_add_constant_update
 func.func @test_add_constant_update(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi64>, %updates: tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>> {
   %cst = stablehlo.constant dense<(2.0, 5.0)> : tensor<complex<f32>>
   %0 = "stablehlo.scatter"(%input, %indices, %updates) <{scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>}> ({
@@ -107,25 +103,19 @@ func.func @test_add_constant_update(%input: tensor<4xcomplex<f32>>, %indices: te
   }) : (tensor<4xcomplex<f32>>, tensor<2x1xi64>, tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>>
   return %0 : tensor<4xcomplex<f32>>
 }
-// CHECK-LABEL: @test_add_constant_update
-// CHECK-DAG: %[[IMAG_CST:.*]] = stablehlo.constant dense<5.000000e+00> : tensor<f32>
-// CHECK-DAG: %[[REAL_CST:.*]] = stablehlo.constant dense<2.000000e+00> : tensor<f32>
-// CHECK: %[[REAL_INPUT:.*]] = stablehlo.real %arg0
-// CHECK: %[[IMAG_INPUT:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_UPDATE:.*]] = stablehlo.real %arg2
-// CHECK: %[[IMAG_UPDATE:.*]] = stablehlo.imag %arg2
-// CHECK: %[[REAL_SCATTER:.*]] = "stablehlo.scatter"(%[[REAL_INPUT]], %arg1, %[[REAL_UPDATE]])
-// CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %{{.*}}: tensor<f32>):
-// CHECK:   %[[ADD:.*]] = stablehlo.add %[[ARG0]], %[[REAL_CST]] : tensor<f32>
+// CHECK: %[[CST:.*]] = stablehlo.constant dense<{{\[}}[2.000000e+00, 5.000000e+00], [2.000000e+00, 5.000000e+00]]> : tensor<2x2xf32>
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
+// CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[CST]])
+// CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
+// CHECK:   %[[ADD:.*]] = stablehlo.add %[[ARG0]], %[[ARG1]] : tensor<f32>
 // CHECK:   stablehlo.return %[[ADD]] : tensor<f32>
-// CHECK: %[[IMAG_SCATTER:.*]] = "stablehlo.scatter"(%[[IMAG_INPUT]], %arg1, %[[IMAG_UPDATE]])
-// CHECK: ^bb0(%[[ARG0:.*]]: tensor<f32>, %{{.*}}: tensor<f32>):
-// CHECK:   %[[ADD:.*]] = stablehlo.add %[[ARG0]], %[[IMAG_CST]] : tensor<f32>
-// CHECK:   stablehlo.return %[[ADD]] : tensor<f32>
-// CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_SCATTER]], %[[IMAG_SCATTER]]
+// CHECK: stablehlo.slice
+// CHECK: stablehlo.slice
+// CHECK: %[[RESULT:.*]] = stablehlo.complex
 // CHECK: return %[[RESULT]]
 
 // Test: AddConstantInput scatter on complex tensors
+// CHECK-LABEL: @test_add_constant_input
 func.func @test_add_constant_input(%input: tensor<4xcomplex<f32>>, %indices: tensor<2x1xi64>, %updates: tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>> {
   %cst = stablehlo.constant dense<(1.5, 2.5)> : tensor<complex<f32>>
   %0 = "stablehlo.scatter"(%input, %indices, %updates) <{scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>}> ({
@@ -135,20 +125,15 @@ func.func @test_add_constant_input(%input: tensor<4xcomplex<f32>>, %indices: ten
   }) : (tensor<4xcomplex<f32>>, tensor<2x1xi64>, tensor<2xcomplex<f32>>) -> tensor<4xcomplex<f32>>
   return %0 : tensor<4xcomplex<f32>>
 }
-// CHECK-LABEL: @test_add_constant_input
-// CHECK-DAG: %[[IMAG_CST:.*]] = stablehlo.constant dense<2.500000e+00> : tensor<f32>
-// CHECK-DAG: %[[REAL_CST:.*]] = stablehlo.constant dense<1.500000e+00> : tensor<f32>
-// CHECK: %[[REAL_INPUT:.*]] = stablehlo.real %arg0
-// CHECK: %[[IMAG_INPUT:.*]] = stablehlo.imag %arg0
-// CHECK: %[[REAL_UPDATE:.*]] = stablehlo.real %arg2
-// CHECK: %[[IMAG_UPDATE:.*]] = stablehlo.imag %arg2
-// CHECK: %[[REAL_SCATTER:.*]] = "stablehlo.scatter"(%[[REAL_INPUT]], %arg1, %[[REAL_UPDATE]])
+// The constant + update gets precomputed and folded
+// CHECK: %[[CST:.*]] = stablehlo.constant dense<{{\[}}[1.500000e+00, 2.500000e+00], [1.500000e+00, 2.500000e+00]]> : tensor<2x2xf32>
+// CHECK: %[[CONCAT_INPUT:.*]] = stablehlo.concatenate
+// CHECK: %[[CONCAT_UPDATE:.*]] = stablehlo.concatenate
+// CHECK: %[[ADD:.*]] = stablehlo.add %[[CST]], %[[CONCAT_UPDATE]]
+// CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%[[CONCAT_INPUT]], %arg1, %[[ADD]])
 // CHECK: ^bb0(%{{.*}}: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
-// CHECK:   %[[ADD:.*]] = stablehlo.add %[[REAL_CST]], %[[ARG1]] : tensor<f32>
-// CHECK:   stablehlo.return %[[ADD]] : tensor<f32>
-// CHECK: %[[IMAG_SCATTER:.*]] = "stablehlo.scatter"(%[[IMAG_INPUT]], %arg1, %[[IMAG_UPDATE]])
-// CHECK: ^bb0(%{{.*}}: tensor<f32>, %[[ARG1:.*]]: tensor<f32>):
-// CHECK:   %[[ADD:.*]] = stablehlo.add %[[IMAG_CST]], %[[ARG1]] : tensor<f32>
-// CHECK:   stablehlo.return %[[ADD]] : tensor<f32>
-// CHECK: %[[RESULT:.*]] = stablehlo.complex %[[REAL_SCATTER]], %[[IMAG_SCATTER]]
+// CHECK:   stablehlo.return %[[ARG1]] : tensor<f32>
+// CHECK: stablehlo.slice
+// CHECK: stablehlo.slice
+// CHECK: %[[RESULT:.*]] = stablehlo.complex
 // CHECK: return %[[RESULT]]

--- a/test/lit_tests/split_complex_scatter_setindex.mlir
+++ b/test/lit_tests/split_complex_scatter_setindex.mlir
@@ -31,14 +31,13 @@ module {
 // The constant input (0.0 + 5.0i) gets decomposed, reshaped, and folded into a pad op.
 // CHECK: %[[REAL:.*]] = stablehlo.real %3
 // CHECK-NEXT: %[[IMAG:.*]] = stablehlo.imag %3
-// CHECK-NEXT: %[[REAL_R:.*]] = stablehlo.reshape %[[REAL]]
-// CHECK-NEXT: %[[IMAG_R:.*]] = stablehlo.reshape %[[IMAG]]
-// CHECK-NEXT: %[[CONCAT:.*]] = stablehlo.concatenate %[[REAL_R]], %[[IMAG_R]], dim = 1
+// CHECK-NEXT: %[[CONCAT_RAW:.*]] = stablehlo.concatenate %[[REAL]], %[[IMAG]], dim = 0
+// CHECK-NEXT: %[[CONCAT:.*]] = stablehlo.reshape %[[CONCAT_RAW]]
 // CHECK-NEXT: %[[SCATTER:.*]] = "stablehlo.scatter"(%{{.*}}, %7, %[[CONCAT]])
-// CHECK-SAME: update_window_dims = [1]
-// CHECK-SAME: inserted_window_dims = [0, 1]
+// CHECK-SAME: update_window_dims = [0]
+// CHECK-SAME: inserted_window_dims = [1, 2]
 // CHECK: ^bb0(%{{.*}}: tensor<f64>, %[[ARG8:.*]]: tensor<f64>):
 // CHECK-NEXT:   stablehlo.return %[[ARG8]] : tensor<f64>
-// CHECK: stablehlo.slice %[[SCATTER]] [0:128, 0:128, 0:1]
-// CHECK: stablehlo.slice %[[SCATTER]] [0:128, 0:128, 1:2]
+// CHECK: stablehlo.slice %[[SCATTER]] [0:1, 0:128, 0:128]
+// CHECK: stablehlo.slice %[[SCATTER]] [1:2, 0:128, 0:128]
 // CHECK: stablehlo.complex


### PR DESCRIPTION
stablehlo::BitcastConvertOp doesnt allow reinterpretting complex -> real