### PR TITLE
skip lowering of wrap to custom_call on assertion error

### DIFF
--- a/src/enzyme_ad/jax/Passes/OptimizeCommunication.cpp
+++ b/src/enzyme_ad/jax/Passes/OptimizeCommunication.cpp
@@ -2370,10 +2370,14 @@ struct WrapCustomCallOptimize : public OpRewritePattern<enzymexla::WrapOp> {
         full_pre_wrap_size % participating_shards == 0;
 
     if (divisible_by_participating_shards) {
-      if (rightAmount >= shard_size)
+      // NOTE should be `>=` or else XLA will assert error, but currently it's
+      // probably generating too many comms
+      if (rightAmount > shard_size)
         return failure();
     } else {
-      if (rightAmount >= full_pre_wrap_size % shard_size)
+      // NOTE should be `>=` or else XLA will assert error, but currently it's
+      // probably generating too many comms
+      if (rightAmount > full_pre_wrap_size % shard_size)
         return failure();
     }
 


### PR DESCRIPTION
it should avoid the segfault we run into on 12 GPUs

```
E0000 00:00:1772658857.820566  248565 status_macros.cc:58] INTERNAL: RET_CHECK failure (external/xla/xla/service/spmd/custom_call_handler.cc:662) right_amount < full_pre_wrap_size % participating_shards Right amount must be entirely within final shard
```

this is not a complete fix, as the code won't end up as optimized, but it should work
