### PR TITLE
Make patch command work with BSD sed

### DIFF
--- a/third_party/xprof/workspace.bzl
+++ b/third_party/xprof/workspace.bzl
@@ -46,7 +46,7 @@ cc_library(
     http_archive(
         name = "com_github_googlecloudplatform_google_cloud_cpp",
         patch_cmds = [
-            """find . -type f -exec sed -i.bak -e 's/Windows.h/windows.h/g' -e 's/Ntstatus.h/ntstatus.h/g' {} +""",
+            """find . -type f -name '*.cc' -exec sed -i.bak -e 's/Windows.h/windows.h/g' -e 's/Ntstatus.h/ntstatus.h/g' {} +""",
         ],
         repo_mapping = {
             "@com_github_curl_curl": "@curl",


### PR DESCRIPTION
The `find ... sed` command fails with BSD sed because the filter is being applied to binary files, and BSD sed attempts to interpret them as UTF-8 and errors:

```
~/google-cloud-cpp on  HEAD (7e88b2b)
❯ find . -type f -exec sed -i.bak -e 's/Windows.h/windows.h/g' -e 's/Ntstatus.h/ntstatus.h/g' {} +
sed: RE error: illegal byte sequence
sed: RE error: illegal byte sequence
```

This PR restricts the sed command to only files with a `.cc` extension which are all text files. It's safe because the header files above are only imported in `.cc` files, at least in the 3.1.0 release of `google-cloud-cpp` that is specified (https://github.com/googleapis/google-cloud-cpp/releases/tag/v3.1.0):

```
~/google-cloud-cpp on  HEAD (7e88b2b)
❯ rg -l 'Windows.h'
google/cloud/internal/win32/sign_using_sha256.cc
google/cloud/internal/win32/parse_service_account_p12_file.cc
google/cloud/internal/win32/win32_helpers.cc
google/cloud/internal/sha256_hmac.cc
google/cloud/internal/sha256_hash.cc

~/google-cloud-cpp on  HEAD (7e88b2b)
❯ rg -l 'Ntstatus.h'
google/cloud/internal/win32/sign_using_sha256.cc
```

Discovered when building Reactant locally on my Mac.