### PR TITLE
recognize negaitve multirotate and use its neutral

### DIFF
--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -2254,6 +2254,11 @@ def ReduceUnusedMultiRotate : EnzymeHLOPatternOp<
   let patterns = ["ReduceUnusedMultiRotate"];
 }
 
+def UseMultiRotateNeutralResult : EnzymeHLOPatternOp<
+    "use_multirotate_neutral_result"> {
+  let patterns = ["UseMultiRotateNeutralResult"];
+}
+
 def SelectPad : EnzymeHLOPatternOp<
     "select_pad"> {
   let patterns = ["SelectPad"];

--- a/test/lit_tests/recognize_multirotate.mlir
+++ b/test/lit_tests/recognize_multirotate.mlir
@@ -197,3 +197,19 @@ func.func @with_unused_value(%arg0: tensor<10x20xf32>) -> (tensor<10x20xf32>, te
 // CHECK:           %[[VAL_1:.*]] = "enzymexla.rotate"(%[[VAL_0]]) <{amount = 2 : si32, dimension = 1 : si32}> : (tensor<10x20xf32>) -> tensor<10x20xf32>
 // CHECK:           return %[[VAL_0]], %[[VAL_1]] : tensor<10x20xf32>, tensor<10x20xf32>
 // CHECK:         }
+
+
+sdy.mesh @mesh = <["x"=2, "y"=2]>
+func.func @recognize_multirotate_negative(%1604: tensor<4x1520x3056xf32>) -> (tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>) {
+    %2706 = "enzymexla.rotate"(%1604) <{amount = 3054 : si32, dimension = 2 : si32}> {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"y"}, {"x"}]>]>} : (tensor<4x1520x3056xf32>) -> tensor<4x1520x3056xf32>
+    %2707 = "enzymexla.rotate"(%1604) <{amount = 3053 : si32, dimension = 2 : si32}> {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"y"}, {"x"}]>]>} : (tensor<4x1520x3056xf32>) -> tensor<4x1520x3056xf32>
+    %2710 = "enzymexla.rotate"(%1604) <{amount = 3055 : si32, dimension = 2 : si32}> {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"y"}, {"x"}]>]>} : (tensor<4x1520x3056xf32>) -> tensor<4x1520x3056xf32>
+    %2715 = "enzymexla.rotate"(%1604) <{amount = 1 : si32, dimension = 2 : si32}> {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>], sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"y"}, {"x"}]>]>} : (tensor<4x1520x3056xf32>) -> tensor<4x1520x3056xf32>
+    %2719 = "enzymexla.rotate"(%1604) <{amount = 2 : si32, dimension = 2 : si32}> {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"y"}, {"x"}]>]>} : (tensor<4x1520x3056xf32>) -> tensor<4x1520x3056xf32>
+    return %2706, %2707, %2710, %2715, %2719 : tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>
+}
+
+// CHECK-LABEL:   func.func @recognize_multirotate_negative
+// CHECK-SAME:         (%[[ARG:.+]]: tensor<4x1520x3056xf32>) -> (
+// CHECK:          %{{.*}}:6 = "enzymexla.multi_rotate"(%arg0) <{dimension = 2 : si32, left_amount = 2 : si32, right_amount = 3 : si32}> {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>]>} : (tensor<4x1520x3056xf32>) -> (tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>)
+// CHECK-NOT:      enzymexla.rotate

--- a/test/lit_tests/use_multirotate_neutral_result.mlir
+++ b/test/lit_tests/use_multirotate_neutral_result.mlir
@@ -1,0 +1,19 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=use_multirotate_neutral_result" --transform-interpreter --enzyme-hlo-remove-transform | FileCheck %s
+
+sdy.mesh @mesh = <["x"=2, "y"=2]>
+
+// CHECK-LABEL:   func.func @use_multirotate_neutral_result
+// CHECK-SAME:         (%[[ARG:.+]]: tensor<4x1520x3056xf32>, %[[ARG1:.+]]: tensor<4x1520x3056xf32>
+func.func @use_multirotate_neutral_result(%arg0: tensor<4x1520x3056xf32>, %arg1: tensor<4x1520x3056xf32>) -> (tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>) {
+    // CHECK: stablehlo.add %[[ARG]], %[[ARG1]]
+    // CHECK: stablehlo.add %[[ARG]], %[[ARG]]
+    // CHECK: %[[ROTATED:.+]]:6 = "enzymexla.multi_rotate"(%[[ARG]])
+    // CHECK: stablehlo.add %[[ROTATED]]#2, %[[ARG1]]
+    // CHECK: stablehlo.add %[[ROTATED]]#2, %[[ROTATED]]#2
+    %0 = stablehlo.add %arg0, %arg1 : tensor<4x1520x3056xf32>
+    %1 = stablehlo.add %arg0, %arg0 : tensor<4x1520x3056xf32>
+    %2:6 = "enzymexla.multi_rotate"(%arg0) <{dimension = 2 : si32, left_amount = 2 : si32, right_amount = 3 : si32}> {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>, <@mesh, [{}, {"y"}, {"x"}]>]>} : (tensor<4x1520x3056xf32>) -> (tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>)
+    %3 = stablehlo.add %arg0, %arg1 : tensor<4x1520x3056xf32>
+    %4 = stablehlo.add %arg0, %arg0 : tensor<4x1520x3056xf32>
+    return %0, %1, %2#1, %3, %4 : tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>, tensor<4x1520x3056xf32>
+}


### PR DESCRIPTION
Fix multirotate recognition to recognize wraparound values as negative/right rotation. Add a new pattern to update uses of multirotate operand with its unrotated result to help bufferization.

Fixes #2098.