### PR TITLE
make enzymexla dialect dependent on gpu

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Dialect.td
+++ b/src/enzyme_ad/jax/Dialect/Dialect.td
@@ -22,6 +22,7 @@ def EnzymeXLA_Dialect : Dialect {
   let cppNamespace = "::mlir::enzymexla";
   let useDefaultAttributePrinterParser = 1;
   // let useDefaultTypePrinterParser = 1;
+  let dependentDialects = ["mlir::gpu::GPUDialect"];
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
fixes some spotty lit tests failures with enzymexla.memcpy/memset parsing failing. btw, why not use gpu.memcpy/gpu.memset @wsmoses?
