### PR TITLE
Tessera struct returns

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -142,7 +142,7 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   bool has_sret = (fn->hasAttr("tessera.sret_attrs"));
   auto fnType = fn.getFunctionType();
 
-  // If tessera.define has sret attribute, 
+  // If tessera.define has sret attribute,
   // tessera.call operand count = tessera.define input count - 1
   if (has_sret && (fnType.getNumInputs() - 1) != getNumOperands())
     return emitOpError("incorrect number of operands for callee");
@@ -154,7 +154,8 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     if (getOperand(i - startIdx).getType() != fnType.getInput(i))
       return emitOpError("operand type mismatch: expected operand type ")
              << fnType.getInput(i) << ", but provided "
-             << getOperand(i - startIdx).getType() << " for operand number " << i - startIdx;
+             << getOperand(i - startIdx).getType() << " for operand number "
+             << i - startIdx;
 
   // If tessera.define has sret attribute,
   // tessera.call result count = tessera.define result count + 1
@@ -169,7 +170,7 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     auto sretType = cast<TypeAttr>(firstArgAttr.get("llvm.sret")).getValue();
     if (getResult(0).getType() != sretType)
       return emitOpError("result type mismatch: expected ")
-	      << sretType << " but got " << getResult(0).getType();
+             << sretType << " but got " << getResult(0).getType();
   } else {
     for (unsigned i = 0, e = fnType.getNumResults(); i != e; ++i)
       if (getResult(i).getType() != fnType.getResult(i)) {

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -59,19 +59,20 @@ public:
     auto llvmFuncType = funcOp.getFunctionType();
     auto params = llvmFuncType.getParams();
     auto retType = llvmFuncType.getReturnType();
-    
+
     // Check if first argument has sret attribute
     bool hasSret = false;
     auto argAttrs = funcOp.getArgAttrsAttr();
     if (!params.empty() && argAttrs) {
       auto firstArgAttrs = cast<DictionaryAttr>(argAttrs[0]);
-      if (auto sretAttr = firstArgAttrs.get("llvm.sret"))
+      if (auto sretAttr =
+              firstArgAttrs.get(LLVM::LLVMDialect::getStructRetAttrName()))
         hasSret = true;
     }
 
-    auto fnType =
-        FunctionType::get(ctx, params, isa<LLVM::LLVMVoidType>(retType)
-                              ? TypeRange{} : TypeRange{retType});
+    auto fnType = FunctionType::get(
+        ctx, params,
+        isa<LLVM::LLVMVoidType>(retType) ? TypeRange{} : TypeRange{retType});
 
     // Replace current function name with tessera name defined in
     // tessera.convert attribute
@@ -94,7 +95,7 @@ public:
     tesseraDefineOp->setAttr("tessera.original_name",
                              rewriter.getStringAttr(funcName));
 
-    // Add attribute if function uses struct return and store the first arg's 
+    // Add attribute if function uses struct return and store the first arg's
     // attributes for exact reconstruction later
     if (hasSret)
       tesseraDefineOp->setAttr("tessera.sret_attrs", argAttrs[0]);
@@ -136,33 +137,43 @@ public:
     Value sretPtr;
     Type sretType;
     auto operands = callOp.getOperands();
+    auto argAttrs = callOp.getArgAttrsAttr();
     SmallVector<Value> newOperands;
-    if (!operands.empty()) {
-      auto argAttrs = callOp.getArgAttrsAttr();
-      if (argAttrs) {
-        auto firstArgAttrs = cast<DictionaryAttr>(argAttrs[0]);
-        if (auto sretAttr = firstArgAttrs.get("llvm.sret")) {
-	  sretPtr = callOp.getOperand(0);
-	  sretType = cast<TypeAttr>(sretAttr).getValue();
+    SmallVector<Attribute> newArgAttrs;
+    SmallVector<NamedAttribute> newAttrs;
+
+    if (!operands.empty() && argAttrs) {
+      auto firstArgAttrs = cast<DictionaryAttr>(argAttrs[0]);
+      if (auto sretAttr =
+              firstArgAttrs.get(LLVM::LLVMDialect::getStructRetAttrName())) {
+        sretPtr = callOp.getOperand(0);
+        sretType = cast<TypeAttr>(sretAttr).getValue();
+        // Build operands and arg attributes without first element
+        for (int i = 1; i < operands.size(); i++)
+          newOperands.push_back(callOp.getOperand(i));
+        for (int j = 1; j < argAttrs.size(); j++)
+          newArgAttrs.push_back(argAttrs[j]);
+        // Filter out arg_attrs from attributes
+        for (auto attr : callOp->getAttrs()) {
+          if (attr.getName() != callOp.getArgAttrsAttrName())
+            newAttrs.push_back(attr);
         }
       }
     }
 
-    // Remove first operand if it had sret attribute. 
-    int startIdx = sretPtr? 1 : 0;
-    for (int i = startIdx; i < operands.size(); i++) {
-      newOperands.push_back(callOp.getOperand(i));
-    }
-
     // Create tessera.call op with SSA return type
-    auto newCall = rewriter.create<tessera::CallOp>(
-        callOp.getLoc(), sretType ? TypeRange{sretType} : TypeRange(callOp.getResultTypes()), 
-	newOperands, callOp->getAttrs());
-    
-    if (sretPtr)
-      rewriter.create<LLVM::StoreOp>(callOp.getLoc(), newCall.getResult(0), sretPtr);
-
-    rewriter.eraseOp(callOp);
+    if (sretPtr) {
+      auto newCall = rewriter.create<tessera::CallOp>(
+          callOp.getLoc(), TypeRange{sretType}, newOperands, newAttrs);
+      rewriter.create<LLVM::StoreOp>(callOp.getLoc(), newCall.getResult(0),
+                                     sretPtr);
+      newCall->setAttr(newCall.getArgAttrsAttrName(),
+                       rewriter.getArrayAttr(newArgAttrs));
+      rewriter.eraseOp(callOp);
+    } else {
+      rewriter.replaceOpWithNewOp<tessera::CallOp>(
+          callOp, callOp.getResultTypes(), operands, callOp->getAttrs());
+    }
 
     return success();
   }
@@ -202,7 +213,8 @@ struct LLVMToTesseraPass
 
     GreedyRewriteConfig config;
     config.setUseTopDownTraversal(true);
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns), config))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
+                                     config))) {
       llvm::errs() << "Failed to convert LLVM dialect operations to tessera "
                       "dialect operations\n";
       signalPassFailure();

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -78,11 +78,13 @@ public:
     auto funcOp = LLVM::LLVMFuncOp::create(rewriter, defineOp.getLoc(),
                                            funcName, llvmFuncType);
 
-    // Copy over all attributes other than the function name and type.
+    // Copy over all attributes other than the function name and type and
+    // attributes used only for tessera conversion
     for (const auto &namedAttr : defineOp->getAttrs()) {
       if (namedAttr.getName() != defineOp.getFunctionTypeAttrName() &&
           namedAttr.getName() != SymbolTable::getSymbolAttrName() &&
-          namedAttr.getName() != "tessera.original_name")
+          namedAttr.getName() != "tessera.original_name" &&
+          namedAttr.getName() != "tessera.sret_attrs")
         funcOp->setAttr(namedAttr.getName(), namedAttr.getValue());
     }
 
@@ -109,9 +111,73 @@ public:
   LogicalResult matchAndRewrite(tessera::CallOp callOp,
                                 PatternRewriter &rewriter) const override {
 
-    rewriter.replaceOpWithNewOp<LLVM::CallOp>(callOp, callOp.getResultTypes(),
-                                              callOp.getOperands(),
-                                              callOp->getAttrs());
+    auto calleeAttr = callOp.getCalleeAttr();
+    if (!calleeAttr)
+      return failure();
+
+    auto callee = SymbolTable::lookupSymbolIn(
+        callOp->getParentOfType<ModuleOp>(), calleeAttr);
+
+    // Check if callee has sret attribute. If so, allocate new pointer to
+    // contain result of tessera.call and insert as first argument in llvm.call.
+    auto defineOp = dyn_cast_or_null<tessera::DefineOp>(callee);
+    if (!defineOp)
+      return failure();
+
+    auto sretAttrs =
+        defineOp->getAttrOfType<DictionaryAttr>("tessera.sret_attrs");
+    if (sretAttrs) {
+      if (callOp.getNumResults() == 0)
+        return callOp.emitOpError(
+            "tessera.call to sret function must have a result");
+      auto sretType = callOp.getResult(0).getType();
+      int64_t alignment = 0;
+      if (auto alignAttr = sretAttrs.get(LLVM::LLVMDialect::getAlignAttrName()))
+        alignment = cast<IntegerAttr>(alignAttr).getInt();
+      Value one = rewriter.create<LLVM::ConstantOp>(
+          callOp.getLoc(), rewriter.getI32Type(),
+          rewriter.getI32IntegerAttr(1));
+
+      // Allocate stack storage for the sret return value
+      Value sretPtr = rewriter.create<LLVM::AllocaOp>(
+          callOp.getLoc(), LLVM::LLVMPointerType::get(callOp->getContext()),
+          sretType, one, alignment);
+
+      // Build new operands with sretPtr as first arg
+      SmallVector<Value> newOperands;
+      newOperands.push_back(sretPtr);
+      for (auto operand : callOp.getOperands())
+        newOperands.push_back(operand);
+
+      // Reconstruct arg attributes with sret attr first
+      SmallVector<Attribute> newArgAttrs;
+      newArgAttrs.push_back(sretAttrs);
+      if (auto argAttrs = callOp.getArgAttrsAttr()) {
+        for (auto argAttr : argAttrs)
+          newArgAttrs.push_back(argAttr);
+      }
+
+      // Filter out arg_attrs from attributes
+      SmallVector<NamedAttribute> newAttrs;
+      for (auto attr : callOp->getAttrs()) {
+        if (attr.getName() != callOp.getArgAttrsAttrName())
+          newAttrs.push_back(attr);
+      }
+
+      auto newCall = rewriter.create<LLVM::CallOp>(callOp.getLoc(), TypeRange{},
+                                                   newOperands, newAttrs);
+      newCall->setAttr(newCall.getArgAttrsAttrName(),
+                       rewriter.getArrayAttr(newArgAttrs));
+
+      // Load result from sret pointer and replace uses
+      auto loadedResult =
+          rewriter.create<LLVM::LoadOp>(callOp.getLoc(), sretType, sretPtr);
+      rewriter.replaceOp(callOp, loadedResult.getResult());
+    } else {
+      rewriter.replaceOpWithNewOp<LLVM::CallOp>(callOp, callOp.getResultTypes(),
+                                                callOp.getOperands(),
+                                                callOp->getAttrs());
+    }
 
     return success();
   }

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -72,8 +72,8 @@ llvm.func @caller() {
 }
 
 // CHECK-LABEL: tessera.define @tessera_sret_func
-// CHECK-SAME: tessera.has_sret
-// CHECK: tessera.return {{.*}} : !llvm.struct<(f32, f32)>
+// CHECK-SAME: tessera.sret_attrs = {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}
+// CHECK: tessera.return
 
 // CHECK-LABEL: llvm.func @caller
 // CHECK: %[[RES:.*]] = tessera.call @tessera_sret_func

--- a/test/lit_tests/tessera/tessera_to_llvm.mlir
+++ b/test/lit_tests/tessera/tessera_to_llvm.mlir
@@ -33,3 +33,32 @@ tessera.define @tessera_func_with_call() attributes {tessera.original_name = "fu
 // CHECK-LABEL: llvm.func @func_with_call
 // CHECK: llvm.call @helper() : () -> ()
 // CHECK: llvm.return
+
+// -----
+
+tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {CConv = #llvm.cconv<ccc>, linkage = #llvm.linkage<external>, tessera.original_name = "sret_func", tessera.sret_attrs = {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, unnamed_addr = 0 : i64, visibility_ = 0 : i64} {
+  %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
+  llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
+  tessera.return
+}
+
+llvm.func @caller() {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %0 x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = tessera.call @tessera_sret_func(%2) {CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, arg_attrs = [{llvm.nonnull, llvm.noundef}], fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>} : (!llvm.ptr) -> !llvm.struct<(f32, f32)>
+  llvm.store %3, %1 : !llvm.struct<(f32, f32)>, !llvm.ptr
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @sret_func
+// CHECK-SAME: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}
+// CHECK-LABEL: llvm.func @caller
+// CHECK: %[[A1:.*]] = llvm.alloca
+// CHECK: %[[A2:.*]] = llvm.alloca
+// CHECK: %[[SRET:.*]] = llvm.alloca
+// CHECK: llvm.call @sret_func(%[[SRET]], %[[A2]])
+// CHECK-SAME: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}
+// CHECK: %[[LOADED:.*]] = llvm.load %[[SRET]]
+// CHECK: llvm.store %[[LOADED]], {{.*}}
+// CHECK-NOT: tessera.call


### PR DESCRIPTION
Handles struct returns (sret) in the conversion to and from the tessera dialect, in order to later enable pattern matching on SSA values rather than hidden pointer arguments.

In the LLVM -> Tessera pass, removes the sret pointer from the `tessera.call` operand list and promotes the return value to an SSA result.

In the Tessera -> LLVM pass, allocates stack storage for the return value, inserts it as the hidden first argument to `llvm.call`, and loads the result back as an SSA value to replace uses of the `tessera.call` result.