### PR TITLE
Fix CbrtOp derivative NaN gradient on negative inputs (#2571)

### DIFF
--- a/src/enzyme_ad/jax/Implementations/HLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/HLODerivatives.td
@@ -1078,8 +1078,12 @@ def : HLODerivative<"ClampOp", (Op $min, $operand, $max), [
         (SelectIfActive $operand, (Shadow $operand), (HLOConstantFP<"0"> $operand)))
 )>;
 
+// d/dx cbrt(x) = 1 / (3 * cbrt(x)^2). Computed from the real primal cbrt(x),
+// which is defined and smooth for x < 0, rather than through pow(x, -2/3),
+// which is NaN on negative bases (StableHLO power spec: power([-36],[1.1]) = -nan).
+// Mirrors jax.lax.cbrt's JVP (g * (1/3) * integer_pow(ans, -2)). See issue #2571.
 def : HLODerivative<"CbrtOp", (Op $x), [
-  (CheckedMul (DiffeRet), (Div (Pow $x, (Div (HLOConstantFP<"-2">), (HLOConstantFP<"3">))), (HLOConstantFP<"3">))),
+  (CheckedDiv (DiffeRet), (Mul (HLOConstantFP<"3">), (Mul (Cbrt $x), (Cbrt $x)))),
 ]>;
 
 def : HLOInactiveOp<"CompareOp">;

--- a/test/lit_tests/diffrules/stablehlo/cbrt.mlir
+++ b/test/lit_tests/diffrules/stablehlo/cbrt.mlir
@@ -25,31 +25,53 @@ func.func @cbrt(%x : tensor<2xf32>) -> tensor<2xf32> {
 // REVERSE-NEXT:    return %3 : tensor<2xf32>
 // REVERSE-NEXT:  }
 
-// Negative inputs: cbrt is real and smooth for x < 0 (cbrt(-8) = -2), so the
+// Exercise both signs. cbrt is real and smooth for x < 0 (cbrt(-8) = -2), so the
 // true gradient 1/(3*cbrt(x)^2) is a finite real with the same magnitude as on
-// the positives. The old pow(x,-2/3) rule returned NaN here. See issue #2571.
+// the positives. The old pow(x,-2/3) rule returned NaN on negatives. See issue #2571.
 func.func @main() {
-  %x = stablehlo.constant dense<[-8.0, -27.0]> : tensor<2xf32>
-  %out = stablehlo.constant dense<[-2.0, -3.0]> : tensor<2xf32>
-  %expected = stablehlo.constant dense<[0.083333336, 0.037037037]> : tensor<2xf32>
-
   %dx = stablehlo.constant dense<1.0> : tensor<2xf32>
 
-  %fwd:2 = enzyme.fwddiff @cbrt(%x, %dx) {
+  // Positive inputs: unchanged from the pre-fix behavior.
+  %xp = stablehlo.constant dense<[8.0, 27.0]> : tensor<2xf32>
+  %outp = stablehlo.constant dense<[2.0, 3.0]> : tensor<2xf32>
+  %expectedp = stablehlo.constant dense<[0.083333336, 0.037037037]> : tensor<2xf32>
+
+  %fwdp:2 = enzyme.fwddiff @cbrt(%xp, %dx) {
     activity=[#enzyme<activity enzyme_dup>],
     ret_activity=[#enzyme<activity enzyme_dup>]
   } : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>)
 
-  check.expect_almost_eq %fwd#0, %out : tensor<2xf32>
-  check.expect_almost_eq %fwd#1, %expected : tensor<2xf32>
+  check.expect_almost_eq %fwdp#0, %outp : tensor<2xf32>
+  check.expect_almost_eq %fwdp#1, %expectedp : tensor<2xf32>
 
-  %rev:2 = enzyme.autodiff @cbrt(%x, %dx) {
+  %revp:2 = enzyme.autodiff @cbrt(%xp, %dx) {
     activity=[#enzyme<activity enzyme_active>],
     ret_activity=[#enzyme<activity enzyme_active>]
   } : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>)
 
-  check.expect_almost_eq %rev#0, %out : tensor<2xf32>
-  check.expect_almost_eq %rev#1, %expected : tensor<2xf32>
+  check.expect_almost_eq %revp#0, %outp : tensor<2xf32>
+  check.expect_almost_eq %revp#1, %expectedp : tensor<2xf32>
+
+  // Negative inputs: the regression this PR fixes. Same gradient magnitude.
+  %xn = stablehlo.constant dense<[-8.0, -27.0]> : tensor<2xf32>
+  %outn = stablehlo.constant dense<[-2.0, -3.0]> : tensor<2xf32>
+  %expectedn = stablehlo.constant dense<[0.083333336, 0.037037037]> : tensor<2xf32>
+
+  %fwdn:2 = enzyme.fwddiff @cbrt(%xn, %dx) {
+    activity=[#enzyme<activity enzyme_dup>],
+    ret_activity=[#enzyme<activity enzyme_dup>]
+  } : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>)
+
+  check.expect_almost_eq %fwdn#0, %outn : tensor<2xf32>
+  check.expect_almost_eq %fwdn#1, %expectedn : tensor<2xf32>
+
+  %revn:2 = enzyme.autodiff @cbrt(%xn, %dx) {
+    activity=[#enzyme<activity enzyme_active>],
+    ret_activity=[#enzyme<activity enzyme_active>]
+  } : (tensor<2xf32>, tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>)
+
+  check.expect_almost_eq %revn#0, %outn : tensor<2xf32>
+  check.expect_almost_eq %revn#1, %expectedn : tensor<2xf32>
 
   func.return
 }

--- a/test/lit_tests/diffrules/stablehlo/cbrt.mlir
+++ b/test/lit_tests/diffrules/stablehlo/cbrt.mlir
@@ -8,27 +8,29 @@ func.func @cbrt(%x : tensor<2xf32>) -> tensor<2xf32> {
 }
 
 // FORWARD:  func.func @cbrt(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
-// FORWARD-NEXT:    %cst = stablehlo.constant dense<0.333333343> : tensor<2xf32>
-// FORWARD-NEXT:    %cst_0 = stablehlo.constant dense<-0.666666686> : tensor<2xf32>
-// FORWARD-NEXT:    %0 = stablehlo.power %arg0, %cst_0 : tensor<2xf32>
-// FORWARD-NEXT:    %1 = stablehlo.multiply %0, %cst : tensor<2xf32>
-// FORWARD-NEXT:    %2 = stablehlo.multiply %arg1, %1 : tensor<2xf32>
-// FORWARD-NEXT:    %3 = stablehlo.cbrt %arg0 : tensor<2xf32>
-// FORWARD-NEXT:    return %3, %2 : tensor<2xf32>, tensor<2xf32>
+// FORWARD-NEXT:    %cst = stablehlo.constant dense<3.000000e+00> : tensor<2xf32>
+// FORWARD-NEXT:    %0 = stablehlo.cbrt %arg0 : tensor<2xf32>
+// FORWARD-NEXT:    %1 = stablehlo.multiply %0, %0 : tensor<2xf32>
+// FORWARD-NEXT:    %2 = stablehlo.multiply %cst, %1 : tensor<2xf32>
+// FORWARD-NEXT:    %3 = stablehlo.divide %arg1, %2 : tensor<2xf32>
+// FORWARD-NEXT:    return %0, %3 : tensor<2xf32>, tensor<2xf32>
 // FORWARD-NEXT:  }
 
 // REVERSE:  func.func @cbrt(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
-// REVERSE-NEXT:    %cst = stablehlo.constant dense<0.333333343> : tensor<2xf32>
-// REVERSE-NEXT:    %cst_0 = stablehlo.constant dense<-0.666666686> : tensor<2xf32>
-// REVERSE-NEXT:    %0 = stablehlo.power %arg0, %cst_0 : tensor<2xf32>
-// REVERSE-NEXT:    %1 = stablehlo.multiply %0, %cst : tensor<2xf32>
-// REVERSE-NEXT:    %2 = stablehlo.multiply %arg1, %1 : tensor<2xf32>
-// REVERSE-NEXT:    return %2 : tensor<2xf32>
+// REVERSE-NEXT:    %cst = stablehlo.constant dense<3.000000e+00> : tensor<2xf32>
+// REVERSE-NEXT:    %0 = stablehlo.cbrt %arg0 : tensor<2xf32>
+// REVERSE-NEXT:    %1 = stablehlo.multiply %0, %0 : tensor<2xf32>
+// REVERSE-NEXT:    %2 = stablehlo.multiply %cst, %1 : tensor<2xf32>
+// REVERSE-NEXT:    %3 = stablehlo.divide %arg1, %2 : tensor<2xf32>
+// REVERSE-NEXT:    return %3 : tensor<2xf32>
 // REVERSE-NEXT:  }
 
+// Negative inputs: cbrt is real and smooth for x < 0 (cbrt(-8) = -2), so the
+// true gradient 1/(3*cbrt(x)^2) is a finite real with the same magnitude as on
+// the positives. The old pow(x,-2/3) rule returned NaN here. See issue #2571.
 func.func @main() {
-  %x = stablehlo.constant dense<[8.0, 27.0]> : tensor<2xf32>
-  %out = stablehlo.constant dense<[2.0, 3.0]> : tensor<2xf32>
+  %x = stablehlo.constant dense<[-8.0, -27.0]> : tensor<2xf32>
+  %out = stablehlo.constant dense<[-2.0, -3.0]> : tensor<2xf32>
   %expected = stablehlo.constant dense<[0.083333336, 0.037037037]> : tensor<2xf32>
 
   %dx = stablehlo.constant dense<1.0> : tensor<2xf32>


### PR DESCRIPTION
Fixes #2571 (maintainer-approved: "PR also welcome here!").

## Problem

The `CbrtOp` AD rule (`HLODerivatives.td`) computes the gradient as `(1/3) * pow(x, -2/3)`. A non-integer exponent on a negative base is NaN (StableHLO `power` spec: `power([-36.0], [1.1]) = -nan`), but `stablehlo.cbrt` is real and smooth for `x < 0` (`cbrt(-8) = -2`). So for finite `x < 0` the **primal is correct but the gradient is NaN**, where the true derivative `1/(3*cbrt(x)^2)` is a finite real.

## Fix

Compute the derivative from the already-real primal, dropping the `power` op entirely:

```
d/dx = DiffeRet / (3 * cbrt(x)^2)
```

This mirrors `jax.lax.cbrt`'s JVP (`g * (1/3) * integer_pow(ans, -2)`). Because the failure came from routing through `power` on a negative base, removing `power` means the fix cannot reproduce it. Verified against `jax.grad(jnp.cbrt)` across the sign range (float64):

| x | `jax.grad` | old `pow(x,-2/3)/3` | new `1/(3*cbrt^2)` |
|---|---|---|---|
| -8 | 0.083333 | NaN | 0.083333 |
| -2 | 0.209987 | NaN | 0.209987 |
| -0.5 | 0.529134 | NaN | 0.529134 |
| 2 | 0.209987 | 0.209987 | 0.209987 |

At `x = 0` the derivative is a genuine singularity (+/-inf), the same boundary `SqrtOp` already special-cases.

## Test

`test/lit_tests/diffrules/stablehlo/cbrt.mlir`'s `@main` numerically checks the gradient under `stablehlo-translate --interpret`, but only sampled positive inputs. Flipped to `[-8.0, -27.0]`: true gradients are sign-independent so `%expected` is unchanged, but the old rule produced NaN there. The FORWARD/REVERSE FileCheck blocks are updated to the new (power-free) IR.

> Note: I cannot build Enzyme-JAX locally, so the FORWARD/REVERSE `CHECK` lines are a best-effort prediction of the post-optimization IR. If CI's FileCheck flags an operand-order or constant-format mismatch, I will push a fixup to match. The source fix and the numeric `@main` check are the substantive parts.

Found mechanically with a value-and-gradient soundness gate over the rewrite/AD-rule library; happy to share the process if useful.
