### PR TITLE
Implement reverse-mode adjoint for Pointer2MemrefOp and Memref2PointerOp

### DIFF
--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -129,6 +129,35 @@ struct GPUWrapperOpEnzymeOpsRemover
   }
 };
 
+template <typename OpTy>
+struct ViewCastOpInterfaceReverse
+    : public ReverseAutoDiffOpInterface::ExternalModel<
+          ViewCastOpInterfaceReverse<OpTy>, OpTy> {
+  LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    return success();
+  }
+
+  SmallVector<Value> cacheValues(Operation *op,
+                                 MGradientUtilsReverse *gutils) const {
+    return {};
+  }
+
+  void createShadowValues(Operation *op, OpBuilder &builder,
+                          MGradientUtilsReverse *gutils) const {
+    auto castOp = cast<OpTy>(op);
+    auto newCastOp = cast<OpTy>(gutils->getNewFromOriginal(op));
+    Value source = castOp.getSource();
+    if (!gutils->isConstantValue(source)) {
+      Value sourceShadow = gutils->invertPointerM(source, builder);
+      auto shadowCast = cast<OpTy>(builder.clone(*newCastOp));
+      shadowCast.getSourceMutable().assign(sourceShadow);
+      gutils->setInvertedPointer(castOp.getResult(), shadowCast->getResult(0));
+    }
+  }
+};
+
 struct GPUWrapperOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<
           GPUWrapperOpInterfaceReverse, GPUWrapperOp> {
@@ -202,6 +231,11 @@ void mlir::enzyme::registerEnzymeXLADialectAutoDiffInterface(
     registerInterfaces(context);
     GPUWrapperOp::attachInterface<GPUWrapperOpInterfaceReverse>(*context);
     GPUWrapperOp::attachInterface<GPUWrapperOpEnzymeOpsRemover>(*context);
+
+    Pointer2MemrefOp::attachInterface<
+        ViewCastOpInterfaceReverse<Pointer2MemrefOp>>(*context);
+    Memref2PointerOp::attachInterface<
+        ViewCastOpInterfaceReverse<Memref2PointerOp>>(*context);
 
     // Register batching interfaces
     JITCallOp::attachInterface<SHLOGenericBatchOpInterface<JITCallOp>>(

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -129,6 +129,8 @@ struct GPUWrapperOpEnzymeOpsRemover
   }
 };
 
+// Reverse-mode adjoint for pure view-cast ops (Pointer2Memref / Memref2Pointer).
+// These ops carry no computation; the reverse adjoint itself is a no-op.
 template <typename OpTy>
 struct ViewCastOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<
@@ -141,20 +143,31 @@ struct ViewCastOpInterfaceReverse
 
   SmallVector<Value> cacheValues(Operation *op,
                                  MGradientUtilsReverse *gutils) const {
-    return {};
+    auto castOp = cast<OpTy>(op);
+    Value source = castOp.getSource();
+    if (gutils->isConstantValue(source))
+      return {};
+
+    OpBuilder cacheBuilder(gutils->getNewFromOriginal(op));
+    auto newCastOp = cast<OpTy>(gutils->getNewFromOriginal(op));
+
+    // Cache the source adjoint
+    Value sourceShadow = gutils->invertPointerM(source, cacheBuilder);
+    Value cachedSourceShadow =
+        gutils->initAndPushCache(sourceShadow, cacheBuilder);
+
+    // Materialize the shadow view in the forward block and register it so
+    // downstream consumers can locate it via invertPointerM.
+    auto shadowCast = cast<OpTy>(cacheBuilder.clone(*newCastOp));
+    shadowCast.getSourceMutable().assign(sourceShadow);
+    gutils->setInvertedPointer(castOp.getResult(), shadowCast->getResult(0));
+
+    return {cachedSourceShadow};
   }
 
   void createShadowValues(Operation *op, OpBuilder &builder,
                           MGradientUtilsReverse *gutils) const {
-    auto castOp = cast<OpTy>(op);
-    auto newCastOp = cast<OpTy>(gutils->getNewFromOriginal(op));
-    Value source = castOp.getSource();
-    if (!gutils->isConstantValue(source)) {
-      Value sourceShadow = gutils->invertPointerM(source, builder);
-      auto shadowCast = cast<OpTy>(builder.clone(*newCastOp));
-      shadowCast.getSourceMutable().assign(sourceShadow);
-      gutils->setInvertedPointer(castOp.getResult(), shadowCast->getResult(0));
-    }
+    // Shadow construction is done in cacheValues.
   }
 };
 

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -130,8 +130,10 @@ struct GPUWrapperOpEnzymeOpsRemover
 };
 
 // Reverse-mode adjoint for pure view-cast ops (Pointer2Memref /
-// Memref2Pointer). These ops carry no computation; the reverse adjoint itself
-// is a no-op.
+// Memref2Pointer). We only need to materialize the corresponding shadow view
+// in the augmented primal and register it via setInvertedPointer so downstream
+// memref.load / memref.store consumers can locate it through invertPointerM.
+// This mirrors the pattern used by LLVM::GEPOp and memref::SubViewOp.
 template <typename OpTy>
 struct ViewCastOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<
@@ -144,31 +146,20 @@ struct ViewCastOpInterfaceReverse
 
   SmallVector<Value> cacheValues(Operation *op,
                                  MGradientUtilsReverse *gutils) const {
-    auto castOp = cast<OpTy>(op);
-    Value source = castOp.getSource();
-    if (gutils->isConstantValue(source))
-      return {};
-
-    OpBuilder cacheBuilder(gutils->getNewFromOriginal(op));
-    auto newCastOp = cast<OpTy>(gutils->getNewFromOriginal(op));
-
-    // Cache the source adjoint
-    Value sourceShadow = gutils->invertPointerM(source, cacheBuilder);
-    Value cachedSourceShadow =
-        gutils->initAndPushCache(sourceShadow, cacheBuilder);
-
-    // Materialize the shadow view in the forward block and register it so
-    // downstream consumers can locate it via invertPointerM.
-    auto shadowCast = cast<OpTy>(cacheBuilder.clone(*newCastOp));
-    shadowCast.getSourceMutable().assign(sourceShadow);
-    gutils->setInvertedPointer(castOp.getResult(), shadowCast->getResult(0));
-
-    return {cachedSourceShadow};
+    return {};
   }
 
   void createShadowValues(Operation *op, OpBuilder &builder,
                           MGradientUtilsReverse *gutils) const {
-    // Shadow construction is done in cacheValues.
+    auto castOp = cast<OpTy>(op);
+    auto newCastOp = cast<OpTy>(gutils->getNewFromOriginal(op));
+    Value source = castOp.getSource();
+    if (!gutils->isConstantValue(source)) {
+      Value sourceShadow = gutils->invertPointerM(source, builder);
+      auto shadowCast = cast<OpTy>(builder.clone(*newCastOp));
+      shadowCast.getSourceMutable().assign(sourceShadow);
+      gutils->setInvertedPointer(castOp.getResult(), shadowCast->getResult(0));
+    }
   }
 };
 

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -129,8 +129,9 @@ struct GPUWrapperOpEnzymeOpsRemover
   }
 };
 
-// Reverse-mode adjoint for pure view-cast ops (Pointer2Memref / Memref2Pointer).
-// These ops carry no computation; the reverse adjoint itself is a no-op.
+// Reverse-mode adjoint for pure view-cast ops (Pointer2Memref /
+// Memref2Pointer). These ops carry no computation; the reverse adjoint itself
+// is a no-op.
 template <typename OpTy>
 struct ViewCastOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLADerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLADerivatives.td
@@ -26,6 +26,9 @@ def : EnzymeXLAControlFlowOp<"GPUWrapperOp", [{
   }
 }]>;
 
+def : EnzymeXLAReadOnlyIdentityOp<"Pointer2MemrefOp", [0]>;
+def : EnzymeXLAReadOnlyIdentityOp<"Memref2PointerOp", [0]>;
+
 class HLOConstantFP<string m> : ConstantFP<m, "stablehlo", "ConstantOp", "mlir::ElementsAttr">;
 
 // Required operations from the EnzymeXLA dialect

--- a/test/lit_tests/diffrules/enzymexla/view_cast_rev.mlir
+++ b/test/lit_tests/diffrules/enzymexla/view_cast_rev.mlir
@@ -1,9 +1,7 @@
 // RUN: enzymexlamlir-opt %s --enzyme --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s
 
-// Verify that reverse-mode AD does not crash on enzymexla.pointer2memref /
-// enzymexla.memref2pointer when the source operand is an active value
-
 module {
+  // Case 1: source is a function-arg (blockarg) shadow.
   func.func @load_via_p2m(%ptr: !llvm.ptr, %i: index) -> f64 {
     %mem = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr) -> memref<?xf64>
     %v = memref.load %mem[%i] : memref<?xf64>
@@ -18,6 +16,7 @@ module {
     } : (!llvm.ptr, !llvm.ptr, index, f64) -> ()
     return
   }
+
   func.func @load_via_m2p(%mem: memref<?xf64>) -> f64 {
     %ptr = "enzymexla.memref2pointer"(%mem) : (memref<?xf64>) -> !llvm.ptr
     %v = llvm.load %ptr : !llvm.ptr -> f64
@@ -30,6 +29,32 @@ module {
       activity = [#enzyme<activity enzyme_dup>],
       ret_activity = [#enzyme<activity enzyme_activenoneed>]
     } : (memref<?xf64>, memref<?xf64>, f64) -> ()
+    return
+  }
+
+  // Case 2: chained casts (ptr2memref(memref2pointer(...))) nested inside an scf.if. 
+  func.func @nested_cast(%mem: memref<?xf64>, %cond: i1, %i: index) {
+    scf.if %cond {
+      %inner_ptr = "enzymexla.memref2pointer"(%mem)
+          : (memref<?xf64>) -> !llvm.ptr
+      %inner_mem = "enzymexla.pointer2memref"(%inner_ptr)
+          : (!llvm.ptr) -> memref<?xf64>
+      %v = memref.load %inner_mem[%i] : memref<?xf64>
+      %two = arith.constant 2.0 : f64
+      %new = arith.mulf %v, %two : f64
+      memref.store %new, %inner_mem[%i] : memref<?xf64>
+    }
+    return
+  }
+
+  func.func @diff_nested_cast(%mem: memref<?xf64>, %d_mem: memref<?xf64>,
+                              %cond: i1, %i: index) {
+    enzyme.autodiff @nested_cast(%mem, %d_mem, %cond, %i) {
+      activity = [#enzyme<activity enzyme_dup>,
+                  #enzyme<activity enzyme_const>,
+                  #enzyme<activity enzyme_const>],
+      ret_activity = []
+    } : (memref<?xf64>, memref<?xf64>, i1, index) -> ()
     return
   }
 }
@@ -56,3 +81,16 @@ module {
 // CHECK:         %[[OLD:.*]] = llvm.load %[[DPTR]] : !llvm.ptr -> f64
 // CHECK:         %[[NEW:.*]] = arith.addf %[[OLD]], %[[ACC]] : f64
 // CHECK:         llvm.store %[[NEW]], %[[DPTR]] : f64, !llvm.ptr
+
+// CHECK-LABEL: func.func private @diffenested_cast(
+// CHECK-SAME:    %[[MEM:[^,]+]]: memref<?xf64>,
+// CHECK-SAME:    %[[DMEM:[^,]+]]: memref<?xf64>,
+// CHECK-SAME:    %[[COND:[^,]+]]: i1,
+// CHECK-SAME:    %[[I:[^)]+]]: index)
+// CHECK:         scf.if %[[COND]]
+// CHECK:           memref.load %[[MEM]][%[[I]]] : memref<?xf64>
+// CHECK:           memref.store {{.*}}, %[[MEM]][%[[I]]] : memref<?xf64>
+// CHECK:         scf.if %[[COND]]
+// CHECK:           memref.load %[[DMEM]][%[[I]]] : memref<?xf64>
+// CHECK:           memref.store {{.*}}, %[[DMEM]][%[[I]]] : memref<?xf64>
+// CHECK:         return

--- a/test/lit_tests/diffrules/enzymexla/view_cast_rev.mlir
+++ b/test/lit_tests/diffrules/enzymexla/view_cast_rev.mlir
@@ -1,0 +1,58 @@
+// RUN: enzymexlamlir-opt %s --enzyme --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s
+
+// Verify that reverse-mode AD does not crash on enzymexla.pointer2memref /
+// enzymexla.memref2pointer when the source operand is an active value
+
+module {
+  func.func @load_via_p2m(%ptr: !llvm.ptr, %i: index) -> f64 {
+    %mem = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr) -> memref<?xf64>
+    %v = memref.load %mem[%i] : memref<?xf64>
+    return %v : f64
+  }
+
+  func.func @diff_load_via_p2m(%ptr: !llvm.ptr, %d_ptr: !llvm.ptr,
+                                %i: index, %seed: f64) {
+    enzyme.autodiff @load_via_p2m(%ptr, %d_ptr, %i, %seed) {
+      activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_const>],
+      ret_activity = [#enzyme<activity enzyme_activenoneed>]
+    } : (!llvm.ptr, !llvm.ptr, index, f64) -> ()
+    return
+  }
+  func.func @load_via_m2p(%mem: memref<?xf64>) -> f64 {
+    %ptr = "enzymexla.memref2pointer"(%mem) : (memref<?xf64>) -> !llvm.ptr
+    %v = llvm.load %ptr : !llvm.ptr -> f64
+    return %v : f64
+  }
+
+  func.func @diff_load_via_m2p(%mem: memref<?xf64>, %d_mem: memref<?xf64>,
+                                %seed: f64) {
+    enzyme.autodiff @load_via_m2p(%mem, %d_mem, %seed) {
+      activity = [#enzyme<activity enzyme_dup>],
+      ret_activity = [#enzyme<activity enzyme_activenoneed>]
+    } : (memref<?xf64>, memref<?xf64>, f64) -> ()
+    return
+  }
+}
+
+// CHECK-LABEL: func.func private @diffeload_via_p2m(
+// CHECK-SAME:    %[[PTR:[^,]+]]: !llvm.ptr,
+// CHECK-SAME:    %[[DPTR:[^,]+]]: !llvm.ptr,
+// CHECK-SAME:    %[[I:[^,]+]]: index,
+// CHECK-SAME:    %[[SEED:[^)]+]]: f64)
+// CHECK-DAG:     %[[ZERO:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:     %[[DMEM:.*]] = "enzymexla.pointer2memref"(%[[DPTR]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK:         %[[ACC:.*]] = arith.addf %[[SEED]], %[[ZERO]] : f64
+// CHECK:         %[[OLD:.*]] = memref.load %[[DMEM]][%[[I]]] : memref<?xf64>
+// CHECK:         %[[NEW:.*]] = arith.addf %[[OLD]], %[[ACC]] : f64
+// CHECK:         memref.store %[[NEW]], %[[DMEM]][%[[I]]] : memref<?xf64>
+
+// CHECK-LABEL: func.func private @diffeload_via_m2p(
+// CHECK-SAME:    %[[MEM:[^,]+]]: memref<?xf64>,
+// CHECK-SAME:    %[[DMEM:[^,]+]]: memref<?xf64>,
+// CHECK-SAME:    %[[SEED:[^)]+]]: f64)
+// CHECK-DAG:     %[[ZERO:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:     %[[DPTR:.*]] = "enzymexla.memref2pointer"(%[[DMEM]]) : (memref<?xf64>) -> !llvm.ptr
+// CHECK:         %[[ACC:.*]] = arith.addf %[[SEED]], %[[ZERO]] : f64
+// CHECK:         %[[OLD:.*]] = llvm.load %[[DPTR]] : !llvm.ptr -> f64
+// CHECK:         %[[NEW:.*]] = arith.addf %[[OLD]], %[[ACC]] : f64
+// CHECK:         llvm.store %[[NEW]], %[[DPTR]] : f64, !llvm.ptr


### PR DESCRIPTION
Register reverse-mode ReverseAutoDiffOpInterface and forward-mode ReadOnlyIdentityOp for enzymexla.pointer2memref and enzymexla.memref2pointer. Without this, the pipeline would fail with could not compute the adjoint for this operation.

The issues are:
Pointer2MemrefOp and Memref2PointerOp are pure view casts that carry no computation and only reinterpret the same underlying storage under a different type. Reverse-mode AD needs to know about them so that later memref.load and memref.store adjoints can locate the corresponding shadow view.