### PR TITLE
Optimize complex multiplication between a complex number and a purely real or purely imginary number

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -552,6 +552,8 @@ static void addBaseTransformPasses(std::vector<std::string> &list,
   list.push_back("reduce_max_min_mul_positive_scalar");
   list.push_back("add_complex_simplify");
   list.push_back("sub_complex_simplify");
+  list.push_back("real_complex_mul_simplify");
+  list.push_back("imaginary_complex_mul_simplify");
   list.push_back("exponential_minus_one_fuse");
   list.push_back("scatter_of_scatter_simplify");
 }

--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -587,6 +587,8 @@ static void addBaseTransformPasses(std::vector<std::string> &list,
   list.push_back("reduce_max_min_mul_positive_scalar");
   list.push_back("add_complex_simplify");
   list.push_back("sub_complex_simplify");
+  list.push_back("real_complex_mul_simplify");
+  list.push_back("imaginary_complex_mul_simplify");
   list.push_back("exponential_minus_one_fuse");
   list.push_back("scatter_of_scatter_simplify");
 }

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7942,8 +7942,10 @@ struct RealComplexMulSimplify
         loc, realTensor.getType(), complexTensor);
     auto newRealPart = rewriter.create<stablehlo::MulOp>(
         loc, realTensor.getType(), realTensor, realPart);
+    newRealPart->setAttrs(op->getAttrs());
     auto newImagPart = rewriter.create<stablehlo::MulOp>(
         loc, realTensor.getType(), realTensor, imagPart);
+    newImagPart->setAttrs(op->getAttrs());
     auto newComplex = rewriter.create<stablehlo::ComplexOp>(
         loc, op.getType(), newRealPart, newImagPart);
     rewriter.replaceOp(op, newComplex);

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7932,6 +7932,10 @@ struct RealComplexMulSimplify
     } else {
       return failure();
     }
+    // Should be better handled by constant folding
+    if (matchPattern(purelyRealOperand, m_Constant())) {
+      return failure();
+    }
     auto complexTensorTy = cast<TensorType>(op.getType());
     auto floatElTy =
         cast<ComplexType>(complexTensorTy.getElementType()).getElementType();
@@ -8000,6 +8004,10 @@ struct ImaginaryComplexMulSimplify
       purelyImaginaryOperand = op.getRhs();
       complexOperand = op.getLhs();
     } else {
+      return failure();
+    }
+    // Should be better handled by constant folding
+    if (matchPattern(purelyImaginaryOperand, m_Constant())) {
       return failure();
     }
     auto complexTensorTy = cast<TensorType>(op.getType());

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7905,47 +7905,49 @@ struct RealComplexMulSimplify
     if (!isa<ComplexType>(resultType)) {
       return failure();
     }
-    auto convertOp = op.getLhs().getDefiningOp<stablehlo::ConvertOp>();
 
-    if (!convertOp) {
-      convertOp = op.getRhs().getDefiningOp<stablehlo::ConvertOp>();
-    } else if (op.getRhs().getDefiningOp<stablehlo::ConvertOp>()) {
+    Value purelyRealOperand = nullptr;
+    Value complexOperand = nullptr;
+
+    auto lhsState = getAttributeFromIR<enzymexla::GuaranteedAnalysisResultAttr>(
+        op.getLhs(), "enzymexla.complex_is_purely_real",
+        enzymexla::GuaranteedAnalysisResult::UNKNOWN);
+    bool lhsIsReal =
+        (lhsState == enzymexla::GuaranteedAnalysisResult::GUARANTEED);
+
+    auto rhsState = getAttributeFromIR<enzymexla::GuaranteedAnalysisResultAttr>(
+        op.getRhs(), "enzymexla.complex_is_purely_real",
+        enzymexla::GuaranteedAnalysisResult::UNKNOWN);
+    bool rhsIsReal =
+        (rhsState == enzymexla::GuaranteedAnalysisResult::GUARANTEED);
+
+    if (lhsIsReal && rhsIsReal) {
+      return failure();
+    } else if (lhsIsReal) {
+      purelyRealOperand = op.getLhs();
+      complexOperand = op.getRhs();
+    } else if (rhsIsReal) {
+      purelyRealOperand = op.getRhs();
+      complexOperand = op.getLhs();
+    } else {
       return failure();
     }
-
-    if (!convertOp) {
-      return failure();
-    }
-
-    auto realTensor = (convertOp.getOperand());
-    auto complexTensor =
-        (convertOp->getResult(0) == op.getLhs()) ? op.getRhs() : op.getLhs();
-
-    auto srcType = cast<ShapedType>(realTensor.getType()).getElementType();
-    auto dstType = cast<ShapedType>(complexTensor.getType()).getElementType();
-
-    if (!isa<ComplexType>(dstType) || !isa<FloatType>(srcType)) {
-      return failure();
-    }
-    // Since I think it is legal to convert from f32 to for example
-    // complex<f64>, we need to check that element type is the same
-    auto complexElementType = cast<ComplexType>(dstType).getElementType();
-    if (srcType != complexElementType) {
-      return failure();
-    }
+    auto complexTensorTy = cast<TensorType>(op.getType());
+    auto floatElTy =
+        cast<ComplexType>(complexTensorTy.getElementType()).getElementType();
+    auto floatTensorType = complexTensorTy.clone(floatElTy);
 
     Location loc = op.getLoc();
-
-    auto realPart = rewriter.create<stablehlo::RealOp>(
-        loc, realTensor.getType(), complexTensor);
-    auto imagPart = rewriter.create<stablehlo::ImagOp>(
-        loc, realTensor.getType(), complexTensor);
+    auto realExtractedFromPurelyReal = rewriter.create<stablehlo::RealOp>(
+        loc, floatTensorType, purelyRealOperand);
+    auto realPartOfComplex =
+        rewriter.create<stablehlo::RealOp>(loc, floatTensorType, complexOperand);
+    auto imagPartOfComplex =
+        rewriter.create<stablehlo::ImagOp>(loc, floatTensorType, complexOperand);
     auto newRealPart = rewriter.create<stablehlo::MulOp>(
-        loc, realTensor.getType(), realTensor, realPart);
-    newRealPart->setAttrs(op->getAttrs());
+        loc, floatTensorType, realExtractedFromPurelyReal, realPartOfComplex);
     auto newImagPart = rewriter.create<stablehlo::MulOp>(
-        loc, realTensor.getType(), realTensor, imagPart);
-    newImagPart->setAttrs(op->getAttrs());
+        loc, floatTensorType, realExtractedFromPurelyReal, imagPartOfComplex);
     auto newComplex = rewriter.create<stablehlo::ComplexOp>(
         loc, op.getType(), newRealPart, newImagPart);
     rewriter.replaceOp(op, newComplex);

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7887,6 +7887,70 @@ struct MulSimplify
   }
 };
 
+struct RealComplexMulSimplify
+    : public CheckedOpRewritePattern<stablehlo::MulOp, RealComplexMulSimplify> {
+  using CheckedOpRewritePattern<
+      stablehlo::MulOp, RealComplexMulSimplify>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::MulOp op,
+                                    PatternRewriter &rewriter) const {
+    // (a + b*i) * (c + d*i)
+    // with b = 0
+    // (a*c - b*d) + (c*b + a*d)*i = (a*c - 0*d) + (c*0 + a*d)*i = a*c + a*d*i
+    // So if one of the operands is a convert from real to complex, we can
+    // simplify to mul real number with real part and mul real number with imag
+    // part instead of converting the real number to complex number.
+
+    auto resultType = cast<ShapedType>(op.getType()).getElementType();
+    if (!isa<ComplexType>(resultType)) {
+      return failure();
+    }
+    auto convertOp = op.getLhs().getDefiningOp<stablehlo::ConvertOp>();
+
+    if (!convertOp) {
+      convertOp = op.getRhs().getDefiningOp<stablehlo::ConvertOp>();
+    } else if (op.getRhs().getDefiningOp<stablehlo::ConvertOp>()) {
+      return failure();
+    }
+
+    if (!convertOp) {
+      return failure();
+    }
+
+    auto realTensor = (convertOp.getOperand());
+    auto complexTensor =
+        (convertOp->getResult(0) == op.getLhs()) ? op.getRhs() : op.getLhs();
+
+    auto srcType = cast<ShapedType>(realTensor.getType()).getElementType();
+    auto dstType = cast<ShapedType>(complexTensor.getType()).getElementType();
+
+    if (!isa<ComplexType>(dstType) || !isa<FloatType>(srcType)) {
+      return failure();
+    }
+    // Since I think it is legal to convert from f32 to for example
+    // complex<f64>, we need to check that element type is the same
+    auto complexElementType = cast<ComplexType>(dstType).getElementType();
+    if (srcType != complexElementType) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+
+    auto realPart = rewriter.create<stablehlo::RealOp>(
+        loc, realTensor.getType(), complexTensor);
+    auto imagPart = rewriter.create<stablehlo::ImagOp>(
+        loc, realTensor.getType(), complexTensor);
+    auto newRealPart = rewriter.create<stablehlo::MulOp>(
+        loc, realTensor.getType(), realTensor, realPart);
+    auto newImagPart = rewriter.create<stablehlo::MulOp>(
+        loc, realTensor.getType(), realTensor, imagPart);
+    auto newComplex = rewriter.create<stablehlo::ComplexOp>(
+        loc, op.getType(), newRealPart, newImagPart);
+    rewriter.replaceOp(op, newComplex);
+    return success();
+  }
+};
+
 struct DivSimplify
     : public CheckedOpRewritePattern<stablehlo::DivOp, DivSimplify> {
   using CheckedOpRewritePattern<stablehlo::DivOp,
@@ -36155,6 +36219,7 @@ struct EnzymeHLOOptPass
         RealConvertSimplify,
         ConjComplexSimplify,
         ElementwiseComplexSimplify,
+        RealComplexMulSimplify,
         SplitConvolutionIntoReverseConvolution,
         ScatterMultiplySimplify,
         ScatterDivSimplify,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7940,10 +7940,10 @@ struct RealComplexMulSimplify
     Location loc = op.getLoc();
     auto realExtractedFromPurelyReal = rewriter.create<stablehlo::RealOp>(
         loc, floatTensorType, purelyRealOperand);
-    auto realPartOfComplex =
-        rewriter.create<stablehlo::RealOp>(loc, floatTensorType, complexOperand);
-    auto imagPartOfComplex =
-        rewriter.create<stablehlo::ImagOp>(loc, floatTensorType, complexOperand);
+    auto realPartOfComplex = rewriter.create<stablehlo::RealOp>(
+        loc, floatTensorType, complexOperand);
+    auto imagPartOfComplex = rewriter.create<stablehlo::ImagOp>(
+        loc, floatTensorType, complexOperand);
     auto newRealPart = rewriter.create<stablehlo::MulOp>(
         loc, floatTensorType, realExtractedFromPurelyReal, realPartOfComplex);
     auto newImagPart = rewriter.create<stablehlo::MulOp>(

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7932,10 +7932,6 @@ struct RealComplexMulSimplify
     } else {
       return failure();
     }
-    // Should be better handled by constant folding
-    if (matchPattern(purelyRealOperand, m_Constant())) {
-      return failure();
-    }
     auto complexTensorTy = cast<TensorType>(op.getType());
     auto floatElTy =
         cast<ComplexType>(complexTensorTy.getElementType()).getElementType();
@@ -8004,10 +8000,6 @@ struct ImaginaryComplexMulSimplify
       purelyImaginaryOperand = op.getRhs();
       complexOperand = op.getLhs();
     } else {
-      return failure();
-    }
-    // Should be better handled by constant folding
-    if (matchPattern(purelyImaginaryOperand, m_Constant())) {
       return failure();
     }
     auto complexTensorTy = cast<TensorType>(op.getType());

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7955,6 +7955,81 @@ struct RealComplexMulSimplify
   }
 };
 
+struct ImaginaryComplexMulSimplify
+    : public CheckedOpRewritePattern<stablehlo::MulOp,
+                                     ImaginaryComplexMulSimplify> {
+  using CheckedOpRewritePattern<
+      stablehlo::MulOp, ImaginaryComplexMulSimplify>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::MulOp op,
+                                    PatternRewriter &rewriter) const {
+    // (a + b*i) * (c + d*i)
+    // with a = 0
+    // (a*c - b*d) + (c*b + a*d)*i = (0*c - b*d) + (c*b + 0*d)*i = -b*d + c*b*i
+    // So if one of the operands is a purely imaginary number, we can
+    // simplify by multiplying the imaginary component with the complex
+    // operand's real and imaginary parts, and negating the real result to
+    // account for i*i = -1.
+
+    auto resultType = cast<ShapedType>(op.getType()).getElementType();
+    if (!isa<ComplexType>(resultType)) {
+      return failure();
+    }
+
+    Value purelyImaginaryOperand = nullptr;
+    Value complexOperand = nullptr;
+
+    auto lhsState = getAttributeFromIR<enzymexla::GuaranteedAnalysisResultAttr>(
+        op.getLhs(), "enzymexla.complex_is_purely_imaginary",
+        enzymexla::GuaranteedAnalysisResult::UNKNOWN);
+    bool lhsIsImaginary =
+        (lhsState == enzymexla::GuaranteedAnalysisResult::GUARANTEED);
+
+    auto rhsState = getAttributeFromIR<enzymexla::GuaranteedAnalysisResultAttr>(
+        op.getRhs(), "enzymexla.complex_is_purely_imaginary",
+        enzymexla::GuaranteedAnalysisResult::UNKNOWN);
+    bool rhsIsImaginary =
+        (rhsState == enzymexla::GuaranteedAnalysisResult::GUARANTEED);
+
+    if (lhsIsImaginary && rhsIsImaginary) {
+      return failure();
+    } else if (lhsIsImaginary) {
+      purelyImaginaryOperand = op.getLhs();
+      complexOperand = op.getRhs();
+    } else if (rhsIsImaginary) {
+      purelyImaginaryOperand = op.getRhs();
+      complexOperand = op.getLhs();
+    } else {
+      return failure();
+    }
+    auto complexTensorTy = cast<TensorType>(op.getType());
+    auto floatElTy =
+        cast<ComplexType>(complexTensorTy.getElementType()).getElementType();
+    auto floatTensorType = complexTensorTy.clone(floatElTy);
+
+    Location loc = op.getLoc();
+    auto imaginaryExtractedFromPurelyImaginary =
+        rewriter.create<stablehlo::ImagOp>(loc, floatTensorType,
+                                           purelyImaginaryOperand);
+    auto realPartOfComplex = rewriter.create<stablehlo::RealOp>(
+        loc, floatTensorType, complexOperand);
+    auto imagPartOfComplex = rewriter.create<stablehlo::ImagOp>(
+        loc, floatTensorType, complexOperand);
+    auto newRealPart = rewriter.create<stablehlo::MulOp>(
+        loc, floatTensorType, imaginaryExtractedFromPurelyImaginary,
+        imagPartOfComplex);
+    auto negatedRealPart =
+        rewriter.create<stablehlo::NegOp>(loc, floatTensorType, newRealPart);
+    auto newImagPart = rewriter.create<stablehlo::MulOp>(
+        loc, floatTensorType, imaginaryExtractedFromPurelyImaginary,
+        realPartOfComplex);
+    auto newComplex = rewriter.create<stablehlo::ComplexOp>(
+        loc, op.getType(), negatedRealPart, newImagPart);
+    rewriter.replaceOp(op, newComplex);
+    return success();
+  }
+};
+
 struct DivSimplify
     : public CheckedOpRewritePattern<stablehlo::DivOp, DivSimplify> {
   using CheckedOpRewritePattern<stablehlo::DivOp,
@@ -36224,6 +36299,7 @@ struct EnzymeHLOOptPass
         ConjComplexSimplify,
         ElementwiseComplexSimplify,
         RealComplexMulSimplify,
+        ImaginaryComplexMulSimplify,
         SplitConvolutionIntoReverseConvolution,
         ScatterMultiplySimplify,
         ScatterDivSimplify,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7969,6 +7969,70 @@ struct MulSimplify
   }
 };
 
+struct RealComplexMulSimplify
+    : public CheckedOpRewritePattern<stablehlo::MulOp, RealComplexMulSimplify> {
+  using CheckedOpRewritePattern<
+      stablehlo::MulOp, RealComplexMulSimplify>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::MulOp op,
+                                    PatternRewriter &rewriter) const {
+    // (a + b*i) * (c + d*i)
+    // with b = 0
+    // (a*c - b*d) + (c*b + a*d)*i = (a*c - 0*d) + (c*0 + a*d)*i = a*c + a*d*i
+    // So if one of the operands is a convert from real to complex, we can
+    // simplify to mul real number with real part and mul real number with imag
+    // part instead of converting the real number to complex number.
+
+    auto resultType = cast<ShapedType>(op.getType()).getElementType();
+    if (!isa<ComplexType>(resultType)) {
+      return failure();
+    }
+    auto convertOp = op.getLhs().getDefiningOp<stablehlo::ConvertOp>();
+
+    if (!convertOp) {
+      convertOp = op.getRhs().getDefiningOp<stablehlo::ConvertOp>();
+    } else if (op.getRhs().getDefiningOp<stablehlo::ConvertOp>()) {
+      return failure();
+    }
+
+    if (!convertOp) {
+      return failure();
+    }
+
+    auto realTensor = (convertOp.getOperand());
+    auto complexTensor =
+        (convertOp->getResult(0) == op.getLhs()) ? op.getRhs() : op.getLhs();
+
+    auto srcType = cast<ShapedType>(realTensor.getType()).getElementType();
+    auto dstType = cast<ShapedType>(complexTensor.getType()).getElementType();
+
+    if (!isa<ComplexType>(dstType) || !isa<FloatType>(srcType)) {
+      return failure();
+    }
+    // Since I think it is legal to convert from f32 to for example
+    // complex<f64>, we need to check that element type is the same
+    auto complexElementType = cast<ComplexType>(dstType).getElementType();
+    if (srcType != complexElementType) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+
+    auto realPart = rewriter.create<stablehlo::RealOp>(
+        loc, realTensor.getType(), complexTensor);
+    auto imagPart = rewriter.create<stablehlo::ImagOp>(
+        loc, realTensor.getType(), complexTensor);
+    auto newRealPart = rewriter.create<stablehlo::MulOp>(
+        loc, realTensor.getType(), realTensor, realPart);
+    auto newImagPart = rewriter.create<stablehlo::MulOp>(
+        loc, realTensor.getType(), realTensor, imagPart);
+    auto newComplex = rewriter.create<stablehlo::ComplexOp>(
+        loc, op.getType(), newRealPart, newImagPart);
+    rewriter.replaceOp(op, newComplex);
+    return success();
+  }
+};
+
 struct DivSimplify
     : public CheckedOpRewritePattern<stablehlo::DivOp, DivSimplify> {
   using CheckedOpRewritePattern<stablehlo::DivOp,
@@ -36875,6 +36939,7 @@ struct EnzymeHLOOptPass
         RealConvertSimplify,
         ConjComplexSimplify,
         ElementwiseComplexSimplify,
+        RealComplexMulSimplify,
         SplitConvolutionIntoReverseConvolution,
         ScatterMultiplySimplify,
         ScatterDivSimplify,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7987,47 +7987,49 @@ struct RealComplexMulSimplify
     if (!isa<ComplexType>(resultType)) {
       return failure();
     }
-    auto convertOp = op.getLhs().getDefiningOp<stablehlo::ConvertOp>();
 
-    if (!convertOp) {
-      convertOp = op.getRhs().getDefiningOp<stablehlo::ConvertOp>();
-    } else if (op.getRhs().getDefiningOp<stablehlo::ConvertOp>()) {
+    Value purelyRealOperand = nullptr;
+    Value complexOperand = nullptr;
+
+    auto lhsState = getAttributeFromIR<enzymexla::GuaranteedAnalysisResultAttr>(
+        op.getLhs(), "enzymexla.complex_is_purely_real",
+        enzymexla::GuaranteedAnalysisResult::UNKNOWN);
+    bool lhsIsReal =
+        (lhsState == enzymexla::GuaranteedAnalysisResult::GUARANTEED);
+
+    auto rhsState = getAttributeFromIR<enzymexla::GuaranteedAnalysisResultAttr>(
+        op.getRhs(), "enzymexla.complex_is_purely_real",
+        enzymexla::GuaranteedAnalysisResult::UNKNOWN);
+    bool rhsIsReal =
+        (rhsState == enzymexla::GuaranteedAnalysisResult::GUARANTEED);
+
+    if (lhsIsReal && rhsIsReal) {
+      return failure();
+    } else if (lhsIsReal) {
+      purelyRealOperand = op.getLhs();
+      complexOperand = op.getRhs();
+    } else if (rhsIsReal) {
+      purelyRealOperand = op.getRhs();
+      complexOperand = op.getLhs();
+    } else {
       return failure();
     }
-
-    if (!convertOp) {
-      return failure();
-    }
-
-    auto realTensor = (convertOp.getOperand());
-    auto complexTensor =
-        (convertOp->getResult(0) == op.getLhs()) ? op.getRhs() : op.getLhs();
-
-    auto srcType = cast<ShapedType>(realTensor.getType()).getElementType();
-    auto dstType = cast<ShapedType>(complexTensor.getType()).getElementType();
-
-    if (!isa<ComplexType>(dstType) || !isa<FloatType>(srcType)) {
-      return failure();
-    }
-    // Since I think it is legal to convert from f32 to for example
-    // complex<f64>, we need to check that element type is the same
-    auto complexElementType = cast<ComplexType>(dstType).getElementType();
-    if (srcType != complexElementType) {
-      return failure();
-    }
+    auto complexTensorTy = cast<TensorType>(op.getType());
+    auto floatElTy =
+        cast<ComplexType>(complexTensorTy.getElementType()).getElementType();
+    auto floatTensorType = complexTensorTy.clone(floatElTy);
 
     Location loc = op.getLoc();
-
-    auto realPart = rewriter.create<stablehlo::RealOp>(
-        loc, realTensor.getType(), complexTensor);
-    auto imagPart = rewriter.create<stablehlo::ImagOp>(
-        loc, realTensor.getType(), complexTensor);
+    auto realExtractedFromPurelyReal = rewriter.create<stablehlo::RealOp>(
+        loc, floatTensorType, purelyRealOperand);
+    auto realPartOfComplex =
+        rewriter.create<stablehlo::RealOp>(loc, floatTensorType, complexOperand);
+    auto imagPartOfComplex =
+        rewriter.create<stablehlo::ImagOp>(loc, floatTensorType, complexOperand);
     auto newRealPart = rewriter.create<stablehlo::MulOp>(
-        loc, realTensor.getType(), realTensor, realPart);
-    newRealPart->setAttrs(op->getAttrs());
+        loc, floatTensorType, realExtractedFromPurelyReal, realPartOfComplex);
     auto newImagPart = rewriter.create<stablehlo::MulOp>(
-        loc, realTensor.getType(), realTensor, imagPart);
-    newImagPart->setAttrs(op->getAttrs());
+        loc, floatTensorType, realExtractedFromPurelyReal, imagPartOfComplex);
     auto newComplex = rewriter.create<stablehlo::ComplexOp>(
         loc, op.getType(), newRealPart, newImagPart);
     rewriter.replaceOp(op, newComplex);

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8037,6 +8037,81 @@ struct RealComplexMulSimplify
   }
 };
 
+struct ImaginaryComplexMulSimplify
+    : public CheckedOpRewritePattern<stablehlo::MulOp,
+                                     ImaginaryComplexMulSimplify> {
+  using CheckedOpRewritePattern<
+      stablehlo::MulOp, ImaginaryComplexMulSimplify>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::MulOp op,
+                                    PatternRewriter &rewriter) const {
+    // (a + b*i) * (c + d*i)
+    // with a = 0
+    // (a*c - b*d) + (c*b + a*d)*i = (0*c - b*d) + (c*b + 0*d)*i = -b*d + c*b*i
+    // So if one of the operands is a purely imaginary number, we can
+    // simplify by multiplying the imaginary component with the complex
+    // operand's real and imaginary parts, and negating the real result to
+    // account for i*i = -1.
+
+    auto resultType = cast<ShapedType>(op.getType()).getElementType();
+    if (!isa<ComplexType>(resultType)) {
+      return failure();
+    }
+
+    Value purelyImaginaryOperand = nullptr;
+    Value complexOperand = nullptr;
+
+    auto lhsState = getAttributeFromIR<enzymexla::GuaranteedAnalysisResultAttr>(
+        op.getLhs(), "enzymexla.complex_is_purely_imaginary",
+        enzymexla::GuaranteedAnalysisResult::UNKNOWN);
+    bool lhsIsImaginary =
+        (lhsState == enzymexla::GuaranteedAnalysisResult::GUARANTEED);
+
+    auto rhsState = getAttributeFromIR<enzymexla::GuaranteedAnalysisResultAttr>(
+        op.getRhs(), "enzymexla.complex_is_purely_imaginary",
+        enzymexla::GuaranteedAnalysisResult::UNKNOWN);
+    bool rhsIsImaginary =
+        (rhsState == enzymexla::GuaranteedAnalysisResult::GUARANTEED);
+
+    if (lhsIsImaginary && rhsIsImaginary) {
+      return failure();
+    } else if (lhsIsImaginary) {
+      purelyImaginaryOperand = op.getLhs();
+      complexOperand = op.getRhs();
+    } else if (rhsIsImaginary) {
+      purelyImaginaryOperand = op.getRhs();
+      complexOperand = op.getLhs();
+    } else {
+      return failure();
+    }
+    auto complexTensorTy = cast<TensorType>(op.getType());
+    auto floatElTy =
+        cast<ComplexType>(complexTensorTy.getElementType()).getElementType();
+    auto floatTensorType = complexTensorTy.clone(floatElTy);
+
+    Location loc = op.getLoc();
+    auto imaginaryExtractedFromPurelyImaginary =
+        rewriter.create<stablehlo::ImagOp>(loc, floatTensorType,
+                                           purelyImaginaryOperand);
+    auto realPartOfComplex = rewriter.create<stablehlo::RealOp>(
+        loc, floatTensorType, complexOperand);
+    auto imagPartOfComplex = rewriter.create<stablehlo::ImagOp>(
+        loc, floatTensorType, complexOperand);
+    auto newRealPart = rewriter.create<stablehlo::MulOp>(
+        loc, floatTensorType, imaginaryExtractedFromPurelyImaginary,
+        imagPartOfComplex);
+    auto negatedRealPart =
+        rewriter.create<stablehlo::NegOp>(loc, floatTensorType, newRealPart);
+    auto newImagPart = rewriter.create<stablehlo::MulOp>(
+        loc, floatTensorType, imaginaryExtractedFromPurelyImaginary,
+        realPartOfComplex);
+    auto newComplex = rewriter.create<stablehlo::ComplexOp>(
+        loc, op.getType(), negatedRealPart, newImagPart);
+    rewriter.replaceOp(op, newComplex);
+    return success();
+  }
+};
+
 struct DivSimplify
     : public CheckedOpRewritePattern<stablehlo::DivOp, DivSimplify> {
   using CheckedOpRewritePattern<stablehlo::DivOp,
@@ -36944,6 +37019,7 @@ struct EnzymeHLOOptPass
         ConjComplexSimplify,
         ElementwiseComplexSimplify,
         RealComplexMulSimplify,
+        ImaginaryComplexMulSimplify,
         SplitConvolutionIntoReverseConvolution,
         ScatterMultiplySimplify,
         ScatterDivSimplify,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8014,6 +8014,10 @@ struct RealComplexMulSimplify
     } else {
       return failure();
     }
+    // Should be better handled by constant folding
+    if (matchPattern(purelyRealOperand, m_Constant())) {
+      return failure();
+    }
     auto complexTensorTy = cast<TensorType>(op.getType());
     auto floatElTy =
         cast<ComplexType>(complexTensorTy.getElementType()).getElementType();
@@ -8082,6 +8086,10 @@ struct ImaginaryComplexMulSimplify
       purelyImaginaryOperand = op.getRhs();
       complexOperand = op.getLhs();
     } else {
+      return failure();
+    }
+    // Should be better handled by constant folding
+    if (matchPattern(purelyImaginaryOperand, m_Constant())) {
       return failure();
     }
     auto complexTensorTy = cast<TensorType>(op.getType());

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8014,10 +8014,6 @@ struct RealComplexMulSimplify
     } else {
       return failure();
     }
-    // Should be better handled by constant folding
-    if (matchPattern(purelyRealOperand, m_Constant())) {
-      return failure();
-    }
     auto complexTensorTy = cast<TensorType>(op.getType());
     auto floatElTy =
         cast<ComplexType>(complexTensorTy.getElementType()).getElementType();
@@ -8086,10 +8082,6 @@ struct ImaginaryComplexMulSimplify
       purelyImaginaryOperand = op.getRhs();
       complexOperand = op.getLhs();
     } else {
-      return failure();
-    }
-    // Should be better handled by constant folding
-    if (matchPattern(purelyImaginaryOperand, m_Constant())) {
       return failure();
     }
     auto complexTensorTy = cast<TensorType>(op.getType());

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8024,8 +8024,10 @@ struct RealComplexMulSimplify
         loc, realTensor.getType(), complexTensor);
     auto newRealPart = rewriter.create<stablehlo::MulOp>(
         loc, realTensor.getType(), realTensor, realPart);
+    newRealPart->setAttrs(op->getAttrs());
     auto newImagPart = rewriter.create<stablehlo::MulOp>(
         loc, realTensor.getType(), realTensor, imagPart);
+    newImagPart->setAttrs(op->getAttrs());
     auto newComplex = rewriter.create<stablehlo::ComplexOp>(
         loc, op.getType(), newRealPart, newImagPart);
     rewriter.replaceOp(op, newComplex);

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8022,10 +8022,10 @@ struct RealComplexMulSimplify
     Location loc = op.getLoc();
     auto realExtractedFromPurelyReal = rewriter.create<stablehlo::RealOp>(
         loc, floatTensorType, purelyRealOperand);
-    auto realPartOfComplex =
-        rewriter.create<stablehlo::RealOp>(loc, floatTensorType, complexOperand);
-    auto imagPartOfComplex =
-        rewriter.create<stablehlo::ImagOp>(loc, floatTensorType, complexOperand);
+    auto realPartOfComplex = rewriter.create<stablehlo::RealOp>(
+        loc, floatTensorType, complexOperand);
+    auto imagPartOfComplex = rewriter.create<stablehlo::ImagOp>(
+        loc, floatTensorType, complexOperand);
     auto newRealPart = rewriter.create<stablehlo::MulOp>(
         loc, floatTensorType, realExtractedFromPurelyReal, realPartOfComplex);
     auto newImagPart = rewriter.create<stablehlo::MulOp>(

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -2543,6 +2543,11 @@ def ApplyRealConvertSimplifyPatterns : EnzymeHLOPatternOp<
   let patterns = ["RealConvertSimplify"];
 }
 
+def ApplyImaginaryComplexMulSimplifyPatterns
+    : EnzymeHLOPatternOp<"imaginary_complex_mul_simplify"> {
+  let patterns = ["ImaginaryComplexMulSimplify"];
+}
+
 def ApplyConjComplexSimplifyPatterns : EnzymeHLOPatternOp<
     "conj_complex_simplify"> {
   let patterns = ["ConjComplexSimplify"];

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -3176,6 +3176,11 @@ def ApplySubComplexSimplifyPatterns: EnzymeHLOPatternOp<
   let patterns = ["BinaryOpComplexSimplifyBase<stablehlo::SubtractOp>"];
 }
 
+def ApplyRealComplexMulSimplify : EnzymeHLOPatternOp<
+    "real_complex_mul_simplify"> {
+  let patterns = ["RealComplexMulSimplify"];
+}
+
 def ApplyScatterOfScatterSimplifyPatterns : EnzymeHLOPatternOp<
     "scatter_of_scatter_simplify"> {
   let patterns = ["ScatterOfScatterSimplify"];

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -2691,6 +2691,11 @@ def ApplyRealConvertSimplifyPatterns : EnzymeHLOPatternOp<
   let patterns = ["RealConvertSimplify"];
 }
 
+def ApplyImaginaryComplexMulSimplifyPatterns
+    : EnzymeHLOPatternOp<"imaginary_complex_mul_simplify"> {
+  let patterns = ["ImaginaryComplexMulSimplify"];
+}
+
 def ApplyConjComplexSimplifyPatterns : EnzymeHLOPatternOp<
     "conj_complex_simplify"> {
   let patterns = ["ConjComplexSimplify"];

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -3324,6 +3324,11 @@ def ApplySubComplexSimplifyPatterns: EnzymeHLOPatternOp<
   let patterns = ["BinaryOpComplexSimplifyBase<stablehlo::SubtractOp>"];
 }
 
+def ApplyRealComplexMulSimplify : EnzymeHLOPatternOp<
+    "real_complex_mul_simplify"> {
+  let patterns = ["RealComplexMulSimplify"];
+}
+
 def ApplyScatterOfScatterSimplifyPatterns : EnzymeHLOPatternOp<
     "scatter_of_scatter_simplify"> {
   let patterns = ["ScatterOfScatterSimplify"];

--- a/test/lit_tests/conj_convert.mlir
+++ b/test/lit_tests/conj_convert.mlir
@@ -20,6 +20,6 @@ func.func @conj_2(%arg0: tensor<64x64xf64>) -> tensor<64x64xf64> {
 }
 
 // CHECK: func.func @conj_2(%arg0: tensor<64x64xf64>) -> tensor<64x64xf64> {
-// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %arg0 {enzymexla.complex_is_purely_imaginary = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<64x64xf64>
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %arg0 : tensor<64x64xf64>
 // CHECK-NEXT:     return %0 : tensor<64x64xf64>
 // CHECK-NEXT: }

--- a/test/lit_tests/imaginarycomplexmulsimplify.mlir
+++ b/test/lit_tests/imaginarycomplexmulsimplify.mlir
@@ -1,0 +1,16 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=imaginary_complex_mul_simplify" --transform-interpreter --enzyme-hlo-remove-transform -allow-unregistered-dialect | FileCheck %s
+
+func.func @main(%arg0: tensor<4368xcomplex<f64>>, %arg1: tensor<4368xcomplex<f64>>) -> tensor<4368xcomplex<f64>> {
+  %0 = stablehlo.reshape %arg0 {enzymexla.complex_is_purely_imaginary = [#enzymexla<guaranteed GUARANTEED>]} : (tensor<4368xcomplex<f64>>) -> tensor<4368xcomplex<f64>>
+  %1 = stablehlo.multiply %0, %arg1 : tensor<4368xcomplex<f64>>
+  return %1 : tensor<4368xcomplex<f64>>
+}
+
+// CHECK: %[[IMAG_LHS:.*]] = stablehlo.imag %0
+// CHECK: %[[REAL_RHS:.*]] = stablehlo.real %arg1
+// CHECK: %[[IMAG_RHS:.*]] = stablehlo.imag %arg1
+// CHECK: %[[MUL_IMAGS:.*]] = stablehlo.multiply %[[IMAG_LHS]], %[[IMAG_RHS]]
+// CHECK: %[[NEG_REAL:.*]] = stablehlo.negate %[[MUL_IMAGS]]
+// CHECK: %[[MUL_MIXED:.*]] = stablehlo.multiply %[[IMAG_LHS]], %[[REAL_RHS]]
+// CHECK: %[[COMPLEX:.*]] = stablehlo.complex %[[NEG_REAL]], %[[MUL_MIXED]]
+// CHECK: return %[[COMPLEX]]

--- a/test/lit_tests/linalg/blas/gemm.mlir
+++ b/test/lit_tests/linalg/blas/gemm.mlir
@@ -83,7 +83,7 @@ func.func @matmul_none_transpose(%A: tensor<2x4xf32>, %B: tensor<3x4xf32>) -> te
 // CHECK-NEXT: }
 
 func.func @matmul_adjoint_adjoint(%A: tensor<4x2xcomplex<f32>>, %B: tensor<3x4xcomplex<f32>>) -> tensor<2x3xcomplex<f32>> {
-    %alpha = stablehlo.constant dense<(1.0, 0.0)> : tensor<complex<f32>>
+    %alpha = stablehlo.constant dense<(1.0, 1.0)> : tensor<complex<f32>>
     %beta = stablehlo.constant dense<(0.0, 0.0)> : tensor<complex<f32>>
     %C = stablehlo.constant dense<(0.0, 0.0)> : tensor<2x3xcomplex<f32>>
     %0 = enzymexla.blas.gemm %alpha, %A, %B, %beta, %C {transa = #enzymexla.transpose<adjoint>, transb = #enzymexla.transpose<adjoint>} : (tensor<complex<f32>>, tensor<4x2xcomplex<f32>>, tensor<3x4xcomplex<f32>>, tensor<complex<f32>>, tensor<2x3xcomplex<f32>>) -> tensor<2x3xcomplex<f32>>
@@ -91,7 +91,7 @@ func.func @matmul_adjoint_adjoint(%A: tensor<4x2xcomplex<f32>>, %B: tensor<3x4xc
 }
 
 // CHECK-NEXT: func.func @matmul_adjoint_adjoint(%arg0: tensor<4x2xcomplex<f32>>, %arg1: tensor<3x4xcomplex<f32>>) -> tensor<2x3xcomplex<f32>> {
-// CHECK-NEXT:   %cst = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<2x3xcomplex<f32>>
+// CHECK-NEXT:   %cst = stablehlo.constant dense<(1.000000e+00,1.000000e+00)> : tensor<2x3xcomplex<f32>>
 // CHECK-NEXT:   %0 = chlo.conj %arg0 : tensor<4x2xcomplex<f32>> -> tensor<4x2xcomplex<f32>>
 // CHECK-NEXT:   %1 = chlo.conj %arg1 : tensor<3x4xcomplex<f32>> -> tensor<3x4xcomplex<f32>>
 // CHECK-NEXT:   %2 = stablehlo.dot_general %0, %1, contracting_dims = [0] x [1] : (tensor<4x2xcomplex<f32>>, tensor<3x4xcomplex<f32>>) -> tensor<2x3xcomplex<f32>>

--- a/test/lit_tests/realcomplexmulsimplify.mlir
+++ b/test/lit_tests/realcomplexmulsimplify.mlir
@@ -1,0 +1,17 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=real_complex_mul_simplify" --transform-interpreter --enzyme-hlo-remove-transform -allow-unregistered-dialect | FileCheck %s
+func.func @main(%arg0: tensor<4368xf64> , %arg1: tensor<4368xcomplex<f64>> ) -> tensor<4368xcomplex<f64>> {
+    %0 = stablehlo.convert %arg0 : (tensor<4368xf64>) -> tensor<4368xcomplex<f64>>
+    %1 = stablehlo.multiply %0, %arg1 : tensor<4368xcomplex<f64>>
+    return %1 : tensor<4368xcomplex<f64>>
+}
+
+// CHECK-LABEL: func.func @main
+// CHECK-SAME:  (%[[ARG0:.*]]: tensor<4368xf64>, %[[ARG1:.*]]: tensor<4368xcomplex<f64>>)
+
+// CHECK-DAG: %[[REAL:.*]] = stablehlo.real %[[ARG1]]
+// CHECK-DAG: %[[IMAG:.*]] = stablehlo.imag %[[ARG1]]
+// CHECK-DAG: %[[MUL_REAL:.*]] = stablehlo.multiply %[[ARG0]], %[[REAL]]
+// CHECK-DAG: %[[MUL_IMAG:.*]] = stablehlo.multiply %[[ARG0]], %[[IMAG]]
+
+// CHECK:     %[[RESULT:.*]] = stablehlo.complex %[[MUL_REAL]], %[[MUL_IMAG]]
+// CHECK:     return %[[RESULT]]

--- a/test/lit_tests/realcomplexmulsimplify.mlir
+++ b/test/lit_tests/realcomplexmulsimplify.mlir
@@ -1,7 +1,6 @@
 // RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=real_complex_mul_simplify" --transform-interpreter --enzyme-hlo-remove-transform -allow-unregistered-dialect | FileCheck %s
 
 func.func @main(%arg0: tensor<4368xf64>, %arg1: tensor<4368xcomplex<f64>>) -> tensor<4368xcomplex<f64>> {
-  // Add the attribute right here so the pattern knows it is allowed to fire!
   %0 = stablehlo.convert %arg0 {enzymexla.complex_is_purely_real = [#enzymexla<guaranteed GUARANTEED>]} : (tensor<4368xf64>) -> tensor<4368xcomplex<f64>>
   %1 = stablehlo.multiply %0, %arg1 : tensor<4368xcomplex<f64>>
   return %1 : tensor<4368xcomplex<f64>>

--- a/test/lit_tests/realcomplexmulsimplify.mlir
+++ b/test/lit_tests/realcomplexmulsimplify.mlir
@@ -1,17 +1,16 @@
 // RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=real_complex_mul_simplify" --transform-interpreter --enzyme-hlo-remove-transform -allow-unregistered-dialect | FileCheck %s
-func.func @main(%arg0: tensor<4368xf64> , %arg1: tensor<4368xcomplex<f64>> ) -> tensor<4368xcomplex<f64>> {
-    %0 = stablehlo.convert %arg0 : (tensor<4368xf64>) -> tensor<4368xcomplex<f64>>
-    %1 = stablehlo.multiply %0, %arg1 : tensor<4368xcomplex<f64>>
-    return %1 : tensor<4368xcomplex<f64>>
+
+func.func @main(%arg0: tensor<4368xf64>, %arg1: tensor<4368xcomplex<f64>>) -> tensor<4368xcomplex<f64>> {
+  // Add the attribute right here so the pattern knows it is allowed to fire!
+  %0 = stablehlo.convert %arg0 {enzymexla.complex_is_purely_real = [#enzymexla<guaranteed GUARANTEED>]} : (tensor<4368xf64>) -> tensor<4368xcomplex<f64>>
+  %1 = stablehlo.multiply %0, %arg1 : tensor<4368xcomplex<f64>>
+  return %1 : tensor<4368xcomplex<f64>>
 }
 
-// CHECK-LABEL: func.func @main
-// CHECK-SAME:  (%[[ARG0:.*]]: tensor<4368xf64>, %[[ARG1:.*]]: tensor<4368xcomplex<f64>>)
-
-// CHECK-DAG: %[[REAL:.*]] = stablehlo.real %[[ARG1]]
-// CHECK-DAG: %[[IMAG:.*]] = stablehlo.imag %[[ARG1]]
-// CHECK-DAG: %[[MUL_REAL:.*]] = stablehlo.multiply %[[ARG0]], %[[REAL]]
-// CHECK-DAG: %[[MUL_IMAG:.*]] = stablehlo.multiply %[[ARG0]], %[[IMAG]]
-
-// CHECK:     %[[RESULT:.*]] = stablehlo.complex %[[MUL_REAL]], %[[MUL_IMAG]]
-// CHECK:     return %[[RESULT]]
+// CHECK: %[[REAL_LHS:.*]] = stablehlo.real %0
+// CHECK: %[[REAL_RHS:.*]] = stablehlo.real %arg1
+// CHECK: %[[IMAG_RHS:.*]] = stablehlo.imag %arg1
+// CHECK: %[[MUL_REAL:.*]] = stablehlo.multiply %[[REAL_LHS]], %[[REAL_RHS]]
+// CHECK: %[[MUL_IMAG:.*]] = stablehlo.multiply %[[REAL_LHS]], %[[IMAG_RHS]]
+// CHECK: %[[COMPLEX:.*]] = stablehlo.complex %[[MUL_REAL]], %[[MUL_IMAG]]
+// CHECK: return %[[COMPLEX]]

--- a/test/lit_tests/split_complex_scatter_setindex.mlir
+++ b/test/lit_tests/split_complex_scatter_setindex.mlir
@@ -31,10 +31,10 @@ module {
 // The constant input (0.0 + 5.0i) gets decomposed, reshaped, and folded into a pad op.
 // CHECK: %[[REAL:.*]] = stablehlo.real %arg4
 // CHECK: %[[IMAG:.*]] = stablehlo.imag %arg4
-// CHECK: %[[CONCAT:.*]] = stablehlo.concatenate %[[REAL]], %[[IMAG]], dim = 0
-// CHECK: %[[MUL:.*]] = stablehlo.multiply %{{.*}}, %[[CONCAT]]
-// CHECK: %[[SCATTER_UPDATE:.*]] = stablehlo.reshape %[[MUL]]
-// CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%{{.*}}, %7, %[[SCATTER_UPDATE]])
+// CHECK: %[[CONCAT_RAW:.*]] = stablehlo.concatenate %[[REAL]], %[[IMAG]], dim = 0
+// CHECK-NEXT: %[[MUL:.*]] = stablehlo.multiply %{{.*}}, %[[CONCAT_RAW]]
+// CHECK-NEXT: %[[CONCAT:.*]] = stablehlo.reshape %[[MUL]]
+// CHECK-NEXT: %[[SCATTER:.*]] = "stablehlo.scatter"(%{{.*}}, %7, %[[CONCAT]])
 // CHECK-SAME: update_window_dims = [0]
 // CHECK-SAME: inserted_window_dims = [1, 2]
 // CHECK: ^bb0(%{{.*}}: tensor<f64>, %[[ARG8:.*]]: tensor<f64>):

--- a/test/lit_tests/split_complex_scatter_setindex.mlir
+++ b/test/lit_tests/split_complex_scatter_setindex.mlir
@@ -29,11 +29,12 @@ module {
 
 // The Setindex scatter on complex constant input gets transformed to a single scatter.
 // The constant input (0.0 + 5.0i) gets decomposed, reshaped, and folded into a pad op.
-// CHECK: %[[REAL:.*]] = stablehlo.real %3
-// CHECK-NEXT: %[[IMAG:.*]] = stablehlo.imag %3
-// CHECK-NEXT: %[[CONCAT_RAW:.*]] = stablehlo.concatenate %[[REAL]], %[[IMAG]], dim = 0
-// CHECK-NEXT: %[[CONCAT:.*]] = stablehlo.reshape %[[CONCAT_RAW]]
-// CHECK-NEXT: %[[SCATTER:.*]] = "stablehlo.scatter"(%{{.*}}, %7, %[[CONCAT]])
+// CHECK: %[[REAL:.*]] = stablehlo.real %arg4
+// CHECK: %[[IMAG:.*]] = stablehlo.imag %arg4
+// CHECK: %[[CONCAT:.*]] = stablehlo.concatenate %[[REAL]], %[[IMAG]], dim = 0
+// CHECK: %[[MUL:.*]] = stablehlo.multiply %{{.*}}, %[[CONCAT]]
+// CHECK: %[[SCATTER_UPDATE:.*]] = stablehlo.reshape %[[MUL]]
+// CHECK: %[[SCATTER:.*]] = "stablehlo.scatter"(%{{.*}}, %7, %[[SCATTER_UPDATE]])
 // CHECK-SAME: update_window_dims = [0]
 // CHECK-SAME: inserted_window_dims = [1, 2]
 // CHECK: ^bb0(%{{.*}}: tensor<f64>, %[[ARG8:.*]]: tensor<f64>):


### PR DESCRIPTION
closes #1988
This PR adds a rewrite pattern for stablehlo.multiply to optimize complex multiplication when the imaginary component of the first operand is zero.Mathematical simplification:Given 
$(a + bi) \times (c + di)$ : If $b = 0$, the expression simplifies: 
$(a \cdot c - b \cdot d) + (c \cdot b + a \cdot d)i \implies (a \cdot c - 0 \cdot d) + (c \cdot 0 + a \cdot d)i = a \cdot c + a \cdot d \cdot i$


