### PR TITLE
feat: ml.softplus operation

### DIFF
--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -55,6 +55,12 @@ def TensorFloat
                  "getElementType()).getElementType())))">,
            "tensor<float or complex<float> scalar>", "::mlir::TensorType">;
 
+def TensorFloatAnyRank
+  : Type<CPred<"::llvm::isa<::mlir::TensorType>($_self) && "
+               "::llvm::isa<::mlir::FloatType>(::llvm::cast<::mlir::"
+               "TensorType>($_self).getElementType())">,
+           "tensor with floating-point element type", "::mlir::TensorType">;
+
 def KernelCallOp : EnzymeXLA_Op<"kernel_call", [
   AttrSizedOperandSegments, DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   DeclareOpInterfaceMethods<CallOpInterface>,
@@ -1163,6 +1169,20 @@ def ReluOp: EnzymeXLA_Op<"ml.relu", [Pure, SameOperandsAndResultType, Elementwis
   );
 
   let results = (outs HLO_Tensor:$result);
+
+  let assemblyFormat = [{
+    $input attr-dict `:` functional-type($input, results)
+  }];
+}
+
+def SoftplusOp: EnzymeXLA_Op<"ml.softplus", [Pure, SameOperandsAndResultType, Elementwise]> {
+  let summary = "Computes the Softplus activation function";
+
+  let arguments = (ins
+    TensorFloatAnyRank:$input
+  );
+
+  let results = (outs TensorFloatAnyRank:$result);
 
   let assemblyFormat = [{
     $input attr-dict `:` functional-type($input, results)

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAML.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAML.cpp
@@ -31,11 +31,14 @@ struct LowerReluOpToStablehlo : public OpRewritePattern<enzymexla::ReluOp> {
 
   LogicalResult matchAndRewrite(enzymexla::ReluOp op,
                                 PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<stablehlo::MaxOp>(
-        op, op.getOperand(),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(),
-            cast<ElementsAttr>(makeAttr(op.getType(), 0))));
+    auto loc = op.getLoc();
+    auto operand = op.getOperand();
+
+    auto zero = stablehlo::ConstantOp::create(
+        rewriter, loc, cast<ElementsAttr>(makeAttr(op.getType(), 0)));
+    auto maxTerm = stablehlo::MaxOp::create(rewriter, loc, operand, zero);
+
+    rewriter.replaceOp(op, maxTerm);
     return success();
   }
 };
@@ -61,21 +64,24 @@ private:
   LogicalResult rewriteAsErf(enzymexla::GeluOp op,
                              PatternRewriter &rewriter) const {
     // x * (0.5 * (1 + erf(x / sqrt(2))))
+    auto loc = op.getLoc();
     auto operand = op.getOperand();
-    rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
-        op, operand,
-        stablehlo::MulOp::create(
-            rewriter, op.getLoc(),
-            createConstantOpFromScalar(rewriter, op, 0.5),
-            stablehlo::AddOp::create(
-                rewriter, op.getLoc(),
-                createConstantOpFromScalar(rewriter, op, 1),
-                chlo::ErfOp::create(
-                    rewriter, op.getLoc(),
-                    stablehlo::MulOp::create(
-                        rewriter, op.getLoc(), operand,
-                        createConstantOpFromScalar(rewriter, op,
-                                                   1 / std::sqrt(2)))))));
+
+    auto cstHalf = createConstantOpFromScalar(rewriter, op, 0.5);
+    auto cstOne = createConstantOpFromScalar(rewriter, op, 1);
+    auto cstInvSqrt2 =
+        createConstantOpFromScalar(rewriter, op, 1 / std::sqrt(2));
+
+    auto xOverSqrt2 =
+        stablehlo::MulOp::create(rewriter, loc, operand, cstInvSqrt2);
+    auto erfTerm = chlo::ErfOp::create(rewriter, loc, xOverSqrt2);
+    auto onePlusErf = stablehlo::AddOp::create(rewriter, loc, cstOne, erfTerm);
+    auto halfTimesOnePlusErf =
+        stablehlo::MulOp::create(rewriter, loc, cstHalf, onePlusErf);
+    auto result =
+        stablehlo::MulOp::create(rewriter, loc, operand, halfTimesOnePlusErf);
+
+    rewriter.replaceOp(op, result);
     return success();
   }
 
@@ -84,32 +90,31 @@ private:
     // Ordering of the operations is important here. This comes from
     // https://github.com/openxla/xla/blob/3ab47f2c9324b10751ef18e58d2b303732685f30/xla/service/gpu/transforms/gemm_rewriter.cc#L773-L803
     // x * (0.5 * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x^3)))
+    auto loc = op.getLoc();
     auto operand = op.getOperand();
-    rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
-        op, operand,
-        stablehlo::MulOp::create(
-            rewriter, op.getLoc(),
-            createConstantOpFromScalar(rewriter, op, 0.5),
-            stablehlo::AddOp::create(
-                rewriter, op.getLoc(),
-                createConstantOpFromScalar(rewriter, op, 1),
-                stablehlo::TanhOp::create(
-                    rewriter, op.getLoc(),
-                    stablehlo::MulOp::create(
-                        rewriter, op.getLoc(),
-                        createConstantOpFromScalar(rewriter, op,
-                                                   std::sqrt(2.0 / M_PI)),
-                        stablehlo::AddOp::create(
-                            rewriter, op.getLoc(), operand,
-                            stablehlo::MulOp::create(
-                                rewriter, op.getLoc(),
-                                createConstantOpFromScalar(rewriter, op,
-                                                           0.044715),
-                                stablehlo::MulOp::create(
-                                    rewriter, op.getLoc(), operand,
-                                    stablehlo::MulOp::create(
-                                        rewriter, op.getLoc(), operand,
-                                        operand)))))))));
+
+    auto cstHalf = createConstantOpFromScalar(rewriter, op, 0.5);
+    auto cstOne = createConstantOpFromScalar(rewriter, op, 1);
+    auto cstSqrt2OverPi =
+        createConstantOpFromScalar(rewriter, op, std::sqrt(2.0 / M_PI));
+    auto cstCoeff = createConstantOpFromScalar(rewriter, op, 0.044715);
+
+    auto x2 = stablehlo::MulOp::create(rewriter, loc, operand, operand);
+    auto x3 = stablehlo::MulOp::create(rewriter, loc, operand, x2);
+    auto coeffTimesX3 = stablehlo::MulOp::create(rewriter, loc, cstCoeff, x3);
+    auto xPlusPoly =
+        stablehlo::AddOp::create(rewriter, loc, operand, coeffTimesX3);
+    auto scaled =
+        stablehlo::MulOp::create(rewriter, loc, cstSqrt2OverPi, xPlusPoly);
+    auto tanhTerm = stablehlo::TanhOp::create(rewriter, loc, scaled);
+    auto onePlusTanh =
+        stablehlo::AddOp::create(rewriter, loc, cstOne, tanhTerm);
+    auto halfTimesOnePlusTanh =
+        stablehlo::MulOp::create(rewriter, loc, cstHalf, onePlusTanh);
+    auto result =
+        stablehlo::MulOp::create(rewriter, loc, operand, halfTimesOnePlusTanh);
+
+    rewriter.replaceOp(op, result);
     return success();
   }
 
@@ -118,24 +123,59 @@ private:
     // This is effectively the same as the tanh formulation but is typically
     // faster and more numerically accurate.
     // x * sigmoid(sqrt(8 / pi) * x * (1 + 0.044715 * x^2))
+    auto loc = op.getLoc();
     auto operand = op.getOperand();
-    rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
-        op, operand,
-        stablehlo::LogisticOp::create(
-            rewriter, op.getLoc(),
-            stablehlo::MulOp::create(
-                rewriter, op.getLoc(),
-                createConstantOpFromScalar(rewriter, op, std::sqrt(8.0 / M_PI)),
-                stablehlo::MulOp::create(
-                    rewriter, op.getLoc(), operand,
-                    stablehlo::AddOp::create(
-                        rewriter, op.getLoc(),
-                        createConstantOpFromScalar(rewriter, op, 1),
-                        stablehlo::MulOp::create(
-                            rewriter, op.getLoc(),
-                            createConstantOpFromScalar(rewriter, op, 0.044715),
-                            stablehlo::MulOp::create(rewriter, op.getLoc(),
-                                                     operand, operand)))))));
+
+    auto cstSqrt8OverPi =
+        createConstantOpFromScalar(rewriter, op, std::sqrt(8.0 / M_PI));
+    auto cstOne = createConstantOpFromScalar(rewriter, op, 1);
+    auto cstCoeff = createConstantOpFromScalar(rewriter, op, 0.044715);
+
+    auto x2 = stablehlo::MulOp::create(rewriter, loc, operand, operand);
+    auto coeffTimesX2 = stablehlo::MulOp::create(rewriter, loc, cstCoeff, x2);
+    auto onePlusCoeffX2 =
+        stablehlo::AddOp::create(rewriter, loc, cstOne, coeffTimesX2);
+    auto xTimesInner =
+        stablehlo::MulOp::create(rewriter, loc, operand, onePlusCoeffX2);
+    auto scaled =
+        stablehlo::MulOp::create(rewriter, loc, cstSqrt8OverPi, xTimesInner);
+    auto sigmoid = stablehlo::LogisticOp::create(rewriter, loc, scaled);
+    auto result = stablehlo::MulOp::create(rewriter, loc, operand, sigmoid);
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct LowerSoftplusOpToStablehlo
+    : public OpRewritePattern<enzymexla::SoftplusOp> {
+  using OpRewritePattern<enzymexla::SoftplusOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(enzymexla::SoftplusOp op,
+                                PatternRewriter &rewriter) const override {
+    // Numerically stable Softplus with NaN propagation:
+    // softplus(x) = x                            if x != x (NaN)
+    //               max(x, 0) + log1p(exp(-|x|)) otherwise
+    auto loc = op.getLoc();
+    auto operand = op.getOperand();
+
+    auto zero = createConstantOpFromScalar(rewriter, op, 0);
+
+    auto maxTerm = stablehlo::MaxOp::create(rewriter, loc, operand, zero);
+    auto absOperand = stablehlo::AbsOp::create(rewriter, loc, operand);
+    auto negAbsOperand = stablehlo::NegOp::create(rewriter, loc, absOperand);
+    auto expNegAbs = stablehlo::ExpOp::create(rewriter, loc, negAbsOperand);
+    auto logTerm = stablehlo::Log1pOp::create(rewriter, loc, expNegAbs);
+    auto stableSoftplus =
+        stablehlo::AddOp::create(rewriter, loc, maxTerm, logTerm);
+
+    auto nanPred = stablehlo::CompareOp::create(
+        rewriter, loc, operand, operand, stablehlo::ComparisonDirection::NE,
+        stablehlo::ComparisonType::FLOAT);
+
+    auto result = stablehlo::SelectOp::create(rewriter, loc, nanPred, operand,
+                                              stableSoftplus);
+    rewriter.replaceOp(op, result);
     return success();
   }
 };
@@ -151,6 +191,7 @@ struct LowerEnzymeXLAMLPass
     // SHLO Lowering
     patterns.add<LowerReluOpToStablehlo>(context);
     patterns.add<LowerGeluOpToStablehlo>(context);
+    patterns.add<LowerSoftplusOpToStablehlo>(context);
 
     GreedyRewriteConfig config;
     config.enableFolding();
@@ -161,7 +202,8 @@ struct LowerEnzymeXLAMLPass
 
     // Verify that all illegal ops have been lowered
     auto walkResult = getOperation()->walk([&](Operation *op) {
-      if (isa<enzymexla::ReluOp, enzymexla::GeluOp>(op)) {
+      if (isa<enzymexla::ReluOp, enzymexla::GeluOp, enzymexla::SoftplusOp>(
+              op)) {
         op->emitError("Failed to lower enzymexla ML operation");
         return WalkResult::interrupt();
       }

--- a/test/lit_tests/ml/softplus.mlir
+++ b/test/lit_tests/ml/softplus.mlir
@@ -1,0 +1,56 @@
+// RUN: enzymexlamlir-opt %s --lower-enzymexla-ml | FileCheck %s --check-prefix=LOWER
+// RUN: enzymexlamlir-opt %s --lower-enzymexla-ml | stablehlo-translate - --interpret
+
+func.func @apply_softplus(%arg0: tensor<7xf32>) -> tensor<7xf32> {
+  %0 = enzymexla.ml.softplus %arg0 : (tensor<7xf32>) -> tensor<7xf32>
+  return %0 : tensor<7xf32>
+}
+
+func.func @apply_softplus_scalar(%arg0: tensor<f32>) -> tensor<f32> {
+  %0 = enzymexla.ml.softplus %arg0 : (tensor<f32>) -> tensor<f32>
+  return %0 : tensor<f32>
+}
+
+func.func @main() {
+  // Numerics test for stable softplus form on finite inputs.
+  %input = stablehlo.constant dense<[-1000.0, -2.0, -1.0, 0.0, 1.0, 2.0, 1000.0]> : tensor<7xf32>
+  %expected = stablehlo.constant dense<[0.0, 0.126928001, 0.313261688, 0.693147182, 1.31326175, 2.12692809, 1000.0]> : tensor<7xf32>
+
+  %res = func.call @apply_softplus(%input) : (tensor<7xf32>) -> tensor<7xf32>
+  check.expect_almost_eq %res, %expected : tensor<7xf32>
+
+  // NaN propagation test: softplus(NaN) == NaN
+  %zero = stablehlo.constant dense<0.0> : tensor<f32>
+  %nan = stablehlo.divide %zero, %zero : tensor<f32>
+  %nan_res = func.call @apply_softplus_scalar(%nan) : (tensor<f32>) -> tensor<f32>
+  %is_nan = stablehlo.compare  NE, %nan_res, %nan_res,  FLOAT : (tensor<f32>, tensor<f32>) -> tensor<i1>
+  check.expect_eq_const %is_nan, dense<true> : tensor<i1>
+
+  return
+}
+
+// LOWER: func.func @apply_softplus(%arg0: tensor<7xf32>) -> tensor<7xf32> {
+// LOWER-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<7xf32>
+// LOWER-NEXT:    %0 = stablehlo.maximum %arg0, %cst : tensor<7xf32>
+// LOWER-NEXT:    %1 = stablehlo.abs %arg0 : tensor<7xf32>
+// LOWER-NEXT:    %2 = stablehlo.negate %1 : tensor<7xf32>
+// LOWER-NEXT:    %3 = stablehlo.exponential %2 : tensor<7xf32>
+// LOWER-NEXT:    %4 = stablehlo.log_plus_one %3 : tensor<7xf32>
+// LOWER-NEXT:    %5 = stablehlo.add %0, %4 : tensor<7xf32>
+// LOWER-NEXT:    %6 = stablehlo.compare  NE, %arg0, %arg0,  FLOAT : (tensor<7xf32>, tensor<7xf32>) -> tensor<7xi1>
+// LOWER-NEXT:    %7 = stablehlo.select %6, %arg0, %5 : tensor<7xi1>, tensor<7xf32>
+// LOWER-NEXT:    return %7 : tensor<7xf32>
+// LOWER-NEXT:  }
+
+// LOWER: func.func @apply_softplus_scalar(%arg0: tensor<f32>) -> tensor<f32> {
+// LOWER-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// LOWER-NEXT:    %0 = stablehlo.maximum %arg0, %cst : tensor<f32>
+// LOWER-NEXT:    %1 = stablehlo.abs %arg0 : tensor<f32>
+// LOWER-NEXT:    %2 = stablehlo.negate %1 : tensor<f32>
+// LOWER-NEXT:    %3 = stablehlo.exponential %2 : tensor<f32>
+// LOWER-NEXT:    %4 = stablehlo.log_plus_one %3 : tensor<f32>
+// LOWER-NEXT:    %5 = stablehlo.add %0, %4 : tensor<f32>
+// LOWER-NEXT:    %6 = stablehlo.compare  NE, %arg0, %arg0,  FLOAT : (tensor<f32>, tensor<f32>) -> tensor<i1>
+// LOWER-NEXT:    %7 = stablehlo.select %6, %arg0, %5 : tensor<i1>, tensor<f32>
+// LOWER-NEXT:    return %7 : tensor<f32>
+// LOWER-NEXT:  }


### PR DESCRIPTION
partial fix to https://github.com/EnzymeAD/Reactant.jl/issues/2637 (opening follow up PRs for derivative rules and const prop)

softplus implementation mimics that of Jax