### PR TITLE
[CI] Fix syntax of update nightly release step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,8 +229,7 @@ jobs:
           tag: nightly
           name: Nightly Release
           body: "Latest nightly build of Enzyme-JAX."
-          artifacts:
-            - "bazel-bin/enzymexlamlir-opt,bazel-bin/*.whl"
+          artifacts: "bazel-bin/enzymexlamlir-opt,bazel-bin/*.whl"
           allowUpdates: true
           removeArtifacts: true
           replacesArtifacts: true


### PR DESCRIPTION
2f41e8dfd5f4ca2a83814bf40fd225e510777dc8 the build workflow because of wrong syntax