### PR TITLE
[CI] Disable disk and repository cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           # Avoid downloading Bazel every time.
           bazelisk-cache: true
           # Store build cache per workflow only for macOS.
-          disk-cache: {{ runner.os == macOS && format('{0}-{1}-{2}', github.workflow, matrix.os, matrix.python) || false }}
+          disk-cache: ${{ runner.os == 'macOS' && format('build-{0}-{1}-{2}', github.workflow, matrix.os, matrix.python) || false }}
           # Do not share repository cache between workflows.
           repository-cache: false
           bazelisk-version: 1.x

--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -67,7 +67,7 @@ jobs:
           # Avoid downloading Bazel every time.
           bazelisk-cache: true
           # Store build cache per workflow only for macOS.
-          disk-cache: {{ runner.os == macOS && format('{0}-{1}-{2}', github.workflow, matrix.os, matrix.python) || false }}
+          disk-cache: ${{ runner.os == 'macOS' && format('gb-25-{0}-{1}-{2}', github.workflow, matrix.os, matrix.python) || false }}
           # Do not share repository cache between workflows.
           repository-cache: false
           bazelisk-version: 1.x


### PR DESCRIPTION
I believe this is redundant now that we have a more efficient cache, and dropping this cache leaves more space for other GitHub-hosted caches (e.g. the ones for Julia jobs)