### PR TITLE
[AffineCFG] Re-arrange sum expression after recreateexpr optimization

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -1914,19 +1914,19 @@ struct CanonicalieForBounds : public OpRewritePattern<affine::AffineForOp> {
     // ubMap.dump();
     // forOp.dump();
 
-    // Any canonicalization change in map or operands always leads to updated
-    // map(s).
-    if ((lbMap == prevLbMap && ubMap == prevUbMap) &&
-        (!areChanged(lbOperands, origLbOperands)) &&
-        (!areChanged(ubOperands, origUbOperands)))
+    bool lbChanged = canonicalizeSum(lbMap) != canonicalizeSum(prevLbMap) ||
+                     areChanged(lbOperands, origLbOperands);
+    bool ubChanged = canonicalizeSum(ubMap) != canonicalizeSum(prevUbMap) ||
+                     areChanged(ubOperands, origUbOperands);
+    if (!lbChanged && !ubChanged)
       return failure();
 
     // llvm::errs() << "oldParent:" << *forOp.getParentOp() << "\n";
     // llvm::errs() << "oldfor:" << forOp << "\n";
 
-    if ((lbMap != prevLbMap) || areChanged(lbOperands, origLbOperands))
+    if (lbChanged)
       forOp.setLowerBound(lbOperands, lbMap);
-    if ((ubMap != prevUbMap) || areChanged(ubOperands, origUbOperands))
+    if (ubChanged)
       forOp.setUpperBound(ubOperands, ubMap);
 
     // llvm::errs() << "newfor:" << forOp << "\n";

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2196,19 +2196,19 @@ struct CanonicalieForBounds : public OpRewritePattern<affine::AffineForOp> {
     // ubMap.dump();
     // forOp.dump();
 
-    // Any canonicalization change in map or operands always leads to updated
-    // map(s).
-    if ((lbMap == prevLbMap && ubMap == prevUbMap) &&
-        (!areChanged(lbOperands, origLbOperands)) &&
-        (!areChanged(ubOperands, origUbOperands)))
+    bool lbChanged = canonicalizeSum(lbMap) != canonicalizeSum(prevLbMap) ||
+                     areChanged(lbOperands, origLbOperands);
+    bool ubChanged = canonicalizeSum(ubMap) != canonicalizeSum(prevUbMap) ||
+                     areChanged(ubOperands, origUbOperands);
+    if (!lbChanged && !ubChanged)
       return failure();
 
     // llvm::errs() << "oldParent:" << *forOp.getParentOp() << "\n";
     // llvm::errs() << "oldfor:" << forOp << "\n";
 
-    if ((lbMap != prevLbMap) || areChanged(lbOperands, origLbOperands))
+    if (lbChanged)
       forOp.setLowerBound(lbOperands, lbMap);
-    if ((ubMap != prevUbMap) || areChanged(ubOperands, origUbOperands))
+    if (ubChanged)
       forOp.setUpperBound(ubOperands, ubMap);
 
     // llvm::errs() << "newfor:" << forOp << "\n";

--- a/src/enzyme_ad/jax/Passes/Passes.h
+++ b/src/enzyme_ad/jax/Passes/Passes.h
@@ -43,6 +43,8 @@ void populateLibDeviceFuncsToOpsPatterns(MLIRContext *context,
 
 void addSingleIter(mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx);
 
+mlir::AffineExpr canonicalizeSum(mlir::AffineExpr expr);
+mlir::AffineMap canonicalizeSum(mlir::AffineMap map);
 mlir::AffineExpr recreateExpr(mlir::AffineExpr expr);
 mlir::AffineMap recreateExpr(mlir::AffineMap expr);
 mlir::IntegerSet recreateExpr(mlir::IntegerSet expr);

--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -539,6 +539,32 @@ AffineMap mlir::enzyme::recreateExpr(AffineMap map) {
                         map.getContext());
 }
 
+AffineExpr mlir::enzyme::canonicalizeSum(AffineExpr expr) {
+  auto bin = dyn_cast<AffineBinaryOpExpr>(expr);
+  if (!bin)
+    return expr;
+  if (bin.getKind() != AffineExprKind::Add)
+    return getAffineBinaryOpExpr(bin.getKind(), canonicalizeSum(bin.getLHS()),
+                                 canonicalizeSum(bin.getRHS()));
+
+  auto terms = getSumOperands(expr);
+  for (auto &term : terms)
+    term = canonicalizeSum(term);
+  llvm::sort(terms, affineCmp);
+  auto res = terms[0];
+  for (int i = 1; i < terms.size(); i++)
+    res = res + terms[i];
+  return res;
+}
+
+AffineMap mlir::enzyme::canonicalizeSum(AffineMap map) {
+  SmallVector<AffineExpr> exprs;
+  for (auto expr : map.getResults())
+    exprs.push_back(canonicalizeSum(expr));
+  return AffineMap::get(map.getNumDims(), map.getNumSymbols(), exprs,
+                        map.getContext());
+}
+
 struct IslToAffineExprConverter {
   MLIRContext *mlirContext;
   unsigned symOffset;

--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -546,6 +546,32 @@ AffineMap mlir::enzyme::recreateExpr(AffineMap map) {
                         map.getContext());
 }
 
+AffineExpr mlir::enzyme::canonicalizeSum(AffineExpr expr) {
+  auto bin = dyn_cast<AffineBinaryOpExpr>(expr);
+  if (!bin)
+    return expr;
+  if (bin.getKind() != AffineExprKind::Add)
+    return getAffineBinaryOpExpr(bin.getKind(), canonicalizeSum(bin.getLHS()),
+                                 canonicalizeSum(bin.getRHS()));
+
+  auto terms = getSumOperands(expr);
+  for (auto &term : terms)
+    term = canonicalizeSum(term);
+  llvm::sort(terms, affineCmp);
+  auto res = terms[0];
+  for (int i = 1; i < terms.size(); i++)
+    res = res + terms[i];
+  return res;
+}
+
+AffineMap mlir::enzyme::canonicalizeSum(AffineMap map) {
+  SmallVector<AffineExpr> exprs;
+  for (auto expr : map.getResults())
+    exprs.push_back(canonicalizeSum(expr));
+  return AffineMap::get(map.getNumDims(), map.getNumSymbols(), exprs,
+                        map.getContext());
+}
+
 struct IslToAffineExprConverter {
   MLIRContext *mlirContext;
   unsigned symOffset;

--- a/test/lit_tests/raising/affinecfg_forbounds.mlir
+++ b/test/lit_tests/raising/affinecfg_forbounds.mlir
@@ -1,0 +1,28 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+func.func @forbound_reassoc(%arg0: i32, %init: f64) -> f64 {
+  %cst = arith.constant 1.000000e+00 : f64
+  %s = arith.index_cast %arg0 : i32 to index
+  %r = affine.for %i = 0 to %s iter_args(%acc = %init) -> (f64) {
+    %ri = affine.for %j = 0 to affine_map<(d0)[s0] -> (-d0 + s0 - 1)>(%i)[%s]
+            iter_args(%a = %acc) -> (f64) {
+      %sum = arith.addf %a, %cst : f64
+      affine.yield %sum : f64
+    }
+    affine.yield %ri : f64
+  }
+  return %r : f64
+}
+
+// CHECK-LABEL:   func.func @forbound_reassoc(
+// CHECK-SAME:                                %[[ARG0:.*]]: i32, %[[ARG1:.*]]: f64) -> f64 {
+// CHECK:           %[[CST:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK:           %[[IDX:.*]] = arith.index_cast %[[ARG0]] : i32 to index
+// CHECK:           %[[OUT:.*]] = affine.parallel (%[[IV0:.*]]) = (0) to (symbol(%[[IDX]])) reduce ("addf") -> (f64) {
+// CHECK:             %[[IN:.*]] = affine.parallel (%[[IV1:.*]]) = (0) to (-%[[IV0]] + symbol(%[[IDX]]) - 1) reduce ("addf") -> (f64) {
+// CHECK:               affine.yield %[[CST]] : f64
+// CHECK:             }
+// CHECK:             affine.yield %[[IN]] : f64
+// CHECK:           }
+// CHECK:           %[[ADD:.*]] = arith.addf %[[ARG1]], %[[OUT]] : f64
+// CHECK:           return %[[ADD]] : f64


### PR DESCRIPTION
The minimal reproducer example is:
```mlir
func.func @forbound_reassoc(%arg0: i32, %init: f64) -> f64 {
  %cst = arith.constant 1.000000e+00 : f64
  %s = arith.index_cast %arg0 : i32 to index
  %r = affine.for %i = 0 to %s iter_args(%acc = %init) -> (f64) {
    %ri = affine.for %j = 0 to affine_map<(d0)[s0] -> (-d0 + s0 - 1)>(%i)[%s]
            iter_args(%a = %acc) -> (f64) {
      %sum = arith.addf %a, %cst : f64
      affine.yield %sum : f64
    }
    affine.yield %ri : f64
  }
  return %r : f64
}
```
The bug here is:
when `CanonicalieForBounds` apply on `affine.for %j = 0 to affine_map<(d0)[s0] -> (-d0 + s0 - 1)>(%i)[%s]...`'s upper bound, the upper bound map and operands `affine_map<(d0)[s0] -> (-d0 + s0 - 1)>(%i)[%s]` will not change, but `recreateExpr` https://github.com/EnzymeAD/Enzyme-JAX/blob/6af35e740558bd5edbe5d7b1b694b4c39329aa07/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp#L453
change the tree associations of sum expression:
from `Add(Add(Mul(d0, C-1), s0), C-1)` to `Add(Mul(d0, C-1), Add(s0, C-1))`
causing `--affine-cfg` fails to converage.

The fix:
I add a `canonicalizeSum` to rearrange the sum expression, align with the rule in default mlir `simplifyAdd`, https://github.com/llvm/llvm-project/blob/5db7e5b483a32f37d1d77a6f18d2bc4c59fa460a/mlir/lib/IR/AffineExpr.cpp#L662