### PR TITLE
feat: fold concat of reverse slices into stablehlo.reverse

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -388,6 +388,7 @@ static void addBaseTransformPasses(std::vector<std::string> &list,
   list.push_back("slice_elementwise<1>");
   list.push_back("dot_reshape_dot<1>");
   list.push_back("concat_fuse<1>");
+  list.push_back("concat_slices_to_reverse<1>");
   list.push_back("concat_push_binop_add<1>");
   list.push_back("concat_push_binop_mul<1>");
   list.push_back("reduce_concat<1>");

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6219,7 +6219,8 @@ struct ConcatFuse final
   }
 };
 
-// concat(slice(src,[N-1:N,...]), slice(src,[N-2:N-1,...]), ..., slice(src,[0:1,...]), dim=D)
+// concat(slice(src,[N-1:N,...]), slice(src,[N-2:N-1,...]), ...,
+// slice(src,[0:1,...]), dim=D)
 // -> reverse(src, dims=[D])
 struct ConcatSlicesToReverse final
     : CheckedOpRewritePattern<stablehlo::ConcatenateOp, ConcatSlicesToReverse> {
@@ -6228,34 +6229,30 @@ struct ConcatSlicesToReverse final
   LogicalResult matchAndRewriteImpl(stablehlo::ConcatenateOp op,
                                     PatternRewriter &rewriter) const {
     auto concatDim = op.getDimension();
+    auto operands = op.getOperands();
+    int64_t N = (int64_t)operands.size();
 
-    SmallVector<stablehlo::SliceOp> slices;
-    for (auto operand : op.getOperands()) {
-      auto slice = operand.getDefiningOp<stablehlo::SliceOp>();
-      if (!slice)
-        return failure();
-      slices.push_back(slice);
-    }
-
-    if (slices.empty())
+    if (N == 0)
       return failure();
 
-    Value src = slices[0].getOperand();
-    for (auto slice : slices)
-      if (slice.getOperand() != src)
-        return failure();
+    auto firstSlice = operands[0].getDefiningOp<stablehlo::SliceOp>();
+    if (!firstSlice)
+      return failure();
 
+    Value src = firstSlice.getOperand();
     auto srcType = cast<RankedTensorType>(src.getType());
     int64_t rank = srcType.getRank();
-    int64_t N = (int64_t)slices.size();
 
     if (srcType.getShape()[concatDim] != N)
       return failure();
 
     for (int64_t i = 0; i < N; ++i) {
-      auto starts = slices[i].getStartIndices();
-      auto limits = slices[i].getLimitIndices();
-      auto strides = slices[i].getStrides();
+      auto slice = operands[i].getDefiningOp<stablehlo::SliceOp>();
+      if (!slice || slice.getOperand() != src)
+        return failure();
+      auto starts = slice.getStartIndices();
+      auto limits = slice.getLimitIndices();
+      auto strides = slice.getStrides();
       for (int64_t d = 0; d < rank; ++d) {
         if (strides[d] != 1)
           return failure();
@@ -13219,8 +13216,7 @@ struct DUSSliceSimplify final
         });
 
     LLVM_DEBUG(
-        for (auto [idx, operandSize, updateSize]
-             : llvm::zip_equal(
+        for (auto [idx, operandSize, updateSize] : llvm::zip_equal(
                  newDusIndices,
                  cast<RankedTensorType>(preSliceOperand.getType()).getShape(),
                  cast<RankedTensorType>(preSliceUpdate.getType()).getShape())) {
@@ -35872,13 +35868,13 @@ struct EnzymeHLOOptPass
                  RecognizeFromConstant>(max_constant_expansion, context,
                                         PatternBenefit(65000));
 
-patterns.add<
+    patterns.add<
         ConvertConcat, DynamicUpdateToConcat, SliceOfDynamicUpdate,
         SliceOfUpdateWithoutCorners, SliceElementwise, SliceReshapeElementwise,
         DynamicSliceElementwise, SlicePad, SliceReshapePad, ReshapeSliceReshape,
         DotReshapeDot, ChloInfConstProp, CHLOLGammaConstProp, GammaConstProp,
         TGammaConstProp, LGammaConstProp, BinomialProgressConstProp, ConcatFuse,
-        ConcatToBroadcast, PadPad, PadReshapePad,
+        ConcatToBroadcast, ConcatSlicesToReverse, PadPad, PadReshapePad,
         ConcatPushBinop<stablehlo::AddOp>, ConcatPushBinop<stablehlo::MulOp>,
         ScatterToDynamicUpdateSlice, ReduceConcat, ConcatSlice, ConcatMultiPad,
         ConcatWrap, WidenWrap, WidenExtend, ConcatConcatAxisSwap, SliceConcat,
@@ -35888,7 +35884,7 @@ patterns.add<
         BinBroadcastSplat<stablehlo::MulOp>, RotatePad, ConjReal,
         ConvertMulConvert, ConvertBinopConvert<stablehlo::MinOp>,
         ConvertBinopConvert<stablehlo::MaxOp>, NegateReduceWindowSub>(context);
-        
+
     // Unary constant propagation patterns
     patterns
         .add<UnaryConstProp<stablehlo::NotOp, stablehlo::notOp>,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -6219,6 +6219,62 @@ struct ConcatFuse final
   }
 };
 
+// concat(slice(src,[N-1:N,...]), slice(src,[N-2:N-1,...]), ..., slice(src,[0:1,...]), dim=D)
+// -> reverse(src, dims=[D])
+struct ConcatSlicesToReverse final
+    : CheckedOpRewritePattern<stablehlo::ConcatenateOp, ConcatSlicesToReverse> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ConcatenateOp op,
+                                    PatternRewriter &rewriter) const {
+    auto concatDim = op.getDimension();
+
+    SmallVector<stablehlo::SliceOp> slices;
+    for (auto operand : op.getOperands()) {
+      auto slice = operand.getDefiningOp<stablehlo::SliceOp>();
+      if (!slice)
+        return failure();
+      slices.push_back(slice);
+    }
+
+    if (slices.empty())
+      return failure();
+
+    Value src = slices[0].getOperand();
+    for (auto slice : slices)
+      if (slice.getOperand() != src)
+        return failure();
+
+    auto srcType = cast<RankedTensorType>(src.getType());
+    int64_t rank = srcType.getRank();
+    int64_t N = (int64_t)slices.size();
+
+    if (srcType.getShape()[concatDim] != N)
+      return failure();
+
+    for (int64_t i = 0; i < N; ++i) {
+      auto starts = slices[i].getStartIndices();
+      auto limits = slices[i].getLimitIndices();
+      auto strides = slices[i].getStrides();
+      for (int64_t d = 0; d < rank; ++d) {
+        if (strides[d] != 1)
+          return failure();
+        if (d == (int64_t)concatDim) {
+          if (starts[d] != N - 1 - i || limits[d] != N - i)
+            return failure();
+        } else {
+          if (starts[d] != 0 || limits[d] != srcType.getShape()[d])
+            return failure();
+        }
+      }
+    }
+
+    rewriter.replaceOpWithNewOp<stablehlo::ReverseOp>(
+        op, src, SmallVector<int64_t>{(int64_t)concatDim});
+    return success();
+  }
+};
+
 struct ConcatToBroadcast final
     : CheckedOpRewritePattern<stablehlo::ConcatenateOp, ConcatToBroadcast> {
   using CheckedOpRewritePattern::CheckedOpRewritePattern;
@@ -35816,7 +35872,7 @@ struct EnzymeHLOOptPass
                  RecognizeFromConstant>(max_constant_expansion, context,
                                         PatternBenefit(65000));
 
-    patterns.add<
+patterns.add<
         ConvertConcat, DynamicUpdateToConcat, SliceOfDynamicUpdate,
         SliceOfUpdateWithoutCorners, SliceElementwise, SliceReshapeElementwise,
         DynamicSliceElementwise, SlicePad, SliceReshapePad, ReshapeSliceReshape,
@@ -35832,7 +35888,7 @@ struct EnzymeHLOOptPass
         BinBroadcastSplat<stablehlo::MulOp>, RotatePad, ConjReal,
         ConvertMulConvert, ConvertBinopConvert<stablehlo::MinOp>,
         ConvertBinopConvert<stablehlo::MaxOp>, NegateReduceWindowSub>(context);
-
+        
     // Unary constant propagation patterns
     patterns
         .add<UnaryConstProp<stablehlo::NotOp, stablehlo::notOp>,

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -13216,7 +13216,8 @@ struct DUSSliceSimplify final
         });
 
     LLVM_DEBUG(
-        for (auto [idx, operandSize, updateSize] : llvm::zip_equal(
+        for (auto [idx, operandSize, updateSize]
+             : llvm::zip_equal(
                  newDusIndices,
                  cast<RankedTensorType>(preSliceOperand.getType()).getShape(),
                  cast<RankedTensorType>(preSliceUpdate.getType()).getShape())) {

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1588,6 +1588,10 @@ def ConcatToBroadcastPatterns : EnzymeHLOPatternOp<
     "concat_to_broadcast"> {
   let patterns = ["ConcatToBroadcast"];
 }
+def ConcatSlicesToReversePatterns : EnzymeHLOPatternOp<
+    "concat_slices_to_reverse"> {
+  let patterns = ["ConcatSlicesToReverse"];
+}
 def DotReshapePadPatterns : EnzymeHLOPatternOp<
     "dot_reshape_pad"> {
   let patterns = ["DotReshapePad"];

--- a/test/lit_tests/concat_slices_to_reverse.mlir
+++ b/test/lit_tests/concat_slices_to_reverse.mlir
@@ -38,3 +38,39 @@ func.func @no_fold_wrong_order(%arg0: tensor<4xf32>) -> tensor<4xf32> {
   return %4 : tensor<4xf32>
   // CHECK-NOT: stablehlo.reverse
 }
+
+// Negative: one operand is not a slice → must not fold
+// CHECK-LABEL: func.func @no_fold_not_all_slices
+func.func @no_fold_not_all_slices(%arg0: tensor<4xf32>, %arg1: tensor<1xf32>) -> tensor<4xf32> {
+  %0 = stablehlo.slice %arg0 [3:4] : (tensor<4xf32>) -> tensor<1xf32>
+  %1 = stablehlo.slice %arg0 [2:3] : (tensor<4xf32>) -> tensor<1xf32>
+  %2 = stablehlo.slice %arg0 [1:2] : (tensor<4xf32>) -> tensor<1xf32>
+  // fourth operand is a plain argument, not a slice
+  %3 = stablehlo.concatenate %0, %1, %2, %arg1, dim = 0 : (tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<4xf32>
+  return %3 : tensor<4xf32>
+  // CHECK-NOT: stablehlo.reverse
+}
+
+// Negative: slices come from different source tensors → must not fold
+// CHECK-LABEL: func.func @no_fold_different_sources
+func.func @no_fold_different_sources(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = stablehlo.slice %arg0 [3:4] : (tensor<4xf32>) -> tensor<1xf32>
+  %1 = stablehlo.slice %arg0 [2:3] : (tensor<4xf32>) -> tensor<1xf32>
+  %2 = stablehlo.slice %arg1 [1:2] : (tensor<4xf32>) -> tensor<1xf32>
+  %3 = stablehlo.slice %arg0 [0:1] : (tensor<4xf32>) -> tensor<1xf32>
+  %4 = stablehlo.concatenate %0, %1, %2, %3, dim = 0 : (tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<4xf32>
+  return %4 : tensor<4xf32>
+  // CHECK-NOT: stablehlo.reverse
+}
+
+// Negative: fewer slices than source extent (N=3, extent=4) → must not fold
+// CHECK-LABEL: func.func @no_fold_incomplete_coverage
+func.func @no_fold_incomplete_coverage(%arg0: tensor<4xf32>) -> tensor<3xf32> {
+  %0 = stablehlo.slice %arg0 [3:4] : (tensor<4xf32>) -> tensor<1xf32>
+  %1 = stablehlo.slice %arg0 [2:3] : (tensor<4xf32>) -> tensor<1xf32>
+  %2 = stablehlo.slice %arg0 [1:2] : (tensor<4xf32>) -> tensor<1xf32>
+  // [0:1] is missing; N=3 but source extent=4
+  %3 = stablehlo.concatenate %0, %1, %2, dim = 0 : (tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<3xf32>
+  return %3 : tensor<3xf32>
+  // CHECK-NOT: stablehlo.reverse
+}

--- a/test/lit_tests/concat_slices_to_reverse.mlir
+++ b/test/lit_tests/concat_slices_to_reverse.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// 3-D tensor: slices along dim 0 in reverse order → stablehlo.reverse
+// CHECK-LABEL: func.func @reverse_dim0
+func.func @reverse_dim0(%arg0: tensor<5x3x10xf32>) -> tensor<5x3x10xf32> {
+  %0 = stablehlo.slice %arg0 [4:5, 0:3, 0:10] : (tensor<5x3x10xf32>) -> tensor<1x3x10xf32>
+  %1 = stablehlo.slice %arg0 [3:4, 0:3, 0:10] : (tensor<5x3x10xf32>) -> tensor<1x3x10xf32>
+  %2 = stablehlo.slice %arg0 [2:3, 0:3, 0:10] : (tensor<5x3x10xf32>) -> tensor<1x3x10xf32>
+  %3 = stablehlo.slice %arg0 [1:2, 0:3, 0:10] : (tensor<5x3x10xf32>) -> tensor<1x3x10xf32>
+  %4 = stablehlo.slice %arg0 [0:1, 0:3, 0:10] : (tensor<5x3x10xf32>) -> tensor<1x3x10xf32>
+  %5 = stablehlo.concatenate %0, %1, %2, %3, %4, dim = 0 : (tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>, tensor<1x3x10xf32>) -> tensor<5x3x10xf32>
+  return %5 : tensor<5x3x10xf32>
+  // CHECK: %[[R:.*]] = stablehlo.reverse %arg0, dims = [0]
+  // CHECK-NEXT: return %[[R]]
+}
+
+// 1-D tensor: simple reverse
+// CHECK-LABEL: func.func @reverse_1d
+func.func @reverse_1d(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = stablehlo.slice %arg0 [3:4] : (tensor<4xf32>) -> tensor<1xf32>
+  %1 = stablehlo.slice %arg0 [2:3] : (tensor<4xf32>) -> tensor<1xf32>
+  %2 = stablehlo.slice %arg0 [1:2] : (tensor<4xf32>) -> tensor<1xf32>
+  %3 = stablehlo.slice %arg0 [0:1] : (tensor<4xf32>) -> tensor<1xf32>
+  %4 = stablehlo.concatenate %0, %1, %2, %3, dim = 0 : (tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<4xf32>
+  return %4 : tensor<4xf32>
+  // CHECK: %[[R:.*]] = stablehlo.reverse %arg0, dims = [0]
+  // CHECK-NEXT: return %[[R]]
+}
+
+// Negative: slices NOT in reverse order → must not fold
+// CHECK-LABEL: func.func @no_fold_wrong_order
+func.func @no_fold_wrong_order(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = stablehlo.slice %arg0 [0:1] : (tensor<4xf32>) -> tensor<1xf32>
+  %1 = stablehlo.slice %arg0 [1:2] : (tensor<4xf32>) -> tensor<1xf32>
+  %2 = stablehlo.slice %arg0 [2:3] : (tensor<4xf32>) -> tensor<1xf32>
+  %3 = stablehlo.slice %arg0 [3:4] : (tensor<4xf32>) -> tensor<1xf32>
+  %4 = stablehlo.concatenate %0, %1, %2, %3, dim = 0 : (tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<4xf32>
+  return %4 : tensor<4xf32>
+  // CHECK-NOT: stablehlo.reverse
+}


### PR DESCRIPTION
Adds ConcatSlicesToReverse canonicalization pattern in EnzymeHLOOpt.cpp 
that detects N unit-stride slices of the same tensor concatenated in 
reverse order and replaces the sequence with a single stablehlo.reverse op.

Changes:
- EnzymeHLOOpt.cpp: added ConcatSlicesToReverse pattern, registered 
  alongside ConcatFuse and ConcatToBroadcast
- test/lit_tests/concat_slices_to_reverse.mlir: 3 test cases (3D positive, 
  1D positive, negative/no-fold case)

Fixes #1409