### PR TITLE
Fix XLA concat cost model penalty for stencil codes

### DIFF
--- a/patches/xla_concat_cost.patch
+++ b/patches/xla_concat_cost.patch
@@ -1,0 +1,26 @@
+diff --git a/xla/service/gpu/model/gpu_hlo_cost_analysis.cc b/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
+index e395f548ad..147b2a11ea 100644
+--- a/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
++++ b/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
+@@ -448,7 +448,20 @@ absl::Status GpuHloCostAnalysis::HandleConcatenate(const HloInstruction* hlo) {
+   // tiling patterns.
+   int64_t dim = Cast<HloConcatenateInstruction>(hlo)->concatenate_dimension();
+   if (dim > 0 && hlo->operand(0)->shape().dimensions()[dim] & 31) {
+-    flop_per_element = 400;
++    // Only apply the divergence penalty if the number of elements after
++    // the concat dimension is small enough that a significant fraction of
++    // warps will cross the operand boundary. When there are many elements
++    // after the concat dim, each warp processes elements within a single
++    // operand, and divergence is negligible.
++    int64_t elements_after_concat_dim = 1;
++    for (int64_t i = dim + 1; i < hlo->shape().dimensions_size(); ++i) {
++      elements_after_concat_dim *= hlo->operand(0)->shape().dimensions()[i];
++    }
++    // 128 elements = 4 warps. Below this threshold, divergence affects
++    // >25% of warps. Above it, divergence is <25% and not worth penalizing.
++    if (elements_after_concat_dim < 128) {
++      flop_per_element = 400;
++    }
+   }
+   current_properties_[kFlopsKey] =
+       flop_per_element * ShapeUtil::ElementsInRecursive(hlo->shape());

--- a/third_party/xla/workspace.bzl
+++ b/third_party/xla/workspace.bzl
@@ -17,6 +17,6 @@ def repo(extra_patches = [], override_commit = ""):
         strip_prefix = "xla-{commit}".format(commit = commit),
         urls = ["https://github.com/openxla/xla/archive/{commit}.tar.gz".format(commit = commit)],
         patch_cmds = XLA_PATCHES + extra_patches,
-        patches = ["//:patches/xla.patch", "//:patches/xla_win.patch"],
+        patches = ["//:patches/xla.patch", "//:patches/xla_win.patch", "//:patches/xla_concat_cost.patch"],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
## Summary

Narrows the XLA concat flop penalty so it only fires when warp divergence is significant.

## Problem

`HandleConcatenate` in `gpu_hlo_cost_analysis.cc` adds **400 fake FLOPs/element** when `dim > 0 && operand_dim_size % 32 != 0`. For GB-25's stencil halos (sizes 1, 759, 760, 1528), **321 of 467 concatenates (69%)** hit this, making the cost model think they're 67x more expensive than reality.

This prevents the priority fusion pass from absorbing concat ops into compute kernels. Instead they become a separate data-shuffling kernel that materializes huge intermediate buffers — **7 seconds (24% of kernel time)** on A100.

This is the root cause of the 21.6s → 29.1s regression between mst3v2 and Reactant main on vanilla XLA. (The spill patch accidentally masked this by forcing fusion via an Infinite() cost bug.)

## Fix

Only apply the 400-flop penalty when `elements_after_concat_dim < 128` — i.e., when >25% of warps would cross the concat boundary. For GB-25's dim=1 concats with 1528 trailing elements, only 2% of warps are affected.

## Test results

- `DontFuseConcat` LLM test passes (shapes have 64 trailing elements < 128)
- `gpu_hlo_cost_analysis_test` passes
- `priority_fusion_test` passes
- GB-25 locally: 609 → 564 fusions, concats absorbed into compute kernels

🤖 Generated with [Claude Code](https://claude.com/claude-code)