### PR TITLE
revert `comm.mpi.requested` type

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Comm/MPIOps.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/MPIOps.td
@@ -115,23 +115,23 @@ def MPI_IrecvOp : Comm_Op<"mpi.irecv", []> {
     I32 : $source,
     MPI_Comm : $comm
   );
-
-  let results = (outs MPI_Requested : $requested);
+  let results = (outs
+    AnyTensor : $buf,
+    MPI_Request : $request
+  );
   let assemblyFormat = "operands attr-dict `:` type(results)";
 }
 
 def MPI_WaitOp : Comm_Op<"mpi.wait", []> {
   let summary = "Equivalent to `MPI_Wait`";
-  let arguments = (ins MPI_Requested : $requested);
-  let results = (outs AnyTensor : $buf);
-  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
+  let arguments = (ins MPI_Request : $request);
+  let assemblyFormat = "operands attr-dict `:` type(operands)";
 }
 
 def MPI_WaitallOp : Comm_Op<"mpi.waitall", []> {
   let summary = "Equivalent to `MPI_Waitall`";
-  let arguments = (ins Variadic<MPI_Requested> : $requesteds);
-  let results = (outs Variadic<AnyTensor> : $bufs);
-  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
+  let arguments = (ins Variadic<MPI_Request> : $requests);
+  let assemblyFormat = "operands attr-dict `:` type(operands)";
 }
 
 def MPI_AllreduceOp : Comm_Op<"mpi.allreduce", []> {

--- a/src/enzyme_ad/jax/Dialect/Comm/MPITypes.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/MPITypes.td
@@ -13,12 +13,6 @@ def MPI_Request : Comm_Type<"MPI_Request", "mpi.request"> {
   let summary = "MPI asynchronous request handler";
 }
 
-def MPI_Requested : Comm_Type<"MPI_Requested", "mpi.requested"> {
-  let summary = "MPI asynchronous request handler paired with linked tensor";
-  let parameters = (ins AnyType : $requestedType);
-  let assemblyFormat = "`<` $requestedType `>`";
-}
-
 def MPI_Datatype : Comm_Type<"MPI_Datatype", "mpi.datatype"> {
   let summary = "MPI datatype handler";
 }

--- a/test/lit_tests/comm/mpi/irecv.mlir
+++ b/test/lit_tests/comm/mpi/irecv.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[TAG:.*]]: i32, %[[SOURCE:.*]]: i32, %[[COMM:.*]]: !comm.mpi.comm) -> !comm.mpi.requested<tensor<4xf32>> {
-func.func @main(%tag : i32, %source : i32, %comm : !comm.mpi.comm) -> !comm.mpi.requested<tensor<4xf32>> {
-    // CHECK-NEXT: %[[v0:.*]] = comm.mpi.irecv %[[TAG]], %[[SOURCE]], %[[COMM]] : !comm.mpi.requested<tensor<4xf32>>
-    %0 = comm.mpi.irecv %tag, %source, %comm : !comm.mpi.requested<tensor<4xf32>>
-    return %0 : !comm.mpi.requested<tensor<4xf32>>
+// CHECK: func.func @main(%[[TAG:.*]]: i32, %[[SOURCE:.*]]: i32, %[[COMM:.*]]: !comm.mpi.comm) -> (tensor<4xf32>, !comm.mpi.request) {
+func.func @main(%tag : i32, %source : i32, %comm : !comm.mpi.comm) -> (tensor<4xf32>, !comm.mpi.request) {
+    // CHECK-NEXT: %[[buf:.*]], %[[request:.*]] = comm.mpi.irecv %[[TAG]], %[[SOURCE]], %[[COMM]] : tensor<4xf32>, !comm.mpi.request
+    %0:2 = comm.mpi.irecv %tag, %source, %comm : tensor<4xf32>, !comm.mpi.request
+    return %0#0, %0#1 : tensor<4xf32>, !comm.mpi.request
 }

--- a/test/lit_tests/comm/mpi/wait.mlir
+++ b/test/lit_tests/comm/mpi/wait.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[REQUESTED:.*]]: !comm.mpi.requested<tensor<4xf32>>) -> tensor<4xf32> {
-func.func @main(%requested : !comm.mpi.requested<tensor<4xf32>>) -> tensor<4xf32> {
-    // CHECK-NEXT: %[[v0:.*]] = comm.mpi.wait %[[REQUESTED]] : (!comm.mpi.requested<tensor<4xf32>>) -> tensor<4xf32>
-    %0 = comm.mpi.wait %requested : (!comm.mpi.requested<tensor<4xf32>>) -> tensor<4xf32>
-    return %0 : tensor<4xf32>
+// CHECK: func.func @main(%[[REQUEST:.*]]: !comm.mpi.request) {
+func.func @main(%request : !comm.mpi.request) {
+    // CHECK-NEXT: comm.mpi.wait %[[REQUEST]] : !comm.mpi.request
+    comm.mpi.wait %request : !comm.mpi.request
+    return
 }

--- a/test/lit_tests/comm/mpi/waitall.mlir
+++ b/test/lit_tests/comm/mpi/waitall.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[REQ1:.*]]: !comm.mpi.requested<tensor<4xf32>>, %[[REQ2:.*]]: !comm.mpi.requested<tensor<5x3xf32>>) -> (tensor<4xf32>, tensor<5x3xf32>) {
-func.func @main(%req1 : !comm.mpi.requested<tensor<4xf32>>, %req2 : !comm.mpi.requested<tensor<5x3xf32>>) -> (tensor<4xf32>, tensor<5x3xf32>) {
-    // CHECK-NEXT: %[[v0:.*]] = comm.mpi.waitall %[[REQ1]], %[[REQ2]] : (!comm.mpi.requested<tensor<4xf32>>, !comm.mpi.requested<tensor<5x3xf32>>) -> (tensor<4xf32>, tensor<5x3xf32>)
-    %0:2 = comm.mpi.waitall %req1, %req2 : (!comm.mpi.requested<tensor<4xf32>>, !comm.mpi.requested<tensor<5x3xf32>>) -> (tensor<4xf32>, tensor<5x3xf32>)
-    return %0#0, %0#1 : tensor<4xf32>, tensor<5x3xf32>
+// CHECK: func.func @main(%[[REQ1:.*]]: !comm.mpi.request, %[[REQ2:.*]]: !comm.mpi.request) {
+func.func @main(%req1 : !comm.mpi.request, %req2 : !comm.mpi.request) {
+    // CHECK-NEXT: comm.mpi.waitall %[[REQ1]], %[[REQ2]] : !comm.mpi.request, !comm.mpi.request
+    comm.mpi.waitall %req1, %req2 : !comm.mpi.request, !comm.mpi.request
+    return
 }


### PR DESCRIPTION
it's better if we leave the future type for non-blocking/async operation for a higher-level abstraction and keep this as MPI-like as posible