### PR TITLE
Extend DotGeneralSimplify to handle broadcasted scalars

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -9648,6 +9648,19 @@ struct BroadcastIotaSimplify
   }
 };
 
+
+
+// Returns the rank-0 scalar operand of a broadcast_in_dim that splats a scalar
+// across its entire result (empty broadcast_dimensions <=> rank-0 input), else
+// a null Value. The scalar may be a runtime value, hence a Value rather than an
+// attribute (cf. extractSplatInt).
+static Value extractBroadcastScalar(Value v) {
+  if (auto bcast = v.getDefiningOp<stablehlo::BroadcastInDimOp>())
+    if (bcast.getBroadcastDimensions().empty())
+      return bcast.getOperand();
+  return Value();
+}
+
 struct DotGeneralSimplify
     : public CheckedOpRewritePattern<stablehlo::DotGeneralOp,
                                      DotGeneralSimplify> {
@@ -9685,8 +9698,26 @@ struct DotGeneralSimplify
     Value reduceSumInput;
     SmallVector<int64_t> reduceDims, broadcastDims, broadcastShape;
     SplatElementsAttr splatElementsAttr;
+    Value splatScalar;  // runtime scalar from a rank-0 broadcast, else null
 
-    if (matchPattern(op.getLhs(), m_Constant(&splatElementsAttr))) {
+    bool lhsSplat = matchPattern(op.getLhs(), m_Constant(&splatElementsAttr));
+    if (!lhsSplat)
+      if (Value s = extractBroadcastScalar(op.getLhs())) {
+        lhsSplat = true;
+        splatScalar = s;
+      }
+
+    bool rhsSplat = false;
+    if (!lhsSplat) {
+      rhsSplat = matchPattern(op.getRhs(), m_Constant(&splatElementsAttr));
+      if (!rhsSplat)
+        if (Value s = extractBroadcastScalar(op.getRhs())) {
+          rhsSplat = true;
+          splatScalar = s;
+        }
+    }
+
+    if (lhsSplat) {
       reduceDims = llvm::to_vector(rhsContractingDims);
       reduceSumInput = op.getRhs();
 
@@ -9713,7 +9744,7 @@ struct DotGeneralSimplify
           broadcastDims.push_back(dim);
         }
       }
-    } else if (matchPattern(op.getRhs(), m_Constant(&splatElementsAttr))) {
+    } else if (rhsSplat) {
       reduceDims = llvm::to_vector(lhsContractingDims);
       reduceSumInput = op.getLhs();
 
@@ -9742,7 +9773,7 @@ struct DotGeneralSimplify
       }
     }
 
-    if (splatElementsAttr) {
+    if (lhsSplat || rhsSplat) {
       auto inputType = cast<RankedTensorType>(reduceSumInput.getType());
       auto elemType = inputType.getElementType();
       auto rank0Type = RankedTensorType::get({}, elemType);
@@ -9771,11 +9802,21 @@ struct DotGeneralSimplify
           RankedTensorType::get(broadcastShape, elemType),
           reduceOp.getResult(0), broadcastDims);
 
-      rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
-          op, bcastOp,
-          stablehlo::ConstantOp::create(
-              rewriter, op.getLoc(), bcastOp.getType(),
-              splatElementsAttr.resizeSplat(bcastOp.getType())));
+      // Scale the reduced sum by the splat value. Constant path uses the splat
+      // attribute; runtime path broadcasts the rank-0 scalar to the result
+      // shape. elemType comes from the non-splat operand, and dot_general
+      // requires matching operand element types, so it equals the scalar's type.
+      Value scaleFactor;
+      if (splatElementsAttr) {
+        scaleFactor = stablehlo::ConstantOp::create(
+            rewriter, op.getLoc(), bcastOp.getType(),
+            splatElementsAttr.resizeSplat(bcastOp.getType()));
+      } else {
+        scaleFactor = stablehlo::BroadcastInDimOp::create(
+            rewriter, op.getLoc(), bcastOp.getType(), splatScalar,
+            SmallVector<int64_t>{});
+      }
+      rewriter.replaceOpWithNewOp<stablehlo::MulOp>(op, bcastOp, scaleFactor);
       return success();
     }
 

--- a/test/lit_tests/dot_general_bcast_scalar.mlir
+++ b/test/lit_tests/dot_general_bcast_scalar.mlir
@@ -1,0 +1,29 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt %s | FileCheck %s
+
+// Reproduction for issue #1475:
+// DotGeneralSimplify handles dot_general(splat_constant, X) by folding it
+// into a reduce(X). It does NOT handle the equivalent case where one
+// operand is a broadcast_in_dim of a runtime scalar (e.g., a function
+// argument). The constant-folding canonicalizers can't help here because
+// the scalar value isn't known at compile time.
+
+// Variant A -- broadcast of a CONSTANT scalar: already simplified by the pipeline.
+func.func @bcast_rank0_constant(%arg1: tensor<1024x32xf32>) -> tensor<24x32xf32> {
+    %s = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %ones = stablehlo.broadcast_in_dim %s, dims = [] : (tensor<f32>) -> tensor<24x1024xf32>
+    %r = stablehlo.dot_general %ones, %arg1, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<24x1024xf32>, tensor<1024x32xf32>) -> tensor<24x32xf32>
+    return %r : tensor<24x32xf32>
+}
+// CHECK-LABEL: func.func @bcast_rank0_constant
+// CHECK-NOT: stablehlo.dot_general
+
+// Variant B -- broadcast of a RUNTIME scalar: NOT simplified. This is the gap.
+// After issue #1475 is fixed, the dot_general should be replaced by a
+// reduce(arg1) multiplied by the scalar (broadcast back to the result shape).
+func.func @bcast_rank0_runtime(%s: tensor<f32>, %arg1: tensor<1024x32xf32>) -> tensor<24x32xf32> {
+    %ones = stablehlo.broadcast_in_dim %s, dims = [] : (tensor<f32>) -> tensor<24x1024xf32>
+    %r = stablehlo.dot_general %ones, %arg1, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<24x1024xf32>, tensor<1024x32xf32>) -> tensor<24x32xf32>
+    return %r : tensor<24x32xf32>
+}
+// CHECK-LABEL: func.func @bcast_rank0_runtime
+// CHECK-NOT: stablehlo.dot_general

--- a/test/lit_tests/dot_general_bcast_scalar.mlir
+++ b/test/lit_tests/dot_general_bcast_scalar.mlir
@@ -27,3 +27,11 @@ func.func @bcast_rank0_runtime(%s: tensor<f32>, %arg1: tensor<1024x32xf32>) -> t
 }
 // CHECK-LABEL: func.func @bcast_rank0_runtime
 // CHECK-NOT: stablehlo.dot_general
+// Variant C -- broadcast of a RUNTIME scalar on the RHS operand.
+func.func @bcast_rank0_runtime_rhs(%s: tensor<f32>, %arg0: tensor<32x1024xf32>) -> tensor<32x24xf32> {
+    %ones = stablehlo.broadcast_in_dim %s, dims = [] : (tensor<f32>) -> tensor<1024x24xf32>
+    %r = stablehlo.dot_general %arg0, %ones, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<32x1024xf32>, tensor<1024x24xf32>) -> tensor<32x24xf32>
+    return %r : tensor<32x24xf32>
+}
+// CHECK-LABEL: func.func @bcast_rank0_runtime_rhs
+// CHECK-NOT: stablehlo.dot_general


### PR DESCRIPTION
Fixes #1475.

### Problem

`DotGeneralSimplify` rewrites `dot_general(splat, X)` into a `reduce` over the
contracting dims, scaled by the splat value and broadcast to the result shape.
Detection matched a splat operand only via `m_Constant`, so a
`broadcast_in_dim` of a rank-0 **runtime** scalar (e.g. a function argument)
was missed — no canonicalizer can fold it into a splat constant, so the full
`dot_general` survived even though it is still `s * reduce(X)`.

### Change

- Add `extractBroadcastScalar`, which looks through a rank-0 `broadcast_in_dim`
  (empty `broadcast_dimensions`) to its scalar operand `Value`. Mirrors the
  look-through in `extractSplatInt`, but returns a `Value` since the runtime
  case has no compile-time attribute.
- Detection now accepts either a splat constant or such a broadcast, on either
  operand. The constant path is unchanged; the runtime path scales the reduce
  by a broadcast of the scalar `Value` and always emits the multiply, relying
  on the existing downstream canonicalizer to drop it when the value is 1.
- The `dot_general` element-type constraint guarantees the scalar's type
  matches the reduce result, so no `convert` is needed.

### Tests

`test/lit_tests/dot_general_bcast_scalar.mlir` covers a broadcast of a constant
scalar (already folded by the pipeline) plus runtime scalars on the LHS and RHS
operands, both of which now simplify away the `dot_general`.

Before (runtime scalar, LHS):
```mlir
func.func @bcast_rank0_runtime(%s: tensor<f32>, %arg1: tensor<1024x32xf32>) -> tensor<24x32xf32> {
    %ones = stablehlo.broadcast_in_dim %s, dims = [] : (tensor<f32>) -> tensor<24x1024xf32>
    %r = stablehlo.dot_general %ones, %arg1, contracting_dims = [1] x [0], precision = [DEFAULT, DEFAULT] : (tensor<24x1024xf32>, tensor<1024x32xf32>) -> tensor<24x32xf32>
    return %r : tensor<24x32xf32>
}
```

After:
```mlir
func.func @bcast_rank0_runtime(%arg0: tensor<f32>, %arg1: tensor<1024x32xf32>) -> tensor<24x32xf32> {
    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
    %0 = stablehlo.reduce(%arg1 init: %cst) applies stablehlo.add across dimensions = [0] : (tensor<1024x32xf32>, tensor<f32>) -> tensor<32xf32>
    %1 = stablehlo.broadcast_in_dim %0, dims = [1] : (tensor<32xf32>) -> tensor<24x32xf32>
    %2 = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<f32>) -> tensor<24x32xf32>
    %3 = stablehlo.multiply %1, %2 : tensor<24x32xf32>
    return %3 : tensor<24x32xf32>
}
```