### PR TITLE
 Fix infinite loop in MoveSIToFPToAffine on non-decomposable operands

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2251,7 +2251,18 @@ struct MoveSIToFPToAffine : public OpRewritePattern<arith::SIToFPOp> {
     auto *parentScope = scope->getParentOp();
     DominanceInfo DI(parentScope);
 
-    fully2ComposeAffineMapAndOperands(rewriter, &map, &operands, DI, scope);
+    SmallVector<Operation *> insertedOps;
+    fully2ComposeAffineMapAndOperands(rewriter, &map, &operands, DI, scope,
+                                      &insertedOps);
+
+    if (map.getNumResults() == 1 &&
+        map.getResult(0).getKind() == AffineExprKind::SymbolId) {
+      for (Operation *op : llvm::reverse(insertedOps))
+        if (op->use_empty())
+          rewriter.eraseOp(op);
+      return failure();
+    }
+
     affine::canonicalizeMapAndOperands(&map, &operands);
     map = recreateExpr(map);
 

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2256,11 +2256,17 @@ struct MoveSIToFPToAffine : public OpRewritePattern<arith::SIToFPOp> {
                                       &insertedOps);
 
     if (map.getNumResults() == 1 &&
-        map.getResult(0).getKind() == AffineExprKind::SymbolId) {
-      for (Operation *op : llvm::reverse(insertedOps))
-        if (op->use_empty())
-          rewriter.eraseOp(op);
-      return failure();
+        map.getResult(0).getKind() == AffineExprKind::SymbolId &&
+        operands.size() == 1) {
+      Value sym = operands[0];
+      while (auto ic = sym.getDefiningOp<arith::IndexCastOp>())
+        sym = ic.getIn();
+      if (sym == ifOp.getOperand()) {
+        for (Operation *op : llvm::reverse(insertedOps))
+          if (op->use_empty())
+            rewriter.eraseOp(op);
+        return failure();
+      }
     }
 
     affine::canonicalizeMapAndOperands(&map, &operands);

--- a/test/lit_tests/raising/affinecfg_sitofp.mlir
+++ b/test/lit_tests/raising/affinecfg_sitofp.mlir
@@ -1,0 +1,23 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+func.func @sitofp_invariant_muli(%arg0: i32, %arg1: i32) -> f64 {
+  %cst = arith.constant 0.0 : f64
+  %res = affine.for %iv = 0 to 10 iter_args(%acc = %cst) -> (f64) {
+    %mul = arith.muli %arg0, %arg1 : i32
+    %fp = arith.sitofp %mul : i32 to f64
+    %add = arith.addf %acc, %fp : f64
+    affine.yield %add : f64
+  }
+  return %res : f64
+}
+
+// CHECK-LABEL:   func.func @sitofp_invariant_muli(
+// CHECK-SAME:                     %[[ARG0:.*]]: i32, %[[ARG1:.*]]: i32) -> f64 {
+// CHECK:           %[[CST:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK:           %[[MUL:.*]] = arith.muli %[[ARG0]], %[[ARG1]] : i32
+// CHECK:           %[[PAR:.*]] = affine.parallel (%[[ARG2:.*]]) = (0) to (10) reduce ("addf") -> (f64) {
+// CHECK:             %[[FP:.*]] = arith.sitofp %[[MUL]] : i32 to f64
+// CHECK:             affine.yield %[[FP]] : f64
+// CHECK:           }
+// CHECK:           %[[ADD:.*]] = arith.addf %[[PAR]], %[[CST]] : f64
+// CHECK:           return %[[ADD]] : f64


### PR DESCRIPTION
Fix issue #2415 

The fix here:
After composition, if the operand did not decompose into any affine structure (the map is like `()[s0] -> (s0)`), return failure() instead of emitting the no-op `affine.apply`.

The reason I did not choose to fix in `isValidIndex`:
- https://github.com/EnzymeAD/Enzyme-JAX/blob/f5727c4a5043408379cf007c711e39a6df6ff3e9/src/enzyme_ad/jax/Passes/AffineCFG.cpp#L1220
https://github.com/EnzymeAD/Enzyme-JAX/blob/f5727c4a5043408379cf007c711e39a6df6ff3e9/src/enzyme_ad/jax/Passes/AffineCFG.cpp#L1246
`muli(%m,%n)` could be matched and return true in two if guard, for the first one, to fix it, need to change the condition here: https://github.com/EnzymeAD/Enzyme-JAX/blob/f5727c4a5043408379cf007c711e39a6df6ff3e9/src/enzyme_ad/jax/Passes/AffineCFG.cpp#L77
which I think would obey that: loop-invariant `muli(%m,%n)` can be valid symbol.