### PR TITLE
lower `QRFactorizationOp` to `GeqrfOp` and `OrgqrOp`

### DIFF
--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -754,8 +754,7 @@ def QRFactorizationOp: EnzymeXLA_Op<"linalg.qr", [Pure]> {
   }];
 
   let arguments = (ins
-    HLO_Tensor:$input,
-    DefaultValuedAttr<EnzymeXLA_QrAlgorithmAttr, "mlir::enzymexla::QrAlgorithm::geqrf">:$algorithm
+    HLO_Tensor:$input
   );
 
   let results = (outs

--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -759,7 +759,8 @@ def QRFactorizationOp: EnzymeXLA_Op<"linalg.qr", [Pure]> {
 
   let results = (outs
     HLO_Tensor:$Q,
-    HLO_Tensor:$R
+    HLO_Tensor:$R,
+    HLO_Tensor:$info
   );
 
   let assemblyFormat = [{

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
@@ -45,6 +45,19 @@ struct LUFactorizationOpLowering
   }
 };
 
+struct QRFactorizationOpLowering
+    : public OpRewritePattern<enzymexla::QRFactorizationOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(enzymexla::QRFactorizationOp op,
+                                PatternRewriter &rewriter) const override {
+    auto geqrfOp = enzymexla::GeqrfOp::create(
+        rewriter, op.getLoc(), op->getResultTypes(), op.getInput());
+    rewriter.replaceOp(op, geqrfOp);
+    return success();
+  }
+};
+
 struct SVDFactorizationOpLowering
     : public OpRewritePattern<enzymexla::SVDFactorizationOp> {
   std::string backend;
@@ -108,7 +121,7 @@ struct LowerEnzymeXLALinalgPass
     auto context = getOperation()->getContext();
     RewritePatternSet patterns(context);
 
-    patterns.add<LUFactorizationOpLowering>(context);
+    patterns.add<LUFactorizationOpLowering, QRFactorizationOpLowering>(context);
     patterns.add<SVDFactorizationOpLowering>(backend, context);
 
     GreedyRewriteConfig config;
@@ -120,8 +133,8 @@ struct LowerEnzymeXLALinalgPass
 
     // Verify that all illegal ops have been lowered
     auto walkResult = getOperation()->walk([&](Operation *op) {
-      if (isa<enzymexla::LUFactorizationOp, enzymexla::SVDFactorizationOp>(
-              op)) {
+      if (isa<enzymexla::LUFactorizationOp, enzymexla::QRFactorizationOp,
+              enzymexla::SVDFactorizationOp>(op)) {
         op->emitError("Failed to lower enzymexla linalg operation");
         return WalkResult::interrupt();
       }

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
@@ -51,9 +51,21 @@ struct QRFactorizationOpLowering
 
   LogicalResult matchAndRewrite(enzymexla::QRFactorizationOp op,
                                 PatternRewriter &rewriter) const override {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+
     auto geqrfOp = enzymexla::GeqrfOp::create(
         rewriter, op.getLoc(), op->getResultTypes(), op.getInput());
-    rewriter.replaceOp(op, geqrfOp);
+    auto R = geqrfOp.getOutput();
+    auto tau = geqrfOp.getTau();
+    auto info = geqrfOp.getInfo();
+
+    auto orgqrOp = enzymexla::OrgqrOp::create(rewriter, op.getLoc(),
+                                              op->getResultTypes(), R, tau);
+    auto Q = orgqrOp.getOutput();
+
+    rewriter.replaceAllOpUsesWith(op, ValueRange{Q, R, info});
+
     return success();
   }
 };

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALinalg.cpp
@@ -60,8 +60,8 @@ struct QRFactorizationOpLowering
     auto tau = geqrfOp.getTau();
     auto info = geqrfOp.getInfo();
 
-    auto orgqrOp = enzymexla::OrgqrOp::create(rewriter, op.getLoc(),
-                                              op->getResultTypes(), R, tau);
+    auto orgqrOp = enzymexla::OrgqrOp::create(
+        rewriter, op.getLoc(), op->getResult(0).getType(), R, tau);
     auto Q = orgqrOp.getOutput();
 
     rewriter.replaceAllOpUsesWith(op, ValueRange{Q, R, info});

--- a/test/lit_tests/linalg/qr.mlir
+++ b/test/lit_tests/linalg/qr.mlir
@@ -1,0 +1,8 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cpu blas_int_width=64},enzyme-hlo-opt)" %s | FileCheck %s
+
+func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>) {
+  %0:2 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>)
+  return %0#0, %0#1 : tensor<64x64xf32>, tensor<64x64xf32>
+}
+
+// CHECK: enzymexla.lapack.geqrf

--- a/test/lit_tests/linalg/qr.mlir
+++ b/test/lit_tests/linalg/qr.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-linalg{backend=cpu blas_int_width=64},enzyme-hlo-opt)" %s | FileCheck %s
 
-func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>) {
-  %0:2 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>)
-  return %0#0, %0#1 : tensor<64x64xf32>, tensor<64x64xf32>
+func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<i32>) {
+  %0:3 = enzymexla.linalg.qr %arg0 : (tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<i32>)
+  return %0#0, %0#1, %0#2 : tensor<64x64xf32>, tensor<64x64xf32>, tensor<i32>
 }
 
 // CHECK: enzymexla.lapack.geqrf

--- a/test/lit_tests/linalg/qr.mlir
+++ b/test/lit_tests/linalg/qr.mlir
@@ -6,3 +6,4 @@ func.func @main(%arg0: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf3
 }
 
 // CHECK: enzymexla.lapack.geqrf
+// CHECK-NEXT: enzymexla.lapack.orgqr


### PR DESCRIPTION
for now, i've removed the `algorithm` attr because the lowering to `GeqrtOp` is not really an numerical algorithmic variant (both use Householder reflectors), but an implementation variant (Geqrt uses blocking, which requires to set a block size).