### PR TITLE
Added check on function calls for no capture

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -133,6 +133,35 @@ DefineOp DefineOp::clone() {
   return clone(mapper);
 }
 
+Attribute DefineOp::getSretAttr() {
+  if (getFunctionType().getNumInputs() == 0)
+    return nullptr;
+  if (auto argAttrs = getAllArgAttrs())
+    return cast<DictionaryAttr>(argAttrs[0])
+        .get(LLVM::LLVMDialect::getStructRetAttrName());
+  return nullptr;
+}
+
+// Override getArgAttr to map call-side indices to define-side indices.
+// tessera::DefineOp has one extra argument at index 0 for sret, which
+// is not present in tessera::CallOp operands. This allows generic
+// FunctionOpInterface callers to use call-side indices directly.
+Attribute DefineOp::getArgAttr(unsigned index, StringAttr name) {
+  int offset = getSretAttr() != nullptr ? 1 : 0;
+  if (auto dict = mlir::function_interface_impl::getArgAttrDict(
+          cast<FunctionOpInterface>(getOperation()), index + offset))
+    return dict.get(name);
+  return nullptr;
+}
+
+Attribute DefineOp::getArgAttr(unsigned index, StringRef name) {
+  int offset = getSretAttr() != nullptr ? 1 : 0;
+  if (auto dict = mlir::function_interface_impl::getArgAttrDict(
+          cast<FunctionOpInterface>(getOperation()), index + offset))
+    return dict.get(name);
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 // CallOp
 //===----------------------------------------------------------------------===//
@@ -151,8 +180,7 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   // Verify that the operand and result types match the callee,
   // unless callee has attribute to indicate struct return.
-  bool has_sret = fn.getNumArguments() > 0 &&
-                  fn.getArgAttr(0, LLVM::LLVMDialect::getStructRetAttrName());
+  bool has_sret = fn.getSretAttr() != nullptr;
 
   // If tessera.define has sret attribute,
   // tessera.call operand count = tessera.define input count - 1
@@ -167,17 +195,16 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Allow type mismatch only for byref pointer args that have been converted
   // to values
   int argOffset = has_sret ? 1 : 0;
-  for (unsigned i = argOffset, e = fnType.getNumInputs(); i != e; ++i) {
-    int argIdx = i - argOffset;
-    if (getOperand(argIdx).getType() == fnType.getInput(i))
+  for (unsigned i = 0, e = getNumOperands(); i != e; ++i) {
+    if (getOperand(i).getType() == fnType.getInput(i + argOffset))
       continue;
-    if (isa<LLVM::LLVMPointerType>(fnType.getInput(i)) &&
+    if (isa<LLVM::LLVMPointerType>(fnType.getInput(i + argOffset)) &&
         (fn.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName()) ||
-         byRefArgs[argIdx]))
+         byRefArgs[i]))
       continue;
     return emitOpError("operand type mismatch: expected operand type ")
-           << fnType.getInput(i) << ", but provided "
-           << getOperand(argIdx).getType() << " for operand number " << argIdx;
+           << fnType.getInput(i) << ", but provided " << getOperand(i).getType()
+           << " for operand number " << i;
   }
 
   // If tessera.define has sret attribute,
@@ -188,22 +215,21 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     return emitOpError("incorrect number of results for callee");
 
   if (has_sret) {
-    auto sretType =
-        cast<TypeAttr>(
-            fn.getArgAttr(0, LLVM::LLVMDialect::getStructRetAttrName()))
-            .getValue();
+    auto sret = fn.getSretAttr();
+    auto sretType = cast<TypeAttr>(sret).getValue();
     if (getResult(0).getType() != sretType)
       return emitOpError("result type mismatch: expected ")
              << sretType << " but got " << getResult(0).getType();
-  } else {
-    for (unsigned i = 0, e = fnType.getNumResults(); i != e; ++i)
-      if (getResult(i).getType() != fnType.getResult(i)) {
-        auto diag = emitOpError("result type mismatch at index ") << i;
-        diag.attachNote() << "      op result types: " << getResultTypes();
-        diag.attachNote() << "function result types: " << fnType.getResults();
-        return diag;
-      }
   }
+
+  int offset = has_sret ? 1 : 0;
+  for (unsigned i = 0, e = fnType.getNumResults(); i != e; ++i)
+    if (getResult(i + offset).getType() != fnType.getResult(i)) {
+      auto diag = emitOpError("result type mismatch at index ") << i + offset;
+      diag.attachNote() << "      op result types: " << getResultTypes();
+      diag.attachNote() << "function result types: " << fnType.getResults();
+      return diag;
+    }
 
   return success();
 }

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
@@ -64,6 +64,8 @@ def DefineOp : TesseraOp<"define", [
     /// compatible.
     void cloneInto(DefineOp dest, IRMapping &mapper);
 
+    ::mlir::Attribute getSretAttr();
+
     //===------------------------------------------------------------------===//
     // FunctionOpInterface Methods
     //===------------------------------------------------------------------===//
@@ -78,6 +80,11 @@ def DefineOp : TesseraOp<"define", [
 
     /// Returns the result types of this function.
     ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+
+    /// Returns the argument attribute at the given index, accounting for the
+    /// sret argument offset if present.
+    ::mlir::Attribute getArgAttr(unsigned index, mlir::StringAttr name);
+    ::mlir::Attribute getArgAttr(unsigned index, llvm::StringRef name);
 
     //===------------------------------------------------------------------===//
     // SymbolOpInterface Methods

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/Passes.h"
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
+#include "src/enzyme_ad/jax/Dialect/Tessera/Dialect.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "src/enzyme_ad/jax/Utils.h"
 #include "llvm/ADT/SetVector.h"
@@ -1153,6 +1154,36 @@ Value castToType(Type elType, Value val, Operation *op) {
   llvm_unreachable("mismatched type");
 }
 
+// Check if tessera call captures alloca instance by checking for llvm.nocapture
+// attribute
+bool isTesseraCallNonCapturing(tessera::CallOp callOp, Value val) {
+  auto calleeAttr = callOp.getCalleeAttr();
+  if (calleeAttr) {
+    auto callee = SymbolTable::lookupSymbolIn(
+        callOp->getParentOfType<ModuleOp>(), calleeAttr);
+    auto defineOp = dyn_cast_or_null<tessera::DefineOp>(callee);
+    if (!defineOp)
+      return false;
+
+    int offset = 0;
+    if (defineOp.getNumArguments() > 0 &&
+        defineOp.getArgAttr(0, LLVM::LLVMDialect::getStructRetAttrName()))
+      offset = 1;
+
+    // Find operand that matches value of alloca we are trying to promote and
+    // check for attributes
+    auto operands = callOp.getOperands();
+    for (int i = 0; i < operands.size(); i++) {
+      if (callOp.getOperand(i) == val) {
+        if (defineOp.getArgAttr(i + offset,
+                                LLVM::LLVMDialect::getNoCaptureAttrName()))
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
 // fopen, fclose
 std::set<std::string> NoWriteFunctions = {"exit", "__errno_location"};
 // This is a straightforward implementation not optimized for speed. Optimize
@@ -1338,6 +1369,17 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           if (!callOp.getCallee() ||
               !getNonCapturingFunctions().count(callOp.getCallee()->str()))
             captured = true;
+        }
+        continue;
+      }
+      if (auto callOp = dyn_cast<tessera::CallOp>(user)) {
+        if (callOp.getCallee() != "free") {
+          if (!isTesseraCallNonCapturing(callOp, val)) {
+            LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << callOp << "\n");
+            AliasingStoreOperations.insert(callOp);
+            if (!getNonCapturingFunctions().count(callOp.getCallee().str()))
+              captured = true;
+          }
         }
         continue;
       }
@@ -1923,6 +1965,10 @@ bool isPromotable(mlir::Value AI) {
         if (auto callee = callOp.getCallee())
           if (getNonCapturingFunctions().count(callee->str()))
             continue;
+      } else if (auto callOp = dyn_cast<tessera::CallOp>(U)) {
+        if (isTesseraCallNonCapturing(callOp, val) ||
+            getNonCapturingFunctions().count(callOp.getCallee().str()))
+          continue;
       } else if (auto CO = dyn_cast<memref::CastOp>(U)) {
         list.push_back(CO);
       } else if (auto CO = dyn_cast<Memref2PointerOp>(U)) {

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -25,7 +25,6 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/Passes.h"
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
-#include "src/enzyme_ad/jax/Dialect/Tessera/Dialect.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "src/enzyme_ad/jax/Utils.h"
 #include "llvm/ADT/SetVector.h"
@@ -1154,29 +1153,23 @@ Value castToType(Type elType, Value val, Operation *op) {
   llvm_unreachable("mismatched type");
 }
 
-// Check if tessera call captures alloca instance by checking for llvm.nocapture
+// Check if call captures alloca instance by checking for llvm.nocapture
 // attribute
-bool isTesseraCallNonCapturing(tessera::CallOp callOp, Value val) {
-  auto calleeAttr = callOp.getCalleeAttr();
+bool isCallNonCapturing(CallOpInterface callOp, Value val) {
+  auto calleeAttr = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
   if (calleeAttr) {
     auto callee = SymbolTable::lookupSymbolIn(
         callOp->getParentOfType<ModuleOp>(), calleeAttr);
-    auto defineOp = dyn_cast_or_null<tessera::DefineOp>(callee);
-    if (!defineOp)
+    auto fn = dyn_cast_or_null<FunctionOpInterface>(callee);
+    if (!fn)
       return false;
-
-    int offset = 0;
-    if (defineOp.getNumArguments() > 0 &&
-        defineOp.getArgAttr(0, LLVM::LLVMDialect::getStructRetAttrName()))
-      offset = 1;
 
     // Find operand that matches value of alloca we are trying to promote and
     // check for attributes
-    auto operands = callOp.getOperands();
+    auto operands = callOp.getArgOperands();
     for (int i = 0; i < operands.size(); i++) {
-      if (callOp.getOperand(i) == val) {
-        if (defineOp.getArgAttr(i + offset,
-                                LLVM::LLVMDialect::getNoCaptureAttrName()))
+      if (operands[i] == val) {
+        if (fn.getArgAttr(i, LLVM::LLVMDialect::getNoCaptureAttrName()))
           return true;
       }
     }
@@ -1353,31 +1346,14 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           AliasingStoreOperations.insert(storeOp);
         continue;
       }
-      if (auto callOp = dyn_cast<func::CallOp>(user)) {
-        if (callOp.getCallee() != "free") {
-          LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << callOp << "\n");
-          AliasingStoreOperations.insert(callOp);
-          if (!getNonCapturingFunctions().count(callOp.getCallee().str()))
-            captured = true;
-        }
-        continue;
-      }
-      if (auto callOp = dyn_cast<mlir::LLVM::CallOp>(user)) {
-        if (!callOp.getCallee() || *callOp.getCallee() != "free") {
-          LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << callOp << "\n");
-          AliasingStoreOperations.insert(callOp);
-          if (!callOp.getCallee() ||
-              !getNonCapturingFunctions().count(callOp.getCallee()->str()))
-            captured = true;
-        }
-        continue;
-      }
-      if (auto callOp = dyn_cast<tessera::CallOp>(user)) {
-        if (callOp.getCallee() != "free") {
-          if (!isTesseraCallNonCapturing(callOp, val)) {
+      if (auto callOp = dyn_cast<CallOpInterface>(user)) {
+        auto callee = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
+        if (!callee || callee.getLeafReference() != "free") {
+          if (!isCallNonCapturing(callOp, val)) {
             LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << callOp << "\n");
-            AliasingStoreOperations.insert(callOp);
-            if (!getNonCapturingFunctions().count(callOp.getCallee().str()))
+            AliasingStoreOperations.insert(callOp.getOperation());
+            if (!callee || !getNonCapturingFunctions().count(
+                               callee.getLeafReference().str()))
               captured = true;
           }
         }
@@ -1958,17 +1934,13 @@ bool isPromotable(mlir::Value AI) {
         continue;
       } else if (isa<memref::DeallocOp>(U)) {
         continue;
-      } else if (auto callOp = dyn_cast<func::CallOp>(U)) {
-        if (getNonCapturingFunctions().count(callOp.getCallee().str()))
-          continue;
-      } else if (auto callOp = dyn_cast<LLVM::CallOp>(U)) {
-        if (auto callee = callOp.getCallee())
-          if (getNonCapturingFunctions().count(callee->str()))
+      } else if (auto callOp = dyn_cast<CallOpInterface>(U)) {
+        if (StringAttr callee =
+                dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee())
+                    .getLeafReference())
+          if (isCallNonCapturing(callOp, val) ||
+              getNonCapturingFunctions().count(callee.str()))
             continue;
-      } else if (auto callOp = dyn_cast<tessera::CallOp>(U)) {
-        if (isTesseraCallNonCapturing(callOp, val) ||
-            getNonCapturingFunctions().count(callOp.getCallee().str()))
-          continue;
       } else if (auto CO = dyn_cast<memref::CastOp>(U)) {
         list.push_back(CO);
       } else if (auto CO = dyn_cast<Memref2PointerOp>(U)) {

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -191,8 +191,7 @@ public:
     // type as the SSA return type, since tessera.call returns values directly
     // rather than writing through a pointer.
     if (!operands.empty() && argAttrs) {
-      if (auto sretAttr = defineOp.getArgAttr(
-              0, LLVM::LLVMDialect::getStructRetAttrName())) {
+      if (auto sretAttr = defineOp.getSretAttr()) {
         sretPtr = callOp.getOperand(0);
         sretType = cast<TypeAttr>(sretAttr).getValue();
         // Build arg attrs without first element
@@ -218,9 +217,8 @@ public:
     // byVal attribute or was marked as byRef by the user, load the value
     // from the pointer and store that as the new operand
     int argOffset = sretPtr ? 1 : 0;
-    for (int i = argOffset; i < operands.size(); i++) {
-      auto operand = callOp.getOperand(i);
-      int argIdx = i - argOffset;
+    for (unsigned i = 0; i < operands.size() - argOffset; i++) {
+      auto operand = callOp.getOperand(i + argOffset);
 
       if (!isa<LLVM::LLVMPointerType>(operand.getType())) {
         newOperands.push_back(operand);
@@ -232,16 +230,15 @@ public:
       if (auto byValAttr =
               defineOp.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName())) {
         pointeeType = cast<TypeAttr>(byValAttr).getValue();
-      } else if (byRefArgs[argIdx]) {
-        pointeeType =
-            IntegerType::get(rewriter.getContext(), argSizes[argIdx] * 8);
+      } else if (byRefArgs[i]) {
+        pointeeType = IntegerType::get(rewriter.getContext(), argSizes[i] * 8);
       }
 
       if (pointeeType) {
         auto loadedVal = LLVM::LoadOp::create(rewriter, callOp.getLoc(),
                                               pointeeType, operand);
         newOperands.push_back(loadedVal);
-        loadedOperands.push_back(argIdx);
+        loadedOperands.push_back(i);
       } else {
         newOperands.push_back(operand);
       }

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -152,8 +152,7 @@ public:
       return newAttrs;
     };
 
-    if (defineOp.getNumArguments() > 0 &&
-        defineOp.getArgAttr(0, LLVM::LLVMDialect::getStructRetAttrName())) {
+    if (defineOp.getNumArguments() > 0 && defineOp.getSretAttr()) {
       auto sretArgAttrs = defineOp.getArgAttrDict(0);
       if (callOp.getNumResults() == 0)
         return callOp.emitOpError(
@@ -185,8 +184,8 @@ public:
       for (auto [i, operand] : llvm::enumerate(callOp.getOperands())) {
         if (llvm::is_contained(argsToReplace, (int32_t)i)) {
           int64_t alignment = 0;
-          if (auto alignAttr = defineOp.getArgAttr(
-                  i + 1, LLVM::LLVMDialect::getAlignAttrName()))
+          if (auto alignAttr =
+                  defineOp.getArgAttr(i, LLVM::LLVMDialect::getAlignAttrName()))
             alignment = cast<IntegerAttr>(alignAttr).getInt();
           Value AI = LLVM::AllocaOp::create(
               rewriter, callOp.getLoc(),

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -1,0 +1,146 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+llvm.func @llvm_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) {
+  llvm.return
+}
+llvm.func @llvm_store_to_load_forwarded() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  llvm.call @llvm_foo_nocapture(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK: llvm.func @llvm_store_to_load_forwarded() -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK-NEXT: llvm.store %[[C2]], %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: llvm.call @llvm_foo_nocapture(%[[AL]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT: llvm.return %[[C2]] : i32
+// CHECK-NEXT: }
+
+// -----
+
+llvm.func @llvm_foo_capturing(%arg0: !llvm.ptr) {
+  llvm.return
+}
+llvm.func @llvm_store_to_load_not_forwarded() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  llvm.call @llvm_foo_capturing(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK: llvm.func @llvm_store_to_load_not_forwarded() -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK-NEXT: llvm.store %[[C2]], %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: llvm.call @llvm_foo_capturing(%[[AL]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[AL]] : !llvm.ptr -> i32
+// CHECK-NEXT: llvm.return %[[LOADED]] : i32
+// CHECK-NEXT: }
+
+// -----
+
+func.func @func_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) {
+  func.return
+}
+func.func @func_store_to_load_forwarded() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  func.call @func_foo_nocapture(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  func.return %loaded : i32
+}
+
+// CHECK: func.func @func_store_to_load_forwarded() -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK-NEXT: llvm.store %[[C2]], %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: call @func_foo_nocapture(%[[AL]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT: return %[[C2]] : i32
+// CHECK-NEXT: }
+
+// -----
+
+func.func @func_foo_capturing(%arg0: !llvm.ptr) {
+  func.return
+}
+func.func @func_store_to_load_not_forwarded() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  func.call @func_foo_capturing(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  func.return %loaded : i32
+}
+
+// CHECK: func.func @func_store_to_load_not_forwarded() -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK-NEXT: llvm.store %[[C2]], %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: call @func_foo_capturing(%[[AL]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[AL]] : !llvm.ptr -> i32
+// CHECK-NEXT: return %[[LOADED]] : i32
+// CHECK-NEXT: }
+
+// -----
+
+tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) attributes {argSizes = array<i64: 64>, byRefArgs = array<i1: true>, pure = false} {
+  tessera.return
+}
+tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  tessera.call @tessera_foo_nocapture(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  tessera.return %loaded : i32
+}
+
+// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK-NEXT: llvm.store %[[C2]], %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: tessera.call @tessera_foo_nocapture(%[[AL]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT: tessera.return %[[C2]] : i32
+// CHECK-NEXT: }
+
+// -----
+
+tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {argSizes = array<i64: 64>, byRefArgs = array<i1: true>, pure = false} {
+  tessera.return
+}
+tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  tessera.call @tessera_foo_capturing(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  tessera.return %loaded : i32
+}
+
+// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK-NEXT: llvm.store %[[C2]], %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: tessera.call @tessera_foo_capturing(%[[AL]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[AL]] : !llvm.ptr -> i32
+// CHECK-NEXT: tessera.return %[[LOADED]] : i32
+// CHECK-NEXT: }


### PR DESCRIPTION
Checks function calls that implement the `FunctionOpInterface` to see if they have the `llvm.nocapture` attribute and decide whether or not an alloca instance can be promoted based on whether or not the pointer is captured