### PR TITLE
Fix NonNegativeResultAnalysis square rule to compare Values not defining ops

### DIFF
--- a/src/enzyme_ad/jax/Utils.cpp
+++ b/src/enzyme_ad/jax/Utils.cpp
@@ -987,10 +987,10 @@ NonNegativeResultAnalysis::State NonNegativeResultAnalysis::localGuaranteed(
 
   // (mul a a) is always non-negative
   if (auto mulOp = dyn_cast<stablehlo::MulOp>(op)) {
-    auto lhsOp = mulOp.getLhs().getDefiningOp();
-    auto rhsOp = mulOp.getRhs().getDefiningOp();
-
-    if (lhsOp == rhsOp) {
+    // Compare the operand Values, not their defining ops: two distinct block
+    // arguments both have a null defining op, so a defining-op comparison
+    // would wrongly prove mul(%arg0, %arg1) non-negative.
+    if (mulOp.getLhs() == mulOp.getRhs()) {
       return State::GUARANTEED;
     }
   }

--- a/test/lit_tests/abspositive.mlir
+++ b/test/lit_tests/abspositive.mlir
@@ -95,3 +95,12 @@ func.func @test8(%arg0: tensor<4xf64>) -> tensor<4xf64> {
 // CHECK-NEXT:     %0 = stablehlo.logistic %arg0 {enzymexla.non_negative = [#enzymexla<guaranteed GUARANTEED>]} : tensor<4xf64>
 // CHECK-NEXT:     return %0 : tensor<4xf64>
 // CHECK-NEXT: }
+
+// mul of two distinct block args must NOT be proven non-negative: the product
+// is negative whenever the args have opposite signs, so the abs has to stay.
+func.func @test9(%arg0: tensor<12xf64>, %arg1: tensor<12xf64>) -> tensor<12xf64> {
+    %0 = stablehlo.multiply %arg0, %arg1 : tensor<12xf64>
+    // CHECK: stablehlo.abs
+    %1 = stablehlo.abs %0 : tensor<12xf64>
+    return %1 : tensor<12xf64>
+}


### PR DESCRIPTION
Fixes #2648.

`NonNegativeResultAnalysis`'s "(mul a a) is always non-negative" rule compared the operands' *defining ops* rather than the operands themselves:

```cpp
auto lhsOp = mulOp.getLhs().getDefiningOp();
auto rhsOp = mulOp.getRhs().getDefiningOp();
if (lhsOp == rhsOp) return State::GUARANTEED;
```

Two distinct block arguments both have a `nullptr` defining op, so `null == null` wrongly proved `mul(%arg0, %arg1)` non-negative -- even though the product is negative whenever the args have opposite signs. Any consumer of `guaranteedNonNegativeResult` could then mis-fire (e.g. `AbsPositiveSimplify` dropping an `abs` that is actually load-bearing).

The fix compares the operand `Value`s directly, which is what "same value squared" actually means:

```cpp
if (mulOp.getLhs() == mulOp.getRhs()) return State::GUARANTEED;
```

This is strictly stricter -- it only removes unsound proofs, never adds new ones. The existing `mul(%arg0, %arg0)` cases in `abspositive.mlir` (test3/4/7) still fold, since `%arg0 == %arg0`.

Added `test9` in `abspositive.mlir`: `abs(mul(%arg0, %arg1))` of two distinct block args must keep its `abs` (fails on the pre-fix analysis, passes after).

Found while implementing the non-negativity gate in #2576.