### PR TITLE
reverse diff of `SVDFactorizationOp`

### DIFF
--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -228,6 +228,107 @@ struct GPUWrapperOpInterfaceReverse
                           MGradientUtilsReverse *gutils) const {}
 };
 
+struct SVDFactorizationOpInterfaceReverse
+    : public ReverseAutoDiffOpInterface::ExternalModel<
+          SVDFactorizationOpInterfaceReverse, SVDFactorizationOp> {
+  LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    auto op = cast<SVDFactorizationOp>(op);
+    auto A = op.getA();
+    auto U = gutils->getNewFromOriginal(op.getU());
+    auto S = gutils->getNewFromOriginal(op.getS());
+    auto Vt = gutils->getNewFromOriginal(op.getVt());
+    auto Ubar = gutils->diffe(op.getResult(0), builder);
+    auto Sbar = gutils->diffe(op.getResult(1), builder);
+    auto Vtbar = gutils->diffe(op.getResult(2), builder);
+
+    auto type_A = cast<RankedTensorType>(A.getType());
+    auto rank = type_A.getRank();
+
+    SmallVector<int64_t> perm;
+    for (int64_t i = 0; i < rank - 2; ++i) {
+      perm.push_back(i);
+    }
+    perm.push_back(rank - 1);
+    perm.push_back(rank - 2);
+
+    auto transpose = [&](Value x) -> Value {
+      return stablehlo::TransposeOp::create(
+          builder, x.getLoc(), chlo::ConjOp::create(builder, x.getLoc(), x),
+          perm);
+    };
+    auto matmul = [&](Value a, Value b) -> Value {
+      return enzymexla::GemmOp::create(builder, a.getLoc(), a, b);
+    };
+    auto add = [&](Value a, Value b) -> Value {
+      return stablehlo::AddOp::create(builder, a.getLoc(), a, b);
+    };
+    auto subtract = [&](Value a, Value b) -> Value {
+      return stablehlo::SubtractOp::create(builder, a.getLoc(), a, b);
+    };
+    auto mul = [&](Value a, Value b) -> Value {
+      return stablehlo::MulOp::create(builder, a.getLoc(), a, b);
+    };
+
+    // X = UᵀŪ - ŪᵀU
+    auto X = subtract(matmul(transpose(U), Ubar), matmul(transpose(Ubar), U));
+
+    // Y = VᵀV̄ - V̄ᵀV
+    // NOTE don't worry about extra transpose/conj here. they will be opt away
+    auto V = transpose(Vt);
+    auto Vbar = transpose(Vtbar);
+    auto Y = subtract(matmul(transpose(V), Vbar), matmul(transpose(Vbar), V));
+
+    // TODO F₊[i,j] = 1/(s[j]-s[i]) + 1/(s[j]+s[i]) if i != j else 0
+
+    // TODO F₋[i,j] = 1/(s[j]-s[i]) - 1/(s[j]+s[i]) if i != j else 0
+
+    // Z = F₊ .* X + F₋ .* Y
+    auto Z = add(mul(Fplus, X), mul(Fminus, Y));
+
+    // Ā = 1/2 * U * Z * Vᵀ
+    auto half = stablehlo::ConstantOp::create(
+        builder, op.getLoc(), U.getType(),
+        cast<ElementsAttr>(makeAttr(U.getType(), 0.5)));
+    auto Abar1 = matmul(matmul(mul(half, U), Z), transpose(V));
+
+    // Ā += U * S̄ * Vᵀ
+    auto dotDimsAttr = stablehlo::DotDimensionNumbersAttr::get(
+        builder.getContext(), {rank - 1}, {rank - 2}, {}, {});
+    auto USbar = stablehlo::DotGeneralOp::create(builder, op.getLoc(), U, Sbar,
+                                                 dotDimsAttr, nullptr, nullptr);
+    auto Abar2 = add(Abar1, matmul(USbar, transpose(V)));
+
+    // Ā += (I - U * Uᵀ) * Ū * inv(S) * Vᵀ
+    // TODO auto identity = ...;
+    // TODO auto invS = ...;
+    auto Abar3 = add(
+        Abar2,
+        matmul(matmul(matmul(subtract(identity, matmul(U, transpose(U))), Ubar),
+                      invS),
+               transpose(V)));
+
+    // TODO Ā += U * inv(S) * V̄ᵀ * (I - V * Vᵀ)
+    auto Abar4 = add(
+        Abar3,
+        matmul(U, matmul(invS,
+                         matmul(transpose(Vbar),
+                                subtract(identity, matmul(V, transpose(V)))))));
+
+    gutils->addToDiffe(op.getOperand(), Abar4, builder);
+    return success();
+  }
+
+  SmallVector<Value> cacheValues(Operation *op,
+                                 MGradientUtilsReverse *gutils) const {
+    return {};
+  }
+
+  void createShadowValues(Operation *op, OpBuilder &builder,
+                          MGradientUtilsReverse *gutils) const {}
+};
+
 } // namespace
 
 void mlir::enzyme::registerEnzymeXLADialectAutoDiffInterface(
@@ -236,6 +337,8 @@ void mlir::enzyme::registerEnzymeXLADialectAutoDiffInterface(
     registerInterfaces(context);
     GPUWrapperOp::attachInterface<GPUWrapperOpInterfaceReverse>(*context);
     GPUWrapperOp::attachInterface<GPUWrapperOpEnzymeOpsRemover>(*context);
+    SVDFactorizationOp::attachInterface<SVDFactorizationOpInterfaceReverse>(
+        *context);
 
     Pointer2MemrefOp::attachInterface<
         ViewCastOpInterfaceReverse<Pointer2MemrefOp>>(*context);

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -260,9 +260,9 @@ struct SVDFactorizationOpInterfaceReverse
     auto transpose = [&](Value x) -> Value {
       // TODO fix error: "LLVM ERROR: classof on 'chlo.conj' failed due to the
       // operation not being registered"
-      // Value conj_x = chlo::ConjOp::create(builder, x.getLoc(), x);
-      return stablehlo::TransposeOp::create(builder, x.getLoc(), /*conj_x*/ x,
-                                            perm);
+      Value conj_x = chlo::ConjOp::create(builder, x.getLoc(), x);
+      return stablehlo::TransposeOp::create(builder, x.getLoc(),
+                                            /*conj_x*/ conj_x, perm);
     };
     auto matmul = [&](Value a, Value b) -> Value {
       return enzymexla::GemmOp::create(builder, a.getLoc(), a, b);

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -258,9 +258,11 @@ struct SVDFactorizationOpInterfaceReverse
     perm.push_back(rank - 2);
 
     auto transpose = [&](Value x) -> Value {
-      return stablehlo::TransposeOp::create(
-          builder, x.getLoc(), chlo::ConjOp::create(builder, x.getLoc(), x),
-          perm);
+      // TODO fix error: "LLVM ERROR: classof on 'chlo.conj' failed due to the
+      // operation not being registered"
+      // Value conj_x = chlo::ConjOp::create(builder, x.getLoc(), x);
+      return stablehlo::TransposeOp::create(builder, x.getLoc(), /*conj_x*/ x,
+                                            perm);
     };
     auto matmul = [&](Value a, Value b) -> Value {
       return enzymexla::GemmOp::create(builder, a.getLoc(), a, b);

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -244,6 +244,7 @@ struct SVDFactorizationOpInterfaceReverse
     auto Vtbar = gutils->diffe(op.getResult(2), builder);
 
     auto type_A = cast<RankedTensorType>(A.getType());
+    auto type_elem = type_A.getElementType();
     auto rank = type_A.getRank();
 
     SmallVector<int64_t> perm;
@@ -280,9 +281,53 @@ struct SVDFactorizationOpInterfaceReverse
     auto Vbar = transpose(Vtbar);
     auto Y = subtract(matmul(transpose(V), Vbar), matmul(transpose(Vbar), V));
 
-    // TODO F₊[i,j] = 1/(s[j]-s[i]) + 1/(s[j]+s[i]) if i != j else 0
+    // F₊[i,j] = 1/(s[j]-s[i]) + 1/(s[j]+s[i]) if i != j else 0
+    // F₋[i,j] = 1/(s[j]-s[i]) - 1/(s[j]+s[i]) if i != j else 0
+    SmallVector<int64_t> shape;
+    shape.append(cast<RankedTensorType>(S.getType()).getShape());
+    shape.push_back(shape.back());
 
-    // TODO F₋[i,j] = 1/(s[j]-s[i]) - 1/(s[j]+s[i]) if i != j else 0
+    SmallVector<int64_t> broadcastDims_j;
+    for (int64_t i = 0; i < rank - 2; i++)
+      broadcastDims_j.push_back(i);
+    broadcastDims_j.push_back(rank - 1);
+    auto sj = stablehlo::BroadcastInDimOp::create(builder, op.getLoc(), shape,
+                                                  S, broadcastDims_j);
+
+    SmallVector<int64_t> broadcastDims_i;
+    for (int64_t i = 0; i < rank - 1; i++)
+      broadcastDims_i.push_back(i);
+    auto si = stablehlo::BroadcastInDimOp::create(builder, op.getLoc(), shape,
+                                                  S, broadcastDims_i);
+
+    auto sj_sub_si = subtract(sj, si);
+    auto sj_add_si = add(sj, si);
+
+    auto one = stablehlo::ConstantOp::create(
+        builder, op.getLoc(), sj_sub_si.getType(),
+        cast<ElementsAttr>(makeAttr(sj_sub_si.getType(), 1)));
+    auto reciprocal_sj_sub_si =
+        stablehlo::DivOp::create(builder, op.getLoc(), one, sj_sub_si);
+    auto reciprocal_sj_add_si =
+        stablehlo::DivOp::create(builder, op.getLoc(), one, sj_add_si);
+
+    auto iota_j =
+        stablehlo::IotaOp::create(builder, op.getLoc(), shape, rank - 1);
+    auto iota_i =
+        stablehlo::IotaOp::create(builder, op.getLoc(), shape, rank - 2);
+    auto mask =
+        stablehlo::CompareOp::create(builder, op.getLoc(), iota_j, iota_i,
+                                     stablehlo::ComparisonDirection::EQ);
+    auto zero = stablehlo::ConstantOp::create(
+        builder, op.getLoc(), RankedTensorType::get(shape, type_elem),
+        cast<ElementsAttr>(
+            makeAttr(RankedTensorType::get(shape, type_elem), 0)));
+    auto Fplus = stablehlo::SelectOp::create(
+        builder, op.getLoc(), mask, zero,
+        add(reciprocal_sj_sub_si, reciprocal_sj_add_si));
+    auto Fminus = stablehlo::SelectOp::create(
+        builder, op.getLoc(), mask, zero,
+        subtract(reciprocal_sj_sub_si, reciprocal_sj_add_si));
 
     // Z = F₊ .* X + F₋ .* Y
     auto Z = add(mul(Fplus, X), mul(Fminus, Y));

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -318,11 +318,11 @@ struct SVDFactorizationOpInterfaceReverse
     auto reciprocal_sj_add_si = reciprocal(sj_add_si);
 
     auto identity_f_iota_j = stablehlo::IotaOp::create(
-        builder, op.getLoc(), RankedTensorType::get(shape, builder.getI1Type()),
-        rank - 1);
+        builder, op.getLoc(),
+        RankedTensorType::get(shape, builder.getI32Type()), rank - 1);
     auto identity_f_iota_i = stablehlo::IotaOp::create(
-        builder, op.getLoc(), RankedTensorType::get(shape, builder.getI1Type()),
-        rank - 2);
+        builder, op.getLoc(),
+        RankedTensorType::get(shape, builder.getI32Type()), rank - 2);
     auto identity_f_mask = stablehlo::CompareOp::create(
         builder, op.getLoc(), identity_f_iota_j, identity_f_iota_i,
         stablehlo::ComparisonDirection::EQ);
@@ -360,10 +360,12 @@ struct SVDFactorizationOpInterfaceReverse
     identity_u_shape[rank - 1] = identity_u_shape[rank - 2];
     auto identity_u_iota_i = stablehlo::IotaOp::create(
         builder, op.getLoc(),
-        RankedTensorType::get(identity_u_shape, builder.getI1Type()), rank - 2);
+        RankedTensorType::get(identity_u_shape, builder.getI32Type()),
+        rank - 2);
     auto identity_u_iota_j = stablehlo::IotaOp::create(
         builder, op.getLoc(),
-        RankedTensorType::get(identity_u_shape, builder.getI1Type()), rank - 1);
+        RankedTensorType::get(identity_u_shape, builder.getI32Type()),
+        rank - 1);
     auto identity_u_mask = stablehlo::CompareOp::create(
         builder, op.getLoc(), identity_u_iota_i, identity_u_iota_j,
         stablehlo::ComparisonDirection::EQ);
@@ -396,10 +398,12 @@ struct SVDFactorizationOpInterfaceReverse
     identity_v_shape[rank - 1] = identity_v_shape[rank - 2];
     auto identity_v_iota_i = stablehlo::IotaOp::create(
         builder, op.getLoc(),
-        RankedTensorType::get(identity_v_shape, builder.getI1Type()), rank - 2);
+        RankedTensorType::get(identity_v_shape, builder.getI32Type()),
+        rank - 2);
     auto identity_v_iota_j = stablehlo::IotaOp::create(
         builder, op.getLoc(),
-        RankedTensorType::get(identity_v_shape, builder.getI1Type()), rank - 1);
+        RankedTensorType::get(identity_v_shape, builder.getI32Type()),
+        rank - 1);
     auto identity_v_mask = stablehlo::CompareOp::create(
         builder, op.getLoc(), identity_v_iota_i, identity_v_iota_j,
         stablehlo::ComparisonDirection::EQ);

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -231,11 +231,11 @@ struct GPUWrapperOpInterfaceReverse
 struct SVDFactorizationOpInterfaceReverse
     : public ReverseAutoDiffOpInterface::ExternalModel<
           SVDFactorizationOpInterfaceReverse, SVDFactorizationOp> {
-  LogicalResult createReverseModeAdjoint(Operation *op, OpBuilder &builder,
+  LogicalResult createReverseModeAdjoint(Operation *orig, OpBuilder &builder,
                                          MGradientUtilsReverse *gutils,
                                          SmallVector<Value> caches) const {
-    auto op = cast<SVDFactorizationOp>(op);
-    auto A = op.getA();
+    auto op = cast<SVDFactorizationOp>(orig);
+    auto A = op.getInput();
     auto U = gutils->getNewFromOriginal(op.getU());
     auto S = gutils->getNewFromOriginal(op.getS());
     auto Vt = gutils->getNewFromOriginal(op.getVt());
@@ -246,6 +246,9 @@ struct SVDFactorizationOpInterfaceReverse
     auto type_A = cast<RankedTensorType>(A.getType());
     auto type_elem = type_A.getElementType();
     auto rank = type_A.getRank();
+
+    auto shape_S = cast<RankedTensorType>(S.getType()).getShape();
+    auto shape_U = cast<RankedTensorType>(U.getType()).getShape();
 
     SmallVector<int64_t> perm;
     for (int64_t i = 0; i < rank - 2; ++i) {
@@ -290,47 +293,48 @@ struct SVDFactorizationOpInterfaceReverse
     // F₊[i,j] = 1/(s[j]-s[i]) + 1/(s[j]+s[i]) if i != j else 0
     // F₋[i,j] = 1/(s[j]-s[i]) - 1/(s[j]+s[i]) if i != j else 0
     SmallVector<int64_t> shape;
-    shape.append(cast<RankedTensorType>(S.getType()).getShape());
+    shape.append(shape_S.begin(), shape_S.end());
     shape.push_back(shape.back());
 
     SmallVector<int64_t> broadcastDims_j;
     for (int64_t i = 0; i < rank - 2; i++)
       broadcastDims_j.push_back(i);
     broadcastDims_j.push_back(rank - 1);
-    auto sj = stablehlo::BroadcastInDimOp::create(builder, op.getLoc(), shape,
-                                                  S, broadcastDims_j);
+    auto sj = stablehlo::BroadcastInDimOp::create(
+        builder, op.getLoc(), RankedTensorType::get(shape, type_elem), S,
+        broadcastDims_j);
 
     SmallVector<int64_t> broadcastDims_i;
     for (int64_t i = 0; i < rank - 1; i++)
       broadcastDims_i.push_back(i);
-    auto si = stablehlo::BroadcastInDimOp::create(builder, op.getLoc(), shape,
-                                                  S, broadcastDims_i);
+    auto si = stablehlo::BroadcastInDimOp::create(
+        builder, op.getLoc(), RankedTensorType::get(shape, type_elem), S,
+        broadcastDims_i);
 
     auto sj_sub_si = subtract(sj, si);
     auto sj_add_si = add(sj, si);
 
-    auto one = stablehlo::ConstantOp::create(
-        builder, op.getLoc(), sj_sub_si.getType(),
-        cast<ElementsAttr>(makeAttr(sj_sub_si.getType(), 1)));
     auto reciprocal_sj_sub_si = reciprocal(sj_sub_si);
     auto reciprocal_sj_add_si = reciprocal(sj_add_si);
 
-    auto iota_j =
-        stablehlo::IotaOp::create(builder, op.getLoc(), shape, rank - 1);
-    auto iota_i =
-        stablehlo::IotaOp::create(builder, op.getLoc(), shape, rank - 2);
-    auto mask =
-        stablehlo::CompareOp::create(builder, op.getLoc(), iota_j, iota_i,
-                                     stablehlo::ComparisonDirection::EQ);
-    auto zero = stablehlo::ConstantOp::create(
+    auto identity_f_iota_j = stablehlo::IotaOp::create(
+        builder, op.getLoc(), RankedTensorType::get(shape, builder.getI1Type()),
+        rank - 1);
+    auto identity_f_iota_i = stablehlo::IotaOp::create(
+        builder, op.getLoc(), RankedTensorType::get(shape, builder.getI1Type()),
+        rank - 2);
+    auto identity_f_mask = stablehlo::CompareOp::create(
+        builder, op.getLoc(), identity_f_iota_j, identity_f_iota_i,
+        stablehlo::ComparisonDirection::EQ);
+    auto identity_f_zero = stablehlo::ConstantOp::create(
         builder, op.getLoc(), RankedTensorType::get(shape, type_elem),
         cast<ElementsAttr>(
             makeAttr(RankedTensorType::get(shape, type_elem), 0)));
     auto Fplus = stablehlo::SelectOp::create(
-        builder, op.getLoc(), mask, zero,
+        builder, op.getLoc(), identity_f_mask, identity_f_zero,
         add(reciprocal_sj_sub_si, reciprocal_sj_add_si));
     auto Fminus = stablehlo::SelectOp::create(
-        builder, op.getLoc(), mask, zero,
+        builder, op.getLoc(), identity_f_mask, identity_f_zero,
         subtract(reciprocal_sj_sub_si, reciprocal_sj_add_si));
 
     // Z = F₊ .* X + F₋ .* Y
@@ -345,21 +349,24 @@ struct SVDFactorizationOpInterfaceReverse
     // Ā += U * S̄ * Vᵀ
     auto dotDimsAttr = stablehlo::DotDimensionNumbersAttr::get(
         builder.getContext(), {rank - 1}, {rank - 2}, {}, {});
-    auto USbar = stablehlo::DotGeneralOp::create(builder, op.getLoc(), U, Sbar,
-                                                 dotDimsAttr, nullptr, nullptr);
+    auto USbar =
+        stablehlo::DotGeneralOp::create(builder, op.getLoc(), U.getType(), U,
+                                        Sbar, dotDimsAttr, nullptr, nullptr);
     auto Abar2 = add(Abar1, matmul(USbar, transpose(V)));
 
     // Ā += (I - U * Uᵀ) * Ū * inv(S) * Vᵀ
     SmallVector<int64_t> identity_u_shape;
-    identity_u_shape.append(cast<RankedTensorType>(U.getType()).getShape());
+    identity_u_shape.append(shape_U.begin(), shape_U.end());
     identity_u_shape[rank - 1] = identity_u_shape[rank - 2];
-    auto iota_i = stablehlo::IotaOp::create(builder, op.getLoc(),
-                                            identity_u_shape, rank - 2);
-    auto iota_j = stablehlo::IotaOp::create(builder, op.getLoc(),
-                                            identity_u_shape, rank - 1);
-    auto identity_mask =
-        stablehlo::CompareOp::create(builder, op.getLoc(), iota_i, iota_j,
-                                     stablehlo::ComparisonDirection::EQ);
+    auto identity_u_iota_i = stablehlo::IotaOp::create(
+        builder, op.getLoc(),
+        RankedTensorType::get(identity_u_shape, builder.getI1Type()), rank - 2);
+    auto identity_u_iota_j = stablehlo::IotaOp::create(
+        builder, op.getLoc(),
+        RankedTensorType::get(identity_u_shape, builder.getI1Type()), rank - 1);
+    auto identity_u_mask = stablehlo::CompareOp::create(
+        builder, op.getLoc(), identity_u_iota_i, identity_u_iota_j,
+        stablehlo::ComparisonDirection::EQ);
     auto identity_u_one = stablehlo::ConstantOp::create(
         builder, op.getLoc(),
         RankedTensorType::get(identity_u_shape, type_elem),
@@ -371,11 +378,12 @@ struct SVDFactorizationOpInterfaceReverse
         cast<ElementsAttr>(
             makeAttr(RankedTensorType::get(identity_u_shape, type_elem), 0)));
     auto identity_u = stablehlo::SelectOp::create(
-        builder, op.getLoc(), identity_mask, identity_u_one, identity_u_zero);
+        builder, op.getLoc(), identity_u_mask, identity_u_one, identity_u_zero);
 
     auto invS = reciprocal(S);
     auto UbarinvS = stablehlo::DotGeneralOp::create(
-        builder, op.getLoc(), U, invS, dotDimsAttr, nullptr, nullptr);
+        builder, op.getLoc(), Ubar.getType(), Ubar, invS, dotDimsAttr, nullptr,
+        nullptr);
     auto Abar3 = add(
         Abar2,
         matmul(matmul(subtract(identity_u, matmul(U, transpose(U))), UbarinvS),
@@ -383,15 +391,18 @@ struct SVDFactorizationOpInterfaceReverse
 
     // Ā += U * inv(S) * V̄ᵀ * (I - V * Vᵀ)
     SmallVector<int64_t> identity_v_shape;
-    identity_v_shape.append(cast<RankedTensorType>(V.getType()).getShape());
+    auto shape_V = cast<RankedTensorType>(V.getType()).getShape();
+    identity_v_shape.append(shape_V.begin(), shape_V.end());
     identity_v_shape[rank - 1] = identity_v_shape[rank - 2];
-    auto iota_i = stablehlo::IotaOp::create(builder, op.getLoc(),
-                                            identity_v_shape, rank - 2);
-    auto iota_j = stablehlo::IotaOp::create(builder, op.getLoc(),
-                                            identity_v_shape, rank - 1);
-    auto identity_mask =
-        stablehlo::CompareOp::create(builder, op.getLoc(), iota_i, iota_j,
-                                     stablehlo::ComparisonDirection::EQ);
+    auto identity_v_iota_i = stablehlo::IotaOp::create(
+        builder, op.getLoc(),
+        RankedTensorType::get(identity_v_shape, builder.getI1Type()), rank - 2);
+    auto identity_v_iota_j = stablehlo::IotaOp::create(
+        builder, op.getLoc(),
+        RankedTensorType::get(identity_v_shape, builder.getI1Type()), rank - 1);
+    auto identity_v_mask = stablehlo::CompareOp::create(
+        builder, op.getLoc(), identity_v_iota_i, identity_v_iota_j,
+        stablehlo::ComparisonDirection::EQ);
     auto identity_v_one = stablehlo::ConstantOp::create(
         builder, op.getLoc(),
         RankedTensorType::get(identity_v_shape, type_elem),
@@ -403,10 +414,11 @@ struct SVDFactorizationOpInterfaceReverse
         cast<ElementsAttr>(
             makeAttr(RankedTensorType::get(identity_v_shape, type_elem), 0)));
     auto identity_v = stablehlo::SelectOp::create(
-        builder, op.getLoc(), identity_mask, identity_v_one, identity_v_zero);
+        builder, op.getLoc(), identity_v_mask, identity_v_one, identity_v_zero);
 
-    auto UinvS = stablehlo::DotGeneralOp::create(builder, op.getLoc(), U, invS,
-                                                 dotDimsAttr, nullptr, nullptr);
+    auto UinvS =
+        stablehlo::DotGeneralOp::create(builder, op.getLoc(), U.getType(), U,
+                                        invS, dotDimsAttr, nullptr, nullptr);
     auto Abar4 = add(
         Abar3,
         matmul(UinvS, matmul(transpose(Vbar),

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLAAutoDiffOpInterfaceImpl.cpp
@@ -271,6 +271,12 @@ struct SVDFactorizationOpInterfaceReverse
     auto mul = [&](Value a, Value b) -> Value {
       return stablehlo::MulOp::create(builder, a.getLoc(), a, b);
     };
+    auto reciprocal = [&](Value x) -> Value {
+      auto one = stablehlo::ConstantOp::create(
+          builder, x.getLoc(), x.getType(),
+          cast<ElementsAttr>(makeAttr(x.getType(), 1)));
+      return stablehlo::DivOp::create(builder, x.getLoc(), one, x);
+    };
 
     // X = UᵀŪ - ŪᵀU
     auto X = subtract(matmul(transpose(U), Ubar), matmul(transpose(Ubar), U));
@@ -306,10 +312,8 @@ struct SVDFactorizationOpInterfaceReverse
     auto one = stablehlo::ConstantOp::create(
         builder, op.getLoc(), sj_sub_si.getType(),
         cast<ElementsAttr>(makeAttr(sj_sub_si.getType(), 1)));
-    auto reciprocal_sj_sub_si =
-        stablehlo::DivOp::create(builder, op.getLoc(), one, sj_sub_si);
-    auto reciprocal_sj_add_si =
-        stablehlo::DivOp::create(builder, op.getLoc(), one, sj_add_si);
+    auto reciprocal_sj_sub_si = reciprocal(sj_sub_si);
+    auto reciprocal_sj_add_si = reciprocal(sj_add_si);
 
     auto iota_j =
         stablehlo::IotaOp::create(builder, op.getLoc(), shape, rank - 1);
@@ -346,20 +350,67 @@ struct SVDFactorizationOpInterfaceReverse
     auto Abar2 = add(Abar1, matmul(USbar, transpose(V)));
 
     // Ā += (I - U * Uᵀ) * Ū * inv(S) * Vᵀ
-    // TODO auto identity = ...;
-    // TODO auto invS = ...;
+    SmallVector<int64_t> identity_u_shape;
+    identity_u_shape.append(cast<RankedTensorType>(U.getType()).getShape());
+    identity_u_shape[rank - 1] = identity_u_shape[rank - 2];
+    auto iota_i = stablehlo::IotaOp::create(builder, op.getLoc(),
+                                            identity_u_shape, rank - 2);
+    auto iota_j = stablehlo::IotaOp::create(builder, op.getLoc(),
+                                            identity_u_shape, rank - 1);
+    auto identity_mask =
+        stablehlo::CompareOp::create(builder, op.getLoc(), iota_i, iota_j,
+                                     stablehlo::ComparisonDirection::EQ);
+    auto identity_u_one = stablehlo::ConstantOp::create(
+        builder, op.getLoc(),
+        RankedTensorType::get(identity_u_shape, type_elem),
+        cast<ElementsAttr>(
+            makeAttr(RankedTensorType::get(identity_u_shape, type_elem), 1)));
+    auto identity_u_zero = stablehlo::ConstantOp::create(
+        builder, op.getLoc(),
+        RankedTensorType::get(identity_u_shape, type_elem),
+        cast<ElementsAttr>(
+            makeAttr(RankedTensorType::get(identity_u_shape, type_elem), 0)));
+    auto identity_u = stablehlo::SelectOp::create(
+        builder, op.getLoc(), identity_mask, identity_u_one, identity_u_zero);
+
+    auto invS = reciprocal(S);
+    auto UbarinvS = stablehlo::DotGeneralOp::create(
+        builder, op.getLoc(), U, invS, dotDimsAttr, nullptr, nullptr);
     auto Abar3 = add(
         Abar2,
-        matmul(matmul(matmul(subtract(identity, matmul(U, transpose(U))), Ubar),
-                      invS),
+        matmul(matmul(subtract(identity_u, matmul(U, transpose(U))), UbarinvS),
                transpose(V)));
 
-    // TODO Ā += U * inv(S) * V̄ᵀ * (I - V * Vᵀ)
+    // Ā += U * inv(S) * V̄ᵀ * (I - V * Vᵀ)
+    SmallVector<int64_t> identity_v_shape;
+    identity_v_shape.append(cast<RankedTensorType>(V.getType()).getShape());
+    identity_v_shape[rank - 1] = identity_v_shape[rank - 2];
+    auto iota_i = stablehlo::IotaOp::create(builder, op.getLoc(),
+                                            identity_v_shape, rank - 2);
+    auto iota_j = stablehlo::IotaOp::create(builder, op.getLoc(),
+                                            identity_v_shape, rank - 1);
+    auto identity_mask =
+        stablehlo::CompareOp::create(builder, op.getLoc(), iota_i, iota_j,
+                                     stablehlo::ComparisonDirection::EQ);
+    auto identity_v_one = stablehlo::ConstantOp::create(
+        builder, op.getLoc(),
+        RankedTensorType::get(identity_v_shape, type_elem),
+        cast<ElementsAttr>(
+            makeAttr(RankedTensorType::get(identity_v_shape, type_elem), 1)));
+    auto identity_v_zero = stablehlo::ConstantOp::create(
+        builder, op.getLoc(),
+        RankedTensorType::get(identity_v_shape, type_elem),
+        cast<ElementsAttr>(
+            makeAttr(RankedTensorType::get(identity_v_shape, type_elem), 0)));
+    auto identity_v = stablehlo::SelectOp::create(
+        builder, op.getLoc(), identity_mask, identity_v_one, identity_v_zero);
+
+    auto UinvS = stablehlo::DotGeneralOp::create(builder, op.getLoc(), U, invS,
+                                                 dotDimsAttr, nullptr, nullptr);
     auto Abar4 = add(
         Abar3,
-        matmul(U, matmul(invS,
-                         matmul(transpose(Vbar),
-                                subtract(identity, matmul(V, transpose(V)))))));
+        matmul(UinvS, matmul(transpose(Vbar),
+                             subtract(identity_v, matmul(V, transpose(V))))));
 
     gutils->addToDiffe(op.getOperand(), Abar4, builder);
     return success();

--- a/test/lit_tests/diffrules/enzymexla/svd.mlir
+++ b/test/lit_tests/diffrules/enzymexla/svd.mlir
@@ -5,7 +5,7 @@ func.func @main(%x : tensor<4x4xcomplex<f32>>) -> (tensor<4x4xcomplex<f32>>, ten
   func.return %U, %S, %Vt : tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>, tensor<4x4xcomplex<f32>>
 }
 
-// REVERSE: func.func @main(%arg0: tensor<4x4xcomplex<f32>>, %arg1: tensor<4x4xcomplex<f32>>, %arg2: tensor<4xcomplex<f32>>, %arg3: tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>> {
+// REVERSE-NEXT: func.func @main(%arg0: tensor<4x4xcomplex<f32>>, %arg1: tensor<4x4xcomplex<f32>>, %arg2: tensor<4xcomplex<f32>>, %arg3: tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>> {
 // REVERSE-NEXT:   %cst = stablehlo.constant dense<[[(1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00)]]> : tensor<4x4xcomplex<f32>>
 // REVERSE-NEXT:   %c = stablehlo.constant dense<[[true, false, false, false], [false, true, false, false], [false, false, true, false], [false, false, false, true]]> : tensor<4x4xi1>
 // REVERSE-NEXT:   %cst_0 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<4xcomplex<f32>>
@@ -15,47 +15,51 @@ func.func @main(%x : tensor<4x4xcomplex<f32>>) -> (tensor<4x4xcomplex<f32>>, ten
 // REVERSE-NEXT:   %cst_4 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<complex<f32>>
 // REVERSE-NEXT:   %cst_5 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<4x4xcomplex<f32>>
 // REVERSE-NEXT:   %U, %S, %Vt, %info = enzymexla.linalg.svd %arg0 : (tensor<4x4xcomplex<f32>>) -> (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<i32>)
-// REVERSE-NEXT:   %0 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %1 = enzymexla.blas.gemm %cst_4, %0, %U, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %2 = stablehlo.transpose %U, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %3 = enzymexla.blas.gemm %cst_4, %2, %arg1, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %4 = stablehlo.subtract %3, %1 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %5 = stablehlo.transpose %Vt, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %6 = stablehlo.transpose %arg3, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %7 = enzymexla.blas.gemm %cst_4, %arg3, %5, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %8 = enzymexla.blas.gemm %cst_4, %Vt, %6, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %9 = stablehlo.subtract %8, %7 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %10 = stablehlo.broadcast_in_dim %S, dims = [1] : (tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %11 = stablehlo.broadcast_in_dim %S, dims = [0] : (tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %12 = stablehlo.subtract %10, %11 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %13 = stablehlo.add %10, %11 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %14 = stablehlo.divide %cst_2, %12 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %15 = stablehlo.divide %cst_2, %13 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %16 = stablehlo.add %14, %15 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %17 = stablehlo.select %c, %cst_5, %16 : tensor<4x4xi1>, tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %18 = stablehlo.subtract %14, %15 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %19 = stablehlo.select %c, %cst_5, %18 : tensor<4x4xi1>, tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %20 = stablehlo.multiply %19, %9 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %21 = stablehlo.multiply %17, %4 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %22 = stablehlo.add %21, %20 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %23 = stablehlo.multiply %cst_1, %U : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %24 = enzymexla.blas.gemm %cst_4, %23, %22, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %25 = enzymexla.blas.gemm %cst_4, %24, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %26 = stablehlo.dot_general %U, %arg2, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %27 = enzymexla.blas.gemm %cst_4, %26, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %28 = stablehlo.add %25, %27 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %29 = stablehlo.divide %cst_0, %S : tensor<4xcomplex<f32>>
-// REVERSE-NEXT:   %30 = stablehlo.dot_general %arg1, %29, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %31 = enzymexla.blas.gemm %cst_4, %U, %2, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %32 = stablehlo.subtract %cst, %31 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %33 = enzymexla.blas.gemm %cst_4, %32, %30, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %34 = enzymexla.blas.gemm %cst_4, %33, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %35 = stablehlo.add %28, %34 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %36 = stablehlo.dot_general %U, %29, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %37 = enzymexla.blas.gemm %cst_4, %5, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %38 = stablehlo.subtract %cst, %37 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %39 = enzymexla.blas.gemm %cst_4, %arg3, %38, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %40 = enzymexla.blas.gemm %cst_4, %36, %39, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %41 = stablehlo.add %35, %40 : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   return %41 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %0 = chlo.conj %arg1 : tensor<4x4xcomplex<f32>> -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %1 = stablehlo.transpose %0, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %2 = enzymexla.blas.gemm %cst_4, %1, %U, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %3 = chlo.conj %U : tensor<4x4xcomplex<f32>> -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %4 = stablehlo.transpose %3, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %5 = enzymexla.blas.gemm %cst_4, %4, %arg1, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %6 = stablehlo.subtract %5, %2 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %7 = chlo.conj %Vt : tensor<4x4xcomplex<f32>> -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %8 = stablehlo.transpose %7, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %9 = chlo.conj %arg3 : tensor<4x4xcomplex<f32>> -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %10 = stablehlo.transpose %9, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %11 = enzymexla.blas.gemm %cst_4, %arg3, %8, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %12 = enzymexla.blas.gemm %cst_4, %Vt, %10, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %13 = stablehlo.subtract %12, %11 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %14 = stablehlo.broadcast_in_dim %S, dims = [1] : (tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %15 = stablehlo.broadcast_in_dim %S, dims = [0] : (tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %16 = stablehlo.subtract %14, %15 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %17 = stablehlo.add %14, %15 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %18 = stablehlo.divide %cst_2, %16 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %19 = stablehlo.divide %cst_2, %17 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %20 = stablehlo.add %18, %19 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %21 = stablehlo.select %c, %cst_5, %20 : tensor<4x4xi1>, tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %22 = stablehlo.subtract %18, %19 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %23 = stablehlo.select %c, %cst_5, %22 : tensor<4x4xi1>, tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %24 = stablehlo.multiply %23, %13 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %25 = stablehlo.multiply %21, %6 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %26 = stablehlo.add %25, %24 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %27 = stablehlo.multiply %cst_1, %U : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %28 = enzymexla.blas.gemm %cst_4, %27, %26, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %29 = enzymexla.blas.gemm %cst_4, %28, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %30 = stablehlo.dot_general %U, %arg2, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %31 = enzymexla.blas.gemm %cst_4, %30, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %32 = stablehlo.add %29, %31 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %33 = stablehlo.divide %cst_0, %S : tensor<4xcomplex<f32>>
+// REVERSE-NEXT:   %34 = stablehlo.dot_general %arg1, %33, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %35 = enzymexla.blas.gemm %cst_4, %U, %4, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %36 = stablehlo.subtract %cst, %35 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %37 = enzymexla.blas.gemm %cst_4, %36, %34, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %38 = enzymexla.blas.gemm %cst_4, %37, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %39 = stablehlo.add %32, %38 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %40 = stablehlo.dot_general %U, %33, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %41 = enzymexla.blas.gemm %cst_4, %8, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %42 = stablehlo.subtract %cst, %41 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %43 = enzymexla.blas.gemm %cst_4, %arg3, %42, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %44 = enzymexla.blas.gemm %cst_4, %40, %43, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %45 = stablehlo.add %39, %44 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   return %45 : tensor<4x4xcomplex<f32>>
 // REVERSE-NEXT: }

--- a/test/lit_tests/diffrules/enzymexla/svd.mlir
+++ b/test/lit_tests/diffrules/enzymexla/svd.mlir
@@ -5,9 +5,9 @@ func.func @main(%x : tensor<4x4xcomplex<f32>>) -> (tensor<4x4xcomplex<f32>>, ten
   func.return %U, %S, %Vt : tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>, tensor<4x4xcomplex<f32>>
 }
 
-// REVERSE-NEXT: func.func @main(%arg0: tensor<4x4xcomplex<f32>>, %arg1: tensor<4x4xcomplex<f32>>, %arg2: tensor<4xcomplex<f32>>, %arg3: tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>> {
-// REVERSE-NEXT:   %cst = stablehlo.constant dense<[[(1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00)]]> : tensor<4x4xcomplex<f32>>
-// REVERSE-NEXT:   %c = stablehlo.constant dense<[[true, false, false, false], [false, true, false, false], [false, false, true, false], [false, false, false, true]]> : tensor<4x4xi1>
+// REVERSE: func.func @main(%arg0: tensor<4x4xcomplex<f32>>, %arg1: tensor<4x4xcomplex<f32>>, %arg2: tensor<4xcomplex<f32>>, %arg3: tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>> {
+// REVERSE-NEXT:   %cst = stablehlo.constant
+// REVERSE-NEXT:   %c = stablehlo.constant
 // REVERSE-NEXT:   %cst_0 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<4xcomplex<f32>>
 // REVERSE-NEXT:   %cst_1 = stablehlo.constant dense<(5.000000e-01,0.000000e+00)> : tensor<4x4xcomplex<f32>>
 // REVERSE-NEXT:   %cst_2 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<4x4xcomplex<f32>>

--- a/test/lit_tests/diffrules/enzymexla/svd.mlir
+++ b/test/lit_tests/diffrules/enzymexla/svd.mlir
@@ -1,0 +1,61 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active,enzyme_active,enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --arith-raise --canonicalize --remove-unnecessary-enzyme-ops --enzyme-hlo-opt --drop-unsupported-attributes --verify-each=0 | FileCheck %s --check-prefix=REVERSE
+
+func.func @main(%x : tensor<4x4xcomplex<f32>>) -> (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>, tensor<4x4xcomplex<f32>>) {
+  %U, %S, %Vt, %info = enzymexla.linalg.svd %x : (tensor<4x4xcomplex<f32>>) -> (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<i32>)
+  func.return %U, %S, %Vt : tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>, tensor<4x4xcomplex<f32>>
+}
+
+// REVERSE: func.func @main(%arg0: tensor<4x4xcomplex<f32>>, %arg1: tensor<4x4xcomplex<f32>>, %arg2: tensor<4xcomplex<f32>>, %arg3: tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>> {
+// REVERSE-NEXT:   %cst = stablehlo.constant dense<[[(1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)], [(0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00)]]> : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %c = stablehlo.constant dense<[[true, false, false, false], [false, true, false, false], [false, false, true, false], [false, false, false, true]]> : tensor<4x4xi1>
+// REVERSE-NEXT:   %cst_0 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<4xcomplex<f32>>
+// REVERSE-NEXT:   %cst_1 = stablehlo.constant dense<(5.000000e-01,0.000000e+00)> : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %cst_2 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %cst_3 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
+// REVERSE-NEXT:   %cst_4 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<complex<f32>>
+// REVERSE-NEXT:   %cst_5 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %U, %S, %Vt, %info = enzymexla.linalg.svd %arg0 : (tensor<4x4xcomplex<f32>>) -> (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<i32>)
+// REVERSE-NEXT:   %0 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %1 = enzymexla.blas.gemm %cst_4, %0, %U, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %2 = stablehlo.transpose %U, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %3 = enzymexla.blas.gemm %cst_4, %2, %arg1, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %4 = stablehlo.subtract %3, %1 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %5 = stablehlo.transpose %Vt, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %6 = stablehlo.transpose %arg3, dims = [1, 0] : (tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %7 = enzymexla.blas.gemm %cst_4, %arg3, %5, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %8 = enzymexla.blas.gemm %cst_4, %Vt, %6, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %9 = stablehlo.subtract %8, %7 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %10 = stablehlo.broadcast_in_dim %S, dims = [1] : (tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %11 = stablehlo.broadcast_in_dim %S, dims = [0] : (tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %12 = stablehlo.subtract %10, %11 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %13 = stablehlo.add %10, %11 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %14 = stablehlo.divide %cst_2, %12 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %15 = stablehlo.divide %cst_2, %13 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %16 = stablehlo.add %14, %15 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %17 = stablehlo.select %c, %cst_5, %16 : tensor<4x4xi1>, tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %18 = stablehlo.subtract %14, %15 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %19 = stablehlo.select %c, %cst_5, %18 : tensor<4x4xi1>, tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %20 = stablehlo.multiply %19, %9 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %21 = stablehlo.multiply %17, %4 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %22 = stablehlo.add %21, %20 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %23 = stablehlo.multiply %cst_1, %U : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %24 = enzymexla.blas.gemm %cst_4, %23, %22, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %25 = enzymexla.blas.gemm %cst_4, %24, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %26 = stablehlo.dot_general %U, %arg2, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %27 = enzymexla.blas.gemm %cst_4, %26, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %28 = stablehlo.add %25, %27 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %29 = stablehlo.divide %cst_0, %S : tensor<4xcomplex<f32>>
+// REVERSE-NEXT:   %30 = stablehlo.dot_general %arg1, %29, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %31 = enzymexla.blas.gemm %cst_4, %U, %2, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %32 = stablehlo.subtract %cst, %31 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %33 = enzymexla.blas.gemm %cst_4, %32, %30, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %34 = enzymexla.blas.gemm %cst_4, %33, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %35 = stablehlo.add %28, %34 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %36 = stablehlo.dot_general %U, %29, batching_dims = [1] x [0], contracting_dims = [] x [] : (tensor<4x4xcomplex<f32>>, tensor<4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %37 = enzymexla.blas.gemm %cst_4, %5, %Vt, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %38 = stablehlo.subtract %cst, %37 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %39 = enzymexla.blas.gemm %cst_4, %arg3, %38, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %40 = enzymexla.blas.gemm %cst_4, %36, %39, %cst_3, %cst_5 : (tensor<complex<f32>>, tensor<4x4xcomplex<f32>>, tensor<4x4xcomplex<f32>>, tensor<complex<f32>>, tensor<4x4xcomplex<f32>>) -> tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   %41 = stablehlo.add %35, %40 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT:   return %41 : tensor<4x4xcomplex<f32>>
+// REVERSE-NEXT: }


### PR DESCRIPTION
I found this pass a lil bit too complex to write in TableGen... It can still be adapted but will require more effort.

## To do

- [ ] Fix `LLVM ERROR: classof on 'chlo.conj' failed due to the operation not being registered` error
- [ ] Verify that the result is numerically correct