### PR TITLE
Add GB-25 PR #258 commit to test matrix for perf comparison

### DIFF
--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -49,6 +49,7 @@ jobs:
           # - 'b25f3cbed2bc88c8ffef85f6a5319e2cf7b0454c'
         gb25_commit:
           - 'main'
+          - '0590584bf36f610586fb56a6705b966fdca4497b'
 
         reactant_commit:
           - 'main'

--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -49,7 +49,7 @@ jobs:
           # - 'b25f3cbed2bc88c8ffef85f6a5319e2cf7b0454c'
         gb25_commit:
           - 'main'
-          - '0590584bf36f610586fb56a6705b966fdca4497b'
+          - 'a72b47b78f09d6cb0bbb8ab87e5ccf559270f7ef'
 
         reactant_commit:
           - 'main'

--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -49,7 +49,7 @@ jobs:
           # - 'b25f3cbed2bc88c8ffef85f6a5319e2cf7b0454c'
         gb25_commit:
           - 'main'
-          - 'a72b47b78f09d6cb0bbb8ab87e5ccf559270f7ef'
+          - 'bb161a771e5b78000280d750240faee0379e77ce'
 
         reactant_commit:
           - 'main'

--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -49,7 +49,7 @@ jobs:
           # - 'b25f3cbed2bc88c8ffef85f6a5319e2cf7b0454c'
         gb25_commit:
           - 'main'
-          - 'bb161a771e5b78000280d750240faee0379e77ce'
+          - 'cdea24125a0c8f81c49760176215aff2ad9b94c8'
 
         reactant_commit:
           - 'main'

--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -49,7 +49,7 @@ jobs:
           # - 'b25f3cbed2bc88c8ffef85f6a5319e2cf7b0454c'
         gb25_commit:
           - 'main'
-          - 'cdea24125a0c8f81c49760176215aff2ad9b94c8'
+          - '7d34820d854fb10f9b3dc54ef0722a8dea73a68a'
 
         reactant_commit:
           - 'main'


### PR DESCRIPTION
Pins GB-25 commit [`0590584`](https://github.com/PRONTOLab/GB-25/pull/258/commits/0590584bf36f610586fb56a6705b966fdca4497b) (from PRONTOLab/GB-25#258) alongside `main` in the GB-25 test matrix.

This lets CI run both `main` and the PR #258 commit so we can compare performance side-by-side and confirm whether the perf gap is real or a model-config artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)