### PR TITLE
Simplify real, imag, and abs of complex exp

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -15117,6 +15117,11 @@ struct RealOfExpSimplify final
     if (!exp)
       return failure();
 
+    // Only rewrite when the exp feeds nothing but this op, otherwise the
+    // original exp stays live and we just add redundant work.
+    if (!llvm::hasSingleElement(exp->getUsers()))
+      return failure();
+
     auto loc = op.getLoc();
     auto re = stablehlo::RealOp::create(rewriter, loc, exp.getOperand());
     auto im = stablehlo::ImagOp::create(rewriter, loc, exp.getOperand());
@@ -15141,6 +15146,11 @@ struct ImagOfExpSimplify final
     if (!exp)
       return failure();
 
+    // Only rewrite when the exp feeds nothing but this op, otherwise the
+    // original exp stays live and we just add redundant work.
+    if (!llvm::hasSingleElement(exp->getUsers()))
+      return failure();
+
     auto loc = op.getLoc();
     auto re = stablehlo::RealOp::create(rewriter, loc, exp.getOperand());
     auto im = stablehlo::ImagOp::create(rewriter, loc, exp.getOperand());
@@ -15163,6 +15173,11 @@ struct AbsOfExpSimplify final
 
     auto exp = op.getOperand().getDefiningOp<stablehlo::ExpOp>();
     if (!exp)
+      return failure();
+
+    // Only rewrite when the exp feeds nothing but this op, otherwise the
+    // original exp stays live and we just add redundant work.
+    if (!llvm::hasSingleElement(exp->getUsers()))
       return failure();
 
     auto re =

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -15165,7 +15165,8 @@ struct AbsOfExpSimplify final
     if (!exp)
       return failure();
 
-    auto re = stablehlo::RealOp::create(rewriter, op.getLoc(), exp.getOperand());
+    auto re =
+        stablehlo::RealOp::create(rewriter, op.getLoc(), exp.getOperand());
     rewriter.replaceOpWithNewOp<stablehlo::ExpOp>(op, re);
     return success();
   }

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -15103,6 +15103,74 @@ struct ImagOpCanon final
   }
 };
 
+// real(exp(x)) -> exp(real(x)) * cos(imag(x))
+struct RealOfExpSimplify final
+    : CheckedOpRewritePattern<stablehlo::RealOp, RealOfExpSimplify> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::RealOp op,
+                                    PatternRewriter &rewriter) const {
+    if (!isa<ComplexType>(op.getOperand().getType().getElementType()))
+      return failure();
+
+    auto exp = op.getOperand().getDefiningOp<stablehlo::ExpOp>();
+    if (!exp)
+      return failure();
+
+    auto loc = op.getLoc();
+    auto re = stablehlo::RealOp::create(rewriter, loc, exp.getOperand());
+    auto im = stablehlo::ImagOp::create(rewriter, loc, exp.getOperand());
+    auto expRe = stablehlo::ExpOp::create(rewriter, loc, re);
+    auto cosIm = stablehlo::CosineOp::create(rewriter, loc, im);
+    rewriter.replaceOpWithNewOp<stablehlo::MulOp>(op, expRe, cosIm);
+    return success();
+  }
+};
+
+// imag(exp(x)) -> exp(real(x)) * sin(imag(x))
+struct ImagOfExpSimplify final
+    : CheckedOpRewritePattern<stablehlo::ImagOp, ImagOfExpSimplify> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ImagOp op,
+                                    PatternRewriter &rewriter) const {
+    if (!isa<ComplexType>(op.getOperand().getType().getElementType()))
+      return failure();
+
+    auto exp = op.getOperand().getDefiningOp<stablehlo::ExpOp>();
+    if (!exp)
+      return failure();
+
+    auto loc = op.getLoc();
+    auto re = stablehlo::RealOp::create(rewriter, loc, exp.getOperand());
+    auto im = stablehlo::ImagOp::create(rewriter, loc, exp.getOperand());
+    auto expRe = stablehlo::ExpOp::create(rewriter, loc, re);
+    auto sinIm = stablehlo::SineOp::create(rewriter, loc, im);
+    rewriter.replaceOpWithNewOp<stablehlo::MulOp>(op, expRe, sinIm);
+    return success();
+  }
+};
+
+// abs(exp(x)) -> exp(real(x))
+struct AbsOfExpSimplify final
+    : CheckedOpRewritePattern<stablehlo::AbsOp, AbsOfExpSimplify> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::AbsOp op,
+                                    PatternRewriter &rewriter) const {
+    if (!isa<ComplexType>(op.getOperand().getType().getElementType()))
+      return failure();
+
+    auto exp = op.getOperand().getDefiningOp<stablehlo::ExpOp>();
+    if (!exp)
+      return failure();
+
+    auto re = stablehlo::RealOp::create(rewriter, op.getLoc(), exp.getOperand());
+    rewriter.replaceOpWithNewOp<stablehlo::ExpOp>(op, re);
+    return success();
+  }
+};
+
 // (conj (complex a, (neg b))) -> (complex a b)
 struct ConjComplexNegate final
     : CheckedOpRewritePattern<chlo::ConjOp, ConjComplexNegate> {
@@ -36485,6 +36553,9 @@ struct EnzymeHLOOptPass
         IfToSelect,
         IfPredPropagation,
         ImagOpCanon,
+        RealOfExpSimplify,
+        ImagOfExpSimplify,
+        AbsOfExpSimplify,
         MergeConsecutiveReshapes,
         NoopReduceOpCanon,
         RealOpCanon,

--- a/test/lit_tests/realimagabsexp.mlir
+++ b/test/lit_tests/realimagabsexp.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt %s | FileCheck %s
+
+func.func @real_of_exp(%arg0: tensor<complex<f64>>) -> tensor<f64> {
+  %0 = stablehlo.exponential %arg0 : tensor<complex<f64>>
+  %1 = stablehlo.real %0 : (tensor<complex<f64>>) -> tensor<f64>
+  return %1 : tensor<f64>
+}
+
+// CHECK-LABEL: func.func @real_of_exp(
+// CHECK-DAG:   %[[RE:.+]] = stablehlo.real %arg0
+// CHECK-DAG:   %[[IM:.+]] = stablehlo.imag %arg0
+// CHECK-DAG:   %[[EXP:.+]] = stablehlo.exponential %[[RE]]
+// CHECK-DAG:   %[[COS:.+]] = stablehlo.cosine %[[IM]]
+// CHECK:       %[[MUL:.+]] = stablehlo.multiply %[[EXP]], %[[COS]]
+// CHECK:       return %[[MUL]]
+
+func.func @imag_of_exp(%arg0: tensor<complex<f64>>) -> tensor<f64> {
+  %0 = stablehlo.exponential %arg0 : tensor<complex<f64>>
+  %1 = stablehlo.imag %0 : (tensor<complex<f64>>) -> tensor<f64>
+  return %1 : tensor<f64>
+}
+
+// CHECK-LABEL: func.func @imag_of_exp(
+// CHECK-DAG:   %[[RE:.+]] = stablehlo.real %arg0
+// CHECK-DAG:   %[[IM:.+]] = stablehlo.imag %arg0
+// CHECK-DAG:   %[[EXP:.+]] = stablehlo.exponential %[[RE]]
+// CHECK-DAG:   %[[SIN:.+]] = stablehlo.sine %[[IM]]
+// CHECK:       %[[MUL:.+]] = stablehlo.multiply %[[EXP]], %[[SIN]]
+// CHECK:       return %[[MUL]]
+
+func.func @abs_of_exp(%arg0: tensor<complex<f64>>) -> tensor<f64> {
+  %0 = stablehlo.exponential %arg0 : tensor<complex<f64>>
+  %1 = stablehlo.abs %0 : (tensor<complex<f64>>) -> tensor<f64>
+  return %1 : tensor<f64>
+}
+
+// CHECK-LABEL: func.func @abs_of_exp(
+// CHECK:       %[[RE:.+]] = stablehlo.real %arg0
+// CHECK:       %[[EXP:.+]] = stablehlo.exponential %[[RE]]
+// CHECK:       return %[[EXP]]

--- a/test/lit_tests/realimagabsexp.mlir
+++ b/test/lit_tests/realimagabsexp.mlir
@@ -38,3 +38,16 @@ func.func @abs_of_exp(%arg0: tensor<complex<f64>>) -> tensor<f64> {
 // CHECK:       %[[RE:.+]] = stablehlo.real %arg0
 // CHECK:       %[[EXP:.+]] = stablehlo.exponential %[[RE]]
 // CHECK:       return %[[EXP]]
+
+// The rewrite is skipped when the exp has another user, so it stays as-is.
+func.func @real_of_exp_multi_use(%arg0: tensor<complex<f64>>)
+    -> (tensor<f64>, tensor<complex<f64>>) {
+  %0 = stablehlo.exponential %arg0 : tensor<complex<f64>>
+  %1 = stablehlo.real %0 : (tensor<complex<f64>>) -> tensor<f64>
+  return %1, %0 : tensor<f64>, tensor<complex<f64>>
+}
+
+// CHECK-LABEL: func.func @real_of_exp_multi_use(
+// CHECK:       %[[EXP:.+]] = stablehlo.exponential %arg0
+// CHECK:       %[[REAL:.+]] = stablehlo.real %[[EXP]]
+// CHECK:       return %[[REAL]], %[[EXP]]


### PR DESCRIPTION
Fixes #1990.

Adds three algebraic simplifications to `EnzymeHLOOpt` for `real`, `imag`, and `abs` of a complex `exp`, matching the identities in the issue:

```
real(exp(x)) -> exp(real(x)) * cos(imag(x))
imag(exp(x)) -> exp(real(x)) * sin(imag(x))
abs(exp(x))  -> exp(real(x))
```

Each pattern matches when the operand is a complex-typed `stablehlo.exponential`, guarding on the element type so the non-complex `real`/`imag` cases are left to `RealOpCanon`/`ImagOpCanon`.

Test: `test/lit_tests/realimagabsexp.mlir`.
