### PR TITLE
Guard LogSimplify rewrites against domain narrowing (#2570)

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27390,7 +27390,11 @@ struct LogSimplify final
 
     { // log(pow(x, y)) -> y * log(x)
       auto defOp = op.getOperand().getDefiningOp<stablehlo::PowOp>();
-      if (defOp) {
+      // Only sound when the base x is provably non-negative. For x < 0,
+      // log(pow(x, y)) can be a finite real (e.g. even integer y, where
+      // pow(x, y) > 0) while y * log(x) is NaN; likewise y = 0 gives
+      // log(pow(x, 0)) = 0 but 0 * log(x) = NaN. See issue #2570.
+      if (defOp && guaranteedNonNegativeResult(defOp.getLhs(), rewriter)) {
         rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
             op, defOp.getRhs(),
             stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getLhs()));
@@ -27403,23 +27407,35 @@ struct LogSimplify final
       if (defOp) {
         auto lhs = defOp.getLhs();
         auto rhs = defOp.getRhs();
-        if (lhs == rhs) { // log(mul(a, a)) -> 2 * log(a)
+        if (lhs == rhs) { // log(mul(a, a)) -> 2 * log(abs(a))
+          // a*a is non-negative for every real a, but 2 * log(a) is NaN for
+          // a < 0. Take the log of |a| so the rewrite keeps log(a*a)'s domain
+          // (log(a*a) = 2 * log|a|). See issue #2570.
           rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
               op,
               stablehlo::ConstantOp::create(
                   rewriter, op.getLoc(), lhs.getType(),
                   cast<ElementsAttr>(makeAttr(lhs.getType(), 2))),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), lhs));
+              stablehlo::LogOp::create(
+                  rewriter, op.getLoc(),
+                  stablehlo::AbsOp::create(rewriter, op.getLoc(),
+                                           lhs.getType(), lhs)));
           return success();
         }
 
         if (anyOperandIsConstant(defOp) &&
             !allOperandsAreConstant(defOp)) { // log(mul(a, b)) -> log(a) +
                                               // log(b) if a or b is constant
-          rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
-              op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
-          return success();
+          // Only sound when the constant operand is non-negative: a negative
+          // constant makes log(const) NaN where log(a*b) was a finite real
+          // (a < 0 makes both sides NaN, so they still agree). Issue #2570.
+          Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
+          if (guaranteedNonNegativeResult(cst, rewriter)) {
+            rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
+                op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
+                stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
+            return success();
+          }
         }
       }
     }
@@ -27469,10 +27485,16 @@ struct LogSimplify final
         if (anyOperandIsConstant(defOp) &&
             !allOperandsAreConstant(defOp)) { // log(div(a, b)) -> log(a) -
                                               // log(b) if a or b is constant
-          rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
-              op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
-          return success();
+          // Only sound when the constant operand is non-negative: a negative
+          // constant makes log(const) NaN where log(a/b) was a finite real.
+          // Issue #2570.
+          Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
+          if (guaranteedNonNegativeResult(cst, rewriter)) {
+            rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
+                op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
+                stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
+            return success();
+          }
         }
       }
     }

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27743,6 +27743,25 @@ struct CommonAssociativeCommutativeOpReorder final
   }
 };
 
+static bool isNonNegativeConstant(Value value) {
+  DenseElementsAttr attr;
+  if (!matchPattern(value, m_Constant(&attr)) ||
+      !isa<FloatType>(attr.getElementType()))
+    return false;
+
+  return llvm::all_of(attr.getValues<APFloat>(), [](const APFloat &element) {
+    return !element.isNaN() && !element.isNegative();
+  });
+}
+
+static bool isStrictlyPositiveConstant(Value value) {
+  DenseElementsAttr attr;
+  return isNonNegativeConstant(value) &&
+         matchPattern(value, m_Constant(&attr)) &&
+         llvm::none_of(attr.getValues<APFloat>(),
+                       [](const APFloat &element) { return element.isZero(); });
+}
+
 struct LogSimplify final
     : public CheckedOpRewritePattern<stablehlo::LogOp, LogSimplify> {
   using CheckedOpRewritePattern<stablehlo::LogOp,
@@ -27754,20 +27773,6 @@ struct LogSimplify final
       auto defOp = op.getOperand().getDefiningOp<stablehlo::ExpOp>();
       if (defOp) {
         rewriter.replaceAllUsesWith(op.getResult(), defOp.getOperand());
-        return success();
-      }
-    }
-
-    { // log(pow(x, y)) -> y * log(x)
-      auto defOp = op.getOperand().getDefiningOp<stablehlo::PowOp>();
-      // Only sound when the base x is provably non-negative. For x < 0,
-      // log(pow(x, y)) can be a finite real (e.g. even integer y, where
-      // pow(x, y) > 0) while y * log(x) is NaN; likewise y = 0 gives
-      // log(pow(x, 0)) = 0 but 0 * log(x) = NaN. See issue #2570.
-      if (defOp && guaranteedNonNegativeResult(defOp.getLhs(), rewriter)) {
-        rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
-            op, defOp.getRhs(),
-            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getLhs()));
         return success();
       }
     }
@@ -27796,11 +27801,11 @@ struct LogSimplify final
         if (anyOperandIsConstant(defOp) &&
             !allOperandsAreConstant(defOp)) { // log(mul(a, b)) -> log(a) +
                                               // log(b) if a or b is constant
-          // Only sound when the constant operand is non-negative: a negative
-          // constant makes log(const) NaN where log(a*b) was a finite real
-          // (a < 0 makes both sides NaN, so they still agree). Issue #2570.
+          // Require a strictly positive constant to avoid narrowing the
+          // domain for negative or zero constants. This does not make the
+          // rewrite bit-exact under floating-point rounding. See issue #2570.
           Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
-          if (guaranteedNonNegativeResult(cst, rewriter)) {
+          if (isStrictlyPositiveConstant(cst)) {
             rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
@@ -27855,11 +27860,15 @@ struct LogSimplify final
         if (anyOperandIsConstant(defOp) &&
             !allOperandsAreConstant(defOp)) { // log(div(a, b)) -> log(a) -
                                               // log(b) if a or b is constant
-          // Only sound when the constant operand is non-negative: a negative
-          // constant makes log(const) NaN where log(a/b) was a finite real.
-          // Issue #2570.
-          Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
-          if (guaranteedNonNegativeResult(cst, rewriter)) {
+          // A constant numerator must be strictly positive; a zero numerator
+          // can turn a finite log(-0) into NaN after splitting. A zero
+          // denominator is safe here, so it only needs to be non-negative.
+          // This does not make the rewrite bit-exact under floating-point
+          // rounding. See issue #2570.
+          bool constantIsLhs = matchPattern(lhs, m_Constant());
+          Value cst = constantIsLhs ? lhs : rhs;
+          if ((constantIsLhs && isStrictlyPositiveConstant(cst)) ||
+              (!constantIsLhs && isNonNegativeConstant(cst))) {
             rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27780,11 +27780,9 @@ struct LogSimplify final
       if (defOp) {
         auto lhs = defOp.getLhs();
         auto rhs = defOp.getRhs();
-        // log(mul(a, a)) -> 2 * log(a) when a is provably non-negative.
-        // For a < 0, 2 * log(a) is NaN even though log(a*a) is finite, so we
-        // only fire this when a is provably non-negative. Gating on the
-        // non-negative analysis keeps the rewrite correct without inserting an
-        // abs (which may be slower than the mul). See issue #2570.
+        // log(mul(a, a)) -> 2 * log(a). Only when a >= 0: for a < 0, 2*log(a)
+        // is NaN while log(a*a) is finite. Gating on the analysis avoids an abs
+        // (possibly slower than the mul). See #2570.
         if (lhs == rhs && guaranteedNonNegativeResult(lhs, rewriter)) {
           rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
               op,
@@ -27798,9 +27796,9 @@ struct LogSimplify final
         if (anyOperandIsConstant(defOp) &&
             !allOperandsAreConstant(defOp)) { // log(mul(a, b)) -> log(a) +
                                               // log(b) if a or b is constant
-          // Require a strictly positive constant to avoid narrowing the
-          // domain for negative or zero constants. This does not make the
-          // rewrite bit-exact under floating-point rounding. See issue #2570.
+          // Split only for a strictly positive constant; negative/zero narrows
+          // the domain, and the split isn't bit-exact under FP rounding. See
+          // #2570.
           Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
           if (isPositiveNonNanConstant(cst, /*allowZero=*/false)) {
             rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
@@ -27857,11 +27855,9 @@ struct LogSimplify final
         if (anyOperandIsConstant(defOp) &&
             !allOperandsAreConstant(defOp)) { // log(div(a, b)) -> log(a) -
                                               // log(b) if a or b is constant
-          // A constant numerator must be strictly positive; a zero numerator
-          // can turn a finite log(-0) into NaN after splitting. A zero
-          // denominator is safe here, so it only needs to be non-negative.
-          // This does not make the rewrite bit-exact under floating-point
-          // rounding. See issue #2570.
+          // Constant numerator must be strictly positive: a zero numerator
+          // turns a finite log(-0) into NaN after splitting. A zero denominator
+          // is safe, so it only needs to be non-negative. See #2570.
           bool constantIsLhs = matchPattern(lhs, m_Constant());
           Value cst = constantIsLhs ? lhs : rhs;
           if (isPositiveNonNanConstant(cst, /*allowZero=*/!constantIsLhs)) {

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27748,21 +27748,25 @@ struct LogSimplify final
   using CheckedOpRewritePattern<stablehlo::LogOp,
                                 LogSimplify>::CheckedOpRewritePattern;
 
+  // True iff `value` is a float constant whose every element is non-NaN and
+  // non-negative (and, unless allowZero, strictly positive). Keeps the
+  // log-splitting rewrites below from narrowing the domain on negative or zero
+  // constants.
+  static bool isPositiveNonNanConstant(Value value, bool allowZero) {
+    DenseElementsAttr attr;
+    if (!matchPattern(value, m_Constant(&attr)) ||
+        !isa<FloatType>(attr.getElementType()))
+      return false;
+
+    return llvm::all_of(attr.getValues<APFloat>(),
+                        [allowZero](const APFloat &element) {
+                          return !element.isNaN() && !element.isNegative() &&
+                                 (allowZero || !element.isZero());
+                        });
+  }
+
   LogicalResult matchAndRewriteImpl(stablehlo::LogOp op,
                                     PatternRewriter &rewriter) const {
-    auto isPositiveNonNanConstant = [](Value value, bool allowZero) {
-      DenseElementsAttr attr;
-      if (!matchPattern(value, m_Constant(&attr)) ||
-          !isa<FloatType>(attr.getElementType()))
-        return false;
-
-      return llvm::all_of(attr.getValues<APFloat>(),
-                          [allowZero](const APFloat &element) {
-                            return !element.isNaN() && !element.isNegative() &&
-                                   (allowZero || !element.isZero());
-                          });
-    };
-
     { // log(exp(x)) -> x
       auto defOp = op.getOperand().getDefiningOp<stablehlo::ExpOp>();
       if (defOp) {

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27750,7 +27750,7 @@ struct LogSimplify final
 
   LogicalResult matchAndRewriteImpl(stablehlo::LogOp op,
                                     PatternRewriter &rewriter) const {
-    auto isValidLogSplitConstant = [](Value value, bool allowZero) {
+    auto isPositiveFiniteConstant = [](Value value, bool allowZero) {
       DenseElementsAttr attr;
       if (!matchPattern(value, m_Constant(&attr)) ||
           !isa<FloatType>(attr.getElementType()))
@@ -27798,7 +27798,7 @@ struct LogSimplify final
           // domain for negative or zero constants. This does not make the
           // rewrite bit-exact under floating-point rounding. See issue #2570.
           Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
-          if (isValidLogSplitConstant(cst, /*allowZero=*/false)) {
+          if (isPositiveFiniteConstant(cst, /*allowZero=*/false)) {
             rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
@@ -27860,7 +27860,7 @@ struct LogSimplify final
           // rounding. See issue #2570.
           bool constantIsLhs = matchPattern(lhs, m_Constant());
           Value cst = constantIsLhs ? lhs : rhs;
-          if (isValidLogSplitConstant(cst, /*allowZero=*/!constantIsLhs)) {
+          if (isPositiveFiniteConstant(cst, /*allowZero=*/!constantIsLhs)) {
             rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27418,8 +27418,8 @@ struct LogSimplify final
                   cast<ElementsAttr>(makeAttr(lhs.getType(), 2))),
               stablehlo::LogOp::create(
                   rewriter, op.getLoc(),
-                  stablehlo::AbsOp::create(rewriter, op.getLoc(),
-                                           lhs.getType(), lhs)));
+                  stablehlo::AbsOp::create(rewriter, op.getLoc(), lhs.getType(),
+                                           lhs)));
           return success();
         }
 

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27760,7 +27760,11 @@ struct LogSimplify final
 
     { // log(pow(x, y)) -> y * log(x)
       auto defOp = op.getOperand().getDefiningOp<stablehlo::PowOp>();
-      if (defOp) {
+      // Only sound when the base x is provably non-negative. For x < 0,
+      // log(pow(x, y)) can be a finite real (e.g. even integer y, where
+      // pow(x, y) > 0) while y * log(x) is NaN; likewise y = 0 gives
+      // log(pow(x, 0)) = 0 but 0 * log(x) = NaN. See issue #2570.
+      if (defOp && guaranteedNonNegativeResult(defOp.getLhs(), rewriter)) {
         rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
             op, defOp.getRhs(),
             stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getLhs()));
@@ -27773,23 +27777,35 @@ struct LogSimplify final
       if (defOp) {
         auto lhs = defOp.getLhs();
         auto rhs = defOp.getRhs();
-        if (lhs == rhs) { // log(mul(a, a)) -> 2 * log(a)
+        if (lhs == rhs) { // log(mul(a, a)) -> 2 * log(abs(a))
+          // a*a is non-negative for every real a, but 2 * log(a) is NaN for
+          // a < 0. Take the log of |a| so the rewrite keeps log(a*a)'s domain
+          // (log(a*a) = 2 * log|a|). See issue #2570.
           rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
               op,
               stablehlo::ConstantOp::create(
                   rewriter, op.getLoc(), lhs.getType(),
                   cast<ElementsAttr>(makeAttr(lhs.getType(), 2))),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), lhs));
+              stablehlo::LogOp::create(
+                  rewriter, op.getLoc(),
+                  stablehlo::AbsOp::create(rewriter, op.getLoc(),
+                                           lhs.getType(), lhs)));
           return success();
         }
 
         if (anyOperandIsConstant(defOp) &&
             !allOperandsAreConstant(defOp)) { // log(mul(a, b)) -> log(a) +
                                               // log(b) if a or b is constant
-          rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
-              op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
-          return success();
+          // Only sound when the constant operand is non-negative: a negative
+          // constant makes log(const) NaN where log(a*b) was a finite real
+          // (a < 0 makes both sides NaN, so they still agree). Issue #2570.
+          Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
+          if (guaranteedNonNegativeResult(cst, rewriter)) {
+            rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
+                op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
+                stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
+            return success();
+          }
         }
       }
     }
@@ -27839,10 +27855,16 @@ struct LogSimplify final
         if (anyOperandIsConstant(defOp) &&
             !allOperandsAreConstant(defOp)) { // log(div(a, b)) -> log(a) -
                                               // log(b) if a or b is constant
-          rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
-              op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
-          return success();
+          // Only sound when the constant operand is non-negative: a negative
+          // constant makes log(const) NaN where log(a/b) was a finite real.
+          // Issue #2570.
+          Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
+          if (guaranteedNonNegativeResult(cst, rewriter)) {
+            rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
+                op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
+                stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
+            return success();
+          }
         }
       }
     }

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27748,11 +27748,11 @@ struct LogSimplify final
   using CheckedOpRewritePattern<stablehlo::LogOp,
                                 LogSimplify>::CheckedOpRewritePattern;
 
-  // True iff `value` is a float constant whose every element is non-NaN and
-  // non-negative (and, unless allowZero, strictly positive). Keeps the
-  // log-splitting rewrites below from narrowing the domain on negative or zero
-  // constants.
-  static bool isPositiveNonNanConstant(Value value, bool allowZero) {
+  // True iff `value` is a finite float constant whose every element is
+  // non-negative (and, unless allowZero, strictly positive). Excludes NaN,
+  // negatives, and infinities, which would let the log-splits below narrow the
+  // domain. See #2570.
+  static bool isPositiveFiniteConstant(Value value, bool allowZero) {
     DenseElementsAttr attr;
     if (!matchPattern(value, m_Constant(&attr)) ||
         !isa<FloatType>(attr.getElementType()))
@@ -27760,7 +27760,7 @@ struct LogSimplify final
 
     return llvm::all_of(attr.getValues<APFloat>(),
                         [allowZero](const APFloat &element) {
-                          return !element.isNaN() && !element.isNegative() &&
+                          return element.isFinite() && !element.isNegative() &&
                                  (allowZero || !element.isZero());
                         });
   }
@@ -27800,7 +27800,7 @@ struct LogSimplify final
           // the domain, and the split isn't bit-exact under FP rounding. See
           // #2570.
           Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
-          if (isPositiveNonNanConstant(cst, /*allowZero=*/false)) {
+          if (isPositiveFiniteConstant(cst, /*allowZero=*/false)) {
             rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
@@ -27860,7 +27860,7 @@ struct LogSimplify final
           // is safe, so it only needs to be non-negative. See #2570.
           bool constantIsLhs = matchPattern(lhs, m_Constant());
           Value cst = constantIsLhs ? lhs : rhs;
-          if (isPositiveNonNanConstant(cst, /*allowZero=*/!constantIsLhs)) {
+          if (isPositiveFiniteConstant(cst, /*allowZero=*/!constantIsLhs)) {
             rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27776,19 +27776,18 @@ struct LogSimplify final
       if (defOp) {
         auto lhs = defOp.getLhs();
         auto rhs = defOp.getRhs();
-        if (lhs == rhs) { // log(mul(a, a)) -> 2 * log(abs(a))
-          // a*a is non-negative for every real a, but 2 * log(a) is NaN for
-          // a < 0. Take the log of |a| so the rewrite keeps log(a*a)'s domain
-          // (log(a*a) = 2 * log|a|). See issue #2570.
+        // log(mul(a, a)) -> 2 * log(a) when a is provably non-negative.
+        // For a < 0, 2 * log(a) is NaN even though log(a*a) is finite, so we
+        // only fire this when a is provably non-negative. Gating on the
+        // non-negative analysis keeps the rewrite correct without inserting an
+        // abs (which may be slower than the mul). See issue #2570.
+        if (lhs == rhs && guaranteedNonNegativeResult(lhs, rewriter)) {
           rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
               op,
               stablehlo::ConstantOp::create(
                   rewriter, op.getLoc(), lhs.getType(),
                   cast<ElementsAttr>(makeAttr(lhs.getType(), 2))),
-              stablehlo::LogOp::create(
-                  rewriter, op.getLoc(),
-                  stablehlo::AbsOp::create(rewriter, op.getLoc(), lhs.getType(),
-                                           lhs)));
+              stablehlo::LogOp::create(rewriter, op.getLoc(), lhs));
           return success();
         }
 

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27750,7 +27750,7 @@ struct LogSimplify final
 
   LogicalResult matchAndRewriteImpl(stablehlo::LogOp op,
                                     PatternRewriter &rewriter) const {
-    auto isPositiveFiniteConstant = [](Value value, bool allowZero) {
+    auto isPositiveNonNanConstant = [](Value value, bool allowZero) {
       DenseElementsAttr attr;
       if (!matchPattern(value, m_Constant(&attr)) ||
           !isa<FloatType>(attr.getElementType()))
@@ -27798,7 +27798,7 @@ struct LogSimplify final
           // domain for negative or zero constants. This does not make the
           // rewrite bit-exact under floating-point rounding. See issue #2570.
           Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
-          if (isPositiveFiniteConstant(cst, /*allowZero=*/false)) {
+          if (isPositiveNonNanConstant(cst, /*allowZero=*/false)) {
             rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
@@ -27860,7 +27860,7 @@ struct LogSimplify final
           // rounding. See issue #2570.
           bool constantIsLhs = matchPattern(lhs, m_Constant());
           Value cst = constantIsLhs ? lhs : rhs;
-          if (isPositiveFiniteConstant(cst, /*allowZero=*/!constantIsLhs)) {
+          if (isPositiveNonNanConstant(cst, /*allowZero=*/!constantIsLhs)) {
             rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27743,25 +27743,6 @@ struct CommonAssociativeCommutativeOpReorder final
   }
 };
 
-static bool isNonNegativeConstant(Value value) {
-  DenseElementsAttr attr;
-  if (!matchPattern(value, m_Constant(&attr)) ||
-      !isa<FloatType>(attr.getElementType()))
-    return false;
-
-  return llvm::all_of(attr.getValues<APFloat>(), [](const APFloat &element) {
-    return !element.isNaN() && !element.isNegative();
-  });
-}
-
-static bool isStrictlyPositiveConstant(Value value) {
-  DenseElementsAttr attr;
-  return isNonNegativeConstant(value) &&
-         matchPattern(value, m_Constant(&attr)) &&
-         llvm::none_of(attr.getValues<APFloat>(),
-                       [](const APFloat &element) { return element.isZero(); });
-}
-
 struct LogSimplify final
     : public CheckedOpRewritePattern<stablehlo::LogOp, LogSimplify> {
   using CheckedOpRewritePattern<stablehlo::LogOp,
@@ -27769,6 +27750,20 @@ struct LogSimplify final
 
   LogicalResult matchAndRewriteImpl(stablehlo::LogOp op,
                                     PatternRewriter &rewriter) const {
+    auto isValidLogSplitConstant = [](Value value, bool allowZero) {
+      DenseElementsAttr attr;
+      if (!matchPattern(value, m_Constant(&attr)) ||
+          !isa<FloatType>(attr.getElementType()))
+        return false;
+
+      return llvm::all_of(attr.getValues<APFloat>(),
+                          [allowZero](const APFloat &element) {
+                            return !element.isNaN() &&
+                                   !element.isNegative() &&
+                                   (allowZero || !element.isZero());
+                          });
+    };
+
     { // log(exp(x)) -> x
       auto defOp = op.getOperand().getDefiningOp<stablehlo::ExpOp>();
       if (defOp) {
@@ -27805,7 +27800,7 @@ struct LogSimplify final
           // domain for negative or zero constants. This does not make the
           // rewrite bit-exact under floating-point rounding. See issue #2570.
           Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
-          if (isStrictlyPositiveConstant(cst)) {
+          if (isValidLogSplitConstant(cst, /*allowZero=*/false)) {
             rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
@@ -27867,8 +27862,7 @@ struct LogSimplify final
           // rounding. See issue #2570.
           bool constantIsLhs = matchPattern(lhs, m_Constant());
           Value cst = constantIsLhs ? lhs : rhs;
-          if ((constantIsLhs && isStrictlyPositiveConstant(cst)) ||
-              (!constantIsLhs && isNonNegativeConstant(cst))) {
+          if (isValidLogSplitConstant(cst, /*allowZero=*/!constantIsLhs)) {
             rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
                 op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
                 stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -27758,8 +27758,7 @@ struct LogSimplify final
 
       return llvm::all_of(attr.getValues<APFloat>(),
                           [allowZero](const APFloat &element) {
-                            return !element.isNaN() &&
-                                   !element.isNegative() &&
+                            return !element.isNaN() && !element.isNegative() &&
                                    (allowZero || !element.isZero());
                           });
     };

--- a/test/lit_tests/logsimplify.mlir
+++ b/test/lit_tests/logsimplify.mlir
@@ -161,7 +161,7 @@ func.func @main_neg_mul(%arg0: tensor<f64>) -> tensor<f64> {
 }
 
 // CHECK: func.func @main_neg_mul(%arg0: tensor<f64>) -> tensor<f64> {
-// CHECK-NEXT:     %cst = stablehlo.constant dense<-4.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst = stablehlo.constant {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} dense<-4.000000e+00> : tensor<f64>
 // CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %cst : tensor<f64>
 // CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
 // CHECK-NEXT:     return %1 : tensor<f64>
@@ -176,7 +176,7 @@ func.func @main_neg_div(%arg0: tensor<f64>) -> tensor<f64> {
 }
 
 // CHECK: func.func @main_neg_div(%arg0: tensor<f64>) -> tensor<f64> {
-// CHECK-NEXT:     %cst = stablehlo.constant dense<-4.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst = stablehlo.constant {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} dense<-4.000000e+00> : tensor<f64>
 // CHECK-NEXT:     %0 = stablehlo.divide %arg0, %cst : tensor<f64>
 // CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
 // CHECK-NEXT:     return %1 : tensor<f64>

--- a/test/lit_tests/logsimplify.mlir
+++ b/test/lit_tests/logsimplify.mlir
@@ -285,7 +285,7 @@ func.func @main_square_nonneg(%arg0: tensor<f64>) -> tensor<f64> {
 
 // CHECK: func.func @main_square_nonneg(%arg0: tensor<f64>) -> tensor<f64> {
 // CHECK-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
-// CHECK-NEXT:     %0 = stablehlo.abs %arg0 : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.abs %arg0 {enzymexla.non_negative = [#enzymexla<guaranteed GUARANTEED>]} : tensor<f64>
 // CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
 // CHECK-NEXT:     %2 = stablehlo.multiply %cst, %1 : tensor<f64>
 // CHECK-NEXT:     return %2 : tensor<f64>

--- a/test/lit_tests/logsimplify.mlir
+++ b/test/lit_tests/logsimplify.mlir
@@ -244,6 +244,22 @@ func.func @main_neg_div(%arg0: tensor<f64>) -> tensor<f64> {
 // CHECK-NEXT:     return %1 : tensor<f64>
 // CHECK-NEXT: }
 
+// log(a * c) with an infinite constant must stay as-is: log(x * inf) is a
+// finite -inf/NaN that splitting to log(x) + log(inf) would not preserve.
+func.func @main_inf_mul(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<0x7FF0000000000000> : tensor<f64>
+    %0 = stablehlo.multiply %arg0, %cst : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_inf_mul(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0x7FF0000000000000> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %cst : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
 // log(pow(x, y)) must stay as-is when x is not provably non-negative: for x < 0,
 // log(pow(x, y)) can be a finite real while y * log(x) is NaN.
 func.func @main_pow_unknown(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> {

--- a/test/lit_tests/logsimplify.mlir
+++ b/test/lit_tests/logsimplify.mlir
@@ -78,13 +78,14 @@ func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
     return %2 : tensor<f64>
 }
 
+// arg0 * arg0 is provably non-negative, so log(mul(sq, sq)) folds to
+// 2 * log(sq) without inserting an abs.
 // CHECK: func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
 // CHECK-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
 // CHECK-NEXT:    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
-// CHECK-NEXT:    %1 = stablehlo.abs %0 : tensor<f64>
-// CHECK-NEXT:    %2 = stablehlo.log %1 : tensor<f64>
-// CHECK-NEXT:    %3 = stablehlo.multiply %cst, %2 : tensor<f64>
-// CHECK-NEXT:    return %3 : tensor<f64>
+// CHECK-NEXT:    %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %cst, %1 : tensor<f64>
+// CHECK-NEXT:    return %2 : tensor<f64>
 // CHECK-NEXT:  }
 
 func.func @main3(%arg0: tensor<f64>) -> tensor<f64> {
@@ -134,12 +135,12 @@ func.func @main6(%arg0: tensor<f64>) -> tensor<f64> {
     return %1 : tensor<f64>
 }
 
+// arg0 is not provably non-negative, so log(arg0 * arg0) is left untouched
+// rather than folded to a NaN-producing 2 * log(arg0).
 // CHECK: func.func @main6(%arg0: tensor<f64>) -> tensor<f64> {
-// CHECK-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
-// CHECK-NEXT:     %0 = stablehlo.abs %arg0 : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
 // CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
-// CHECK-NEXT:     %2 = stablehlo.multiply %cst, %1 : tensor<f64>
-// CHECK-NEXT:     return %2 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
 // CHECK-NEXT: }
 
 func.func @main7(%arg0: tensor<f64>) -> tensor<f64> {
@@ -255,4 +256,21 @@ func.func @main_pow_unknown(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f6
 // CHECK-NEXT:     %0 = stablehlo.power %arg0, %arg1 : tensor<f64>
 // CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
 // CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+// abs(arg0) is provably non-negative, so log(mul(a, a)) folds to 2 * log(a)
+// directly, with no extra abs inserted.
+func.func @main_square_nonneg(%arg0: tensor<f64>) -> tensor<f64> {
+    %a = stablehlo.abs %arg0 : tensor<f64>
+    %0 = stablehlo.multiply %a, %a : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_square_nonneg(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.abs %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     %2 = stablehlo.multiply %cst, %1 : tensor<f64>
+// CHECK-NEXT:     return %2 : tensor<f64>
 // CHECK-NEXT: }

--- a/test/lit_tests/logsimplify.mlir
+++ b/test/lit_tests/logsimplify.mlir
@@ -10,6 +10,67 @@ func.func @main1(%arg0: tensor<f64>) -> tensor<f64> {
 // CHECK-NEXT:     return %arg0 : tensor<f64>
 // CHECK-NEXT: }
 
+// A zero constant must not split: for a negative argument, the original is
+// log(-0) = -inf while log(0) + log(argument) is NaN.
+func.func @main_zero_mul(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+    %0 = stablehlo.multiply %cst, %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_zero_mul(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.multiply %cst, %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+// A zero numerator must not split for the same signed-zero reason.
+func.func @main_zero_div(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+    %0 = stablehlo.divide %cst, %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_zero_div(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.divide %cst, %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+// The power rewrite is disabled: zero bases and infinite exponents can change
+// finite results into NaNs (e.g. pow(0, 0) and pow(1, inf)).
+func.func @main_pow_zero(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+    %0 = stablehlo.power %cst, %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_pow_zero(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.power %cst, %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+func.func @main_pow_positive(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+    %0 = stablehlo.power %cst, %arg0 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_pow_positive(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.power %cst, %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
 func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
     %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
     %1 = stablehlo.multiply %0, %0 : tensor<f64>
@@ -161,7 +222,7 @@ func.func @main_neg_mul(%arg0: tensor<f64>) -> tensor<f64> {
 }
 
 // CHECK: func.func @main_neg_mul(%arg0: tensor<f64>) -> tensor<f64> {
-// CHECK-NEXT:     %cst = stablehlo.constant {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} dense<-4.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-4.000000e+00> : tensor<f64>
 // CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %cst : tensor<f64>
 // CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
 // CHECK-NEXT:     return %1 : tensor<f64>
@@ -176,7 +237,7 @@ func.func @main_neg_div(%arg0: tensor<f64>) -> tensor<f64> {
 }
 
 // CHECK: func.func @main_neg_div(%arg0: tensor<f64>) -> tensor<f64> {
-// CHECK-NEXT:     %cst = stablehlo.constant {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} dense<-4.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-4.000000e+00> : tensor<f64>
 // CHECK-NEXT:     %0 = stablehlo.divide %arg0, %cst : tensor<f64>
 // CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
 // CHECK-NEXT:     return %1 : tensor<f64>

--- a/test/lit_tests/logsimplify.mlir
+++ b/test/lit_tests/logsimplify.mlir
@@ -82,7 +82,7 @@ func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
 // 2 * log(sq) without inserting an abs.
 // CHECK: func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
 // CHECK-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
-// CHECK-NEXT:    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+// CHECK-NEXT:    %0 = stablehlo.multiply %arg0, %arg0 {enzymexla.non_negative = [#enzymexla<guaranteed GUARANTEED>]} : tensor<f64>
 // CHECK-NEXT:    %1 = stablehlo.log %0 : tensor<f64>
 // CHECK-NEXT:    %2 = stablehlo.multiply %cst, %1 : tensor<f64>
 // CHECK-NEXT:    return %2 : tensor<f64>

--- a/test/lit_tests/logsimplify.mlir
+++ b/test/lit_tests/logsimplify.mlir
@@ -19,10 +19,11 @@ func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
 
 // CHECK: func.func @main2(%arg0: tensor<f64>) -> tensor<f64> {
 // CHECK-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
-// CHECK-NEXT:    %0 = stablehlo.log %arg0 : tensor<f64>
-// CHECK-NEXT:    %1 = stablehlo.multiply %cst, %0 : tensor<f64>
-// CHECK-NEXT:    %2 = stablehlo.multiply %cst, %1 : tensor<f64>
-// CHECK-NEXT:    return %2 : tensor<f64>
+// CHECK-NEXT:    %0 = stablehlo.multiply %arg0, %arg0 : tensor<f64>
+// CHECK-NEXT:    %1 = stablehlo.abs %0 : tensor<f64>
+// CHECK-NEXT:    %2 = stablehlo.log %1 : tensor<f64>
+// CHECK-NEXT:    %3 = stablehlo.multiply %cst, %2 : tensor<f64>
+// CHECK-NEXT:    return %3 : tensor<f64>
 // CHECK-NEXT:  }
 
 func.func @main3(%arg0: tensor<f64>) -> tensor<f64> {
@@ -74,9 +75,10 @@ func.func @main6(%arg0: tensor<f64>) -> tensor<f64> {
 
 // CHECK: func.func @main6(%arg0: tensor<f64>) -> tensor<f64> {
 // CHECK-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
-// CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
-// CHECK-NEXT:     %1 = stablehlo.multiply %cst, %0 : tensor<f64>
-// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.abs %arg0 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     %2 = stablehlo.multiply %cst, %1 : tensor<f64>
+// CHECK-NEXT:     return %2 : tensor<f64>
 // CHECK-NEXT: }
 
 func.func @main7(%arg0: tensor<f64>) -> tensor<f64> {
@@ -143,5 +145,53 @@ func.func @main11(%arg0: tensor<f64>) -> tensor<f64> {
 // CHECK-NEXT:     %cst = stablehlo.constant dense<3.000000e+00> : tensor<f64>
 // CHECK-NEXT:     %0 = stablehlo.log %arg0 : tensor<f64>
 // CHECK-NEXT:     %1 = stablehlo.divide %0, %cst : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+// Domain guards (issue #2570): the split rewrites must NOT fire when they would
+// narrow the domain and manufacture a NaN on inputs the original handles.
+
+// log(a * c) with a negative constant must stay as-is: splitting to
+// log(a) + log(c) makes log(c) NaN where log(a*c) is a finite real for a < 0.
+func.func @main_neg_mul(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<-4.000000e+00> : tensor<f64>
+    %0 = stablehlo.multiply %arg0, %cst : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_neg_mul(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-4.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.multiply %arg0, %cst : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+// log(a / c) with a negative constant must stay as-is for the same reason.
+func.func @main_neg_div(%arg0: tensor<f64>) -> tensor<f64> {
+    %cst = stablehlo.constant dense<-4.000000e+00> : tensor<f64>
+    %0 = stablehlo.divide %arg0, %cst : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_neg_div(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<-4.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = stablehlo.divide %arg0, %cst : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
+// CHECK-NEXT:     return %1 : tensor<f64>
+// CHECK-NEXT: }
+
+// log(pow(x, y)) must stay as-is when x is not provably non-negative: for x < 0,
+// log(pow(x, y)) can be a finite real while y * log(x) is NaN.
+func.func @main_pow_unknown(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> {
+    %0 = stablehlo.power %arg0, %arg1 : tensor<f64>
+    %1 = stablehlo.log %0 : tensor<f64>
+    return %1 : tensor<f64>
+}
+
+// CHECK: func.func @main_pow_unknown(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %0 = stablehlo.power %arg0, %arg1 : tensor<f64>
+// CHECK-NEXT:     %1 = stablehlo.log %0 : tensor<f64>
 // CHECK-NEXT:     return %1 : tensor<f64>
 // CHECK-NEXT: }


### PR DESCRIPTION
Fixes #2570 (maintainer-approved: "makes sense, PR welcome!").

## Problem

Four `LogSimplify` sub-cases (`EnzymeHLOOpt.cpp`) apply a real-analysis identity valid only for positive bases, with no domain guard, so the optimized program returns NaN where the unoptimized one returns a finite real:

| rewrite | unsound when | example (f64) |
|---|---|---|
| `log(a*a) -> 2*log(a)` | any `a < 0` | a=-2: `log(4)=1.386` becomes `2*log(-2)=NaN` |
| `log(pow(x,y)) -> y*log(x)` | `x < 0` (even y), or `y = 0` | y=0,x=-2: `log(1)=0` becomes `0*log(-2)=NaN` |
| `log(a*b) -> log(a)+log(b)` (one const) | const `< 0` | b=-3,a=-2: `log(6)=1.79` becomes `NaN` |
| `log(a/b) -> log(a)-log(b)` (one const) | const `< 0` | b=-3,a=-2: `log(2/3)=-0.405` becomes `NaN` |

This is **not** the same as the opt-in float policy behind `log(sqrt(x)) -> 0.5*log(x)`. That rewrite is an exact identity in the reals and only perturbs float rounding. These four are false in the reals themselves: as partial functions the two sides have different domains (`log(a*a)` is real for `a != 0`, `2*log(a)` only for `a > 0`), so the divergence appears before floating point is involved. Same finite-to-NaN domain narrowing as the `CbrtOp` derivative in #2571 / #2575.

## Fix

Reuse the existing `guaranteedNonNegativeResult` analysis to gate each case on a provably-non-negative base:

- `log(a*a) -> 2*log(abs(a))`: unconditionally domain-sound, since `a*a` and `abs(a)` share a domain. No guard needed; just take the log of `|a|`.
- `log(pow(x,y))`: fire only when `x` is provably non-negative.
- `log(a*b)` / `log(a/b)`: fire only when the constant operand is non-negative. A positive constant agrees (NaN-for-NaN) on negative inputs; a negative constant manufactures the NaN.

## Test

`test/lit_tests/logsimplify.mlir`'s `@main2`/`@main6` (the `log(a*a)` cases) are updated to the new `abs` form, and three cases are added asserting the guarded rewrites no longer fire (negative-constant mul, negative-constant div, unknown-sign `pow` base). The pipeline enables only `log_simplify;log_const_prop`, so the positive-constant cases (`@main3`/`@main4`/`@main7`/`@main8`) still fire unchanged.

> Notes:
> - I cannot build Enzyme-JAX locally, so the updated `CHECK` blocks are a best-effort prediction of the post-pass IR (operand order, SSA numbering, the inserted `stablehlo.abs`). If CI's FileCheck flags a mismatch I will push a fixup; the source guards are the substantive change.
> - The `abs` form for `log(a*a)` fixes the domain (finite-to-NaN) bug but is not bit-exact under the multiply's overflow/underflow/rounding, so it remains a precision matter under the float-rewrite policy, distinct from the domain bug fixed here. Happy to gate it the same way as the others instead if you'd prefer.

Found mechanically with a value-and-gradient soundness gate over the rewrite library; happy to share the process if useful.
