### PR TITLE
Add name(id) for ISL params and sets

### DIFF
--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -207,6 +207,14 @@ getDomain(isl_ctx *ctx, Operation *op, bool overApproximationAllowed = false) {
 
   isl_space *space =
       isl_space_set_alloc(ctx, cst.getNumSymbolVars(), cst.getNumDimVars());
+  for (unsigned i = 0; i < cst.getNumDimVars(); i++) {
+    isl_id *id = isl_id_alloc(ctx, "dim", (void *)(size_t)(i + 1));
+    space = isl_space_set_dim_id(space, isl_dim_set, i, id);
+  }
+  for (unsigned i = 0; i < cst.getNumSymbolVars(); i++) {
+    isl_id *id = isl_id_alloc(ctx, "sym", (void *)(size_t)(i + 1));
+    space = isl_space_set_dim_id(space, isl_dim_param, i, id);
+  }
   LLVM_DEBUG(llvm::dbgs() << "space: ");
   LLVM_DEBUG(isl_space_dump(space));
   return {isl_set_from_basic_set(isl_basic_set_from_constraint_matrices(
@@ -864,7 +872,7 @@ IslAnalysis::getAffExprs(Operation *op, AffineValueMap avm) {
   unsigned symOffset = cst.getNumDimVars();
   for (unsigned i = 0; i < cst.getNumSymbolVars(); i++) {
     isl_id *id = isl_id_alloc(ctx, "sym", (void *)(size_t)(symOffset + i + 1));
-    space = isl_space_set_dim_id(space, isl_dim_set, i, id);
+    space = isl_space_set_dim_id(space, isl_dim_param, i, id);
   }
 
   isl_local_space *ls = isl_local_space_from_space(isl_space_copy(space));
@@ -966,7 +974,7 @@ std::optional<AffineMap> handleAffineValueMap(IslAnalysis &islAnalysis,
   unsigned symOffset = cst.getNumDimVars();
   for (unsigned i = 0; i < cst.getNumSymbolVars(); i++) {
     isl_id *id = isl_id_alloc(ctx, "sym", (void *)(size_t)(symOffset + i + 1));
-    space = isl_space_set_dim_id(space, isl_dim_set, i, id);
+    space = isl_space_set_dim_id(space, isl_dim_param, i, id);
   }
 
   isl_ast_build *build =

--- a/test/lit_tests/raising/affinecfg_isl_named_params.mlir
+++ b/test/lit_tests/raising/affinecfg_isl_named_params.mlir
@@ -1,0 +1,20 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+module {
+  func.func @test_isl_named_params(%N: index, %buf: memref<?xf32>) {
+    %cst = arith.constant 0.0 : f32
+    affine.for %i = 0 to %N {
+      affine.if affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>(%i)[%N] {
+        affine.store %cst, %buf[%i] : memref<?xf32>
+      }
+    }
+    return
+  }
+}
+
+// CHECK-NOT: unexpected unnamed parameters
+
+// CHECK-LABEL: func.func @test_isl_named_params
+// CHECK-NOT: affine.if
+// CHECK: affine.store
+// CHECK: return


### PR DESCRIPTION
Fix `src/external/isl/isl_space.c:3350: unexpected unnamed parameters`