### PR TITLE
Add XLA patch: collective combiner skip reachable instead of breaking

### DIFF
--- a/patches/xla_collective_combiner.patch
+++ b/patches/xla_collective_combiner.patch
@@ -1,0 +1,15 @@
+diff --git a/xla/service/collective_combiner_utils.h b/xla/service/collective_combiner_utils.h
+index 8784c0f..1e38294 100644
+--- a/xla/service/collective_combiner_utils.h
++++ b/xla/service/collective_combiner_utils.h
+@@ -148,8 +148,8 @@ absl::StatusOr<bool> CombineInstructionsByKey(
+             return reachable;
+           });
+       if (is_reachable) {
+-        VLOG(1) << "Instruction is reachable.";
+-        break;
++        VLOG(1) << "Instruction is reachable, skipping.";
++        continue;
+       }
+
+       VLOG(1) << "Adding instruction to set.";

--- a/third_party/xla/workspace.bzl
+++ b/third_party/xla/workspace.bzl
@@ -17,6 +17,6 @@ def repo(extra_patches = [], override_commit = ""):
         strip_prefix = "xla-{commit}".format(commit = commit),
         urls = ["https://github.com/openxla/xla/archive/{commit}.tar.gz".format(commit = commit)],
         patch_cmds = XLA_PATCHES + extra_patches,
-        patches = ["//:patches/xla.patch", "//:patches/xla_win.patch"],
+        patches = ["//:patches/xla.patch", "//:patches/xla_win.patch", "//:patches/xla_collective_combiner.patch"],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
## Summary

- Add `patches/xla_collective_combiner.patch` — a one-line XLA fix that changes `break` to `continue` in the `CombineInstructionsByKey` template when a dependent (reachable) instruction is encountered
- The combiner now skips dependent instructions and keeps scanning for independent ones, instead of stopping early

## Impact on GB-25 ocean simulation

Validated on the CI HLO dump (pass 0119, pre-combiner):

| Version | Collective-permute count |
|---------|-------------------------|
| Before (break) | 158 |
| After (continue) | **152** |

6 fewer NCCL collective-permute calls per loop iteration. The eliminated ops are halo-exchange permutes (`collective-permute.834`, `.845`, `.964`, `.968`, `.1042`) that were stranded as singletons because a dependent permute appeared before them in topological order.

## Upstream

PR: https://github.com/openxla/xla/pull/39517

## Test plan

- [x] All existing XLA combiner tests pass (AllReduce, AllGather, ReduceScatter, CollectivePermute, GPU/CPU backends)
- [x] New `CombineAcrossInterleavedDependencyChains` test in upstream PR fails with `break`, passes with `continue`
- [x] Validated on real GB-25 HLO dump: 449 → 152 (vs 449 → 158 without fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)