### PR TITLE
add helper script for converting HLO to GraphViz's DOT format

### DIFF
--- a/scripts/hlo-graphviz.sh
+++ b/scripts/hlo-graphviz.sh
@@ -30,11 +30,12 @@ fi
 
 bazel_run() {
     bazel run --action_env=CC=${CC-clang}\
-    --define using_clang=true\
+    --define=using_clang=true\
     --run_under="cd $PWD &&"\
     --ui_event_filters=ERROR\
     --noshow_progress\
     --noshow_loading_progress\
+    --color=no\
     $@
 }
 
@@ -54,7 +55,7 @@ fi
 
 # convert MLIR to graphviz dot format
 TMP_MLIR_OPT_CMD=$(mktemp)
-mlir_opt --view-op-graph $TMP_AWK 2>&1 >/dev/null | awk '{gsub(/\x1b\[[0-9;]*m/, ""); print}' >$TMP_MLIR_OPT_CMD
+mlir_opt --view-op-graph $TMP_AWK 2>$TMP_MLIR_OPT_CMD >/dev/null
 
 if [ -n "$OUTPUT" ]; then
     cp --interactive $TMP_MLIR_OPT_CMD $OUTPUT


### PR DESCRIPTION
xprof's Graph Viewer isn't always available, and when it is, it doesn't work many times (at least for me). this script automates the graph plot using `hlo-translate` and `enzymexlamlir-opt`.

```sh
$ ./scripts/hlo-graphviz.sh -f 'private @fused_computation.720.clone.clone' ../profiles/tpu/2026-03-08T22-20-42.707.57974/simulation-xla-dump-linux-x86-ct6e-180-4tpu-1/xla_dump_run/module_0965.reactant_loop_.cl_878201828.after_optimizations_before_buffer_assignment.txt
digraph G {
  compound = true;
  subgraph cluster_1 {
    v2 [label = " ", shape = plain];
    label = "builtin.module : ()\l";
    subgraph cluster_3 {
      v4 [label = " ", shape = plain];
      label = "";
      subgraph cluster_5 {
        v6 [label = " ", shape = plain];
...
```

there are ways to improve this script, but it works well enough for now.