### PR TITLE
Add unreachable in non-void function in ConvertPolygeistToLLVM

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -882,6 +882,7 @@ LLVM::AtomicOrdering convertAtomicOrdering(enzyme::Ordering ordering) {
   case mlir::enzyme::Ordering::seq_cst:
     return LLVM::AtomicOrdering::seq_cst;
   }
+  llvm_unreachable("Invalid Ordering");
 }
 
 struct CAtomicRMWOpLowering : public CLoadStoreOpLowering<memref::AtomicRMWOp> {


### PR DESCRIPTION
Otherwise, facing this error when building:

```
src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp: In function 'mlir::LLVM::AtomicOrdering {anonymous}::convertAtomicOrdering(mlir::enzyme::Ordering)':
src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp:885: error: control reaches end of non-void function [-Werror=return-type]
  885 | }
      |
cc1plus: some warnings being treated as errors
