### PR TITLE
PolygeistMem2Reg: Type Casting in Store-to-Load Forwarding

### DIFF
--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -945,6 +945,9 @@ def ConvertParallelToGPU2 : Pass<"convert-parallel-to-gpu2"> {
 
 def PolygeistMem2Reg : Pass<"polygeist-mem2reg"> {
   let summary = "Replace scf.if and similar with affine.if";
+  let dependentDialects = [
+    "arith::ArithDialect"
+  ];
 }
 
 def OptimizeCommunication : Pass<"optimize-communication"> {

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -1080,6 +1080,25 @@ void removeRedundantBlockArgs(
   }
 }
 
+// Extract values from struct or array and insert them into a vector
+Value buildVector(OpBuilder &b, Value val, unsigned numElements,
+                  Type elemType) {
+  SmallVector<Value> extracted;
+  for (unsigned i = 0; i < numElements; i++) {
+    extracted.push_back(LLVM::ExtractValueOp::create(b, val.getLoc(), val, i));
+  }
+
+  auto vecType = VectorType::get(numElements, elemType);
+  Value vec = LLVM::PoisonOp::create(b, val.getLoc(), vecType);
+  for (unsigned i = 0; i < extracted.size(); i++) {
+    Value idx = LLVM::ConstantOp::create(b, val.getLoc(), b.getI32Type(),
+                                         b.getI32IntegerAttr(i));
+    vec =
+        LLVM::InsertElementOp::create(b, val.getLoc(), vec, extracted[i], idx);
+  }
+  return vec;
+}
+
 Value castToType(Type elType, Value val, Operation *op) {
   if (val.getType() == elType)
     return val;
@@ -1102,6 +1121,31 @@ Value castToType(Type elType, Value val, Operation *op) {
       b.setInsertionPoint(op);
       return LLVM::InsertValueOp::create(b, val.getLoc(), ud, c0,
                                          b.getDenseI64ArrayAttr({0}));
+    }
+  } else if (auto ST = dyn_cast<LLVM::LLVMStructType>(val.getType())) {
+    if (ST.getBody().size() == 1) {
+      auto extractedVal = LLVM::ExtractValueOp::create(b, val.getLoc(), val, 0);
+      return castToType(elType, extractedVal, op);
+    } else {
+      Type elemType = ST.getBody()[0];
+      if (llvm::all_of(ST.getBody(), [&](Type t) {
+            return t == elemType && isa<VectorElementTypeInterface>(t);
+          })) {
+        Value vec = buildVector(b, val, ST.getBody().size(), elemType);
+        return castToType(elType, vec, op);
+      }
+    }
+  } else if (auto AT = dyn_cast<LLVM::LLVMArrayType>(val.getType())) {
+    Type elemType = AT.getElementType();
+    if (isa<VectorElementTypeInterface>(elemType)) {
+      Value vec = buildVector(b, val, AT.getNumElements(), elemType);
+      return castToType(elType, vec, op);
+    }
+  } else if (auto VT = dyn_cast<VectorType>(val.getType())) {
+    if (isa<IntegerType>(elType)) {
+      DataLayout dl(op->getParentOfType<ModuleOp>());
+      if (dl.getTypeSize(val.getType()) == dl.getTypeSize(elType))
+        return b.create<LLVM::BitcastOp>(val.getLoc(), elType, val);
     }
   }
   llvm::errs() << " mismatched load type, needed: " << elType << " found "

--- a/test/lit_tests/mem2reg_type_casting.mlir
+++ b/test/lit_tests/mem2reg_type_casting.mlir
@@ -11,14 +11,10 @@ llvm.func @forward_same_type(%val: i32) -> i32 {
   llvm.return %0 : i32
 }
 
-// CHECK-LABEL: llvm.func @forward_same_type
-// CHECK-NOT:   llvm.inttoptr
-// CHECK-NOT:   llvm.ptrtoint
-// CHECK-NOT:   arith.bitcast
-// CHECK-NOT:   llvm.bitcast
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       llvm.return %[[VAL:.+]] : i32
+// CHECK: llvm.func @forward_same_type(%[[VAL:.*]]: i32) -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: llvm.return %[[VAL]] : i32
+// CHECK-NEXT: }
 
 // -----
 
@@ -32,11 +28,11 @@ llvm.func @forward_int_to_ptr(%val: i64) -> !llvm.ptr {
   llvm.return %0 : !llvm.ptr
 }
 
-// CHECK-LABEL: llvm.func @forward_int_to_ptr
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[ITP:.+]] = llvm.inttoptr %[[VAL:.+]] : i64 to !llvm.ptr
-// CHECK:       llvm.return %[[ITP]] : !llvm.ptr
+// CHECK: llvm.func @forward_int_to_ptr(%[[VAL:.*]]: i64) -> !llvm.ptr {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[ITP:.*]] = llvm.inttoptr %[[VAL]] : i64 to !llvm.ptr
+// CHECK-NEXT: llvm.return %[[ITP]] : !llvm.ptr
+// CHECK-NEXT: }
 
 // -----
 
@@ -50,11 +46,11 @@ llvm.func @forward_ptr_to_int(%val: !llvm.ptr) -> i64 {
   llvm.return %0 : i64
 }
 
-// CHECK-LABEL: llvm.func @forward_ptr_to_int
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[PTI:.+]] = llvm.ptrtoint %[[VAL:.+]] : !llvm.ptr to i64
-// CHECK:       llvm.return %[[PTI]] : i64
+// CHECK: llvm.func @forward_ptr_to_int(%[[VAL:.*]]: !llvm.ptr) -> i64 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[PTI:.*]] = llvm.ptrtoint %[[VAL]] : !llvm.ptr to i64
+// CHECK-NEXT: llvm.return %[[PTI]] : i64
+// CHECK-NEXT: }
 
 // -----
 
@@ -68,11 +64,11 @@ llvm.func @forward_float_to_int(%val: f32) -> i32 {
   llvm.return %0 : i32
 }
 
-// CHECK-LABEL: llvm.func @forward_float_to_int
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[BC:.+]] = arith.bitcast %[[VAL:.+]] : f32 to i32
-// CHECK:       llvm.return %[[BC]] : i32
+// CHECK: llvm.func @forward_float_to_int(%[[VAL:.*]]: f32) -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[BC:.*]] = arith.bitcast %[[VAL]] : f32 to i32
+// CHECK-NEXT: llvm.return %[[BC]] : i32
+// CHECK-NEXT: }
 
 // -----
 
@@ -86,11 +82,11 @@ llvm.func @forward_int_to_float(%val: i32) -> f32 {
   llvm.return %0 : f32
 }
 
-// CHECK-LABEL: llvm.func @forward_int_to_float
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[BC:.+]] = arith.bitcast %[[VAL:.+]] : i32 to f32
-// CHECK:       llvm.return %[[BC]] : f32
+// CHECK: llvm.func @forward_int_to_float(%[[VAL:.*]]: i32) -> f32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[BC:.*]] = arith.bitcast %[[VAL]] : i32 to f32
+// CHECK-NEXT: llvm.return %[[BC]] : f32
+// CHECK-NEXT: }
 
 // -----
 
@@ -104,12 +100,12 @@ llvm.func @forward_scalar_to_single_field_struct(%val: i32) -> !llvm.struct<(i32
   llvm.return %0 : !llvm.struct<(i32)>
 }
 
-// CHECK-LABEL: llvm.func @forward_scalar_to_single_field_struct
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[UD:.+]] = llvm.mlir.undef : !llvm.struct<(i32)>
-// CHECK:       %[[INS:.+]] = llvm.insertvalue %[[VAL:.+]], %[[UD]][0] : !llvm.struct<(i32)>
-// CHECK:       llvm.return %[[INS]] : !llvm.struct<(i32)>
+// CHECK: llvm.func @forward_scalar_to_single_field_struct(%[[VAL:.*]]: i32) -> !llvm.struct<(i32)> {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[UD:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+// CHECK-NEXT: %[[IV:.*]] = llvm.insertvalue %[[VAL]], %[[UD]][0] : !llvm.struct<(i32)> 
+// CHECK-NEXT: llvm.return %[[IV]] : !llvm.struct<(i32)>
+// CHECK-NEXT: }
 
 // -----
 
@@ -123,11 +119,11 @@ llvm.func @forward_single_field_struct_to_scalar(%val: !llvm.struct<(i32)>) -> i
   llvm.return %0 : i32
 }
 
-// CHECK-LABEL: llvm.func @forward_single_field_struct_to_scalar
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[EX:.+]] = llvm.extractvalue %[[VAL:.+]][0] : !llvm.struct<(i32)>
-// CHECK:       llvm.return %[[EX]] : i32
+// CHECK: llvm.func @forward_single_field_struct_to_scalar(%[[VAL:.*]]: !llvm.struct<(i32)>) -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EV:.*]] = llvm.extractvalue %[[VAL]][0] : !llvm.struct<(i32)> 
+// CHECK-NEXT: llvm.return %[[EV]] : i32
+// CHECK-NEXT: }
 
 // -----
 
@@ -141,12 +137,12 @@ llvm.func @forward_nested_struct_to_scalar(%val: !llvm.struct<(struct<(f32)>)>) 
   llvm.return %0 : f32
 }
 
-// CHECK-LABEL: llvm.func @forward_nested_struct_to_scalar
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[EX0:.+]] = llvm.extractvalue %[[VAL:.+]][0] : !llvm.struct<(struct<(f32)>)>
-// CHECK:       %[[EX1:.+]] = llvm.extractvalue %[[EX0]][0] : !llvm.struct<(f32)>
-// CHECK:       llvm.return %[[EX1]] : f32
+// CHECK: llvm.func @forward_nested_struct_to_scalar(%[[VAL:.*]]: !llvm.struct<(struct<(f32)>)>) -> f32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EV0:.*]] = llvm.extractvalue %[[VAL]][0] : !llvm.struct<(struct<(f32)>)> 
+// CHECK-NEXT: %[[EV1:.*]] = llvm.extractvalue %[[EV0]][0] : !llvm.struct<(f32)> 
+// CHECK-NEXT: llvm.return %[[EV1]] : f32
+// CHECK-NEXT: }
 
 // -----
 
@@ -160,17 +156,17 @@ llvm.func @forward_uniform_struct_to_vector(%val: !llvm.struct<(f32, f32)>) -> v
   llvm.return %0 : vector<2xf32>
 }
 
-// CHECK-LABEL: llvm.func @forward_uniform_struct_to_vector
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[EX0:.+]] = llvm.extractvalue %[[VAL:.+]][0] : !llvm.struct<(f32, f32)>
-// CHECK:       %[[EX1:.+]] = llvm.extractvalue %[[VAL:.+]][1] : !llvm.struct<(f32, f32)>
-// CHECK:       %[[PSN:.+]] = llvm.mlir.poison : vector<2xf32>
-// CHECK:       %[[C0:.+]]  = llvm.mlir.constant(0 : i32) : i32
-// CHECK:       %[[V0:.+]]  = llvm.insertelement %[[EX0]], %[[PSN]][%[[C0]] : i32] : vector<2xf32>
-// CHECK:       %[[C1:.+]]  = llvm.mlir.constant(1 : i32) : i32
-// CHECK:       %[[V1:.+]]  = llvm.insertelement %[[EX1]], %[[V0]][%[[C1]] : i32] : vector<2xf32>
-// CHECK:       llvm.return %[[V1]] : vector<2xf32>
+// CHECK: llvm.func @forward_uniform_struct_to_vector(%[[VAL:.*]]: !llvm.struct<(f32, f32)>) -> vector<2xf32> {
+// CHECK-NEXT: %[[C:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EX0:.*]] = llvm.extractvalue %[[VAL]][0] : !llvm.struct<(f32, f32)>
+// CHECK-NEXT: %[[EX1:.*]] = llvm.extractvalue %[[VAL]][1] : !llvm.struct<(f32, f32)>
+// CHECK-NEXT: %[[PSN:.*]] = llvm.mlir.poison : vector<2xf32>
+// CHECK-NEXT: %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[V0:.*]] = llvm.insertelement %[[EX0]], %[[PSN]][%[[C0]] : i32] : vector<2xf32>
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[V1:.*]] = llvm.insertelement %[[EX1]], %[[V0]][%[[C1]] : i32] : vector<2xf32>
+// CHECK-NEXT: llvm.return %[[V1]] : vector<2xf32>
+// CHECK-NEXT: }
 
 // -----
 
@@ -184,17 +180,17 @@ llvm.func @forward_array_to_vector(%val: !llvm.array<2 x f32>) -> vector<2xf32> 
   llvm.return %0 : vector<2xf32>
 }
 
-// CHECK-LABEL: llvm.func @forward_array_to_vector
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[EX0:.+]] = llvm.extractvalue %[[VAL:.+]][0] : !llvm.array<2 x f32>
-// CHECK:       %[[EX1:.+]] = llvm.extractvalue %[[VAL:.+]][1] : !llvm.array<2 x f32>
-// CHECK:       %[[PSN:.+]] = llvm.mlir.poison : vector<2xf32>
-// CHECK:       %[[C0:.+]]  = llvm.mlir.constant(0 : i32) : i32
-// CHECK:       %[[V0:.+]]  = llvm.insertelement %[[EX0]], %[[PSN]][%[[C0]] : i32] : vector<2xf32>
-// CHECK:       %[[C1:.+]]  = llvm.mlir.constant(1 : i32) : i32
-// CHECK:       %[[V1:.+]]  = llvm.insertelement %[[EX1]], %[[V0]][%[[C1]] : i32] : vector<2xf32>
-// CHECK:       llvm.return %[[V1]] : vector<2xf32>
+// CHECK: llvm.func @forward_array_to_vector(%[[VAL:.*]]: !llvm.array<2 x f32>) -> vector<2xf32> {
+// CHECK-NEXT: %[[C:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EV0:.*]] = llvm.extractvalue %[[VAL]][0] : !llvm.array<2 x f32> 
+// CHECK-NEXT: %[[EV1:.*]] = llvm.extractvalue %[[VAL]][1] : !llvm.array<2 x f32> 
+// CHECK-NEXT: %[[PSN:.*]] = llvm.mlir.poison : vector<2xf32>
+// CHECK-NEXT: %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[V0:.*]] = llvm.insertelement %[[EV0]], %[[PSN]][%[[C0]] : i32] : vector<2xf32>
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[V1:.*]] = llvm.insertelement %[[EV1]], %[[V0]][%[[C1]] : i32] : vector<2xf32>
+// CHECK-NEXT: llvm.return %[[V1]] : vector<2xf32>
+// CHECK-NEXT: }
 
 // -----
 
@@ -208,8 +204,8 @@ llvm.func @forward_vector_to_int_bitcast(%val: vector<4xi8>) -> i32 {
   llvm.return %0 : i32
 }
 
-// CHECK-LABEL: llvm.func @forward_vector_to_int_bitcast
-// CHECK-NOT:   llvm.store
-// CHECK-NOT:   llvm.load
-// CHECK:       %[[BC:.+]] = llvm.bitcast %[[VAL:.+]] : vector<4xi8> to i32
-// CHECK:       llvm.return %[[BC]] : i32
+// CHECK: llvm.func @forward_vector_to_int_bitcast(%[[VAL:.*]]: vector<4xi8>) -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[BC:.*]] = llvm.bitcast %[[VAL]] : vector<4xi8> to i32
+// CHECK-NEXT: llvm.return %[[BC]] : i32
+// CHECK-NEXT: }

--- a/test/lit_tests/mem2reg_type_casting.mlir
+++ b/test/lit_tests/mem2reg_type_casting.mlir
@@ -1,0 +1,215 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+
+// Same type – forwarded with no cast at all
+
+llvm.func @forward_same_type(%val: i32) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %al : i32, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: llvm.func @forward_same_type
+// CHECK-NOT:   llvm.inttoptr
+// CHECK-NOT:   llvm.ptrtoint
+// CHECK-NOT:   arith.bitcast
+// CHECK-NOT:   llvm.bitcast
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       llvm.return %[[VAL:.+]] : i32
+
+// -----
+
+// IntegerType (i64) stored, LLVMPointerType loaded
+
+llvm.func @forward_int_to_ptr(%val: i64) -> !llvm.ptr {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x i64 : (i32) -> !llvm.ptr
+  llvm.store %val, %al : i64, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> !llvm.ptr
+  llvm.return %0 : !llvm.ptr
+}
+
+// CHECK-LABEL: llvm.func @forward_int_to_ptr
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[ITP:.+]] = llvm.inttoptr %[[VAL:.+]] : i64 to !llvm.ptr
+// CHECK:       llvm.return %[[ITP]] : !llvm.ptr
+
+// -----
+
+// LLVMPointerType stored, IntegerType (i64) loaded
+
+llvm.func @forward_ptr_to_int(%val: !llvm.ptr) -> i64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x !llvm.ptr : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.ptr, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> i64
+  llvm.return %0 : i64
+}
+
+// CHECK-LABEL: llvm.func @forward_ptr_to_int
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[PTI:.+]] = llvm.ptrtoint %[[VAL:.+]] : !llvm.ptr to i64
+// CHECK:       llvm.return %[[PTI]] : i64
+
+// -----
+
+// FloatType (f32) stored, IntegerType (i32) loaded
+
+llvm.func @forward_float_to_int(%val: f32) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x f32 : (i32) -> !llvm.ptr
+  llvm.store %val, %al : f32, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: llvm.func @forward_float_to_int
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[BC:.+]] = arith.bitcast %[[VAL:.+]] : f32 to i32
+// CHECK:       llvm.return %[[BC]] : i32
+
+// -----
+
+// IntegerType (i32) stored, FloatType (f32) loaded
+
+llvm.func @forward_int_to_float(%val: i32) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %al : i32, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> f32
+  llvm.return %0 : f32
+}
+
+// CHECK-LABEL: llvm.func @forward_int_to_float
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[BC:.+]] = arith.bitcast %[[VAL:.+]] : i32 to f32
+// CHECK:       llvm.return %[[BC]] : f32
+
+// -----
+
+// Scalar (i32) stored, single-field struct { i32 } loaded
+
+llvm.func @forward_scalar_to_single_field_struct(%val: i32) -> !llvm.struct<(i32)> {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %al : i32, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> !llvm.struct<(i32)>
+  llvm.return %0 : !llvm.struct<(i32)>
+}
+
+// CHECK-LABEL: llvm.func @forward_scalar_to_single_field_struct
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[UD:.+]] = llvm.mlir.undef : !llvm.struct<(i32)>
+// CHECK:       %[[INS:.+]] = llvm.insertvalue %[[VAL:.+]], %[[UD]][0] : !llvm.struct<(i32)>
+// CHECK:       llvm.return %[[INS]] : !llvm.struct<(i32)>
+
+// -----
+
+// Single-field struct { i32 } stored, scalar i32 loaded
+
+llvm.func @forward_single_field_struct_to_scalar(%val: !llvm.struct<(i32)>) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x !llvm.struct<(i32)> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.struct<(i32)>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: llvm.func @forward_single_field_struct_to_scalar
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[EX:.+]] = llvm.extractvalue %[[VAL:.+]][0] : !llvm.struct<(i32)>
+// CHECK:       llvm.return %[[EX]] : i32
+
+// -----
+
+// Nested struct { struct { f32 } } stored, f32 loaded
+
+llvm.func @forward_nested_struct_to_scalar(%val: !llvm.struct<(struct<(f32)>)>) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x !llvm.struct<(struct<(f32)>)> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.struct<(struct<(f32)>)>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> f32
+  llvm.return %0 : f32
+}
+
+// CHECK-LABEL: llvm.func @forward_nested_struct_to_scalar
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[EX0:.+]] = llvm.extractvalue %[[VAL:.+]][0] : !llvm.struct<(struct<(f32)>)>
+// CHECK:       %[[EX1:.+]] = llvm.extractvalue %[[EX0]][0] : !llvm.struct<(f32)>
+// CHECK:       llvm.return %[[EX1]] : f32
+
+// -----
+
+// Uniform two-field struct { f32, f32 } stored, vector<2xf32> loaded
+
+llvm.func @forward_uniform_struct_to_vector(%val: !llvm.struct<(f32, f32)>) -> vector<2xf32> {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x !llvm.struct<(f32, f32)> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.struct<(f32, f32)>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> vector<2xf32>
+  llvm.return %0 : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @forward_uniform_struct_to_vector
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[EX0:.+]] = llvm.extractvalue %[[VAL:.+]][0] : !llvm.struct<(f32, f32)>
+// CHECK:       %[[EX1:.+]] = llvm.extractvalue %[[VAL:.+]][1] : !llvm.struct<(f32, f32)>
+// CHECK:       %[[PSN:.+]] = llvm.mlir.poison : vector<2xf32>
+// CHECK:       %[[C0:.+]]  = llvm.mlir.constant(0 : i32) : i32
+// CHECK:       %[[V0:.+]]  = llvm.insertelement %[[EX0]], %[[PSN]][%[[C0]] : i32] : vector<2xf32>
+// CHECK:       %[[C1:.+]]  = llvm.mlir.constant(1 : i32) : i32
+// CHECK:       %[[V1:.+]]  = llvm.insertelement %[[EX1]], %[[V0]][%[[C1]] : i32] : vector<2xf32>
+// CHECK:       llvm.return %[[V1]] : vector<2xf32>
+
+// -----
+
+// LLVM array [2 x f32] stored, vector<2xf32> loaded
+
+llvm.func @forward_array_to_vector(%val: !llvm.array<2 x f32>) -> vector<2xf32> {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x !llvm.array<2 x f32> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.array<2 x f32>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> vector<2xf32>
+  llvm.return %0 : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @forward_array_to_vector
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[EX0:.+]] = llvm.extractvalue %[[VAL:.+]][0] : !llvm.array<2 x f32>
+// CHECK:       %[[EX1:.+]] = llvm.extractvalue %[[VAL:.+]][1] : !llvm.array<2 x f32>
+// CHECK:       %[[PSN:.+]] = llvm.mlir.poison : vector<2xf32>
+// CHECK:       %[[C0:.+]]  = llvm.mlir.constant(0 : i32) : i32
+// CHECK:       %[[V0:.+]]  = llvm.insertelement %[[EX0]], %[[PSN]][%[[C0]] : i32] : vector<2xf32>
+// CHECK:       %[[C1:.+]]  = llvm.mlir.constant(1 : i32) : i32
+// CHECK:       %[[V1:.+]]  = llvm.insertelement %[[EX1]], %[[V0]][%[[C1]] : i32] : vector<2xf32>
+// CHECK:       llvm.return %[[V1]] : vector<2xf32>
+
+// -----
+
+// VectorType (vector<4xi8>, 4 bytes) stored, IntegerType (i32, 4 bytes) loaded
+
+llvm.func @forward_vector_to_int_bitcast(%val: vector<4xi8>) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x vector<4xi8> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : vector<4xi8>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: llvm.func @forward_vector_to_int_bitcast
+// CHECK-NOT:   llvm.store
+// CHECK-NOT:   llvm.load
+// CHECK:       %[[BC:.+]] = llvm.bitcast %[[VAL:.+]] : vector<4xi8> to i32
+// CHECK:       llvm.return %[[BC]] : i32


### PR DESCRIPTION
Adds more cases for type casting in order to perform store-to-load forwarding, including:
- Struct to vector
- Struct to scalar (using intermediate vector)
- Array to vector
- Array to scalar (using intermediate vector)
- Vector to scalar

This works for nested structs as well.