### PR TITLE
LLVMToMemrefAccess: accept explicit argument type contracts

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToMemrefAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToMemrefAccess.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/MLIRContext.h"
+#include "src/enzyme_ad/jax/Dialect/Dialect.h"
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
 
 #define DEBUG_TYPE "llvm-to-memref-access"
@@ -66,17 +67,48 @@ struct LLVMToMemrefAccessPass
         return;
       funcToKernelMap[callee].insert(callOp);
     });
-    if (funcToKernelMap.empty())
+    SetVector<FunctionOpInterface> candidateFunctions;
+    for (auto &entry : funcToKernelMap)
+      candidateFunctions.insert(entry.first);
+    // The existing path discovers callees through enzymexla custom-call ops.
+    // Imported LLVM kernels are standalone functions with no such callers, so
+    // an explicit argument contract must also make a function a candidate.
+    moduleOp->walk([&](FunctionOpInterface function) {
+      for (unsigned index = 0; index < function.getNumArguments(); ++index) {
+        if (function.getArgAttr(index, "enzymexla.memref_type")) {
+          candidateFunctions.insert(function);
+          break;
+        }
+      }
+    });
+    if (candidateFunctions.empty())
       return;
 
     // Recover memref types for callees
-    for (auto [callee, callers] : funcToKernelMap) {
+    for (auto callee : candidateFunctions) {
+      auto callers = funcToKernelMap.lookup(callee);
       SmallVector<Type> newTypes;
       SmallVector<unsigned> indices;
       for (auto [index, calleeArgTy, calleeArg] :
            llvm::enumerate(callee.getArgumentTypes(), callee.getArguments())) {
-        assert(!callers.empty());
         if (auto ptrTy = dyn_cast<LLVM::LLVMPointerType>(calleeArgTy)) {
+          if (auto typeAttr = dyn_cast_or_null<TypeAttr>(
+                  callee.getArgAttr(index, "enzymexla.memref_type"))) {
+            auto memrefType = dyn_cast<MemRefType>(typeAttr.getValue());
+            if (!memrefType) {
+              callee.emitError() << "enzymexla.memref_type"
+                                 << " must contain a memref type";
+              signalPassFailure();
+              return;
+            }
+            newTypes.push_back(memrefType);
+            indices.push_back(index);
+            continue;
+          }
+          if (callers.empty()) {
+            newTypes.push_back(calleeArgTy);
+            continue;
+          }
           bool sameElementTypeAcrossCallers = true;
           bool sameShapeAcrossCallers = true;
           ArrayRef<int64_t> shape;
@@ -146,6 +178,8 @@ struct LLVMToMemrefAccessPass
           } else {
             newTypes.push_back(calleeArgTy);
           }
+        } else {
+          newTypes.push_back(calleeArgTy);
         }
       }
 
@@ -159,7 +193,7 @@ struct LLVMToMemrefAccessPass
               dyn_cast<LLVM::LLVMFunctionType>(callee.getFunctionType())) {
         if (fty.getReturnType() == LLVM::LLVMVoidType::get(ctx) &&
             !fty.isVarArg()) {
-          newFuncTy = FunctionType::get(ctx, newTypes, fty.getReturnType());
+          newFuncTy = FunctionType::get(ctx, newTypes, {});
         }
       } else if (auto fty = dyn_cast<FunctionType>(callee.getFunctionType())) {
         if (fty.getResults().empty()) {
@@ -194,9 +228,15 @@ struct LLVMToMemrefAccessPass
         // the old one
         newFunc->setAttr("function_type", TypeAttr::get(newFuncTy));
 
-        // Iterate over each argument and copy its attributes
+        // Copy argument attributes, except for the type contract consumed by
+        // this rewrite.
         for (unsigned i = 0; i < callee.getNumArguments(); ++i) {
-          newFunc.setArgAttrs(i, callee.getArgAttrs(i));
+          SmallVector<NamedAttribute> attributes;
+          for (auto attribute : callee.getArgAttrs(i)) {
+            if (attribute.getName() != "enzymexla.memref_type")
+              attributes.push_back(attribute);
+          }
+          newFunc.setArgAttrs(i, DictionaryAttr::get(ctx, attributes));
         }
         callee->erase();
       }

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -859,6 +859,8 @@ def SimplifyAffineExprsPass : Pass<"simplify-affine-exprs"> {
 def LLVMToMemrefAccessPass : Pass<"llvm-to-memref-access"> {
   let summary = "";
   let dependentDialects = [
+    "enzymexla::EnzymeXLADialect",
+    "func::FuncDialect",
     "memref::MemRefDialect",
     "vector::VectorDialect",
   ];

--- a/test/lit_tests/raising/llvm_to_memref_access_arg_attrs.mlir
+++ b/test/lit_tests/raising/llvm_to_memref_access_arg_attrs.mlir
@@ -1,0 +1,24 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-memref-access)" | FileCheck %s
+
+module {
+  llvm.func @cpp_kernel(
+      %out: !llvm.ptr {enzymexla.memref_type = memref<8xf32>},
+      %in: !llvm.ptr {enzymexla.memref_type = memref<8xf32>, llvm.readonly}) {
+    %zero = llvm.mlir.constant(0 : i64) : i64
+    %in_ptr = llvm.getelementptr inbounds %in[%zero]
+      : (!llvm.ptr, i64) -> !llvm.ptr, f32
+    %value = llvm.load %in_ptr : !llvm.ptr -> f32
+    %out_ptr = llvm.getelementptr inbounds %out[%zero]
+      : (!llvm.ptr, i64) -> !llvm.ptr, f32
+    llvm.store %value, %out_ptr : f32, !llvm.ptr
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: func.func @cpp_kernel(
+// CHECK-SAME: %[[OUT:[^:]+]]: memref<8xf32>
+// CHECK-SAME: %[[IN:[^:]+]]: memref<8xf32> {llvm.readonly}
+// CHECK: %[[OUT_PTR:.*]] = "enzymexla.memref2pointer"(%[[OUT]])
+// CHECK: %[[IN_PTR:.*]] = "enzymexla.memref2pointer"(%[[IN]])
+// CHECK: llvm.getelementptr {{.*}} %[[IN_PTR]]
+// CHECK: llvm.getelementptr {{.*}} %[[OUT_PTR]]


### PR DESCRIPTION
LLVM-imported C++ kernels are standalone functions. The existing pass only discovers callees of enzymexla kernel and JIT calls, then recovers their memref types from ranked tensor operands. Imported kernels have no such callers, and their LLVM pointer arguments no longer carry shape information.

We treat functions with an enzymexla.memref_type argument attribute as rewrite candidates and use that contract to replace the corresponding LLVM pointer with a ranked memref while preserving the existing caller-derived recovery path. Also, we preserve unannotated and non-pointer arguments, retain unrelated argument attributes, and consume the type contract when rebuilding the function. 

The PR and some PRs that we have only cover ABI-boundary contract, w/o/ general LLVM pointer type inference. So for future integration, we can absorb internal pointers, dynamic layouts, or aliasing information, and integrate Enzyme TypeAnalysis.

Add a lit test covering a standalone imported kernel, exact shape recovery, contract removal, and preservation of llvm.readonly.

Tests:
  bazel test //test/lit_tests:raising_llvm_to_memref_access_arg_attrs.mlir.test