### PR TITLE
Enable experimental remote repo contents cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
 # Public read-only cache
-common:public_cache --remote_cache="https://storage.googleapis.com/enzyme-presubmit-bazel-cache/" --remote_upload_local_results=false
-common:jll_cache --remote_cache="https://storage.googleapis.com/jll-gcp-cache/" --remote_upload_local_results=false
+common:public_cache --remote_cache="https://storage.googleapis.com/enzyme-presubmit-bazel-cache/" --remote_upload_local_results=false --experimental_remote_repo_contents_cache
+common:jll_cache --remote_cache="https://storage.googleapis.com/jll-gcp-cache/" --remote_upload_local_results=false --experimental_remote_repo_contents_cache
 
 # Cache pushes are limited to Enzyme's CI system.
 common:public_cache_push --config=public_cache --remote_upload_local_results=true --google_default_credentials


### PR DESCRIPTION
Added experimental_remote_repo_contents_cache option to public and jll caches.

This hopefully avoids issues where github file access is slow or down

only in bazel 9+ it seems: https://github.com/bazelbuild/bazel/commit/b8589c3b278e3f5cee6ef85b0dcabb1cdcd69839