### PR TITLE
add BLAS `GemmOp`

### DIFF
--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -581,8 +581,8 @@ def GemmOp : EnzymeXLA_Op<"blas.gemm", [Pure, SameOperandsAndResultElementType]>
     HLO_Tensor:$B,
     TensorFloat:$beta,
     HLO_Tensor:$C,
-    EnzymeXLA_LapackTransposeAttr:$transa,
-    EnzymeXLA_LapackTransposeAttr:$transb
+    DefaultValuedAttr<EnzymeXLA_LapackTransposeAttr, "::mlir::enzymexla::LapackTranspose::none">:$transa,
+    DefaultValuedAttr<EnzymeXLA_LapackTransposeAttr, "::mlir::enzymexla::LapackTranspose::none">:$transb
   );
 
   let results = (outs

--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -594,6 +594,12 @@ def GemmOp : EnzymeXLA_Op<"blas.gemm", [Pure, SameOperandsAndResultElementType]>
   }];
 
   let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "Value":$A, "Value":$B,
+      CArg<"enzymexla::LapackTranspose", "enzymexla::LapackTranspose::none">:$transa,
+      CArg<"enzymexla::LapackTranspose", "enzymexla::LapackTranspose::none">:$transb)>
+  ];
 }
 
 def SymmOp : EnzymeXLA_Op<"blas.symm", [Pure, SameOperandsAndResultElementType]> {

--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -568,6 +568,34 @@ def CommRegionOp : EnzymeXLA_Op<"comm_region", [
 
 // Linear Algebra Ops
 
+def GemmOp : EnzymeXLA_Op<"blas.gemm", [Pure, SameOperandsAndResultElementType]> {
+  let summary = "(Batch) Matrix multiplication with optional transposition of the inputs";
+
+  let description = [{
+    C := alpha*op(A)*op(B) + beta*C"
+  }];
+
+  let arguments = (ins
+    TensorFloat:$alpha,
+    HLO_Tensor:$A,
+    HLO_Tensor:$B,
+    TensorFloat:$beta,
+    HLO_Tensor:$C,
+    EnzymeXLA_LapackTransposeAttr:$transa,
+    EnzymeXLA_LapackTransposeAttr:$transb
+  );
+
+  let results = (outs
+    HLO_Tensor: $output
+  );
+
+  let assemblyFormat = [{
+    $alpha `,` $A `,` $B `,` $beta `,` $C attr-dict `:` functional-type(operands, results)
+  }];
+
+  let hasVerifier = 1;
+}
+
 def SymmOp : EnzymeXLA_Op<"blas.symm", [Pure, SameOperandsAndResultElementType]> {
   let summary = "Multiplication involving a symmetric matrix";
 

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1205,8 +1205,8 @@ LogicalResult enzymexla::GemmOp::verify() {
     return emitOpError("Inner dimensions of A and B must match");
   }
 
-  if (shape_A[outer_dim_A] != shape_C[outer_dim_A] ||
-      shape_B[outer_dim_B] != shape_C[outer_dim_B]) {
+  if (shape_A[outer_dim_A] != shape_C[rank - 2] ||
+      shape_B[outer_dim_B] != shape_C[rank - 1]) {
     return emitOpError(
         "Outer dimensions of A and B must match corresponding dimensions of C");
   }

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1218,6 +1218,50 @@ LogicalResult enzymexla::GemmOp::verify() {
   return success();
 }
 
+void GemmOp::build(OpBuilder &builder, OperationState &result, Value A, Value B,
+                   enzymexla::LapackTranspose transa,
+                   enzymexla::LapackTranspose transb) {
+  auto type_A = cast<RankedTensorType>(A.getType());
+  auto type_B = cast<RankedTensorType>(B.getType());
+
+  auto element_type = type_A.getElementType();
+  auto rank = type_A.getRank();
+
+  auto outer_dim_A =
+      transa == enzymexla::LapackTranspose::none ? rank - 2 : rank - 1;
+  auto outer_dim_B =
+      transb == enzymexla::LapackTranspose::none ? rank - 1 : rank - 2;
+
+  auto shape_a = type_A.getShape();
+  auto shape_b = type_B.getShape();
+  SmallVector<int64_t> shape_c;
+  for (int i = 0; i < rank - 2; i++) {
+    shape_c.push_back(shape_a[i]);
+  }
+  shape_c.push_back(shape_a[outer_dim_A]);
+  shape_c.push_back(shape_b[outer_dim_B]);
+
+  auto type_scalar = RankedTensorType::get({}, element_type);
+  auto alpha = stablehlo::ConstantOp::create(
+      builder, result.location, type_scalar,
+      cast<ElementsAttr>(makeAttr(type_scalar, 1)));
+  auto beta = stablehlo::ConstantOp::create(
+      builder, result.location, type_scalar,
+      cast<ElementsAttr>(makeAttr(type_scalar, 0)));
+
+  auto type_C = RankedTensorType::get(shape_c, element_type);
+  auto C =
+      stablehlo::ConstantOp::create(builder, result.location, type_C,
+                                    cast<ElementsAttr>(makeAttr(type_C, 0)));
+
+  result.addTypes(type_C);
+  result.addOperands({alpha, A, B, beta, C});
+  result.addAttribute("transa", enzymexla::LapackTransposeAttr::get(
+                                    builder.getContext(), transa));
+  result.addAttribute("transb", enzymexla::LapackTransposeAttr::get(
+                                    builder.getContext(), transb));
+}
+
 LogicalResult enzymexla::SyrkOp::verify() {
   auto CType = cast<RankedTensorType>(getC().getType());
   bool isComplex = false;

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1154,6 +1154,70 @@ LogicalResult enzymexla::MemcpyOp::verify() {
   return success();
 }
 
+LogicalResult enzymexla::GemmOp::verify() {
+  auto alpha = getAlpha();
+  auto A = getA();
+  auto B = getB();
+  auto beta = getBeta();
+  auto C = getC();
+
+  auto type_alpha = cast<RankedTensorType>(alpha.getType());
+  auto type_A = cast<RankedTensorType>(A.getType());
+  auto type_B = cast<RankedTensorType>(B.getType());
+  auto type_beta = cast<RankedTensorType>(beta.getType());
+  auto type_C = cast<RankedTensorType>(C.getType());
+
+  auto shape_A = type_A.getShape();
+  auto shape_B = type_B.getShape();
+  auto shape_C = type_C.getShape();
+
+  auto type_element = type_alpha.getElementType();
+  auto rank = type_A.getRank();
+
+  auto inner_dim_A =
+      getTransa() == enzymexla::LapackTranspose::none ? rank - 1 : rank - 2;
+  auto inner_dim_B =
+      getTransb() == enzymexla::LapackTranspose::none ? rank - 2 : rank - 1;
+
+  auto outer_dim_A =
+      getTransa() == enzymexla::LapackTranspose::none ? rank - 2 : rank - 1;
+  auto outer_dim_B =
+      getTransb() == enzymexla::LapackTranspose::none ? rank - 1 : rank - 2;
+
+  if (type_A.getElementType() != type_element ||
+      type_B.getElementType() != type_element ||
+      type_C.getElementType() != type_element ||
+      type_beta.getElementType() != type_element) {
+    return emitOpError("Element types of alpha, A, B and C must match");
+  }
+
+  if (type_A.getRank() != type_B.getRank() ||
+      type_A.getRank() != type_C.getRank()) {
+    return emitOpError("Ranks of A, B and C must match");
+  }
+
+  if (shape_A.drop_back(2) != shape_B.drop_back(2) ||
+      shape_A.drop_back(2) != shape_C.drop_back(2)) {
+    return emitOpError("Batch dimensions of A, B and C must match");
+  }
+
+  if (shape_A[inner_dim_A] != shape_B[inner_dim_B]) {
+    return emitOpError("Inner dimensions of A and B must match");
+  }
+
+  if (shape_A[outer_dim_A] != shape_C[outer_dim_A] ||
+      shape_B[outer_dim_B] != shape_C[outer_dim_B]) {
+    return emitOpError(
+        "Outer dimensions of A and B must match corresponding dimensions of C");
+  }
+
+  if (getResult().getType() != type_C) {
+    return emitOpError("Result type must match C's type");
+  }
+
+  return success();
+}
+
 LogicalResult enzymexla::SyrkOp::verify() {
   auto CType = cast<RankedTensorType>(getC().getType());
   bool isComplex = false;

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLABLAS.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLABLAS.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "stablehlo/dialect/ChloOps.h"
 #include "stablehlo/dialect/StablehloOps.h"
 
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -98,6 +99,16 @@ struct GemmOpLowering : public OpRewritePattern<enzymexla::GemmOp> {
                            ? rank - 2
                            : rank - 1;
 
+    Value maybeConjA = A;
+    if (op.getTransa() == enzymexla::LapackTranspose::adjoint) {
+      maybeConjA = chlo::ConjOp::create(rewriter, op.getLoc(), A);
+    }
+
+    Value maybeConjB = B;
+    if (op.getTransb() == enzymexla::LapackTranspose::adjoint) {
+      maybeConjB = chlo::ConjOp::create(rewriter, op.getLoc(), B);
+    }
+
     SmallVector<int64_t> leftBatchDims, rightBatchDims;
     for (int64_t i = 0; i < rank - 2; ++i) {
       leftBatchDims.push_back(i);
@@ -108,8 +119,9 @@ struct GemmOpLowering : public OpRewritePattern<enzymexla::GemmOp> {
     auto dotDimsAttr = stablehlo::DotDimensionNumbersAttr::get(
         ctx, leftBatchDims, rightBatchDims, leftContractDims,
         rightContractDims);
-    auto dotOp = stablehlo::DotGeneralOp::create(
-        rewriter, op.getLoc(), type_C, A, B, dotDimsAttr, nullptr, nullptr);
+    auto dotOp = stablehlo::DotGeneralOp::create(rewriter, op.getLoc(), type_C,
+                                                 maybeConjA, maybeConjB,
+                                                 dotDimsAttr, nullptr, nullptr);
     auto scaledDot =
         stablehlo::MulOpCreate(rewriter, op->getLoc(), alpha, dotOp);
 

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLABLAS.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLABLAS.cpp
@@ -71,6 +71,59 @@ static std::pair<Value, int64_t> createScalarOperand(PatternRewriter &rewriter,
   }
   return {originalVal, 0};
 }
+
+struct GemmOpLowering : public OpRewritePattern<enzymexla::GemmOp> {
+  GemmOpLowering(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit) {}
+
+  LogicalResult matchAndRewrite(enzymexla::GemmOp op,
+                                PatternRewriter &rewriter) const override {
+    auto ctx = op->getContext();
+    LLVMTypeConverter typeConverter(ctx);
+
+    auto alpha = op.getOperand(0);
+    auto A = op.getOperand(1);
+    auto B = op.getOperand(2);
+    auto beta = op.getOperand(3);
+    auto C = op.getOperand(4);
+
+    auto type_A = cast<RankedTensorType>(A.getType());
+    auto type_C = cast<RankedTensorType>(C.getType());
+    auto rank = type_A.getRank();
+
+    auto inner_dim_A = op.getTransa() == enzymexla::LapackTranspose::none
+                           ? rank - 1
+                           : rank - 2;
+    auto inner_dim_B = op.getTransb() == enzymexla::LapackTranspose::none
+                           ? rank - 2
+                           : rank - 1;
+
+    SmallVector<int64_t> leftBatchDims, rightBatchDims;
+    for (int64_t i = 0; i < rank - 2; ++i) {
+      leftBatchDims.push_back(i);
+      rightBatchDims.push_back(i);
+    }
+    SmallVector<int64_t> leftContractDims = {inner_dim_A};
+    SmallVector<int64_t> rightContractDims = {inner_dim_B};
+    auto dotDimsAttr = stablehlo::DotDimensionNumbersAttr::get(
+        ctx, leftBatchDims, rightBatchDims, leftContractDims,
+        rightContractDims);
+    auto dotOp = stablehlo::DotGeneralOp::create(
+        rewriter, op.getLoc(), type_C, A, B, dotDimsAttr, nullptr, nullptr);
+    auto scaledDot =
+        stablehlo::MulOpCreate(rewriter, op->getLoc(), alpha, dotOp);
+
+    auto scaledC = stablehlo::MulOpCreate(rewriter, op->getLoc(), beta, C);
+    auto addOp =
+        stablehlo::AddOpCreate(rewriter, op->getLoc(), scaledDot, scaledC);
+
+    rewriter.replaceAllUsesWith(op.getResult(), addOp);
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
 struct SymmOpLowering : public OpRewritePattern<enzymexla::SymmOp> {
 
   using OpRewritePattern<enzymexla::SymmOp>::OpRewritePattern;
@@ -995,7 +1048,7 @@ struct LowerEnzymeXLABLASPass
 
     RewritePatternSet patternsSet2(context);
     patternsSet2.add<SyrkOpLowering>(backend, blasIntWidth, context);
-    patternsSet2.add<TrsmOpLowering>(context);
+    patternsSet2.add<GemmOpLowering, TrsmOpLowering>(context);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patternsSet2),
                                      config))) {
       signalPassFailure();
@@ -1003,7 +1056,8 @@ struct LowerEnzymeXLABLASPass
 
     // Verify that all illegal ops have been lowered
     auto walkResult = getOperation()->walk([&](Operation *op) {
-      if (isa<enzymexla::SyrkOp, enzymexla::TrsmOp>(op)) {
+      if (isa<enzymexla::GemmOp, enzymexla::SymmOp, enzymexla::SyrkOp,
+              enzymexla::TrsmOp>(op)) {
         op->emitError("Failed to lower enzymexla.blas operation");
         return WalkResult::interrupt();
       }

--- a/test/lit_tests/linalg/blas/gemm.mlir
+++ b/test/lit_tests/linalg/blas/gemm.mlir
@@ -1,0 +1,100 @@
+// RUN: enzymexlamlir-opt --lower-enzymexla-blas="backend=cpu" --enzyme-hlo-opt --drop-unsupported-attributes %s | FileCheck %s
+
+func.func @fused_matmul_add(%alpha: tensor<f32>, %A: tensor<2x4xf32>, %B: tensor<4x3xf32>, %beta: tensor<f32>, %C: tensor<2x3xf32>) -> tensor<2x3xf32> {
+    %0 = enzymexla.blas.gemm %alpha, %A, %B, %beta, %C : (tensor<f32>, tensor<2x4xf32>, tensor<4x3xf32>, tensor<f32>, tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+}
+
+// CHECK: func.func @fused_matmul_add(%arg0: tensor<f32>, %arg1: tensor<2x4xf32>, %arg2: tensor<4x3xf32>, %arg3: tensor<f32>, %arg4: tensor<2x3xf32>) -> tensor<2x3xf32> {
+// CHECK-NEXT:   %0 = stablehlo.dot_general %arg1, %arg2, contracting_dims = [1] x [0] : (tensor<2x4xf32>, tensor<4x3xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:   %1 = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<f32>) -> tensor<2x3xf32>
+// CHECK-NEXT:   %2 = stablehlo.multiply %1, %0 : tensor<2x3xf32>
+// CHECK-NEXT:   %3 = stablehlo.broadcast_in_dim %arg3, dims = [] : (tensor<f32>) -> tensor<2x3xf32>
+// CHECK-NEXT:   %4 = stablehlo.multiply %3, %arg4 : tensor<2x3xf32>
+// CHECK-NEXT:   %5 = stablehlo.add %2, %4 : tensor<2x3xf32>
+// CHECK-NEXT:   return %5 : tensor<2x3xf32>
+// CHECK-NEXT: }
+
+func.func @matmul(%alpha: tensor<f32>, %A: tensor<2x4xf32>, %B: tensor<4x3xf32>) -> tensor<2x3xf32> {
+    %beta = stablehlo.constant dense<3.0> : tensor<f32>
+    %C = stablehlo.constant dense<0.0> : tensor<2x3xf32>
+    %0 = enzymexla.blas.gemm %alpha, %A, %B, %beta, %C : (tensor<f32>, tensor<2x4xf32>, tensor<4x3xf32>, tensor<f32>, tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+}
+
+// CHECK: func.func @matmul(%arg0: tensor<f32>, %arg1: tensor<2x4xf32>, %arg2: tensor<4x3xf32>) -> tensor<2x3xf32> {
+// CHECK-NEXT:   %0 = stablehlo.dot_general %arg1, %arg2, contracting_dims = [1] x [0] : (tensor<2x4xf32>, tensor<4x3xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:   %1 = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<f32>) -> tensor<2x3xf32>
+// CHECK-NEXT:   %2 = stablehlo.multiply %1, %0 : tensor<2x3xf32>
+// CHECK-NEXT:   return %2 : tensor<2x3xf32>
+// CHECK-NEXT: }
+
+func.func @batch_matmul(%alpha: tensor<f32>, %A: tensor<8x10x2x4xf32>, %B: tensor<8x10x4x3xf32>) -> tensor<8x10x2x3xf32> {
+    %beta = stablehlo.constant dense<3.0> : tensor<f32>
+    %C = stablehlo.constant dense<0.0> : tensor<8x10x2x3xf32>
+    %0 = enzymexla.blas.gemm %alpha, %A, %B, %beta, %C : (tensor<f32>, tensor<8x10x2x4xf32>, tensor<8x10x4x3xf32>, tensor<f32>, tensor<8x10x2x3xf32>) -> tensor<8x10x2x3xf32>
+    return %0 : tensor<8x10x2x3xf32>
+}
+
+// CHECK: func.func @batch_matmul(%arg0: tensor<f32>, %arg1: tensor<8x10x2x4xf32>, %arg2: tensor<8x10x4x3xf32>) -> tensor<8x10x2x3xf32> {
+// CHECK-NEXT:   %0 = stablehlo.dot_general %arg1, %arg2, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2] : (tensor<8x10x2x4xf32>, tensor<8x10x4x3xf32>) -> tensor<8x10x2x3xf32>
+// CHECK-NEXT:   %1 = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<f32>) -> tensor<8x10x2x3xf32>
+// CHECK-NEXT:   %2 = stablehlo.multiply %1, %0 : tensor<8x10x2x3xf32>
+// CHECK-NEXT:   return %2 : tensor<8x10x2x3xf32>
+// CHECK-NEXT: }
+
+func.func @matmul_transpose_transpose(%A: tensor<4x2xf32>, %B: tensor<3x4xf32>) -> tensor<2x3xf32> {
+    %alpha = stablehlo.constant dense<1.0> : tensor<f32>
+    %beta = stablehlo.constant dense<0.0> : tensor<f32>
+    %C = stablehlo.constant dense<0.0> : tensor<2x3xf32>
+    %0 = enzymexla.blas.gemm %alpha, %A, %B, %beta, %C {transa = #enzymexla.transpose<transpose>, transb = #enzymexla.transpose<transpose>} : (tensor<f32>, tensor<4x2xf32>, tensor<3x4xf32>, tensor<f32>, tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+}
+
+// CHECK: func.func @matmul_transpose_transpose(%arg0: tensor<4x2xf32>, %arg1: tensor<3x4xf32>) -> tensor<2x3xf32> {
+// CHECK-NEXT:   %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [0] x [1] : (tensor<4x2xf32>, tensor<3x4xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:   return %0 : tensor<2x3xf32>
+// CHECK-NEXT: }
+
+func.func @matmul_transpose_none(%A: tensor<4x2xf32>, %B: tensor<4x3xf32>) -> tensor<2x3xf32> {
+    %alpha = stablehlo.constant dense<1.0> : tensor<f32>
+    %beta = stablehlo.constant dense<0.0> : tensor<f32>
+    %C = stablehlo.constant dense<0.0> : tensor<2x3xf32>
+    %0 = enzymexla.blas.gemm %alpha, %A, %B, %beta, %C {transa = #enzymexla.transpose<transpose>, transb = #enzymexla.transpose<none>} : (tensor<f32>, tensor<4x2xf32>, tensor<4x3xf32>, tensor<f32>, tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+}
+
+// CHECK: func.func @matmul_transpose_none(%arg0: tensor<4x2xf32>, %arg1: tensor<4x3xf32>) -> tensor<2x3xf32> {
+// CHECK-NEXT:   %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [0] x [0] : (tensor<4x2xf32>, tensor<4x3xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:   return %0 : tensor<2x3xf32>
+// CHECK-NEXT: }
+
+func.func @matmul_none_transpose(%A: tensor<2x4xf32>, %B: tensor<3x4xf32>) -> tensor<2x3xf32> {
+    %alpha = stablehlo.constant dense<1.0> : tensor<f32>
+    %beta = stablehlo.constant dense<0.0> : tensor<f32>
+    %C = stablehlo.constant dense<0.0> : tensor<2x3xf32>
+    %0 = enzymexla.blas.gemm %alpha, %A, %B, %beta, %C {transa = #enzymexla.transpose<none>, transb = #enzymexla.transpose<transpose>} : (tensor<f32>, tensor<2x4xf32>, tensor<3x4xf32>, tensor<f32>, tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+}
+
+// CHECK: func.func @matmul_none_transpose(%arg0: tensor<2x4xf32>, %arg1: tensor<3x4xf32>) -> tensor<2x3xf32> {
+// CHECK-NEXT:   %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [1] x [1] : (tensor<2x4xf32>, tensor<3x4xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:   return %0 : tensor<2x3xf32>
+// CHECK-NEXT: }
+
+func.func @matmul_adjoint_adjoint(%A: tensor<4x2xcomplex<f32>>, %B: tensor<3x4xcomplex<f32>>) -> tensor<2x3xcomplex<f32>> {
+    %alpha = stablehlo.constant dense<(1.0, 0.0)> : tensor<complex<f32>>
+    %beta = stablehlo.constant dense<(0.0, 0.0)> : tensor<complex<f32>>
+    %C = stablehlo.constant dense<(0.0, 0.0)> : tensor<2x3xcomplex<f32>>
+    %0 = enzymexla.blas.gemm %alpha, %A, %B, %beta, %C {transa = #enzymexla.transpose<adjoint>, transb = #enzymexla.transpose<adjoint>} : (tensor<complex<f32>>, tensor<4x2xcomplex<f32>>, tensor<3x4xcomplex<f32>>, tensor<complex<f32>>, tensor<2x3xcomplex<f32>>) -> tensor<2x3xcomplex<f32>>
+    return %0 : tensor<2x3xcomplex<f32>>
+}
+
+// CHECK-NEXT: func.func @matmul_adjoint_adjoint(%arg0: tensor<4x2xcomplex<f32>>, %arg1: tensor<3x4xcomplex<f32>>) -> tensor<2x3xcomplex<f32>> {
+// CHECK-NEXT:   %cst = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<2x3xcomplex<f32>>
+// CHECK-NEXT:   %0 = chlo.conj %arg0 : tensor<4x2xcomplex<f32>> -> tensor<4x2xcomplex<f32>>
+// CHECK-NEXT:   %1 = chlo.conj %arg1 : tensor<3x4xcomplex<f32>> -> tensor<3x4xcomplex<f32>>
+// CHECK-NEXT:   %2 = stablehlo.dot_general %0, %1, contracting_dims = [0] x [1] : (tensor<4x2xcomplex<f32>>, tensor<3x4xcomplex<f32>>) -> tensor<2x3xcomplex<f32>>
+// CHECK-NEXT:   %3 = stablehlo.multiply %cst, %2 : tensor<2x3xcomplex<f32>>
+// CHECK-NEXT:   return %3 : tensor<2x3xcomplex<f32>>
+// CHECK-NEXT: }


### PR DESCRIPTION
just like with `TrsmOp`, there is already a StableHLO op that does its functionality (`stablehlo.dot_general`), but this op is useful for writing BLAS and LAPACK passes as it manages the transposition of inputs and the batching dimensions just like the rest of BLAS/LAPACK ops.