### PR TITLE
Use kernel attribute for gpu kernel funcs

### DIFF
--- a/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
+++ b/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
@@ -497,7 +497,7 @@ enum __device_builtin__ cudaMemcpyKind
           }
         }
 
-        gpufunc->setAttr("gpu.kernel", builder.getUnitAttr());
+        gpufunc.setKernelAttr(builder.getUnitAttr());
 
         gpufunc->walk([](LLVM::ReturnOp op) {
           OpBuilder rewriter(op);

--- a/src/enzyme_ad/jax/Passes/LowerKernel.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerKernel.cpp
@@ -144,7 +144,7 @@ bool CompileGPUKernel(SymbolTableCollection &symbolTable, mlir::Location loc,
       }
 
       op.getFunctionBody().cloneInto(&gpufunc.getBody(), map);
-      gpufunc->setAttr("gpu.kernel", builder.getUnitAttr());
+      gpufunc.setKernelAttr(builder.getUnitAttr());
 
       auto second = entry->getNextNode();
       entry->getOperations().splice(entry->getOperations().end(),


### PR DESCRIPTION
Otherwise, the lowered llvm funcs from it, can end up with two gpu.kernel attributes from here:

https://github.com/llvm/llvm-project/blob/8f7019acdd29270a0a51006a6cbdb43d6844dd20/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp#L117-L118
