### PR TITLE
Fix crash in ConvertParallelToGPU1 pass on grid×block loops with multiple inner parallels

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -1914,19 +1914,19 @@ struct CanonicalieForBounds : public OpRewritePattern<affine::AffineForOp> {
     // ubMap.dump();
     // forOp.dump();
 
-    // Any canonicalization change in map or operands always leads to updated
-    // map(s).
-    if ((lbMap == prevLbMap && ubMap == prevUbMap) &&
-        (!areChanged(lbOperands, origLbOperands)) &&
-        (!areChanged(ubOperands, origUbOperands)))
+    bool lbChanged = canonicalizeSum(lbMap) != canonicalizeSum(prevLbMap) ||
+                     areChanged(lbOperands, origLbOperands);
+    bool ubChanged = canonicalizeSum(ubMap) != canonicalizeSum(prevUbMap) ||
+                     areChanged(ubOperands, origUbOperands);
+    if (!lbChanged && !ubChanged)
       return failure();
 
     // llvm::errs() << "oldParent:" << *forOp.getParentOp() << "\n";
     // llvm::errs() << "oldfor:" << forOp << "\n";
 
-    if ((lbMap != prevLbMap) || areChanged(lbOperands, origLbOperands))
+    if (lbChanged)
       forOp.setLowerBound(lbOperands, lbMap);
-    if ((ubMap != prevUbMap) || areChanged(ubOperands, origUbOperands))
+    if (ubChanged)
       forOp.setUpperBound(ubOperands, ubMap);
 
     // llvm::errs() << "newfor:" << forOp << "\n";

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1886,13 +1886,12 @@ struct InnerParallelSerialization : public OpRewritePattern<scf::ParallelOp> {
     if (!parallelOp->getParentOfType<enzymexla::GPUWrapperOp>()) {
       return failure();
     }
-    size_t parallelCount = 0;
+
+    size_t enclosingGpuDims = 0;
     auto par = parallelOp;
-    while ((par = par->getParentOfType<scf::ParallelOp>())) {
-      parallelCount++;
-    }
-    // is presently one of the three outer parallel loops;
-    if (parallelCount < 2)
+    while ((par = par->getParentOfType<scf::ParallelOp>()))
+      enclosingGpuDims += par.getNumLoops();
+    if (enclosingGpuDims < 6)
       return failure();
 
     // For a parallel loop, we essentially need to create an n-dimensional loop

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1894,7 +1894,8 @@ struct InnerParallelSerialization : public OpRewritePattern<scf::ParallelOp> {
       parallelCount++;
       enclosingGpuDims += par.getNumLoops();
     }
-    if (parallelCount < 2 && enclosingGpuDims < 6)
+    bool shouldInline = parallelCount >= 2 || enclosingGpuDims >= 6;
+    if (!shouldInline)
       return failure();
 
     // For a parallel loop, we essentially need to create an n-dimensional loop

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1887,11 +1887,14 @@ struct InnerParallelSerialization : public OpRewritePattern<scf::ParallelOp> {
       return failure();
     }
 
+    size_t parallelCount = 0;
     size_t enclosingGpuDims = 0;
     auto par = parallelOp;
-    while ((par = par->getParentOfType<scf::ParallelOp>()))
+    while ((par = par->getParentOfType<scf::ParallelOp>())) {
+      parallelCount++;
       enclosingGpuDims += par.getNumLoops();
-    if (enclosingGpuDims < 6)
+    }
+    if (parallelCount < 2 && enclosingGpuDims < 6)
       return failure();
 
     // For a parallel loop, we essentially need to create an n-dimensional loop

--- a/src/enzyme_ad/jax/Passes/Passes.h
+++ b/src/enzyme_ad/jax/Passes/Passes.h
@@ -43,6 +43,8 @@ void populateLibDeviceFuncsToOpsPatterns(MLIRContext *context,
 
 void addSingleIter(mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx);
 
+mlir::AffineExpr canonicalizeSum(mlir::AffineExpr expr);
+mlir::AffineMap canonicalizeSum(mlir::AffineMap map);
 mlir::AffineExpr recreateExpr(mlir::AffineExpr expr);
 mlir::AffineMap recreateExpr(mlir::AffineMap expr);
 mlir::IntegerSet recreateExpr(mlir::IntegerSet expr);

--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -539,6 +539,32 @@ AffineMap mlir::enzyme::recreateExpr(AffineMap map) {
                         map.getContext());
 }
 
+AffineExpr mlir::enzyme::canonicalizeSum(AffineExpr expr) {
+  auto bin = dyn_cast<AffineBinaryOpExpr>(expr);
+  if (!bin)
+    return expr;
+  if (bin.getKind() != AffineExprKind::Add)
+    return getAffineBinaryOpExpr(bin.getKind(), canonicalizeSum(bin.getLHS()),
+                                 canonicalizeSum(bin.getRHS()));
+
+  auto terms = getSumOperands(expr);
+  for (auto &term : terms)
+    term = canonicalizeSum(term);
+  llvm::sort(terms, affineCmp);
+  auto res = terms[0];
+  for (int i = 1; i < terms.size(); i++)
+    res = res + terms[i];
+  return res;
+}
+
+AffineMap mlir::enzyme::canonicalizeSum(AffineMap map) {
+  SmallVector<AffineExpr> exprs;
+  for (auto expr : map.getResults())
+    exprs.push_back(canonicalizeSum(expr));
+  return AffineMap::get(map.getNumDims(), map.getNumSymbols(), exprs,
+                        map.getContext());
+}
+
 struct IslToAffineExprConverter {
   MLIRContext *mlirContext;
   unsigned symOffset;

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-fused-siblings.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-fused-siblings.mlir
@@ -1,0 +1,51 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+module {
+  func.func @fused_siblings(%g0: index, %g1: index, %g2: index,
+                            %b0: index, %b1: index, %b2: index,
+                            %arg: memref<8xf64>) {
+    %r = "enzymexla.gpu_wrapper"(%g0, %g1, %g2, %b0, %b1, %b2) ({
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      %cst = arith.constant 1.0 : f64
+      scf.parallel (%i0, %i1, %i2, %i3, %i4, %i5) =
+          (%c0, %c0, %c0, %c0, %c0, %c0) to (%g0, %g1, %g2, %b0, %b1, %b2)
+          step (%c1, %c1, %c1, %c1, %c1, %c1) {
+        scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+          memref.store %cst, %arg[%j] : memref<8xf64>
+          scf.reduce
+        }
+        scf.parallel (%k) = (%c0) to (%c8) step (%c1) {
+          memref.store %cst, %arg[%k] : memref<8xf64>
+          scf.reduce
+        }
+        scf.parallel (%l) = (%c0) to (%c8) step (%c1) {
+          memref.store %cst, %arg[%l] : memref<8xf64>
+          scf.reduce
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @fused_siblings(
+// CHECK:         "enzymexla.alternatives"() ({
+// CHECK:           "enzymexla.gpu_error"() ({
+// CHECK:             scf.if %{{.*}} {
+// CHECK:               gpu.launch blocks(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) threads(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) {
+// CHECK:                 scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:                   memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<8xf64>
+// CHECK:                 }
+// CHECK:                 scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:                   memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<8xf64>
+// CHECK:                 }
+// CHECK:                 scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:                   memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<8xf64>
+// CHECK:                 }
+// CHECK:                 gpu.terminator
+// CHECK:           "enzymexla.polygeist_yield"() : () -> ()
+// CHECK:         "enzymexla.polygeist_yield"() : () -> ()

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-fused-siblings.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-fused-siblings.mlir
@@ -30,6 +30,31 @@ module {
     }) : (index, index, index, index, index, index) -> index
     return
   }
+
+  func.func @lowdim(%g: index, %b: index, %arg: memref<8xf64>) {
+    %r = "enzymexla.gpu_wrapper"(%g, %g, %g, %b, %b, %b) ({
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      %cst = arith.constant 1.0 : f64
+      scf.parallel (%bx) = (%c0) to (%g) step (%c1) {
+        scf.parallel (%tx) = (%c0) to (%b) step (%c1) {
+          scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+            memref.store %cst, %arg[%j] : memref<8xf64>
+            scf.reduce
+          }
+          scf.parallel (%k) = (%c0) to (%c8) step (%c1) {
+            memref.store %cst, %arg[%k] : memref<8xf64>
+            scf.reduce
+          }
+          scf.reduce
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
 }
 
 // CHECK-LABEL: func.func @fused_siblings(
@@ -49,3 +74,15 @@ module {
 // CHECK:                 gpu.terminator
 // CHECK:           "enzymexla.polygeist_yield"() : () -> ()
 // CHECK:         "enzymexla.polygeist_yield"() : () -> ()
+
+// CHECK-LABEL: func.func @lowdim(
+// CHECK:         "enzymexla.gpu_error"() ({
+// CHECK:           scf.if %{{.*}} {
+// CHECK:             gpu.launch blocks(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) threads(%{{.*}}, %{{.*}}, %{{.*}}) in (%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) {
+// CHECK:               scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:                 memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<8xf64>
+// CHECK:               }
+// CHECK:               scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK:                 memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<8xf64>
+// CHECK:               }
+// CHECK:               gpu.terminator

--- a/test/lit_tests/raising/affinecfg_forbounds.mlir
+++ b/test/lit_tests/raising/affinecfg_forbounds.mlir
@@ -1,0 +1,28 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+func.func @forbound_reassoc(%arg0: i32, %init: f64) -> f64 {
+  %cst = arith.constant 1.000000e+00 : f64
+  %s = arith.index_cast %arg0 : i32 to index
+  %r = affine.for %i = 0 to %s iter_args(%acc = %init) -> (f64) {
+    %ri = affine.for %j = 0 to affine_map<(d0)[s0] -> (-d0 + s0 - 1)>(%i)[%s]
+            iter_args(%a = %acc) -> (f64) {
+      %sum = arith.addf %a, %cst : f64
+      affine.yield %sum : f64
+    }
+    affine.yield %ri : f64
+  }
+  return %r : f64
+}
+
+// CHECK-LABEL:   func.func @forbound_reassoc(
+// CHECK-SAME:                                %[[ARG0:.*]]: i32, %[[ARG1:.*]]: f64) -> f64 {
+// CHECK:           %[[CST:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK:           %[[IDX:.*]] = arith.index_cast %[[ARG0]] : i32 to index
+// CHECK:           %[[OUT:.*]] = affine.parallel (%[[IV0:.*]]) = (0) to (symbol(%[[IDX]])) reduce ("addf") -> (f64) {
+// CHECK:             %[[IN:.*]] = affine.parallel (%[[IV1:.*]]) = (0) to (-%[[IV0]] + symbol(%[[IDX]]) - 1) reduce ("addf") -> (f64) {
+// CHECK:               affine.yield %[[CST]] : f64
+// CHECK:             }
+// CHECK:             affine.yield %[[IN]] : f64
+// CHECK:           }
+// CHECK:           %[[ADD:.*]] = arith.addf %[[ARG1]], %[[OUT]] : f64
+// CHECK:           return %[[ADD]] : f64


### PR DESCRIPTION
The input IRs:
```
scf.parallel (%bx,%by,%bz, %tx,%ty,%tz) {
    scf.parallel (%i) = 0 to 8 { ... }
    scf.parallel (%j) = 0 to 8 { ... }
    scf.parallel (%k) = 0 to 8 { ... }
}
```
`ConvertParallelToGPU1` pass crashed with `llvm_unreachable("Unhandled case")` (in `ParallelizeBlockOps`)

Fix with if the GPUDIMs equals 6 (grid -> [0, 3), block -> [3,6)), `InnerParallelSerialization` will  serialize a parallel loop into scf.for.