### PR TITLE
More type casting logic for aggregates

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -1080,22 +1080,30 @@ void removeRedundantBlockArgs(
   }
 }
 
-// Recursively extract all scalar leaves from a nested struct/array aggregate
-static void collectLeaves(OpBuilder &b, Value val,
-                          SmallVectorImpl<Value> &leaves) {
+// Recursively extract sub-values, stopping as soon as a node matches the target
+// type. Falls all the way to scalar leaves when no intermediate match is found.
+static void collectSubvalues(OpBuilder &b, Value val,
+                             SmallVectorImpl<Value> &subvalues,
+                             Type targetType) {
   Type t = val.getType();
+
+  if (t == targetType) {
+    subvalues.push_back(val);
+    return;
+  }
+
   if (auto ST = dyn_cast<LLVM::LLVMStructType>(t)) {
     for (unsigned i = 0; i < ST.getBody().size(); i++) {
       Value extracted = LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
-      collectLeaves(b, extracted, leaves);
+      collectSubvalues(b, extracted, subvalues, targetType);
     }
   } else if (auto AT = dyn_cast<LLVM::LLVMArrayType>(t)) {
     for (unsigned i = 0; i < AT.getNumElements(); i++) {
       Value extracted = LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
-      collectLeaves(b, extracted, leaves);
+      collectSubvalues(b, extracted, subvalues, targetType);
     }
   } else {
-    leaves.push_back(val);
+    subvalues.push_back(val);
   }
 }
 
@@ -1114,35 +1122,27 @@ Value castToType(Type elType, Value val, Operation *op) {
               isa<FloatType>(val.getType())) &&
              (isa<IntegerType>(elType) || isa<FloatType>(elType))) {
     return arith::BitcastOp::create(b, val.getLoc(), elType, val);
-  } else if (auto ST = dyn_cast<LLVM::LLVMStructType>(elType)) {
-    if (ST.getBody().size() == 1) {
-      auto ud = LLVM::UndefOp::create(b, val.getLoc(), elType);
-      auto c0 = castToType(ST.getBody()[0], val, op);
-      b.setInsertionPoint(op);
-      return LLVM::InsertValueOp::create(b, val.getLoc(), ud, c0,
-                                         b.getDenseI64ArrayAttr({0}));
-    }
   } else if (isa<LLVM::LLVMStructType, LLVM::LLVMArrayType>(val.getType())) {
-    SmallVector<Value> leaves;
-    collectLeaves(b, val, leaves);
-    assert(!leaves.empty());
+    SmallVector<Value> subvalues;
+    collectSubvalues(b, val, subvalues, elType);
+    assert(!subvalues.empty());
 
-    // If there's only one leaf and it already matches, no vector needed
-    if (leaves.size() == 1)
-      return castToType(elType, leaves[0], op);
+    // If there's only one subvalue and it already matches, no vector needed
+    if (subvalues.size() == 1)
+      return castToType(elType, subvalues[0], op);
 
-    // Check that leaves are all the same type
-    Type leafType = leaves[0].getType();
-    assert(
-        llvm::all_of(leaves, [&](Value v) { return v.getType() == leafType; }));
+    // Check that subvalues are all the same type
+    Type leafType = subvalues[0].getType();
+    assert(llvm::all_of(subvalues,
+                        [&](Value v) { return v.getType() == leafType; }));
 
-    // Create a vector of the leaves
-    auto vecType = VectorType::get(leaves.size(), leafType);
+    // Create a vector of the subvalues
+    auto vecType = VectorType::get(subvalues.size(), leafType);
     Value vec = LLVM::PoisonOp::create(b, val.getLoc(), vecType);
-    for (auto [i, leaf] : llvm::enumerate(leaves)) {
+    for (auto [i, subvalue] : llvm::enumerate(subvalues)) {
       Value idx = LLVM::ConstantOp::create(b, val.getLoc(), b.getI32Type(),
                                            b.getI32IntegerAttr(i));
-      vec = LLVM::InsertElementOp::create(b, val.getLoc(), vec, leaf, idx);
+      vec = LLVM::InsertElementOp::create(b, val.getLoc(), vec, subvalue, idx);
     }
     return castToType(elType, vec, op);
 
@@ -1151,6 +1151,14 @@ Value castToType(Type elType, Value val, Operation *op) {
     if (dl.getTypeSize(val.getType()) == dl.getTypeSize(elType)) {
       if (isa<IntegerType>(elType) || isa<FloatType>(elType))
         return LLVM::BitcastOp::create(b, val.getLoc(), elType, val);
+    }
+  } else if (auto ST = dyn_cast<LLVM::LLVMStructType>(elType)) {
+    if (ST.getBody().size() == 1) {
+      auto ud = LLVM::UndefOp::create(b, val.getLoc(), elType);
+      auto c0 = castToType(ST.getBody()[0], val, op);
+      b.setInsertionPoint(op);
+      return LLVM::InsertValueOp::create(b, val.getLoc(), ud, c0,
+                                         b.getDenseI64ArrayAttr({0}));
     }
   }
   llvm::errs() << " mismatched load type, needed: " << elType << " found "

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -1081,18 +1081,17 @@ void removeRedundantBlockArgs(
 }
 
 // Recursively extract all scalar leaves from a nested struct/array aggregate
-static void collectLeaves(OpBuilder &b, Value val, SmallVectorImpl<Value> &leaves) {
+static void collectLeaves(OpBuilder &b, Value val,
+                          SmallVectorImpl<Value> &leaves) {
   Type t = val.getType();
   if (auto ST = dyn_cast<LLVM::LLVMStructType>(t)) {
     for (unsigned i = 0; i < ST.getBody().size(); i++) {
-      Value extracted =
-          LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
+      Value extracted = LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
       collectLeaves(b, extracted, leaves);
     }
   } else if (auto AT = dyn_cast<LLVM::LLVMArrayType>(t)) {
     for (unsigned i = 0; i < AT.getNumElements(); i++) {
-      Value extracted =
-          LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
+      Value extracted = LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
       collectLeaves(b, extracted, leaves);
     }
   } else {
@@ -1127,25 +1126,30 @@ Value castToType(Type elType, Value val, Operation *op) {
     SmallVector<Value> leaves;
     collectLeaves(b, val, leaves);
     assert(!leaves.empty());
+
+    // If there's only one leaf and it already matches, no vector needed
+    if (leaves.size() == 1)
+      return castToType(elType, leaves[0], op);
+
     // Check that leaves are all the same type
     Type leafType = leaves[0].getType();
-    assert(llvm::all_of(leaves, [&](Value v) { 
-      return v.getType() == leafType; 
-    }));
+    assert(
+        llvm::all_of(leaves, [&](Value v) { return v.getType() == leafType; }));
+
+    // Create a vector of the leaves
     auto vecType = VectorType::get(leaves.size(), leafType);
     Value vec = LLVM::PoisonOp::create(b, val.getLoc(), vecType);
     for (auto [i, leaf] : llvm::enumerate(leaves)) {
       Value idx = LLVM::ConstantOp::create(b, val.getLoc(), b.getI32Type(),
-                                          b.getI32IntegerAttr(i));
-      vec =
-          LLVM::InsertElementOp::create(b, val.getLoc(), vec, leaf, idx);
+                                           b.getI32IntegerAttr(i));
+      vec = LLVM::InsertElementOp::create(b, val.getLoc(), vec, leaf, idx);
     }
     return castToType(elType, vec, op);
 
   } else if (auto VT = dyn_cast<VectorType>(val.getType())) {
-    if (isa<IntegerType>(elType)) {
-      DataLayout dl(op->getParentOfType<ModuleOp>());
-      if (dl.getTypeSize(val.getType()) == dl.getTypeSize(elType))
+    DataLayout dl(op->getParentOfType<ModuleOp>());
+    if (dl.getTypeSize(val.getType()) == dl.getTypeSize(elType)) {
+      if (isa<IntegerType>(elType) || isa<FloatType>(elType))
         return LLVM::BitcastOp::create(b, val.getLoc(), elType, val);
     }
   }

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -1080,30 +1080,23 @@ void removeRedundantBlockArgs(
   }
 }
 
-// Recursively extract sub-values, stopping as soon as a node matches the target
-// type. Falls all the way to scalar leaves when no intermediate match is found.
-static void collectSubvalues(OpBuilder &b, Value val,
-                             SmallVectorImpl<Value> &subvalues,
-                             Type targetType) {
+// Recursively extract leaves
+static void collectLeaves(OpBuilder &b, Value val,
+                          SmallVectorImpl<Value> &leaves) {
   Type t = val.getType();
-
-  if (t == targetType) {
-    subvalues.push_back(val);
-    return;
-  }
 
   if (auto ST = dyn_cast<LLVM::LLVMStructType>(t)) {
     for (unsigned i = 0; i < ST.getBody().size(); i++) {
       Value extracted = LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
-      collectSubvalues(b, extracted, subvalues, targetType);
+      collectLeaves(b, extracted, leaves);
     }
   } else if (auto AT = dyn_cast<LLVM::LLVMArrayType>(t)) {
     for (unsigned i = 0; i < AT.getNumElements(); i++) {
       Value extracted = LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
-      collectSubvalues(b, extracted, subvalues, targetType);
+      collectLeaves(b, extracted, leaves);
     }
   } else {
-    subvalues.push_back(val);
+    leaves.push_back(val);
   }
 }
 
@@ -1123,28 +1116,37 @@ Value castToType(Type elType, Value val, Operation *op) {
              (isa<IntegerType>(elType) || isa<FloatType>(elType))) {
     return arith::BitcastOp::create(b, val.getLoc(), elType, val);
   } else if (isa<LLVM::LLVMStructType, LLVM::LLVMArrayType>(val.getType())) {
-    SmallVector<Value> subvalues;
-    collectSubvalues(b, val, subvalues, elType);
-    assert(!subvalues.empty());
-
-    // If there's only one subvalue and it already matches, no vector needed
-    if (subvalues.size() == 1)
-      return castToType(elType, subvalues[0], op);
-
-    // Check that subvalues are all the same type
-    Type leafType = subvalues[0].getType();
-    assert(llvm::all_of(subvalues,
-                        [&](Value v) { return v.getType() == leafType; }));
-
-    // Create a vector of the subvalues
-    auto vecType = VectorType::get(subvalues.size(), leafType);
-    Value vec = LLVM::PoisonOp::create(b, val.getLoc(), vecType);
-    for (auto [i, subvalue] : llvm::enumerate(subvalues)) {
-      Value idx = LLVM::ConstantOp::create(b, val.getLoc(), b.getI32Type(),
-                                           b.getI32IntegerAttr(i));
-      vec = LLVM::InsertElementOp::create(b, val.getLoc(), vec, subvalue, idx);
+    // If the aggregate has only one element, extract and recurse
+    if (auto ST = dyn_cast<LLVM::LLVMStructType>(val.getType())) {
+      if (ST.getBody().size() == 1) {
+        Value extracted = LLVM::ExtractValueOp::create(b, val.getLoc(), val, 0);
+        return castToType(elType, extracted, op);
+      }
+    } else if (auto AT = dyn_cast<LLVM::LLVMArrayType>(val.getType())) {
+      if (AT.getNumElements() == 1) {
+        Value extracted = LLVM::ExtractValueOp::create(b, val.getLoc(), val, 0);
+        return castToType(elType, extracted, op);
+      }
     }
-    return castToType(elType, vec, op);
+    SmallVector<Value> leaves;
+    collectLeaves(b, val, leaves);
+
+    // Only cast if leaves are of the same type
+    if (!leaves.empty()) {
+      Type leafType = leaves[0].getType();
+      if (llvm::all_of(leaves,
+                       [&](Value v) { return v.getType() == leafType; })) {
+        // Create a vector of the leaves
+        auto vecType = VectorType::get(leaves.size(), leafType);
+        Value vec = LLVM::PoisonOp::create(b, val.getLoc(), vecType);
+        for (auto [i, leaf] : llvm::enumerate(leaves)) {
+          Value idx = LLVM::ConstantOp::create(b, val.getLoc(), b.getI32Type(),
+                                               b.getI32IntegerAttr(i));
+          vec = LLVM::InsertElementOp::create(b, val.getLoc(), vec, leaf, idx);
+        }
+        return castToType(elType, vec, op);
+      }
+    }
 
   } else if (auto VT = dyn_cast<VectorType>(val.getType())) {
     DataLayout dl(op->getParentOfType<ModuleOp>());

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -1080,23 +1080,24 @@ void removeRedundantBlockArgs(
   }
 }
 
-// Extract values from struct or array and insert them into a vector
-Value buildVector(OpBuilder &b, Value val, unsigned numElements,
-                  Type elemType) {
-  SmallVector<Value> extracted;
-  for (unsigned i = 0; i < numElements; i++) {
-    extracted.push_back(LLVM::ExtractValueOp::create(b, val.getLoc(), val, i));
+// Recursively extract all scalar leaves from a nested struct/array aggregate
+static void collectLeaves(OpBuilder &b, Value val, SmallVectorImpl<Value> &leaves) {
+  Type t = val.getType();
+  if (auto ST = dyn_cast<LLVM::LLVMStructType>(t)) {
+    for (unsigned i = 0; i < ST.getBody().size(); i++) {
+      Value extracted =
+          LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
+      collectLeaves(b, extracted, leaves);
+    }
+  } else if (auto AT = dyn_cast<LLVM::LLVMArrayType>(t)) {
+    for (unsigned i = 0; i < AT.getNumElements(); i++) {
+      Value extracted =
+          LLVM::ExtractValueOp::create(b, val.getLoc(), val, i);
+      collectLeaves(b, extracted, leaves);
+    }
+  } else {
+    leaves.push_back(val);
   }
-
-  auto vecType = VectorType::get(numElements, elemType);
-  Value vec = LLVM::PoisonOp::create(b, val.getLoc(), vecType);
-  for (unsigned i = 0; i < extracted.size(); i++) {
-    Value idx = LLVM::ConstantOp::create(b, val.getLoc(), b.getI32Type(),
-                                         b.getI32IntegerAttr(i));
-    vec =
-        LLVM::InsertElementOp::create(b, val.getLoc(), vec, extracted[i], idx);
-  }
-  return vec;
 }
 
 Value castToType(Type elType, Value val, Operation *op) {
@@ -1122,25 +1123,25 @@ Value castToType(Type elType, Value val, Operation *op) {
       return LLVM::InsertValueOp::create(b, val.getLoc(), ud, c0,
                                          b.getDenseI64ArrayAttr({0}));
     }
-  } else if (auto ST = dyn_cast<LLVM::LLVMStructType>(val.getType())) {
-    if (ST.getBody().size() == 1) {
-      auto extractedVal = LLVM::ExtractValueOp::create(b, val.getLoc(), val, 0);
-      return castToType(elType, extractedVal, op);
-    } else {
-      Type elemType = ST.getBody()[0];
-      if (llvm::all_of(ST.getBody(), [&](Type t) {
-            return t == elemType && isa<VectorElementTypeInterface>(t);
-          })) {
-        Value vec = buildVector(b, val, ST.getBody().size(), elemType);
-        return castToType(elType, vec, op);
-      }
+  } else if (isa<LLVM::LLVMStructType, LLVM::LLVMArrayType>(val.getType())) {
+    SmallVector<Value> leaves;
+    collectLeaves(b, val, leaves);
+    assert(!leaves.empty());
+    // Check that leaves are all the same type
+    Type leafType = leaves[0].getType();
+    assert(llvm::all_of(leaves, [&](Value v) { 
+      return v.getType() == leafType; 
+    }));
+    auto vecType = VectorType::get(leaves.size(), leafType);
+    Value vec = LLVM::PoisonOp::create(b, val.getLoc(), vecType);
+    for (auto [i, leaf] : llvm::enumerate(leaves)) {
+      Value idx = LLVM::ConstantOp::create(b, val.getLoc(), b.getI32Type(),
+                                          b.getI32IntegerAttr(i));
+      vec =
+          LLVM::InsertElementOp::create(b, val.getLoc(), vec, leaf, idx);
     }
-  } else if (auto AT = dyn_cast<LLVM::LLVMArrayType>(val.getType())) {
-    Type elemType = AT.getElementType();
-    if (isa<VectorElementTypeInterface>(elemType)) {
-      Value vec = buildVector(b, val, AT.getNumElements(), elemType);
-      return castToType(elType, vec, op);
-    }
+    return castToType(elType, vec, op);
+
   } else if (auto VT = dyn_cast<VectorType>(val.getType())) {
     if (isa<IntegerType>(elType)) {
       DataLayout dl(op->getParentOfType<ModuleOp>());

--- a/test/lit_tests/mem2reg_type_casting.mlir
+++ b/test/lit_tests/mem2reg_type_casting.mlir
@@ -244,3 +244,39 @@ llvm.func @forward_nested_aggregate_to_integer(%val: !llvm.struct<(array<2 x arr
 // CHECK-NEXT: %[[BC:.*]] = llvm.bitcast %[[V3]] : vector<4xf32> to i128
 // CHECK-NEXT: llvm.return %[[BC]] : i128
 // CHECK-NEXT: }
+
+// -----
+
+// Nested struct A{B} stored, inner struct B loaded
+
+llvm.func @forward_outer_to_inner_struct(%val: !llvm.struct<(struct<(array<100 x i8>)>)>) -> !llvm.struct<(array<100 x i8>)> {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x !llvm.struct<(struct<(array<100 x i8>)>)> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.struct<(struct<(array<100 x i8>)>)>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> !llvm.struct<(array<100 x i8>)>
+  llvm.return %0 : !llvm.struct<(array<100 x i8>)>
+}
+
+// CHECK: llvm.func @forward_outer_to_inner_struct(%[[VAL:.*]]: !llvm.struct<(struct<(array<100 x i8>)>)>) -> !llvm.struct<(array<100 x i8>)> {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EV:.*]] = llvm.extractvalue %[[VAL]][0] : !llvm.struct<(struct<(array<100 x i8>)>)>
+// CHECK-NEXT: llvm.return %[[EV]] : !llvm.struct<(array<100 x i8>)>
+// CHECK-NEXT: }
+
+// -----
+
+// Nested array stored, inner array loaded
+
+llvm.func @forward_outer_to_inner_array(%val: !llvm.array<1 x array<100 x i8>>) -> !llvm.array<100 x i8> {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x !llvm.array<1 x array<100 x i8>> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.array<1 x array<100 x i8>>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> !llvm.array<100 x i8>
+  llvm.return %0 : !llvm.array<100 x i8>
+}
+
+// CHECK: llvm.func @forward_outer_to_inner_array(%arg0: !llvm.array<1 x array<100 x i8>>) -> !llvm.array<100 x i8> {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EV:.*]] = llvm.extractvalue %arg0[0] : !llvm.array<1 x array<100 x i8>>
+// CHECK-NEXT: llvm.return %[[EV]] : !llvm.array<100 x i8>
+// CHECK-NEXT: }

--- a/test/lit_tests/mem2reg_type_casting.mlir
+++ b/test/lit_tests/mem2reg_type_casting.mlir
@@ -90,6 +90,7 @@ llvm.func @forward_int_to_float(%val: i32) -> f32 {
 
 // -----
 
+
 // Scalar (i32) stored, single-field struct { i32 } loaded
 
 llvm.func @forward_scalar_to_single_field_struct(%val: i32) -> !llvm.struct<(i32)> {
@@ -208,4 +209,38 @@ llvm.func @forward_vector_to_int_bitcast(%val: vector<4xi8>) -> i32 {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[BC:.*]] = llvm.bitcast %[[VAL]] : vector<4xi8> to i32
 // CHECK-NEXT: llvm.return %[[BC]] : i32
+// CHECK-NEXT: }
+
+// -----
+
+// Nested struct/array stored, IntegerType (i128, 16 bytes) loaded
+
+llvm.func @forward_nested_aggregate_to_integer(%val: !llvm.struct<(array<2 x array<2 x f32>>)>) -> i128 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %al = llvm.alloca %c1 x !llvm.struct<(array<2 x array<2 x f32>>)> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.struct<(array<2 x array<2 x f32>>)>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> i128
+  llvm.return %0 : i128
+}
+
+// CHECK: llvm.func @forward_nested_aggregate_to_integer(%[[VAL:.*]]: !llvm.struct<(array<2 x array<2 x f32>>)>) -> i128 {
+// CHECK-NEXT: %[[C:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EX0:.*]] = llvm.extractvalue %[[VAL]][0] : !llvm.struct<(array<2 x array<2 x f32>>)>
+// CHECK-NEXT: %[[EX1:.*]] = llvm.extractvalue %[[EX0]][0] : !llvm.array<2 x array<2 x f32>>
+// CHECK-NEXT: %[[EX2:.*]] = llvm.extractvalue %[[EX1]][0] : !llvm.array<2 x f32>
+// CHECK-NEXT: %[[EX3:.*]] = llvm.extractvalue %[[EX1]][1] : !llvm.array<2 x f32>
+// CHECK-NEXT: %[[EX4:.*]] = llvm.extractvalue %[[EX0]][1] : !llvm.array<2 x array<2 x f32>>
+// CHECK-NEXT: %[[EX5:.*]] = llvm.extractvalue %[[EX4]][0] : !llvm.array<2 x f32>
+// CHECK-NEXT: %[[EX6:.*]] = llvm.extractvalue %[[EX4]][1] : !llvm.array<2 x f32>
+// CHECK-NEXT: %[[PSN:.*]] = llvm.mlir.poison : vector<4xf32>
+// CHECK-NEXT: %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[V0:.*]] = llvm.insertelement %[[EX2]], %[[PSN]][%[[C0]] : i32] : vector<4xf32>
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[V1:.*]] = llvm.insertelement %[[EX3]], %[[V0]][%[[C1]] : i32] : vector<4xf32>
+// CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT: %[[V2:.*]] = llvm.insertelement %[[EX5]], %[[V1]][%[[C2]] : i32] : vector<4xf32>
+// CHECK-NEXT: %[[C3:.*]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK-NEXT: %[[V3:.*]] = llvm.insertelement %[[EX6]], %[[V2]][%[[C3]] : i32] : vector<4xf32>
+// CHECK-NEXT: %[[BC:.*]] = llvm.bitcast %[[V3]] : vector<4xf32> to i128
+// CHECK-NEXT: llvm.return %[[BC]] : i128
 // CHECK-NEXT: }

--- a/test/lit_tests/mem2reg_type_casting.mlir
+++ b/test/lit_tests/mem2reg_type_casting.mlir
@@ -249,34 +249,34 @@ llvm.func @forward_nested_aggregate_to_integer(%val: !llvm.struct<(array<2 x arr
 
 // Nested struct A{B} stored, inner struct B loaded
 
-llvm.func @forward_outer_to_inner_struct(%val: !llvm.struct<(struct<(array<100 x i8>)>)>) -> !llvm.struct<(array<100 x i8>)> {
+llvm.func @forward_outer_to_inner_struct(%val: !llvm.struct<(struct<(array<100000000 x i8>)>)>) -> !llvm.struct<(array<100000000 x i8>)> {
   %c1 = llvm.mlir.constant(1 : i32) : i32
-  %al = llvm.alloca %c1 x !llvm.struct<(struct<(array<100 x i8>)>)> : (i32) -> !llvm.ptr
-  llvm.store %val, %al : !llvm.struct<(struct<(array<100 x i8>)>)>, !llvm.ptr
-  %0 = llvm.load %al : !llvm.ptr -> !llvm.struct<(array<100 x i8>)>
-  llvm.return %0 : !llvm.struct<(array<100 x i8>)>
+  %al = llvm.alloca %c1 x !llvm.struct<(struct<(array<100000000 x i8>)>)> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.struct<(struct<(array<100000000 x i8>)>)>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> !llvm.struct<(array<100000000 x i8>)>
+  llvm.return %0 : !llvm.struct<(array<100000000 x i8>)>
 }
 
-// CHECK: llvm.func @forward_outer_to_inner_struct(%[[VAL:.*]]: !llvm.struct<(struct<(array<100 x i8>)>)>) -> !llvm.struct<(array<100 x i8>)> {
+// CHECK: llvm.func @forward_outer_to_inner_struct(%[[VAL:.*]]: !llvm.struct<(struct<(array<100000000 x i8>)>)>) -> !llvm.struct<(array<100000000 x i8>)> {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT: %[[EV:.*]] = llvm.extractvalue %[[VAL]][0] : !llvm.struct<(struct<(array<100 x i8>)>)>
-// CHECK-NEXT: llvm.return %[[EV]] : !llvm.struct<(array<100 x i8>)>
+// CHECK-NEXT: %[[EV:.*]] = llvm.extractvalue %[[VAL]][0] : !llvm.struct<(struct<(array<100000000 x i8>)>)>
+// CHECK-NEXT: llvm.return %[[EV]] : !llvm.struct<(array<100000000 x i8>)>
 // CHECK-NEXT: }
 
 // -----
 
 // Nested array stored, inner array loaded
 
-llvm.func @forward_outer_to_inner_array(%val: !llvm.array<1 x array<100 x i8>>) -> !llvm.array<100 x i8> {
+llvm.func @forward_outer_to_inner_array(%val: !llvm.array<1 x array<100000000 x i8>>) -> !llvm.array<100000000 x i8> {
   %c1 = llvm.mlir.constant(1 : i32) : i32
-  %al = llvm.alloca %c1 x !llvm.array<1 x array<100 x i8>> : (i32) -> !llvm.ptr
-  llvm.store %val, %al : !llvm.array<1 x array<100 x i8>>, !llvm.ptr
-  %0 = llvm.load %al : !llvm.ptr -> !llvm.array<100 x i8>
-  llvm.return %0 : !llvm.array<100 x i8>
+  %al = llvm.alloca %c1 x !llvm.array<1 x array<100000000 x i8>> : (i32) -> !llvm.ptr
+  llvm.store %val, %al : !llvm.array<1 x array<100000000 x i8>>, !llvm.ptr
+  %0 = llvm.load %al : !llvm.ptr -> !llvm.array<100000000 x i8>
+  llvm.return %0 : !llvm.array<100000000 x i8>
 }
 
-// CHECK: llvm.func @forward_outer_to_inner_array(%arg0: !llvm.array<1 x array<100 x i8>>) -> !llvm.array<100 x i8> {
+// CHECK: llvm.func @forward_outer_to_inner_array(%arg0: !llvm.array<1 x array<100000000 x i8>>) -> !llvm.array<100000000 x i8> {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT: %[[EV:.*]] = llvm.extractvalue %arg0[0] : !llvm.array<1 x array<100 x i8>>
-// CHECK-NEXT: llvm.return %[[EV]] : !llvm.array<100 x i8>
+// CHECK-NEXT: %[[EV:.*]] = llvm.extractvalue %arg0[0] : !llvm.array<1 x array<100000000 x i8>>
+// CHECK-NEXT: llvm.return %[[EV]] : !llvm.array<100000000 x i8>
 // CHECK-NEXT: }


### PR DESCRIPTION
Adds ability to type cast from more complex aggregates, including those with multiple levels of nested structs and arrays, by recursively unwrapping the aggregates. This should prevent the code from crashing in these cases when running `polygeist-mem2reg`.