### PR TITLE
Layout optimizations for symm CPU lowering

### DIFF
--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLABLAS.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLABLAS.cpp
@@ -205,14 +205,19 @@ struct SymmOpLowering : public OpRewritePattern<enzymexla::SymmOp> {
     static int64_t fn_counter = 0;
     std::string funcFnName = blasFnWrapper + "_" + std::to_string(fn_counter++);
 
-    SmallVector<bool> isColMajorArr(12, true);
+    // Pass A, B and C in row-major format (isColMajor = false) to avoid layout
+    // transforms. This requires flipping uplo and side parameters below,
+    // similar to the CUDA FFI implementation in xla_ffi.cpp.
+    // operandRanks: {uplo, side, m, n, alpha, A, lda, B, ldb, beta, C, ldc}
+
+    SmallVector<bool> isColMajorArr(12, false);
     SmallVector<int64_t> operandRanks = {
         0, 0, 0, 0, 0, 2, 0, op.getB().getType().getRank(), 0, 0, 2, 0};
     SmallVector<int64_t> outputRanks = {2};
     auto operandLayouts =
         getSHLOLayout(rewriter, operandRanks, isColMajorArr, 2);
     auto resultLayouts =
-        getSHLOLayout(rewriter, outputRanks, SmallVector<bool>{true}, 2);
+        getSHLOLayout(rewriter, outputRanks, SmallVector<bool>{false}, 2);
 
     SmallVector<Attribute> aliases;
     aliases.push_back(
@@ -247,26 +252,37 @@ struct SymmOpLowering : public OpRewritePattern<enzymexla::SymmOp> {
       auto alpha = entryBlock.getArgument(3);
       auto beta = entryBlock.getArgument(4);
 
+      // We can swap side since (A*B)^T = B^T*A^T, where B^T is also the
+      // column-major interpretation of B. Essentially we ask BLAS to compute
+      // C^T in col-major, which is equivalent to C in row-major
       auto side = stablehlo::ConstantOp::create(
           rewriter, op.getLoc(), uint8Type,
-          cast<ElementsAttr>(makeAttr(uint8Type, side_value)));
+          cast<ElementsAttr>(
+              makeAttr(uint8Type, side_value == 'L' ? 'R' : 'L')));
+
+      // We flip uplo here because A is passed in row-major format.
+      // Row-major A is equivalent to A^T in column-major, and since A is
+      // symmetric, this means we need to swap upper/lower triangular.
       auto uplo = stablehlo::ConstantOp::create(
           rewriter, op.getLoc(), uint8Type,
-          cast<ElementsAttr>(makeAttr(uint8Type, uplo_value)));
+          cast<ElementsAttr>(
+              makeAttr(uint8Type, uplo_value == 'U' ? 'L' : 'U')));
 
+      // For row-major format, lda is the trailing dimension (columns in shape)
+      // This is dimension 1 for a 2D matrix
       auto lda = stablehlo::ConvertOp::create(
           rewriter, op.getLoc(), intType,
-          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), A, 0));
+          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), A, 1));
       auto ldb = stablehlo::ConvertOp::create(
           rewriter, op.getLoc(), intType,
-          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), B, 0));
+          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), B, 1));
       auto ldc = stablehlo::ConvertOp::create(
           rewriter, op.getLoc(), intType,
-          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), C, 0));
+          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), C, 1));
       auto mSize = ldc;
       auto nSize = stablehlo::ConvertOp::create(
           rewriter, op.getLoc(), intType,
-          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), C, 1));
+          stablehlo::GetDimensionSizeOp::create(rewriter, op.getLoc(), C, 0));
 
       auto jitCall = enzymexla::JITCallOp::create(
           rewriter, op.getLoc(), TypeRange{op.getC().getType()},

--- a/test/lit_tests/symm_lowering.mlir
+++ b/test/lit_tests/symm_lowering.mlir
@@ -12,11 +12,11 @@ module {
 
 // CPU: module {
 // CPU-NEXT:   func.func private @enzymexla_blas_ssymm_wrapper_[[SYMMID:[0-9]+]](%arg0: tensor<64x64xf32>, %arg1: tensor<64x32xf32>, %arg2: tensor<64x32xf32>, %arg3: tensor<f32>, %arg4: tensor<f32>) -> tensor<64x32xf32> {
-// CPU-DAG:     %[[cL:.+]] = stablehlo.constant dense<76> : tensor<ui8>
-// CPU-DAG:     %[[cU:.+]] = stablehlo.constant dense<85> : tensor<ui8>
+// CPU-DAG:     %[[cSide:.+]] = stablehlo.constant dense<82> : tensor<ui8>
+// CPU-DAG:     %[[cUplo:.+]] = stablehlo.constant dense<76> : tensor<ui8>
 // CPU-DAG:     %[[c64:.+]] = stablehlo.constant dense<64> : tensor<i64>
 // CPU-DAG:     %[[c32:.+]] = stablehlo.constant dense<32> : tensor<i64>
-// CPU-NEXT:     %0 = enzymexla.jit_call @enzymexla_blas_ssymm_wrapper (%[[cL]], %[[cU]], %[[c64]], %[[c32]], %arg3, %arg0, %[[c64]], %arg1, %[[c64]], %arg4, %arg2, %[[c64]]) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[0, 1]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 10, operand_tuple_indices = []>], result_layouts = [dense<[0, 1]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>) -> tensor<64x32xf32>
+// CPU-NEXT:     %0 = enzymexla.jit_call @enzymexla_blas_ssymm_wrapper (%[[cSide]], %[[cUplo]], %[[c32]], %[[c64]], %arg3, %arg0, %[[c64]], %arg1, %[[c32]], %arg4, %arg2, %[[c32]]) {operand_layouts = [dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>, dense<> : tensor<0xindex>, dense<[1, 0]> : tensor<2xindex>, dense<> : tensor<0xindex>], output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 10, operand_tuple_indices = []>], result_layouts = [dense<[1, 0]> : tensor<2xindex>], xla_side_effect_free} : (tensor<ui8>, tensor<ui8>, tensor<i64>, tensor<i64>, tensor<f32>, tensor<64x64xf32>, tensor<i64>, tensor<64x32xf32>, tensor<i64>, tensor<f32>, tensor<64x32xf32>, tensor<i64>) -> tensor<64x32xf32>
 // CPU-NEXT:     return %0 : tensor<64x32xf32>
 // CPU-NEXT:   }
 // CPU-NEXT:   llvm.func private @enzymexla_blas_ssymm_wrapper(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr, %arg4: !llvm.ptr, %arg5: !llvm.ptr, %arg6: !llvm.ptr, %arg7: !llvm.ptr, %arg8: !llvm.ptr, %arg9: !llvm.ptr, %arg10: !llvm.ptr, %arg11: !llvm.ptr) {


### PR DESCRIPTION
Add flipping `side` and `uplo` layout optimization to CPU lowering of `symm` so that it matches CUDA lowering