### PR TITLE
Tessera: loading byref argument types using global variable approach

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -24,7 +24,7 @@ namespace mlir::enzyme::tessera {} // namespace mlir::enzyme::tessera
 
 void DefineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
                      FunctionType type, DenseBoolArrayAttr byRefArgs,
-                     DenseI64ArrayAttr argSizes, bool pure,
+                     DenseI64ArrayAttr globalTypeIndices, bool pure,
                      StringAttr sym_visibility, ArrayRef<NamedAttribute> attrs,
                      ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(SymbolTable::getSymbolAttrName(),
@@ -32,7 +32,7 @@ void DefineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   state.addAttribute(getFunctionTypeAttrName(state.name), TypeAttr::get(type));
   state.addAttribute("pure", builder.getBoolAttr(pure));
   state.addAttribute("byRefArgs", byRefArgs);
-  state.addAttribute("argSizes", argSizes);
+  state.addAttribute("globalTypeIndices", globalTypeIndices);
 
   if (sym_visibility)
     state.addAttribute(getSymVisibilityAttrName(state.name), sym_visibility);

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -24,15 +24,15 @@ namespace mlir::enzyme::tessera {} // namespace mlir::enzyme::tessera
 
 void DefineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
                      FunctionType type, DenseBoolArrayAttr byRefArgs,
-                     DenseI64ArrayAttr globalTypeIndices, bool pure,
-                     StringAttr sym_visibility, ArrayRef<NamedAttribute> attrs,
+                     ArrayAttr byRefTypes, bool pure, StringAttr sym_visibility,
+                     ArrayRef<NamedAttribute> attrs,
                      ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(SymbolTable::getSymbolAttrName(),
                      builder.getStringAttr(name));
   state.addAttribute(getFunctionTypeAttrName(state.name), TypeAttr::get(type));
   state.addAttribute("pure", builder.getBoolAttr(pure));
   state.addAttribute("byRefArgs", byRefArgs);
-  state.addAttribute("globalTypeIndices", globalTypeIndices);
+  state.addAttribute("byRefTypes", byRefTypes);
 
   if (sym_visibility)
     state.addAttribute(getSymVisibilityAttrName(state.name), sym_visibility);
@@ -160,6 +160,20 @@ Attribute DefineOp::getArgAttr(unsigned index, StringRef name) {
           cast<FunctionOpInterface>(getOperation()), index + offset))
     return dict.get(name);
   return nullptr;
+}
+
+LogicalResult DefineOp::verify() {
+  for (Attribute a : getByRefTypes())
+    if (!isa<TypeAttr>(a))
+      return emitOpError("byRefTypes must contain only TypeAttr elements");
+
+  unsigned numByRef = llvm::count(getByRefArgs(), true);
+  if (getByRefTypes().size() != numByRef)
+    return emitOpError("byRefTypes size (")
+           << getByRefTypes().size() << ") must match number of byRef args ("
+           << numByRef << ")";
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -23,15 +23,13 @@ namespace mlir::enzyme::tessera {} // namespace mlir::enzyme::tessera
 //===----------------------------------------------------------------------===//
 
 void DefineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
-                     FunctionType type, DenseBoolArrayAttr byRefArgs,
-                     ArrayAttr byRefTypes, bool pure, StringAttr sym_visibility,
-                     ArrayRef<NamedAttribute> attrs,
+                     FunctionType type, ArrayAttr byRefTypes, bool pure,
+                     StringAttr sym_visibility, ArrayRef<NamedAttribute> attrs,
                      ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(SymbolTable::getSymbolAttrName(),
                      builder.getStringAttr(name));
   state.addAttribute(getFunctionTypeAttrName(state.name), TypeAttr::get(type));
   state.addAttribute("pure", builder.getBoolAttr(pure));
-  state.addAttribute("byRefArgs", byRefArgs);
   state.addAttribute("byRefTypes", byRefTypes);
 
   if (sym_visibility)
@@ -147,7 +145,7 @@ Attribute DefineOp::getSretAttr() {
 // is not present in tessera::CallOp operands. This allows generic
 // FunctionOpInterface callers to use call-side indices directly.
 Attribute DefineOp::getArgAttr(unsigned index, StringAttr name) {
-  int offset = getSretAttr() != nullptr ? 1 : 0;
+  unsigned offset = getSretAttr() != nullptr ? 1 : 0;
   if (auto dict = mlir::function_interface_impl::getArgAttrDict(
           cast<FunctionOpInterface>(getOperation()), index + offset))
     return dict.get(name);
@@ -155,23 +153,39 @@ Attribute DefineOp::getArgAttr(unsigned index, StringAttr name) {
 }
 
 Attribute DefineOp::getArgAttr(unsigned index, StringRef name) {
-  int offset = getSretAttr() != nullptr ? 1 : 0;
+  unsigned offset = getSretAttr() != nullptr ? 1 : 0;
   if (auto dict = mlir::function_interface_impl::getArgAttrDict(
           cast<FunctionOpInterface>(getOperation()), index + offset))
     return dict.get(name);
   return nullptr;
 }
 
+ArrayRef<Attribute> DefineOp::getByRefTypesArray() {
+  return getByRefTypes().getValue();
+}
+
+Type DefineOp::getByRefType(unsigned argIdx) {
+  auto types = getByRefTypesArray();
+  if (argIdx >= types.size())
+    return Type();
+  auto attr = types[argIdx];
+  if (!isa<TypeAttr>(attr))
+    return Type();
+  return cast<TypeAttr>(attr).getValue();
+}
+
 LogicalResult DefineOp::verify() {
   for (Attribute a : getByRefTypes())
-    if (!isa<TypeAttr>(a))
-      return emitOpError("byRefTypes must contain only TypeAttr elements");
+    if (!isa<TypeAttr>(a) && !isa<UnitAttr>(a))
+      return emitOpError(
+                 "byRefTypes entry must be TypeAttr or UnitAttr, but got ")
+             << a;
 
-  unsigned numByRef = llvm::count(getByRefArgs(), true);
-  if (getByRefTypes().size() != numByRef)
+  unsigned offset = getSretAttr() != nullptr ? 1 : 0;
+  if (getByRefTypes().size() != getFunctionType().getNumInputs() - offset)
     return emitOpError("byRefTypes size (")
-           << getByRefTypes().size() << ") must match number of byRef args ("
-           << numByRef << ")";
+           << getByRefTypes().size() << ") must match number of args ("
+           << getFunctionType().getNumInputs() - offset << ")";
 
   return success();
 }
@@ -204,21 +218,19 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   if (!has_sret && fnType.getNumInputs() != getNumOperands())
     return emitOpError("incorrect number of operands for callee");
 
-  auto byRefArgs = fn.getByRefArgs();
-
   // Allow type mismatch only for byref pointer args that have been converted
   // to values
-  int argOffset = has_sret ? 1 : 0;
+  unsigned argOffset = has_sret ? 1 : 0;
   for (unsigned i = 0, e = getNumOperands(); i != e; ++i) {
     if (getOperand(i).getType() == fnType.getInput(i + argOffset))
       continue;
     if (isa<LLVM::LLVMPointerType>(fnType.getInput(i + argOffset)) &&
         (fn.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName()) ||
-         byRefArgs[i]))
+         fn.getByRefType(i)))
       continue;
     return emitOpError("operand type mismatch: expected operand type ")
-           << fnType.getInput(i) << ", but provided " << getOperand(i).getType()
-           << " for operand number " << i;
+           << fnType.getInput(i + argOffset) << ", but provided "
+           << getOperand(i).getType() << " for operand number " << i;
   }
 
   // If tessera.define has sret attribute,
@@ -236,7 +248,7 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
              << sretType << " but got " << getResult(0).getType();
   }
 
-  int offset = has_sret ? 1 : 0;
+  unsigned offset = has_sret ? 1 : 0;
   for (unsigned i = 0, e = fnType.getNumResults(); i != e; ++i)
     if (getResult(i + offset).getType() != fnType.getResult(i)) {
       auto diag = emitOpError("result type mismatch at index ") << i + offset;

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -166,11 +166,10 @@ ArrayRef<Attribute> DefineOp::getByRefTypesArray() {
 
 Type DefineOp::getByRefType(unsigned argIdx) {
   auto types = getByRefTypesArray();
-  if (argIdx >= types.size())
-    return Type();
+  assert(argIdx < types.size() && "argIdx out of bounds in getByRefType");
   auto attr = types[argIdx];
   if (!isa<TypeAttr>(attr))
-    return Type();
+    return nullptr;
   return cast<TypeAttr>(attr).getValue();
 }
 

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
@@ -29,7 +29,6 @@ def DefineOp : TesseraOp<"define", [
 
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
-	                     DenseBoolArrayAttr:$byRefArgs,
 	                     ArrayAttr:$byRefTypes,
                        BoolAttr:$pure,
                        OptionalAttr<StrAttr>:$sym_visibility,
@@ -40,7 +39,6 @@ def DefineOp : TesseraOp<"define", [
 
   let builders = [OpBuilder<(ins
     "StringRef":$name, "FunctionType":$type,
-    "DenseBoolArrayAttr":$byRefArgs,
     "ArrayAttr":$byRefTypes,
     "bool":$pure,
     CArg<"StringAttr", "{}">:$sym_visibility,
@@ -65,6 +63,16 @@ def DefineOp : TesseraOp<"define", [
     void cloneInto(DefineOp dest, IRMapping &mapper);
 
     ::mlir::Attribute getSretAttr();
+
+    // Returns the stored byref-type array as an ArrayRef. Index convention: sret-excluded
+    // argument index, since it is based on the argument list in the annotation string,
+    // which does not include the sret argument. Each entry is either a TypeAttr
+    // (arg is byref) or null (arg is not byref).
+    ::mlir::ArrayRef<Attribute> getByRefTypesArray();
+
+    // Returns the byref type for a given argument index, or null if the argument is not byref.
+    ::mlir::Type getByRefType(unsigned argIdx);
+
 
     //===------------------------------------------------------------------===//
     // FunctionOpInterface Methods

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
@@ -30,7 +30,7 @@ def DefineOp : TesseraOp<"define", [
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
 	                     DenseBoolArrayAttr:$byRefArgs,
-	                     DenseI64ArrayAttr:$globalTypeIndices,
+	                     ArrayAttr:$byRefTypes,
                        BoolAttr:$pure,
                        OptionalAttr<StrAttr>:$sym_visibility,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
@@ -41,7 +41,7 @@ def DefineOp : TesseraOp<"define", [
   let builders = [OpBuilder<(ins
     "StringRef":$name, "FunctionType":$type,
     "DenseBoolArrayAttr":$byRefArgs,
-    "DenseI64ArrayAttr":$globalTypeIndices,
+    "ArrayAttr":$byRefTypes,
     "bool":$pure,
     CArg<"StringAttr", "{}">:$sym_visibility,
     CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
@@ -94,6 +94,7 @@ def DefineOp : TesseraOp<"define", [
 
   }];
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
@@ -30,7 +30,7 @@ def DefineOp : TesseraOp<"define", [
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
 	                     DenseBoolArrayAttr:$byRefArgs,
-	                     DenseI64ArrayAttr:$argSizes,
+	                     DenseI64ArrayAttr:$globalTypeIndices,
                        BoolAttr:$pure,
                        OptionalAttr<StrAttr>:$sym_visibility,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
@@ -41,7 +41,7 @@ def DefineOp : TesseraOp<"define", [
   let builders = [OpBuilder<(ins
     "StringRef":$name, "FunctionType":$type,
     "DenseBoolArrayAttr":$byRefArgs,
-    "DenseI64ArrayAttr":$argSizes,
+    "DenseI64ArrayAttr":$globalTypeIndices,
     "bool":$pure,
     CArg<"StringAttr", "{}">:$sym_visibility,
     CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -92,23 +92,25 @@ public:
     }
 
     // Parse sizes of args
-    SmallVector<int64_t> sizes;
-    StringRef sizeStr = raw.substr(raw.find(')') + 1);
-    if (!sizeStr.empty() && sizeStr.consume_front(":")) {
-      SmallVector<StringRef> sizeParts;
-      sizeStr.split(sizeParts, ',');
-      for (auto s : sizeParts) {
-        int64_t size;
-        s.trim().getAsInteger(10, size);
-        sizes.push_back(size);
+    SmallVector<int64_t> globalTypeIndices;
+    StringRef indicesStr = raw.substr(raw.find(')') + 1);
+    if (!indicesStr.empty() && indicesStr.consume_front(":globals=")) {
+      SmallVector<StringRef> indexList;
+      indicesStr.split(indexList, ',');
+      for (auto i : indexList) {
+        int64_t index;
+        i.trim().getAsInteger(10, index);
+        globalTypeIndices.push_back(index);
       }
     }
 
-    // Make sure number of arguments matches number of sizes provided
-    if (byRefArgs.size() != sizes.size()) {
-      funcOp->emitError("tessera: number of arguments (")
-          << byRefArgs.size() << ") does not match number of sizes ("
-          << sizes.size() << ")";
+    // Make sure number of arguments marked byref matches number of global
+    // indices provided
+    unsigned numByref = llvm::count(byRefArgs, true);
+    if (numByref != globalTypeIndices.size()) {
+      funcOp->emitError("tessera: number of byref arguments (")
+          << numByref << ") does not match number of global indices ("
+          << globalTypeIndices.size() << ")";
       return failure();
     }
 
@@ -133,7 +135,7 @@ public:
     auto tesseraDefineOp = tessera::DefineOp::create(
         rewriter, funcOp.getLoc(), tesseraName.str(), fnType,
         DenseBoolArrayAttr::get(ctx, byRefArgs),
-        DenseI64ArrayAttr::get(ctx, sizes), isPure);
+        DenseI64ArrayAttr::get(ctx, globalTypeIndices), isPure);
 
     // Copy over all attributes other than the function name and type
     // and tessera_op / pure_tessera_op attribute.
@@ -169,12 +171,13 @@ public:
   LogicalResult matchAndRewrite(LLVM::CallOp callOp,
                                 PatternRewriter &rewriter) const override {
 
+    auto module = callOp->getParentOfType<ModuleOp>();
+
     auto calleeAttr = callOp.getCalleeAttr();
     if (!calleeAttr)
       return failure();
 
-    auto callee = SymbolTable::lookupSymbolIn(
-        callOp->getParentOfType<ModuleOp>(), calleeAttr);
+    auto callee = SymbolTable::lookupSymbolIn(module, calleeAttr);
     // Only rewrite if callee is a tessera.define op
     auto defineOp = dyn_cast_or_null<tessera::DefineOp>(callee);
     if (!defineOp)
@@ -207,8 +210,13 @@ public:
       }
     }
 
+    // Only arguments marked byref will have corresponding global indices, since
+    // they are the only ones with global variables created for them. The sizes
+    // of byRefArgs and globalTypeIndices therefore may not match, but the
+    // number of true values in byRefArgs should match the number of
+    // globalTypeIndices.
     auto byRefArgs = defineOp.getByRefArgs();
-    auto argSizes = defineOp.getArgSizes();
+    auto globalTypeIndices = defineOp.getGlobalTypeIndices();
 
     SmallVector<Value> newOperands;
     SmallVector<int32_t> loadedOperands;
@@ -217,6 +225,7 @@ public:
     // byVal attribute or was marked as byRef by the user, load the value
     // from the pointer and store that as the new operand
     int argOffset = sretPtr ? 1 : 0;
+    unsigned byrefCount = 0;
     for (unsigned i = 0; i < operands.size() - argOffset; i++) {
       auto operand = callOp.getOperand(i + argOffset);
 
@@ -225,13 +234,19 @@ public:
         continue;
       }
 
-      // Determine whether to load pointer and how many bytes to load
+      // Determine whether to load pointer and what type to load based on byVal
+      // attribute or type stored in global variable for byref argument
       Type pointeeType;
       if (auto byValAttr =
               defineOp.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName())) {
         pointeeType = cast<TypeAttr>(byValAttr).getValue();
       } else if (byRefArgs[i]) {
-        pointeeType = IntegerType::get(rewriter.getContext(), argSizes[i] * 8);
+        auto idx = globalTypeIndices[byrefCount++];
+        std::string suffix = "__tessera_byref_arg_type_" + std::to_string(idx);
+        for (auto global : module.getOps<mlir::LLVM::GlobalOp>()) {
+          if (global.getSymName().ends_with(suffix))
+            pointeeType = global.getType();
+        }
       }
 
       if (pointeeType) {

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -68,10 +68,12 @@ public:
     if (!tesseraOpAttr)
       return failure();
 
-    // Parse the tessera op attribute to extract the op name, argument passing
-    // style, and argument sizes. The attribute is expected to be in the format:
-    // "tessera_op(arg1:byref, arg2, ...):size1,size2,..." or
-    // "pure_tessera_op(arg1:byref, arg2, ...):size1,size2,..."
+    // Parse the tessera op attribute, which is expected to be in the format:
+    // "tessera_op(arg1:byref, arg2, ...):globals=index1,..." or
+    // "pure_tessera_op(arg1:byref, arg2, ...):globals=index1,..." where
+    // index1,... corresponds positionally, in left-to-right order, to the byref
+    // args in the arg list above, and are used to look up the types of the
+    // byref args.
     StringRef raw = tesseraOpAttr.getValue();
 
     // Parse op name (everything before the '(')
@@ -79,35 +81,46 @@ public:
 
     // Parse args in parentheses
     StringRef argList = raw.slice(raw.find('(') + 1, raw.find(')'));
-    SmallVector<bool> byRefArgs;
 
+    // Parse indices after ":globals=" (order corresponds to order byref
+    // args appear in argList)
+    SmallVector<StringRef> indexList;
+    StringRef indicesStr = raw.substr(raw.find(')') + 1);
+    if (!indicesStr.empty() && indicesStr.consume_front(":globals=")) {
+      indicesStr.split(indexList, ',');
+    }
+
+    // Identify which args are marked byref and look up their types in
+    // byRefTypesByIndex map
+    SmallVector<Attribute> byRefTypes;
+    unsigned numByRefFound = 0;
     if (!argList.trim().empty()) {
       SmallVector<StringRef> argParts;
       argList.split(argParts, ',');
-      for (auto arg : argParts) {
-        arg = arg.trim();
-        if (arg.contains(":byref") || arg.contains(": byref")) {
-          byRefArgs.push_back(true);
-        } else {
-          byRefArgs.push_back(false);
-        }
-      }
-    }
+      for (unsigned i = 0, e = argParts.size(); i != e; ++i) {
+        StringRef arg = argParts[i].trim();
 
-    // Find the types of the byref arguments by looking for global variables
-    // with names that match the pattern "__tessera_byref_arg_type_<index>"
-    // where <index> is a number parsed in the tessera_op attribute after
-    // "globals=".
-    SmallVector<Attribute> byRefTypes;
-    StringRef indicesStr = raw.substr(raw.find(')') + 1);
-    if (!indicesStr.empty() && indicesStr.consume_front(":globals=")) {
-      SmallVector<StringRef> indexList;
-      indicesStr.split(indexList, ',');
-      for (auto i : indexList) {
-        i = i.trim();
+        // Check if arg is marked as byref. If not, push a unit attribute so
+        // that the byRefTypes array has the same size as the number of args.
+        if (!arg.contains(":byref") && !arg.contains(": byref")) {
+          byRefTypes.push_back(UnitAttr::get(ctx));
+          continue;
+        }
+
+        if (numByRefFound >= indexList.size()) {
+          funcOp->emitError("tessera: not enough byref indices for byref args");
+          return failure();
+        }
+
+        // Find the types of the byref arguments by looking for global variables
+        // with names that match the pattern "__tessera_byref_arg_type_<idx>"
+        // where <idx> is a number parsed in the tessera_op attribute after
+        // "globals=".
+        auto byRefIndex = indexList[numByRefFound++];
         unsigned idx;
-        if (i.getAsInteger(10, idx)) {
-          funcOp->emitError("tessera: invalid byref type index: ") << i;
+        if (byRefIndex.trim().getAsInteger(10, idx)) {
+          funcOp->emitError("tessera: invalid byref type index: ")
+              << byRefIndex;
           return failure();
         }
         auto it = byRefTypesByIndex.find(idx);
@@ -119,12 +132,12 @@ public:
       }
     }
 
-    // Make sure number of arguments marked byref matches number of types found
-    unsigned numByRef = llvm::count(byRefArgs, true);
-    if (numByRef != byRefTypes.size()) {
-      funcOp->emitError("tessera: number of byref arguments (")
-          << numByRef << ") does not match number of byref types ("
-          << byRefTypes.size() << ")";
+    // The format guarantees one global index per byref arg.
+    // A mismatch means the annotation string is malformed or the Clang
+    // plugin's emission order has drifted from this parser's assumption.
+    if (numByRefFound != indexList.size()) {
+      funcOp->emitError(
+          "tessera: mismatch between byref arg count and global index count");
       return failure();
     }
 
@@ -148,7 +161,6 @@ public:
     // args, sizes, and purity (side effect free) attribute
     auto tesseraDefineOp = tessera::DefineOp::create(
         rewriter, funcOp.getLoc(), tesseraName.str(), fnType,
-        DenseBoolArrayAttr::get(ctx, byRefArgs),
         ArrayAttr::get(ctx, byRefTypes), isPure);
 
     // Copy over all attributes other than the function name and type
@@ -172,7 +184,6 @@ public:
     }
 
     rewriter.eraseOp(funcOp);
-
     return success();
   }
 
@@ -227,11 +238,6 @@ public:
       }
     }
 
-    // Load the indices and types of arguments that were marked as byref
-    // in the tessera.define op
-    auto byRefArgs = defineOp.getByRefArgs();
-    auto byRefTypes = defineOp.getByRefTypes();
-
     SmallVector<Value> newOperands;
     SmallVector<int32_t> loadedOperands;
 
@@ -240,7 +246,6 @@ public:
     // byRef by the user, load the value from the pointer and store
     // that as the new operand.
     int argOffset = sretPtr ? 1 : 0;
-    unsigned byRefCount = 0;
     for (unsigned i = 0; i < operands.size() - argOffset; i++) {
       auto operand = callOp.getOperand(i + argOffset);
 
@@ -249,14 +254,15 @@ public:
         continue;
       }
 
-      // Determine whether to load pointer and what type to load based on byVal
-      // attribute or type stored in global variable for byref argument
+      // Determine whether to load pointer and what type to load based on
+      // byVal attribute or byRef attribute on the tessera.define op.
+      // If neither is present, just pass the pointer through.
       Type pointeeType;
       if (auto byValAttr =
               defineOp.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName())) {
         pointeeType = cast<TypeAttr>(byValAttr).getValue();
-      } else if (byRefArgs[i]) {
-        pointeeType = cast<TypeAttr>(byRefTypes[byRefCount++]).getValue();
+      } else if (auto byRefType = defineOp.getByRefType(i)) {
+        pointeeType = byRefType;
       }
 
       if (pointeeType) {

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -42,7 +42,10 @@ namespace {
 // Rewrite 'llvm.func' -> 'tessera.define'
 class FuncOpRewrite final : public OpRewritePattern<LLVM::LLVMFuncOp> {
 public:
-  using OpRewritePattern<LLVM::LLVMFuncOp>::OpRewritePattern;
+  FuncOpRewrite(MLIRContext *ctx,
+                const llvm::DenseMap<unsigned, mlir::Type> &byRefTypesByIndex)
+      : OpRewritePattern<LLVM::LLVMFuncOp>(ctx),
+        byRefTypesByIndex(byRefTypesByIndex) {}
 
   LogicalResult matchAndRewrite(LLVM::LLVMFuncOp funcOp,
                                 PatternRewriter &rewriter) const override {
@@ -91,26 +94,37 @@ public:
       }
     }
 
-    // Parse sizes of args
-    SmallVector<int64_t> globalTypeIndices;
+    // Find the types of the byref arguments by looking for global variables
+    // with names that match the pattern "__tessera_byref_arg_type_<index>"
+    // where <index> is a number parsed in the tessera_op attribute after
+    // "globals=".
+    SmallVector<Attribute> byRefTypes;
     StringRef indicesStr = raw.substr(raw.find(')') + 1);
     if (!indicesStr.empty() && indicesStr.consume_front(":globals=")) {
       SmallVector<StringRef> indexList;
       indicesStr.split(indexList, ',');
       for (auto i : indexList) {
-        int64_t index;
-        i.trim().getAsInteger(10, index);
-        globalTypeIndices.push_back(index);
+        i = i.trim();
+        unsigned idx;
+        if (i.getAsInteger(10, idx)) {
+          funcOp->emitError("tessera: invalid byref type index: ") << i;
+          return failure();
+        }
+        auto it = byRefTypesByIndex.find(idx);
+        if (it == byRefTypesByIndex.end()) {
+          funcOp->emitError("tessera: no byref type found for index: ") << idx;
+          return failure();
+        }
+        byRefTypes.push_back(TypeAttr::get(it->second));
       }
     }
 
-    // Make sure number of arguments marked byref matches number of global
-    // indices provided
-    unsigned numByref = llvm::count(byRefArgs, true);
-    if (numByref != globalTypeIndices.size()) {
+    // Make sure number of arguments marked byref matches number of types found
+    unsigned numByRef = llvm::count(byRefArgs, true);
+    if (numByRef != byRefTypes.size()) {
       funcOp->emitError("tessera: number of byref arguments (")
-          << numByref << ") does not match number of global indices ("
-          << globalTypeIndices.size() << ")";
+          << numByRef << ") does not match number of byref types ("
+          << byRefTypes.size() << ")";
       return failure();
     }
 
@@ -135,7 +149,7 @@ public:
     auto tesseraDefineOp = tessera::DefineOp::create(
         rewriter, funcOp.getLoc(), tesseraName.str(), fnType,
         DenseBoolArrayAttr::get(ctx, byRefArgs),
-        DenseI64ArrayAttr::get(ctx, globalTypeIndices), isPure);
+        ArrayAttr::get(ctx, byRefTypes), isPure);
 
     // Copy over all attributes other than the function name and type
     // and tessera_op / pure_tessera_op attribute.
@@ -161,6 +175,9 @@ public:
 
     return success();
   }
+
+private:
+  const llvm::DenseMap<unsigned, mlir::Type> &byRefTypesByIndex;
 };
 
 // Rewrite 'llvm.call' -> 'tessera.call'
@@ -210,22 +227,20 @@ public:
       }
     }
 
-    // Only arguments marked byref will have corresponding global indices, since
-    // they are the only ones with global variables created for them. The sizes
-    // of byRefArgs and globalTypeIndices therefore may not match, but the
-    // number of true values in byRefArgs should match the number of
-    // globalTypeIndices.
+    // Load the indices and types of arguments that were marked as byref
+    // in the tessera.define op
     auto byRefArgs = defineOp.getByRefArgs();
-    auto globalTypeIndices = defineOp.getGlobalTypeIndices();
+    auto byRefTypes = defineOp.getByRefTypes();
 
     SmallVector<Value> newOperands;
     SmallVector<int32_t> loadedOperands;
 
-    // Build operands without first element. If a pointer operand has a
-    // byVal attribute or was marked as byRef by the user, load the value
-    // from the pointer and store that as the new operand
+    // Build operands without first element if sretPtr is present.
+    // If a pointer operand has a byVal attribute or was marked as
+    // byRef by the user, load the value from the pointer and store
+    // that as the new operand.
     int argOffset = sretPtr ? 1 : 0;
-    unsigned byrefCount = 0;
+    unsigned byRefCount = 0;
     for (unsigned i = 0; i < operands.size() - argOffset; i++) {
       auto operand = callOp.getOperand(i + argOffset);
 
@@ -241,12 +256,7 @@ public:
               defineOp.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName())) {
         pointeeType = cast<TypeAttr>(byValAttr).getValue();
       } else if (byRefArgs[i]) {
-        auto idx = globalTypeIndices[byrefCount++];
-        std::string suffix = "__tessera_byref_arg_type_" + std::to_string(idx);
-        for (auto global : module.getOps<mlir::LLVM::GlobalOp>()) {
-          if (global.getSymName().ends_with(suffix))
-            pointeeType = global.getType();
-        }
+        pointeeType = cast<TypeAttr>(byRefTypes[byRefCount++]).getValue();
       }
 
       if (pointeeType) {
@@ -309,8 +319,39 @@ struct LLVMToTesseraPass
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
+    auto module = cast<ModuleOp>(getOperation());
 
-    patterns.add<FuncOpRewrite, CallOpRewrite, ReturnOpRewrite>(ctx);
+    // Build a lookup of byref argument index -> resolved type by scanning the
+    // module once for globals named "__tessera_byref_arg_type_<index>" (names
+    // may be mangled with compiler-added prefixes, e.g.
+    // "_ZL26__tessera_byref_arg_type_0", so we search for the marker rather
+    // than requiring it at the start). Each tessera.define op's own byref index
+    // list (from its "globals=" attribute) is later resolved against this map,
+    // avoiding a full module rescan per op.
+    llvm::DenseMap<unsigned, mlir::Type> byRefTypesByIndex;
+    StringRef prefix = "__tessera_byref_arg_type_";
+    for (auto global : module.getOps<mlir::LLVM::GlobalOp>()) {
+      StringRef name = global.getSymName();
+      size_t pos = name.find(prefix);
+      if (pos == StringRef::npos)
+        continue;
+      StringRef idxStr = name.drop_front(pos + prefix.size());
+      unsigned idx;
+      if (idxStr.getAsInteger(10, idx))
+        continue; // not a well-formed index suffix, skip
+
+      auto [it, inserted] =
+          byRefTypesByIndex.try_emplace(idx, global.getType());
+      if (!inserted) {
+        llvm::errs()
+            << "Tessera: found multiple globals matching byref type index "
+            << idx << ":\n";
+        return signalPassFailure();
+      }
+    }
+
+    patterns.add<FuncOpRewrite>(ctx, byRefTypesByIndex);
+    patterns.add<CallOpRewrite, ReturnOpRewrite>(ctx);
 
     GreedyRewriteConfig config;
     config.setUseTopDownTraversal(true);
@@ -318,11 +359,10 @@ struct LLVMToTesseraPass
                                      config))) {
       llvm::errs() << "Failed to convert LLVM dialect operations to tessera "
                       "dialect operations\n";
-      signalPassFailure();
+      return signalPassFailure();
     }
 
     // Clean up llvm.global.annotations after conversion if it still exists
-    auto module = cast<ModuleOp>(getOperation());
     if (auto annotations = module.lookupSymbol("llvm.global.annotations")) {
       annotations->erase();
     }

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -84,7 +84,7 @@ public:
       if (namedAttr.getName() != SymbolTable::getSymbolAttrName() &&
           namedAttr.getName() != defineOp.getFunctionTypeAttrName() &&
           namedAttr.getName() != defineOp.getByRefArgsAttrName() &&
-          namedAttr.getName() != defineOp.getGlobalTypeIndicesAttrName() &&
+          namedAttr.getName() != defineOp.getByRefTypesAttrName() &&
           namedAttr.getName() != defineOp.getPureAttrName() &&
           namedAttr.getName() != "tessera.original_name")
         funcOp->setAttr(namedAttr.getName(), namedAttr.getValue());
@@ -259,9 +259,9 @@ struct TesseraToLLVMPass
     patterns.add<CallOpRewrite, ReturnOpRewrite>(ctx);
 
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-      signalPassFailure();
       llvm::errs() << "Failed to convert tessera dialect operations to LLVM "
                       "dialect operations\n";
+      return signalPassFailure();
     }
   }
 };

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -84,7 +84,7 @@ public:
       if (namedAttr.getName() != SymbolTable::getSymbolAttrName() &&
           namedAttr.getName() != defineOp.getFunctionTypeAttrName() &&
           namedAttr.getName() != defineOp.getByRefArgsAttrName() &&
-          namedAttr.getName() != defineOp.getArgSizesAttrName() &&
+          namedAttr.getName() != defineOp.getGlobalTypeIndicesAttrName() &&
           namedAttr.getName() != defineOp.getPureAttrName() &&
           namedAttr.getName() != "tessera.original_name")
         funcOp->setAttr(namedAttr.getName(), namedAttr.getValue());

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -83,7 +83,6 @@ public:
     for (const auto &namedAttr : defineOp->getAttrs()) {
       if (namedAttr.getName() != SymbolTable::getSymbolAttrName() &&
           namedAttr.getName() != defineOp.getFunctionTypeAttrName() &&
-          namedAttr.getName() != defineOp.getByRefArgsAttrName() &&
           namedAttr.getName() != defineOp.getByRefTypesAttrName() &&
           namedAttr.getName() != defineOp.getPureAttrName() &&
           namedAttr.getName() != "tessera.original_name")

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -98,10 +98,10 @@ func.func @func_store_to_load_not_forwarded() -> i32 {
 
 // -----
 
-tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) attributes {argSizes = array<i64: 64>, byRefArgs = array<i1: true>, pure = false} {
+tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) attributes {byRefArgs = array<i1: true>, globalTypeIndices = array<i64>, pure = false} {
   tessera.return
 }
-tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
   %val = llvm.mlir.constant(42 : i32) : i32
@@ -111,7 +111,7 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argSizes = 
   tessera.return %loaded : i32
 }
 
-// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
@@ -122,10 +122,10 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argSizes = 
 
 // -----
 
-tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {argSizes = array<i64: 64>, byRefArgs = array<i1: true>, pure = false} {
+tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {byRefArgs = array<i1: true>, globalTypeIndices = array<i64: 0>, pure = false} {
   tessera.return
 }
-tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
   %val = llvm.mlir.constant(42 : i32) : i32
@@ -135,7 +135,7 @@ tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {argSize
   tessera.return %loaded : i32
 }
 
-// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -98,10 +98,10 @@ func.func @func_store_to_load_not_forwarded() -> i32 {
 
 // -----
 
-tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) attributes {byRefArgs = array<i1: true>, byRefTypes = [i32], pure = false} {
+tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) attributes {byRefTypes = [!llvm.struct<(i32, i32)>], pure = false} {
   tessera.return
 }
-tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
+tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
   %val = llvm.mlir.constant(42 : i32) : i32
@@ -111,7 +111,7 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs =
   tessera.return %loaded : i32
 }
 
-// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
+// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
@@ -122,10 +122,10 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs =
 
 // -----
 
-tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {byRefArgs = array<i1: true>, byRefTypes = [i32], pure = false} {
+tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {byRefTypes = [!llvm.struct<(i32, i32)>], pure = false} {
   tessera.return
 }
-tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
+tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
   %val = llvm.mlir.constant(42 : i32) : i32
@@ -135,7 +135,7 @@ tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefAr
   tessera.return %loaded : i32
 }
 
-// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
+// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -98,10 +98,10 @@ func.func @func_store_to_load_not_forwarded() -> i32 {
 
 // -----
 
-tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) attributes {byRefArgs = array<i1: true>, globalTypeIndices = array<i64>, pure = false} {
+tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) attributes {byRefArgs = array<i1: true>, byRefTypes = [i32], pure = false} {
   tessera.return
 }
-tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
+tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
   %val = llvm.mlir.constant(42 : i32) : i32
@@ -111,7 +111,7 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs =
   tessera.return %loaded : i32
 }
 
-// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
+// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
@@ -122,10 +122,10 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefArgs =
 
 // -----
 
-tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {byRefArgs = array<i1: true>, globalTypeIndices = array<i64: 0>, pure = false} {
+tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {byRefArgs = array<i1: true>, byRefTypes = [i32], pure = false} {
   tessera.return
 }
-tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
+tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
   %val = llvm.mlir.constant(42 : i32) : i32
@@ -135,7 +135,7 @@ tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefAr
   tessera.return %loaded : i32
 }
 
-// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
+// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32

--- a/test/lit_tests/tessera/inv_apply_pdl.mlir
+++ b/test/lit_tests/tessera/inv_apply_pdl.mlir
@@ -29,7 +29,7 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64: 0>, pure = true} {
+// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64>, pure = true} {
 // CHECK-NEXT: tessera.return %[[ARG0]] : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%[[X:.*]]: f32) -> f32 {

--- a/test/lit_tests/tessera/inv_apply_pdl.mlir
+++ b/test/lit_tests/tessera/inv_apply_pdl.mlir
@@ -1,7 +1,7 @@
 // RUN: enzymexlamlir-opt %s -tessera-apply-pdl | FileCheck %s
 
 module {
-  tessera.define @eigen.inv(%arg0 : f32) -> f32 attributes {byRefArgs = array<i1: false>, byRefTypes = [], pure = true} {
+  tessera.define @eigen.inv(%arg0 : f32) -> f32 attributes {byRefTypes = [unit], pure = true} {
     tessera.return %arg0 : f32
   }
 
@@ -29,7 +29,7 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {byRefArgs = array<i1: false>, byRefTypes = [], pure = true} {
+// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {byRefTypes = [unit], pure = true} {
 // CHECK-NEXT: tessera.return %[[ARG0]] : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%[[X:.*]]: f32) -> f32 {

--- a/test/lit_tests/tessera/inv_apply_pdl.mlir
+++ b/test/lit_tests/tessera/inv_apply_pdl.mlir
@@ -1,7 +1,7 @@
 // RUN: enzymexlamlir-opt %s -tessera-apply-pdl | FileCheck %s
 
 module {
-  tessera.define @eigen.inv(%arg0 : f32) -> f32 attributes {argSizes = array<i64: 4>, byRefArgs = array<i1: false>, pure = true} {
+  tessera.define @eigen.inv(%arg0 : f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64>, pure = true} {
     tessera.return %arg0 : f32
   }
 
@@ -29,7 +29,7 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {argSizes = array<i64: 4>, byRefArgs = array<i1: false>, pure = true} {
+// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64: 0>, pure = true} {
 // CHECK-NEXT: tessera.return %[[ARG0]] : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%[[X:.*]]: f32) -> f32 {

--- a/test/lit_tests/tessera/inv_apply_pdl.mlir
+++ b/test/lit_tests/tessera/inv_apply_pdl.mlir
@@ -1,7 +1,7 @@
 // RUN: enzymexlamlir-opt %s -tessera-apply-pdl | FileCheck %s
 
 module {
-  tessera.define @eigen.inv(%arg0 : f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64>, pure = true} {
+  tessera.define @eigen.inv(%arg0 : f32) -> f32 attributes {byRefArgs = array<i1: false>, byRefTypes = [], pure = true} {
     tessera.return %arg0 : f32
   }
 
@@ -29,7 +29,7 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64>, pure = true} {
+// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {byRefArgs = array<i1: false>, byRefTypes = [], pure = true} {
 // CHECK-NEXT: tessera.return %[[ARG0]] : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%[[X:.*]]: f32) -> f32 {

--- a/test/lit_tests/tessera/lift_tessera_annotations.mlir
+++ b/test/lit_tests/tessera/lift_tessera_annotations.mlir
@@ -45,7 +45,7 @@ module {
   }
 }
 
-// CHECK: llvm.func @inverse(%[[ARG0:.*]]: f32) -> f32 attributes {tessera_op = "eigen.inv(x):globals=4"} {
+// CHECK: llvm.func @inverse(%[[ARG0:.*]]: f32) -> f32 attributes {tessera_op = "eigen.inv(x:byref):globals=4"} {
 // CHECK-NEXT: llvm.return %[[ARG0]] : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%[[X:.*]]: f32) -> f32 {

--- a/test/lit_tests/tessera/lift_tessera_annotations.mlir
+++ b/test/lit_tests/tessera/lift_tessera_annotations.mlir
@@ -4,7 +4,7 @@ module {
   llvm.mlir.global internal @__tessera_optimize_rule_0(0 : i32) {addr_space = 0 : i32, alignment = 4 : i64, dso_local} : i32
   llvm.mlir.global private unnamed_addr constant @".str"("tessera_optimize=eigen.inv(eigen.inv(x)) -> x\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
   llvm.mlir.global private unnamed_addr constant @".str.1"("<invalid loc>\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
-  llvm.mlir.global private unnamed_addr constant @".str.2"("tessera_op=eigen.inv(x):4\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
+  llvm.mlir.global private unnamed_addr constant @".str.2"("tessera_op=eigen.inv(x:byref):globals=4\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
   llvm.mlir.global private unnamed_addr constant @".str.3"("/home/jessicacotturone21/Reactant/enzyme/pragma_test.c\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
   llvm.mlir.global appending @llvm.global.annotations() {addr_space = 0 : i32, section = "llvm.metadata"} : !llvm.array<2 x struct<(ptr, ptr, ptr, i32, ptr)>> {
     %0 = llvm.mlir.zero : !llvm.ptr
@@ -45,7 +45,7 @@ module {
   }
 }
 
-// CHECK: llvm.func @inverse(%[[ARG0:.*]]: f32) -> f32 attributes {tessera_op = "eigen.inv(x):4"} {
+// CHECK: llvm.func @inverse(%[[ARG0:.*]]: f32) -> f32 attributes {tessera_op = "eigen.inv(x):globals=4"} {
 // CHECK-NEXT: llvm.return %[[ARG0]] : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%[[X:.*]]: f32) -> f32 {

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -5,7 +5,6 @@ llvm.func @simple_func() attributes {tessera_op = "tessera_simple_func()"} {
 }
 
 // CHECK: tessera.define @tessera_simple_func()
-// CHECK-SAME: byRefArgs = array<i1>
 // CHECK-SAME: byRefTypes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "simple_func"
@@ -19,8 +18,7 @@ llvm.func @func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {tessera_op 
 }
 
 // CHECK: tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32)
-// CHECK-SAME: byRefArgs = array<i1: false, false>
-// CHECK-SAME: byRefTypes = []
+// CHECK-SAME: byRefTypes = [unit, unit]
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_args"
 // CHECK-NEXT: tessera.return %arg0 : i32
@@ -29,13 +27,12 @@ llvm.func @func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {tessera_op 
 
 llvm.mlir.global internal constant @_ZL26__tessera_byref_arg_type_0() : !llvm.struct<(f32)>
 
-llvm.func @pure_func(%arg0: i32, %arg1: f32) -> i32 attributes {pure_tessera_op = "tessera_pure_func(x, y:byref):globals=0"} {
+llvm.func @pure_func(%arg0: i32, %arg1: !llvm.ptr) -> i32 attributes {pure_tessera_op = "tessera_pure_func(x, y:byref):globals=0"} {
   llvm.return %arg0 : i32
 }
 
-// CHECK: tessera.define @tessera_pure_func(%arg0: i32, %arg1: f32)
-// CHECK-SAME: byRefArgs = array<i1: false, true>
-// CHECK-SAME: byRefTypes = [!llvm.struct<(f32)>]
+// CHECK: tessera.define @tessera_pure_func(%arg0: i32, %arg1: !llvm.ptr)
+// CHECK-SAME: byRefTypes = [unit, !llvm.struct<(f32)>]
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "pure_func"
 // CHECK-NEXT: tessera.return %arg0 : i32
@@ -52,14 +49,12 @@ llvm.func @func_with_call() attributes {tessera_op = "tessera_func_with_call()"}
 }
 
 // CHECK: tessera.define @tessera_helper()
-// CHECK-SAME: byRefArgs = array<i1>
 // CHECK-SAME: byRefTypes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "helper"
 // CHECK-NEXT: tessera.return
 
 // CHECK: tessera.define @tessera_func_with_call()
-// CHECK-SAME: byRefArgs = array<i1>
 // CHECK-SAME: byRefTypes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_call"
@@ -105,7 +100,6 @@ llvm.func @caller() {
 }
 
 // CHECK: tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly})
-// CHECK-SAME: byRefArgs = array<i1: true>
 // CHECK-SAME: byRefTypes = [!llvm.struct<(f32, f32)>]
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "sret_func"

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -6,7 +6,7 @@ llvm.func @simple_func() attributes {tessera_op = "tessera_simple_func()"} {
 
 // CHECK: tessera.define @tessera_simple_func()
 // CHECK-SAME: byRefArgs = array<i1>
-// CHECK-SAME: globalTypeIndices = array<i64>
+// CHECK-SAME: byRefTypes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "simple_func"
 // CHECK-NEXT: tessera.return
@@ -20,12 +20,14 @@ llvm.func @func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {tessera_op 
 
 // CHECK: tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32)
 // CHECK-SAME: byRefArgs = array<i1: false, false>
-// CHECK-SAME: globalTypeIndices = array<i64>
+// CHECK-SAME: byRefTypes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_args"
 // CHECK-NEXT: tessera.return %arg0 : i32
 
 // -----
+
+llvm.mlir.global internal constant @_ZL26__tessera_byref_arg_type_0() : !llvm.struct<(f32)>
 
 llvm.func @pure_func(%arg0: i32, %arg1: f32) -> i32 attributes {pure_tessera_op = "tessera_pure_func(x, y:byref):globals=0"} {
   llvm.return %arg0 : i32
@@ -33,7 +35,7 @@ llvm.func @pure_func(%arg0: i32, %arg1: f32) -> i32 attributes {pure_tessera_op 
 
 // CHECK: tessera.define @tessera_pure_func(%arg0: i32, %arg1: f32)
 // CHECK-SAME: byRefArgs = array<i1: false, true>
-// CHECK-SAME: globalTypeIndices = array<i64: 0>
+// CHECK-SAME: byRefTypes = [!llvm.struct<(f32)>]
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "pure_func"
 // CHECK-NEXT: tessera.return %arg0 : i32
@@ -51,14 +53,14 @@ llvm.func @func_with_call() attributes {tessera_op = "tessera_func_with_call()"}
 
 // CHECK: tessera.define @tessera_helper()
 // CHECK-SAME: byRefArgs = array<i1>
-// CHECK-SAME: globalTypeIndices = array<i64>
+// CHECK-SAME: byRefTypes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "helper"
 // CHECK-NEXT: tessera.return
 
 // CHECK: tessera.define @tessera_func_with_call()
 // CHECK-SAME: byRefArgs = array<i1>
-// CHECK-SAME: globalTypeIndices = array<i64>
+// CHECK-SAME: byRefTypes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_call"
 // CHECK-NEXT: tessera.call @tessera_helper()
@@ -86,9 +88,9 @@ llvm.func @func_with_indirect_call(%arg0: !llvm.ptr) {
 
 // -----
 
-llvm.mlir.global internal constant @_ZL26__tessera_byref_arg_type_0() : !llvm.struct<(f32, f32)>
+llvm.mlir.global internal constant @_ZL26__tessera_byref_arg_type_1() : !llvm.struct<(f32, f32)>
 
-llvm.func @sret_func(%arg0: !llvm.ptr {llvm.sret = !llvm.struct<(f32, f32)>, llvm.align = 8 : i64, llvm.nonnull}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {pure_tessera_op = "tessera_sret_func(x:byref):globals=0"} {
+llvm.func @sret_func(%arg0: !llvm.ptr {llvm.sret = !llvm.struct<(f32, f32)>, llvm.align = 8 : i64, llvm.nonnull}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {pure_tessera_op = "tessera_sret_func(x:byref):globals=1"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
   llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
   llvm.return
@@ -104,7 +106,7 @@ llvm.func @caller() {
 
 // CHECK: tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly})
 // CHECK-SAME: byRefArgs = array<i1: true>
-// CHECK-SAME: globalTypeIndices = array<i64: 0>
+// CHECK-SAME: byRefTypes = [!llvm.struct<(f32, f32)>]
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "sret_func"
 // CHECK-NEXT: %[[LOAD:.*]] = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -119,6 +119,6 @@ llvm.func @caller() {
 // CHECK-NEXT: %[[RES:.*]] = tessera.call @tessera_sret_func(%[[LOADED]])
 // CHECK-SAME: arg_attrs = [{llvm.nonnull, llvm.noundef}]
 // CHECK-SAME: tessera.loaded_operands = array<i32: 0>
-// CHECK-SAME: !llvm.struct<(f32, f32)> -> !llvm.struct<(f32, f32)>
+// CHECK-SAME: (!llvm.struct<(f32, f32)>) -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: llvm.store %[[RES]], %[[A1]] : !llvm.struct<(f32, f32)>, !llvm.ptr
 // CHECK-NEXT: llvm.return

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -5,8 +5,8 @@ llvm.func @simple_func() attributes {tessera_op = "tessera_simple_func()"} {
 }
 
 // CHECK: tessera.define @tessera_simple_func()
-// CHECK-SAME: argSizes = array<i64>
 // CHECK-SAME: byRefArgs = array<i1>
+// CHECK-SAME: globalTypeIndices = array<i64>
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "simple_func"
 // CHECK-NEXT: tessera.return
@@ -14,26 +14,26 @@ llvm.func @simple_func() attributes {tessera_op = "tessera_simple_func()"} {
 // -----
 
 
-llvm.func @func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {tessera_op = "tessera_func_with_args(x, y): 4,4"} {
+llvm.func @func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {tessera_op = "tessera_func_with_args(x, y)"} {
   llvm.return %arg0 : i32
 }
 
 // CHECK: tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32)
-// CHECK-SAME: argSizes = array<i64: 4, 4>
 // CHECK-SAME: byRefArgs = array<i1: false, false>
+// CHECK-SAME: globalTypeIndices = array<i64>
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_args"
 // CHECK-NEXT: tessera.return %arg0 : i32
 
 // -----
 
-llvm.func @pure_func(%arg0: i32, %arg1: f32) -> i32 attributes {pure_tessera_op = "tessera_pure_func(x, y): 4,4"} {
+llvm.func @pure_func(%arg0: i32, %arg1: f32) -> i32 attributes {pure_tessera_op = "tessera_pure_func(x, y:byref):globals=0"} {
   llvm.return %arg0 : i32
 }
 
 // CHECK: tessera.define @tessera_pure_func(%arg0: i32, %arg1: f32)
-// CHECK-SAME: argSizes = array<i64: 4, 4>
-// CHECK-SAME: byRefArgs = array<i1: false, false>
+// CHECK-SAME: byRefArgs = array<i1: false, true>
+// CHECK-SAME: globalTypeIndices = array<i64: 0>
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "pure_func"
 // CHECK-NEXT: tessera.return %arg0 : i32
@@ -50,15 +50,15 @@ llvm.func @func_with_call() attributes {tessera_op = "tessera_func_with_call()"}
 }
 
 // CHECK: tessera.define @tessera_helper()
-// CHECK-SAME: argSizes = array<i64>
 // CHECK-SAME: byRefArgs = array<i1>
+// CHECK-SAME: globalTypeIndices = array<i64>
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "helper"
 // CHECK-NEXT: tessera.return
 
 // CHECK: tessera.define @tessera_func_with_call()
-// CHECK-SAME: argSizes = array<i64>
 // CHECK-SAME: byRefArgs = array<i1>
+// CHECK-SAME: globalTypeIndices = array<i64>
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_call"
 // CHECK-NEXT: tessera.call @tessera_helper()
@@ -86,7 +86,9 @@ llvm.func @func_with_indirect_call(%arg0: !llvm.ptr) {
 
 // -----
 
-llvm.func @sret_func(%arg0: !llvm.ptr {llvm.sret = !llvm.struct<(f32, f32)>, llvm.align = 8 : i64, llvm.nonnull}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {pure_tessera_op = "tessera_sret_func(x:byref):64"} {
+llvm.mlir.global internal constant @_ZL26__tessera_byref_arg_type_0() : !llvm.struct<(f32, f32)>
+
+llvm.func @sret_func(%arg0: !llvm.ptr {llvm.sret = !llvm.struct<(f32, f32)>, llvm.align = 8 : i64, llvm.nonnull}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {pure_tessera_op = "tessera_sret_func(x:byref):globals=0"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
   llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
   llvm.return
@@ -101,8 +103,8 @@ llvm.func @caller() {
 }
 
 // CHECK: tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly})
-// CHECK-SAME: argSizes = array<i64: 64>
 // CHECK-SAME: byRefArgs = array<i1: true>
+// CHECK-SAME: globalTypeIndices = array<i64: 0>
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "sret_func"
 // CHECK-NEXT: %[[LOAD:.*]] = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
@@ -113,10 +115,10 @@ llvm.func @caller() {
 // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[A1:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[A2:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[A2]] : !llvm.ptr -> i512
+// CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[A2]] : !llvm.ptr -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: %[[RES:.*]] = tessera.call @tessera_sret_func(%[[LOADED]])
 // CHECK-SAME: arg_attrs = [{llvm.nonnull, llvm.noundef}]
 // CHECK-SAME: tessera.loaded_operands = array<i32: 0>
-// CHECK-SAME: (i512) -> !llvm.struct<(f32, f32)>
+// CHECK-SAME: !llvm.struct<(f32, f32)> -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: llvm.store %[[RES]], %[[A1]] : !llvm.struct<(f32, f32)>, !llvm.ptr
 // CHECK-NEXT: llvm.return

--- a/test/lit_tests/tessera/mag_apply_pdl.mlir
+++ b/test/lit_tests/tessera/mag_apply_pdl.mlir
@@ -1,11 +1,11 @@
 // RUN: enzymexlamlir-opt %s -tessera-apply-pdl | FileCheck %s
 
 module {
-  tessera.define @eigen.mag(%arg0 : f32, %arg1 : f32, %arg2 : f32) -> f32 attributes {byRefArgs = array<i1: false, false, false>, globalTypeIndices = array<i64>, pure = true} {
+  tessera.define @eigen.mag(%arg0 : f32, %arg1 : f32, %arg2 : f32) -> f32 attributes {byRefArgs = array<i1: false, false, false>, byRefTypes = [], pure = true} {
       tessera.return %arg0 : f32
   }
   
-  tessera.define @arith.negf(%arg0 : f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64>, pure = true} {
+  tessera.define @arith.negf(%arg0 : f32) -> f32 attributes {byRefArgs = array<i1: false>, byRefTypes = [], pure = true} {
       tessera.return %arg0 : f32
   }
 
@@ -39,10 +39,10 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.mag(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 attributes {byRefArgs = array<i1: false, false, false>, globalTypeIndices = array<i64>, pure = true} {
+// CHECK: tessera.define @eigen.mag(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 attributes {byRefArgs = array<i1: false, false, false>, byRefTypes = [], pure = true} {
 // CHECK-NEXT: tessera.return %arg0 : f32
 // CHECK-NEXT: }
-// CHECK-NEXT: tessera.define @arith.negf(%arg0: f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64>, pure = true} {
+// CHECK-NEXT: tessera.define @arith.negf(%arg0: f32) -> f32 attributes {byRefArgs = array<i1: false>, byRefTypes = [], pure = true} {
 // CHECK-NEXT: tessera.return %arg0 : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {

--- a/test/lit_tests/tessera/mag_apply_pdl.mlir
+++ b/test/lit_tests/tessera/mag_apply_pdl.mlir
@@ -1,11 +1,11 @@
 // RUN: enzymexlamlir-opt %s -tessera-apply-pdl | FileCheck %s
 
 module {
-  tessera.define @eigen.mag(%arg0 : f32, %arg1 : f32, %arg2 : f32) -> f32 attributes {byRefArgs = array<i1: false, false, false>, byRefTypes = [], pure = true} {
+  tessera.define @eigen.mag(%arg0 : f32, %arg1 : f32, %arg2 : f32) -> f32 attributes {byRefTypes = [unit, unit, unit], pure = true} {
       tessera.return %arg0 : f32
   }
   
-  tessera.define @arith.negf(%arg0 : f32) -> f32 attributes {byRefArgs = array<i1: false>, byRefTypes = [], pure = true} {
+  tessera.define @arith.negf(%arg0 : f32) -> f32 attributes {byRefTypes = [unit], pure = true} {
       tessera.return %arg0 : f32
   }
 
@@ -39,10 +39,10 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.mag(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 attributes {byRefArgs = array<i1: false, false, false>, byRefTypes = [], pure = true} {
+// CHECK: tessera.define @eigen.mag(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 attributes {byRefTypes = [unit, unit, unit], pure = true} {
 // CHECK-NEXT: tessera.return %arg0 : f32
 // CHECK-NEXT: }
-// CHECK-NEXT: tessera.define @arith.negf(%arg0: f32) -> f32 attributes {byRefArgs = array<i1: false>, byRefTypes = [], pure = true} {
+// CHECK-NEXT: tessera.define @arith.negf(%arg0: f32) -> f32 attributes {byRefTypes = [unit], pure = true} {
 // CHECK-NEXT: tessera.return %arg0 : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {

--- a/test/lit_tests/tessera/mag_apply_pdl.mlir
+++ b/test/lit_tests/tessera/mag_apply_pdl.mlir
@@ -39,10 +39,10 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.mag(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 attributes {argSizes = array<i64: 4, 4, 4>, byRefArgs = array<i1: false, false, false>, pure = true} {
+// CHECK: tessera.define @eigen.mag(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 attributes {byRefArgs = array<i1: false, false, false>, globalTypeIndices = array<i64>, pure = true} {
 // CHECK-NEXT: tessera.return %arg0 : f32
 // CHECK-NEXT: }
-// CHECK-NEXT: tessera.define @arith.negf(%arg0: f32) -> f32 attributes {argSizes = array<i64: 4>, byRefArgs = array<i1: false>, pure = true} {
+// CHECK-NEXT: tessera.define @arith.negf(%arg0: f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64>, pure = true} {
 // CHECK-NEXT: tessera.return %arg0 : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {

--- a/test/lit_tests/tessera/mag_apply_pdl.mlir
+++ b/test/lit_tests/tessera/mag_apply_pdl.mlir
@@ -1,11 +1,11 @@
 // RUN: enzymexlamlir-opt %s -tessera-apply-pdl | FileCheck %s
 
 module {
-  tessera.define @eigen.mag(%arg0 : f32, %arg1 : f32, %arg2 : f32) -> f32 attributes {argSizes = array<i64: 4, 4, 4>, byRefArgs = array<i1: false, false, false>, pure = true} {
+  tessera.define @eigen.mag(%arg0 : f32, %arg1 : f32, %arg2 : f32) -> f32 attributes {byRefArgs = array<i1: false, false, false>, globalTypeIndices = array<i64>, pure = true} {
       tessera.return %arg0 : f32
   }
   
-  tessera.define @arith.negf(%arg0 : f32) -> f32 attributes {argSizes = array<i64: 4>, byRefArgs = array<i1: false>, pure = true} {
+  tessera.define @arith.negf(%arg0 : f32) -> f32 attributes {byRefArgs = array<i1: false>, globalTypeIndices = array<i64>, pure = true} {
       tessera.return %arg0 : f32
   }
 

--- a/test/lit_tests/tessera/roundtrip.mlir
+++ b/test/lit_tests/tessera/roundtrip.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-tessera.define @foo() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
+tessera.define @foo() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
   tessera.return
 }
 
@@ -9,7 +9,7 @@ tessera.define @foo() attributes {byRefArgs = array<i1>, globalTypeIndices = arr
 
 // -----
 
-tessera.define @bar() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
+tessera.define @bar() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
   %0 = arith.constant 42 : i32
   tessera.return %0 : i32
 }
@@ -19,7 +19,7 @@ tessera.define @bar() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndice
 
 // -----
 
-tessera.define @caller() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
+tessera.define @caller() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
   tessera.call @foo() : () -> ()
   tessera.return
 }
@@ -30,7 +30,7 @@ tessera.define @caller() attributes {byRefArgs = array<i1>, globalTypeIndices = 
 
 // -----
 
-tessera.define @with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefArgs = array<i1: false, false>, globalTypeIndices = array<i64>, pure = false} {
+tessera.define @with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefArgs = array<i1: false, false>, byRefTypes = [], pure = false} {
   %0 = tessera.call @bar() : () -> i32
   tessera.return %0 : i32
 }

--- a/test/lit_tests/tessera/roundtrip.mlir
+++ b/test/lit_tests/tessera/roundtrip.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-tessera.define @foo() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
+tessera.define @foo() attributes {byRefTypes = [], pure = false} {
   tessera.return
 }
 
@@ -9,7 +9,7 @@ tessera.define @foo() attributes {byRefArgs = array<i1>, byRefTypes = [], pure =
 
 // -----
 
-tessera.define @bar() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
+tessera.define @bar() -> i32 attributes {byRefTypes = [], pure = false} {
   %0 = arith.constant 42 : i32
   tessera.return %0 : i32
 }
@@ -19,7 +19,7 @@ tessera.define @bar() -> i32 attributes {byRefArgs = array<i1>, byRefTypes = [],
 
 // -----
 
-tessera.define @caller() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false} {
+tessera.define @caller() attributes {byRefTypes = [], pure = false} {
   tessera.call @foo() : () -> ()
   tessera.return
 }
@@ -30,7 +30,7 @@ tessera.define @caller() attributes {byRefArgs = array<i1>, byRefTypes = [], pur
 
 // -----
 
-tessera.define @with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefArgs = array<i1: false, false>, byRefTypes = [], pure = false} {
+tessera.define @with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefTypes = [unit, unit], pure = false} {
   %0 = tessera.call @bar() : () -> i32
   tessera.return %0 : i32
 }

--- a/test/lit_tests/tessera/roundtrip.mlir
+++ b/test/lit_tests/tessera/roundtrip.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-tessera.define @foo() attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+tessera.define @foo() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
   tessera.return
 }
 
@@ -9,7 +9,7 @@ tessera.define @foo() attributes {argSizes = array<i64>, byRefArgs = array<i1>, 
 
 // -----
 
-tessera.define @bar() -> i32 attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+tessera.define @bar() -> i32 attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
   %0 = arith.constant 42 : i32
   tessera.return %0 : i32
 }
@@ -19,7 +19,7 @@ tessera.define @bar() -> i32 attributes {argSizes = array<i64>, byRefArgs = arra
 
 // -----
 
-tessera.define @caller() attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false} {
+tessera.define @caller() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false} {
   tessera.call @foo() : () -> ()
   tessera.return
 }
@@ -30,7 +30,7 @@ tessera.define @caller() attributes {argSizes = array<i64>, byRefArgs = array<i1
 
 // -----
 
-tessera.define @with_args(%arg0: i32, %arg1: f32) -> i32 attributes {argSizes = array<i64: 4, 4>, byRefArgs = array<i1: false, false>, pure = false} {
+tessera.define @with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefArgs = array<i1: false, false>, globalTypeIndices = array<i64>, pure = false} {
   %0 = tessera.call @bar() : () -> i32
   tessera.return %0 : i32
 }

--- a/test/lit_tests/tessera/tessera_to_llvm.mlir
+++ b/test/lit_tests/tessera/tessera_to_llvm.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s -tessera-to-llvm -split-input-file | FileCheck %s
 
-tessera.define @tessera_simple_func() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false, tessera.original_name = "simple_func"} {
+tessera.define @tessera_simple_func() attributes {byRefTypes = [], pure = false, tessera.original_name = "simple_func"} {
   tessera.return
 }
 
@@ -9,7 +9,7 @@ tessera.define @tessera_simple_func() attributes {byRefArgs = array<i1>, byRefTy
 
 // -----
 
-tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefArgs = array<i1: false, false>, byRefTypes = [], pure = false, tessera.original_name = "func_with_args"} {
+tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefTypes = [unit, unit], pure = false, tessera.original_name = "func_with_args"} {
   tessera.return %arg0 : i32
 }
 
@@ -18,11 +18,11 @@ tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes
 
 // -----
 
-tessera.define @tessera_helper() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false, tessera.original_name = "helper"} {
+tessera.define @tessera_helper() attributes {byRefTypes = [], pure = false, tessera.original_name = "helper"} {
   tessera.return
 }
 
-tessera.define @tessera_func_with_call() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false, tessera.original_name = "func_with_call"} {
+tessera.define @tessera_func_with_call() attributes {byRefTypes = [], pure = false, tessera.original_name = "func_with_call"} {
   tessera.call @tessera_helper() {op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 0, 0>} : () -> ()
   tessera.return
 }
@@ -37,7 +37,7 @@ tessera.define @tessera_func_with_call() attributes {byRefArgs = array<i1>, byRe
 // -----
 
 tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) 
-attributes {byRefArgs = array<i1: true>, byRefTypes = [!llvm.struct<(f32, f32)>], linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
+attributes {byRefTypes = [!llvm.struct<(f32, f32)>], linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
   llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
   tessera.return

--- a/test/lit_tests/tessera/tessera_to_llvm.mlir
+++ b/test/lit_tests/tessera/tessera_to_llvm.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s -tessera-to-llvm -split-input-file | FileCheck %s
 
-tessera.define @tessera_simple_func() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false, tessera.original_name = "simple_func"} {
+tessera.define @tessera_simple_func() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false, tessera.original_name = "simple_func"} {
   tessera.return
 }
 
@@ -9,7 +9,7 @@ tessera.define @tessera_simple_func() attributes {byRefArgs = array<i1>, globalT
 
 // -----
 
-tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefArgs = array<i1: false, false>, globalTypeIndices = array<i64>, pure = false, tessera.original_name = "func_with_args"} {
+tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefArgs = array<i1: false, false>, byRefTypes = [], pure = false, tessera.original_name = "func_with_args"} {
   tessera.return %arg0 : i32
 }
 
@@ -18,11 +18,11 @@ tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes
 
 // -----
 
-tessera.define @tessera_helper() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false, tessera.original_name = "helper"} {
+tessera.define @tessera_helper() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false, tessera.original_name = "helper"} {
   tessera.return
 }
 
-tessera.define @tessera_func_with_call() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false, tessera.original_name = "func_with_call"} {
+tessera.define @tessera_func_with_call() attributes {byRefArgs = array<i1>, byRefTypes = [], pure = false, tessera.original_name = "func_with_call"} {
   tessera.call @tessera_helper() {op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 0, 0>} : () -> ()
   tessera.return
 }
@@ -37,7 +37,7 @@ tessera.define @tessera_func_with_call() attributes {byRefArgs = array<i1>, glob
 // -----
 
 tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) 
-attributes {byRefArgs = array<i1: true>, globalTypeIndices = array<i64: 0>, linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
+attributes {byRefArgs = array<i1: true>, byRefTypes = [!llvm.struct<(f32, f32)>], linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
   llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
   tessera.return

--- a/test/lit_tests/tessera/tessera_to_llvm.mlir
+++ b/test/lit_tests/tessera/tessera_to_llvm.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s -tessera-to-llvm -split-input-file | FileCheck %s
 
-tessera.define @tessera_simple_func() attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false, tessera.original_name = "simple_func"} {
+tessera.define @tessera_simple_func() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false, tessera.original_name = "simple_func"} {
   tessera.return
 }
 
@@ -9,7 +9,7 @@ tessera.define @tessera_simple_func() attributes {argSizes = array<i64>, byRefAr
 
 // -----
 
-tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {argSizes = array<i64: 4, 4>, byRefArgs = array<i1: false, false>, pure = false, tessera.original_name = "func_with_args"} {
+tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefArgs = array<i1: false, false>, globalTypeIndices = array<i64>, pure = false, tessera.original_name = "func_with_args"} {
   tessera.return %arg0 : i32
 }
 
@@ -18,11 +18,11 @@ tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes
 
 // -----
 
-tessera.define @tessera_helper() attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false, tessera.original_name = "helper"} {
+tessera.define @tessera_helper() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false, tessera.original_name = "helper"} {
   tessera.return
 }
 
-tessera.define @tessera_func_with_call() attributes {argSizes = array<i64>, byRefArgs = array<i1>, pure = false, tessera.original_name = "func_with_call"} {
+tessera.define @tessera_func_with_call() attributes {byRefArgs = array<i1>, globalTypeIndices = array<i64>, pure = false, tessera.original_name = "func_with_call"} {
   tessera.call @tessera_helper() {op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 0, 0>} : () -> ()
   tessera.return
 }
@@ -36,7 +36,8 @@ tessera.define @tessera_func_with_call() attributes {argSizes = array<i64>, byRe
 
 // -----
 
-tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {argSizes = array<i64: 64>, byRefArgs = array<i1: true>, linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
+tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) 
+attributes {byRefArgs = array<i1: true>, globalTypeIndices = array<i64: 0>, linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
   llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
   tessera.return
@@ -46,8 +47,8 @@ llvm.func @caller() {
   %0 = llvm.mlir.constant(1 : i32) : i32
   %1 = llvm.alloca %0 x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %2 = llvm.alloca %0 x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-  %3 = llvm.load %2 : !llvm.ptr -> i512
-  %4 = tessera.call @tessera_sret_func(%3) {arg_attrs = [{llvm.nonnull, llvm.noundef}], op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>, tessera.loaded_operands = array<i32: 0>} : (i512) -> !llvm.struct<(f32, f32)>
+  %3 = llvm.load %2 : !llvm.ptr -> !llvm.struct<(f32, f32)>
+  %4 = tessera.call @tessera_sret_func(%3) {arg_attrs = [{llvm.nonnull, llvm.noundef}], op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>, tessera.loaded_operands = array<i32: 0>} : (!llvm.struct<(f32, f32)>) -> !llvm.struct<(f32, f32)>
   llvm.store %4, %1 : !llvm.struct<(f32, f32)>, !llvm.ptr
   llvm.return
 }
@@ -61,10 +62,10 @@ llvm.func @caller() {
 // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[A1:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[A2:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[A2]] : !llvm.ptr -> i512
+// CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[A2]] : !llvm.ptr -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: %[[SRET:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK-NEXT: %[[A3:.*]] = llvm.alloca %[[ONE]] x i512 : (i32) -> !llvm.ptr
-// CHECK-NEXT: llvm.store %[[LOADED]], %[[A3]] : i512, !llvm.ptr
+// CHECK-NEXT: %[[A3:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> : (i32) -> !llvm.ptr
+// CHECK-NEXT: llvm.store %[[LOADED]], %[[A3]] : !llvm.struct<(f32, f32)>, !llvm.ptr
 // CHECK-NEXT: llvm.call @sret_func(%[[SRET]], %[[A3]]) : (!llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, !llvm.ptr {llvm.nonnull, llvm.noundef}) -> ()
 // CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[SRET]] : !llvm.ptr -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: llvm.store %[[LOADED]], %[[A1]] : !llvm.struct<(f32, f32)>, !llvm.ptr


### PR DESCRIPTION
Creates a `byRefTypes` `ArrayAttr` stored on the `tessera.define` op, which contains the types of each of the arguments that are marked byRef, or unit if an argument is not byRef. The order of the types in the array aligns with the order of the arguments. The sret argument is not included. `byRefArgs` (the boolean array which indicated true or false based on if an argument was marked as byRef or not) has been eliminated, since `byRefTypes` contains this information by either storing a `TypeAttr` or a `UnitAttr`.

If an argument is marked as byRef, the type is found by looking up the global variable emitted in the Clang plugin.

The types are used in the `tessera.call` op rewrite to load the arguments that are marked as byref.