### PR TITLE
support llvm.alloca for ParallelizeBlockOps

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1474,6 +1474,7 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
         legal = true;
         assert(helper.lb);
         assert(helper.ub);
+        break;
       }
       if (!legal) {
         return rewriter.notifyMatchFailure(loop,

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1446,6 +1446,16 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
 
   LogicalResult matchAndRewrite(WhileOp loop,
                                 PatternRewriter &rewriter) const override {
+    if (getenv("DEBUG_WHILE_TO_FOR")) {
+      llvm::errs() << "MoveWhileToFor: trying to match WhileOp at ";
+      loop.getLoc().print(llvm::errs());
+      llvm::errs() << "\n  inits=" << loop.getInits().size()
+                    << " results=" << loop.getResults().size()
+                    << " before_args=" << loop.getBefore().front().getNumArguments()
+                    << " after_args=" << loop.getAfter().front().getNumArguments()
+                    << " before_ops=" << loop.getBefore().front().getOperations().size()
+                    << "\n";
+    }
     auto condOp = loop.getConditionOp();
     SmallVector<Value, 2> results = {condOp.getArgs()};
     WhileToForHelper helper(loop,
@@ -1501,10 +1511,12 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
 
         if (auto trueBlockArg =
                 dyn_cast<BlockArgument>(selectOp.getTrueValue())) {
-          newArg = loop.getOperand(trueBlockArg.getArgNumber());
+          if (trueBlockArg.getOwner() == &condOp->getParentRegion()->front())
+            newArg = loop.getOperand(trueBlockArg.getArgNumber());
         } else if (auto falseBlockArg =
                        dyn_cast<BlockArgument>(selectOp.getFalseValue())) {
-          newArg = loop.getOperand(falseBlockArg.getArgNumber());
+          if (falseBlockArg.getOwner() == &condOp->getParentRegion()->front())
+            newArg = loop.getOperand(falseBlockArg.getArgNumber());
         }
       }
       if (!newArg)

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1446,16 +1446,6 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
 
   LogicalResult matchAndRewrite(WhileOp loop,
                                 PatternRewriter &rewriter) const override {
-    if (getenv("DEBUG_WHILE_TO_FOR")) {
-      llvm::errs() << "MoveWhileToFor: trying to match WhileOp at ";
-      loop.getLoc().print(llvm::errs());
-      llvm::errs() << "\n  inits=" << loop.getInits().size()
-                    << " results=" << loop.getResults().size()
-                    << " before_args=" << loop.getBefore().front().getNumArguments()
-                    << " after_args=" << loop.getAfter().front().getNumArguments()
-                    << " before_ops=" << loop.getBefore().front().getOperations().size()
-                    << "\n";
-    }
     auto condOp = loop.getConditionOp();
     SmallVector<Value, 2> results = {condOp.getArgs()};
     WhileToForHelper helper(loop,
@@ -1511,11 +1501,9 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
 
         if (auto trueBlockArg =
                 dyn_cast<BlockArgument>(selectOp.getTrueValue())) {
-          if (trueBlockArg.getOwner() == &condOp->getParentRegion()->front())
             newArg = loop.getOperand(trueBlockArg.getArgNumber());
         } else if (auto falseBlockArg =
                        dyn_cast<BlockArgument>(selectOp.getFalseValue())) {
-          if (falseBlockArg.getOwner() == &condOp->getParentRegion()->front())
             newArg = loop.getOperand(falseBlockArg.getArgNumber());
         }
       }

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1501,10 +1501,10 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
 
         if (auto trueBlockArg =
                 dyn_cast<BlockArgument>(selectOp.getTrueValue())) {
-            newArg = loop.getOperand(trueBlockArg.getArgNumber());
+          newArg = loop.getOperand(trueBlockArg.getArgNumber());
         } else if (auto falseBlockArg =
                        dyn_cast<BlockArgument>(selectOp.getFalseValue())) {
-            newArg = loop.getOperand(falseBlockArg.getArgNumber());
+          newArg = loop.getOperand(falseBlockArg.getArgNumber());
         }
       }
       if (!newArg)

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1474,7 +1474,6 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
         legal = true;
         assert(helper.lb);
         assert(helper.ub);
-        break;
       }
       if (!legal) {
         return rewriter.notifyMatchFailure(loop,

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -557,18 +557,6 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       emitAlternative(atoi(blockSizeStr), alternativesOp);
       if (curRegion == 0) {
         llvm::errs() << " Failed to make kernel with exact dimension\n";
-        // if (getenv("DUMP_MLIR_ON_EXACT_DIM_FAIL")) {
-        //   if (auto parentFunc =
-        //   wrapper->getParentOfType<mlir::FunctionOpInterface>()) {
-        //     llvm::errs() << "=== FUNC IR at 'Failed to make kernel with exact
-        //     dimension' ===\n"; parentFunc.print(llvm::errs()); llvm::errs()
-        //     << "\n=== END FUNC IR ===\n";
-        //   } else {
-        //     llvm::errs() << "=== WRAPPER IR at 'Failed to make kernel with
-        //     exact dimension' ===\n"; wrapper.print(llvm::errs());
-        //     llvm::errs() << "\n=== END WRAPPER IR ===\n";
-        //   }
-        // }
         assert(wrapper.getOperands().size() == 6);
         assert(pop.getUpperBound().size() == 6 &&
                pop.getUpperBound() == wrapper.getOperands());

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -606,7 +606,6 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
 
     rewriter.eraseOp(wrapper);
 
-    llvm::errs() << "=== SplitParallelOp: matched ===\n";
     return success();
   }
 
@@ -1112,7 +1111,6 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
     for (Operation *op : llvm::reverse(toErase))
       rewriter.eraseOp(op);
 
-    llvm::errs() << "=== ParallelizeBlockOps: matched ===\n";
     return success();
   }
 };
@@ -1174,7 +1172,6 @@ struct HandleWrapperRootAlloca
     for (Operation *op : llvm::reverse(toErase))
       rewriter.eraseOp(op);
 
-    llvm::errs() << "=== CreateParallelOps: matched ===\n";
     return success();
   }
 };
@@ -1371,7 +1368,6 @@ struct HandleWrapperRootOps : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       rewriter.eraseOp(op);
     }
 
-    llvm::errs() << "=== HandleWrapperRootOps: matched ===\n";
     return success();
   }
 };
@@ -1763,8 +1759,6 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
         auto cast = memref::CastOp::create(rewriter, alloca.getLoc(),
                                            alloca.getType(), newAlloca);
         it->replaceAllUsesWith(cast);
-        // } else if (dyn_cast<LLVM::AllocaOp>(&*it)) {
-        //   shared memory
       } else {
         assert(0);
       }
@@ -2005,11 +1999,9 @@ struct ConvertParallelToGPU1Pass
       GreedyRewriteConfig config;
       config.enableFolding();
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
-        llvm::errs() << "=== InnerParallelSerialization: FAILED ===\n";
         signalPassFailure();
         return;
       }
-      llvm::errs() << "=== InnerParallelSerialization: SUCCESS ===\n";
     }
     // TODO we need to transform all parallels in gpu_wrappers to have lower
     // bounds of 0 and steps of 1 as we kind of assume that in many patterns (or
@@ -2050,10 +2042,8 @@ struct ConvertParallelToGPU1Pass
       populateNormalizationPatterns(patterns);
       GreedyRewriteConfig config;
       config.enableFolding();
-      llvm::errs()
-          << "=== runNormalization: before applyPatternsGreedily ===\n";
+      
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
-        llvm::errs() << "=== runNormalization: FAILED ===\n";
         signalPassFailure();
         return;
       }
@@ -2474,11 +2464,9 @@ struct ConvertParallelToGPU1Pass
       GreedyRewriteConfig config;
       config.enableFolding();
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
-        llvm::errs() << "=== ParallelToGPULaunch: FAILED ===\n";
         signalPassFailure();
         return;
       }
-      llvm::errs() << "=== ParallelToGPULaunch: SUCCESS ===\n";
     }
     {
       RewritePatternSet patterns(&getContext());

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -185,7 +185,7 @@ getDirectlyNestedSingleParallel_(const char *PATTERN, Block *block,
                                  bool allowAllocas = false,
                                  bool allowIndexComputation = false) {
   auto it = block->begin();
-  while ((allowAllocas && isa<memref::AllocaOp>(&*it)) ||
+  while ((allowAllocas && (isa<memref::AllocaOp>(&*it) || isa<LLVM::AllocaOp>(&*it))) ||
          (allowIndexComputation && isa<arith::ArithDialect>(it->getDialect())))
     it++;
   auto pop = dyn_cast<scf::ParallelOp>(&*it);
@@ -556,6 +556,17 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       emitAlternative(atoi(blockSizeStr), alternativesOp);
       if (curRegion == 0) {
         llvm::errs() << " Failed to make kernel with exact dimension\n";
+        // if (getenv("DUMP_MLIR_ON_EXACT_DIM_FAIL")) {
+        //   if (auto parentFunc = wrapper->getParentOfType<mlir::FunctionOpInterface>()) {
+        //     llvm::errs() << "=== FUNC IR at 'Failed to make kernel with exact dimension' ===\n";
+        //     parentFunc.print(llvm::errs());
+        //     llvm::errs() << "\n=== END FUNC IR ===\n";
+        //   } else {
+        //     llvm::errs() << "=== WRAPPER IR at 'Failed to make kernel with exact dimension' ===\n";
+        //     wrapper.print(llvm::errs());
+        //     llvm::errs() << "\n=== END WRAPPER IR ===\n";
+        //   }
+        // }
         assert(wrapper.getOperands().size() == 6);
         assert(pop.getUpperBound().size() == 6 &&
                pop.getUpperBound() == wrapper.getOperands());
@@ -593,6 +604,7 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
 
     rewriter.eraseOp(wrapper);
 
+    llvm::errs() << "=== SplitParallelOp: matched ===\n";
     return success();
   }
 
@@ -1057,6 +1069,7 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
     {
       auto zeroindex = arith::ConstantIndexOp::create(rewriter, loc, 0);
       rewriter.setInsertionPoint(innerBlock->getTerminator());
+      mlir::enzymexla::BarrierOp::create(rewriter, loc, innerBlock->getArguments());
       auto cmpOp =
           arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
                                 zeroindex, innerBlock->getArgument(0));
@@ -1079,8 +1092,12 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
           llvm_unreachable("Unhandled case");
           break;
         } else if (auto alloca = dyn_cast<LLVM::AllocaOp>(&op)) {
-          llvm_unreachable("Unhandled case");
-          break;
+          mlir::OpBuilder::InsertionGuard guard(rewriter);
+          rewriter.setInsertionPointToStart(innerBlock);
+          auto *newOp = rewriter.clone(op, mapping);
+          rewriter.replaceOpUsesWithinBlock(&op, newOp->getResults(), innerBlock);
+          toErase.push_back(&op);
+          continue;
         } else {
           rewriter.clone(op, mapping);
         }
@@ -1091,6 +1108,7 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
     for (Operation *op : llvm::reverse(toErase))
       rewriter.eraseOp(op);
 
+    llvm::errs() << "=== ParallelizeBlockOps: matched ===\n";
     return success();
   }
 };
@@ -1152,6 +1170,7 @@ struct HandleWrapperRootAlloca
     for (Operation *op : llvm::reverse(toErase))
       rewriter.eraseOp(op);
 
+    llvm::errs() << "=== CreateParallelOps: matched ===\n";
     return success();
   }
 };
@@ -1348,6 +1367,7 @@ struct HandleWrapperRootOps : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       rewriter.eraseOp(op);
     }
 
+    llvm::errs() << "=== HandleWrapperRootOps: matched ===\n";
     return success();
   }
 };
@@ -1739,6 +1759,8 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
         auto cast = memref::CastOp::create(rewriter, alloca.getLoc(),
                                            alloca.getType(), newAlloca);
         it->replaceAllUsesWith(cast);
+      // } else if (dyn_cast<LLVM::AllocaOp>(&*it)) {
+      //   shared memory
       } else {
         assert(0);
       }
@@ -1979,9 +2001,11 @@ struct ConvertParallelToGPU1Pass
       GreedyRewriteConfig config;
       config.enableFolding();
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
+        llvm::errs() << "=== InnerParallelSerialization: FAILED ===\n";
         signalPassFailure();
         return;
       }
+      llvm::errs() << "=== InnerParallelSerialization: SUCCESS ===\n";
     }
     // TODO we need to transform all parallels in gpu_wrappers to have lower
     // bounds of 0 and steps of 1 as we kind of assume that in many patterns (or
@@ -2022,7 +2046,9 @@ struct ConvertParallelToGPU1Pass
       populateNormalizationPatterns(patterns);
       GreedyRewriteConfig config;
       config.enableFolding();
+      llvm::errs() << "=== runNormalization: before applyPatternsGreedily ===\n";
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
+        llvm::errs() << "=== runNormalization: FAILED ===\n";
         signalPassFailure();
         return;
       }
@@ -2443,9 +2469,11 @@ struct ConvertParallelToGPU1Pass
       GreedyRewriteConfig config;
       config.enableFolding();
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
+        llvm::errs() << "=== ParallelToGPULaunch: FAILED ===\n";
         signalPassFailure();
         return;
       }
+      llvm::errs() << "=== ParallelToGPULaunch: SUCCESS ===\n";
     }
     {
       RewritePatternSet patterns(&getContext());

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -185,7 +185,8 @@ getDirectlyNestedSingleParallel_(const char *PATTERN, Block *block,
                                  bool allowAllocas = false,
                                  bool allowIndexComputation = false) {
   auto it = block->begin();
-  while ((allowAllocas && (isa<memref::AllocaOp>(&*it) || isa<LLVM::AllocaOp>(&*it))) ||
+  while ((allowAllocas &&
+          (isa<memref::AllocaOp>(&*it) || isa<LLVM::AllocaOp>(&*it))) ||
          (allowIndexComputation && isa<arith::ArithDialect>(it->getDialect())))
     it++;
   auto pop = dyn_cast<scf::ParallelOp>(&*it);
@@ -557,13 +558,14 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       if (curRegion == 0) {
         llvm::errs() << " Failed to make kernel with exact dimension\n";
         // if (getenv("DUMP_MLIR_ON_EXACT_DIM_FAIL")) {
-        //   if (auto parentFunc = wrapper->getParentOfType<mlir::FunctionOpInterface>()) {
-        //     llvm::errs() << "=== FUNC IR at 'Failed to make kernel with exact dimension' ===\n";
-        //     parentFunc.print(llvm::errs());
-        //     llvm::errs() << "\n=== END FUNC IR ===\n";
+        //   if (auto parentFunc =
+        //   wrapper->getParentOfType<mlir::FunctionOpInterface>()) {
+        //     llvm::errs() << "=== FUNC IR at 'Failed to make kernel with exact
+        //     dimension' ===\n"; parentFunc.print(llvm::errs()); llvm::errs()
+        //     << "\n=== END FUNC IR ===\n";
         //   } else {
-        //     llvm::errs() << "=== WRAPPER IR at 'Failed to make kernel with exact dimension' ===\n";
-        //     wrapper.print(llvm::errs());
+        //     llvm::errs() << "=== WRAPPER IR at 'Failed to make kernel with
+        //     exact dimension' ===\n"; wrapper.print(llvm::errs());
         //     llvm::errs() << "\n=== END WRAPPER IR ===\n";
         //   }
         // }
@@ -1069,7 +1071,8 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
     {
       auto zeroindex = arith::ConstantIndexOp::create(rewriter, loc, 0);
       rewriter.setInsertionPoint(innerBlock->getTerminator());
-      mlir::enzymexla::BarrierOp::create(rewriter, loc, innerBlock->getArguments());
+      mlir::enzymexla::BarrierOp::create(rewriter, loc,
+                                         innerBlock->getArguments());
       auto cmpOp =
           arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
                                 zeroindex, innerBlock->getArgument(0));
@@ -1095,7 +1098,8 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
           mlir::OpBuilder::InsertionGuard guard(rewriter);
           rewriter.setInsertionPointToStart(innerBlock);
           auto *newOp = rewriter.clone(op, mapping);
-          rewriter.replaceOpUsesWithinBlock(&op, newOp->getResults(), innerBlock);
+          rewriter.replaceOpUsesWithinBlock(&op, newOp->getResults(),
+                                            innerBlock);
           toErase.push_back(&op);
           continue;
         } else {
@@ -1759,8 +1763,8 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
         auto cast = memref::CastOp::create(rewriter, alloca.getLoc(),
                                            alloca.getType(), newAlloca);
         it->replaceAllUsesWith(cast);
-      // } else if (dyn_cast<LLVM::AllocaOp>(&*it)) {
-      //   shared memory
+        // } else if (dyn_cast<LLVM::AllocaOp>(&*it)) {
+        //   shared memory
       } else {
         assert(0);
       }
@@ -2046,7 +2050,8 @@ struct ConvertParallelToGPU1Pass
       populateNormalizationPatterns(patterns);
       GreedyRewriteConfig config;
       config.enableFolding();
-      llvm::errs() << "=== runNormalization: before applyPatternsGreedily ===\n";
+      llvm::errs()
+          << "=== runNormalization: before applyPatternsGreedily ===\n";
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         llvm::errs() << "=== runNormalization: FAILED ===\n";
         signalPassFailure();

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1083,7 +1083,7 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
           break;
         } else if (auto alloca = dyn_cast<LLVM::AllocaOp>(&op)) {
           mlir::OpBuilder::InsertionGuard guard(rewriter);
-          rewriter.setInsertionPointToStart(innerBlock);
+          rewriter.setInsertionPointToStart(ifOp.thenBlock());
           auto *newOp = rewriter.clone(op, mapping);
           rewriter.replaceOpUsesWithinBlock(&op, newOp->getResults(),
                                             innerBlock);

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1082,8 +1082,6 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
           llvm_unreachable("Unhandled case");
           break;
         } else if (auto alloca = dyn_cast<LLVM::AllocaOp>(&op)) {
-          mlir::OpBuilder::InsertionGuard guard(rewriter);
-          rewriter.setInsertionPointToStart(ifOp.thenBlock());
           auto *newOp = rewriter.clone(op, mapping);
           rewriter.replaceOpUsesWithinBlock(&op, newOp->getResults(),
                                             innerBlock);
@@ -1654,6 +1652,11 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
         gridPop.getBody(), /* allowAllocas */ true);
     if (!blockPop)
       return failure();
+
+    for (auto it = gridPop.begin(); !isa<scf::ParallelOp>(&*it); ++it)
+      if (isa<LLVM::AllocaOp>(&*it))
+        llvm_unreachable("LLVM::AllocaOp before block parallel not yet "
+                         "supported in ParallelToGPULaunch");
 
     rewriter.setInsertionPoint(wrapper);
     auto errOp = enzymexla::GPUErrorOp::create(rewriter, loc);

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -2042,7 +2042,7 @@ struct ConvertParallelToGPU1Pass
       populateNormalizationPatterns(patterns);
       GreedyRewriteConfig config;
       config.enableFolding();
-      
+
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         signalPassFailure();
         return;

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-llvm-alloca.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-llvm-alloca.mlir
@@ -1,0 +1,50 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// Tests that ParallelizeBlockOps correctly handles LLVM::AllocaOp:
+//   BarrierOp inserted before C' section
+//   LLVM::AllocaOp in "after parallel" cloned to innerBlock start
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+  llvm.func local_unnamed_addr @test_parallelize_block_ops_llvm_alloca(%arg0: !llvm.ptr {llvm.noundef}) -> (i32 {llvm.noundef}) attributes {dso_local, passthrough = ["mustprogress"]} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %0 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xf64, 1>
+    %1 = "enzymexla.gpu_wrapper"(%c4, %c1, %c1, %c8, %c1, %c1) ({
+      scf.parallel (%arg1) = (%c0) to (%c4) step (%c1) {
+        // A: read ops before inner parallel
+        %2 = memref.load %0[%arg1] : memref<?xf64, 1>
+        scf.parallel (%arg2) = (%c0) to (%c8) step (%c1) {
+          // B: inner parallel body
+          %5 = memref.load %0[%arg2] : memref<?xf64, 1>
+          %6 = arith.addf %5, %5 : f64
+          memref.store %6, %0[%arg2] : memref<?xf64, 1>
+          scf.reduce
+        }
+        // C: LLVM::AllocaOp + write after inner parallel
+        %3 = llvm.alloca %c1_i64 x !llvm.struct<"struct.Result", (f64)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+        %4 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<?xf64>
+        memref.store %2, %4[%c0] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    llvm.return %c0_i32 : i32
+  }
+}
+
+// CHECK:  llvm.func local_unnamed_addr @test_parallelize_block_ops_llvm_alloca(%arg0: !llvm.ptr {llvm.noundef}) -> (i32 {llvm.noundef}) attributes {dso_local, passthrough = ["mustprogress"]} {
+// CHECK:    gpu.launch blocks(%arg1, %arg2, %arg3) in (%arg7 = %c4, %arg8 = %c1, %arg9 = %c1) threads(%arg4, %arg5, %arg6) in (%arg10 = %c8, %arg11 = %c1, %arg12 = %c1) {
+// CHECK:      %[[ALLOCA:.*]] = llvm.alloca %{{.*}} x !llvm.struct<"struct.Result", (f64)>
+// CHECK:      %[[LOAD_A:.*]] = memref.load %{{.*}}[%block_id_x]
+// CHECK:      %[[LOAD_B:.*]] = memref.load %{{.*}}[%thread_id_x]
+// CHECK:      arith.addf
+// CHECK:      memref.store
+// CHECK:      gpu.barrier
+// CHECK:      scf.if
+// CHECK:        "enzymexla.pointer2memref"(%[[ALLOCA]])
+// CHECK:        memref.store %[[LOAD_A]]
+// CHECK:      gpu.terminator

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-llvm-alloca.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-llvm-alloca.mlir
@@ -37,14 +37,36 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vec
 }
 
 // CHECK:  llvm.func local_unnamed_addr @test_parallelize_block_ops_llvm_alloca(%arg0: !llvm.ptr {llvm.noundef}) -> (i32 {llvm.noundef}) attributes {dso_local, passthrough = ["mustprogress"]} {
-// CHECK:    gpu.launch blocks(%arg1, %arg2, %arg3) in (%arg7 = %c4, %arg8 = %c1, %arg9 = %c1) threads(%arg4, %arg5, %arg6) in (%arg10 = %c8, %arg11 = %c1, %arg12 = %c1) {
-// CHECK:      %[[ALLOCA:.*]] = llvm.alloca %{{.*}} x !llvm.struct<"struct.Result", (f64)>
-// CHECK:      %[[LOAD_A:.*]] = memref.load %{{.*}}[%block_id_x]
-// CHECK:      %[[LOAD_B:.*]] = memref.load %{{.*}}[%thread_id_x]
-// CHECK:      arith.addf
-// CHECK:      memref.store
-// CHECK:      gpu.barrier
-// CHECK:      scf.if
-// CHECK:        "enzymexla.pointer2memref"(%[[ALLOCA]])
-// CHECK:        memref.store %[[LOAD_A]]
-// CHECK:      gpu.terminator
+// CHECK-NEXT:    %true = arith.constant true
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %c4 = arith.constant 4 : index
+// CHECK-NEXT:    %c8 = arith.constant 8 : index
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    %c1_i64 = arith.constant 1 : i64
+// CHECK-NEXT:    %0 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xf64, 1>
+// CHECK-NEXT:    %1 = "enzymexla.gpu_error"() ({
+// CHECK-NEXT:      scf.if %true {
+// CHECK-NEXT:        gpu.launch blocks(%arg1, %arg2, %arg3) in (%arg7 = %c4, %arg8 = %c1, %arg9 = %c1) threads(%arg4, %arg5, %arg6) in (%arg10 = %c8, %arg11 = %c1, %arg12 = %c1) {
+// CHECK-NEXT:          %c1_i64_0 = arith.constant 1 : i64
+// CHECK-NEXT:          %c0_1 = arith.constant 0 : index
+// CHECK-NEXT:          %block_id_x = gpu.block_id  x
+// CHECK-NEXT:          %thread_id_x = gpu.thread_id  x
+// CHECK-NEXT:          %2 = llvm.alloca %c1_i64_0 x !llvm.struct<"struct.Result", (f64)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:          %3 = memref.load %0[%block_id_x] : memref<?xf64, 1>
+// CHECK-NEXT:          %4 = memref.load %0[%thread_id_x] : memref<?xf64, 1>
+// CHECK-NEXT:          %5 = arith.addf %4, %4 : f64
+// CHECK-NEXT:          memref.store %5, %0[%thread_id_x] : memref<?xf64, 1>
+// CHECK-NEXT:          gpu.barrier
+// CHECK-NEXT:          %6 = arith.cmpi eq, %thread_id_x, %c0_1 : index
+// CHECK-NEXT:          scf.if %6 {
+// CHECK-NEXT:            %7 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:            memref.store %3, %7[%c0_1] : memref<?xf64>
+// CHECK-NEXT:          }
+// CHECK-NEXT:          gpu.terminator
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:      "enzymexla.polygeist_yield"() : () -> ()
+// CHECK-NEXT:    }) : () -> index
+// CHECK-NEXT:    llvm.return %c0_i32 : i32
+// CHECK-NEXT:  }

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-llvm-alloca.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-llvm-alloca.mlir
@@ -48,20 +48,20 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vec
 // CHECK-NEXT:    %1 = "enzymexla.gpu_error"() ({
 // CHECK-NEXT:      scf.if %true {
 // CHECK-NEXT:        gpu.launch blocks(%arg1, %arg2, %arg3) in (%arg7 = %c4, %arg8 = %c1, %arg9 = %c1) threads(%arg4, %arg5, %arg6) in (%arg10 = %c8, %arg11 = %c1, %arg12 = %c1) {
-// CHECK-NEXT:          %c1_i64_0 = arith.constant 1 : i64
-// CHECK-NEXT:          %c0_1 = arith.constant 0 : index
+// CHECK-NEXT:          %c0_0 = arith.constant 0 : index
+// CHECK-NEXT:          %c1_i64_1 = arith.constant 1 : i64
 // CHECK-NEXT:          %block_id_x = gpu.block_id  x
 // CHECK-NEXT:          %thread_id_x = gpu.thread_id  x
-// CHECK-NEXT:          %2 = llvm.alloca %c1_i64_0 x !llvm.struct<"struct.Result", (f64)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
-// CHECK-NEXT:          %3 = memref.load %0[%block_id_x] : memref<?xf64, 1>
-// CHECK-NEXT:          %4 = memref.load %0[%thread_id_x] : memref<?xf64, 1>
-// CHECK-NEXT:          %5 = arith.addf %4, %4 : f64
-// CHECK-NEXT:          memref.store %5, %0[%thread_id_x] : memref<?xf64, 1>
+// CHECK-NEXT:          %2 = memref.load %0[%block_id_x] : memref<?xf64, 1>
+// CHECK-NEXT:          %3 = memref.load %0[%thread_id_x] : memref<?xf64, 1>
+// CHECK-NEXT:          %4 = arith.addf %3, %3 : f64
+// CHECK-NEXT:          memref.store %4, %0[%thread_id_x] : memref<?xf64, 1>
 // CHECK-NEXT:          gpu.barrier
-// CHECK-NEXT:          %6 = arith.cmpi eq, %thread_id_x, %c0_1 : index
-// CHECK-NEXT:          scf.if %6 {
-// CHECK-NEXT:            %7 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<?xf64>
-// CHECK-NEXT:            memref.store %3, %7[%c0_1] : memref<?xf64>
+// CHECK-NEXT:          %5 = arith.cmpi eq, %thread_id_x, %c0_0 : index
+// CHECK-NEXT:          scf.if %5 {
+// CHECK-NEXT:            %6 = llvm.alloca %c1_i64_1 x !llvm.struct<"struct.Result", (f64)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:            %7 = "enzymexla.pointer2memref"(%6) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:            memref.store %2, %7[%c0_0] : memref<?xf64>
 // CHECK-NEXT:          }
 // CHECK-NEXT:          gpu.terminator
 // CHECK-NEXT:        }


### PR DESCRIPTION
This PR trying to support LLVM allocaOp in the ParallizeBlockOps
```
scf.parallel {
   A()
   scf.parallel {
    B()
   }
   llvm.alloca ...
   C()
}
```