### PR TITLE
Prefer {Optional,Required}PassInfoMixin

### DIFF
--- a/src/external/polly/include/polly/DependenceInfo.h
+++ b/src/external/polly/include/polly/DependenceInfo.h
@@ -223,7 +223,7 @@ struct DependenceAnalysis final : public AnalysisInfoMixin<DependenceAnalysis> {
 };
 
 struct DependenceInfoPrinterPass final
-    : RequiredPassInfoMixin<DependenceInfoPrinterPass> {
+    : llvm::RequiredPassInfoMixin<DependenceInfoPrinterPass> {
   DependenceInfoPrinterPass(raw_ostream &OS) : OS(OS) {}
 
   PreservedAnalyses run(Scop &S, ScopAnalysisManager &,

--- a/src/external/polly/include/polly/DependenceInfo.h
+++ b/src/external/polly/include/polly/DependenceInfo.h
@@ -223,7 +223,7 @@ struct DependenceAnalysis final : public AnalysisInfoMixin<DependenceAnalysis> {
 };
 
 struct DependenceInfoPrinterPass final
-    : PassInfoMixin<DependenceInfoPrinterPass> {
+    : RequiredPassInfoMixin<DependenceInfoPrinterPass> {
   DependenceInfoPrinterPass(raw_ostream &OS) : OS(OS) {}
 
   PreservedAnalyses run(Scop &S, ScopAnalysisManager &,

--- a/src/external/polly/include/polly/ScopDetection.h
+++ b/src/external/polly/include/polly/ScopDetection.h
@@ -73,9 +73,9 @@ using llvm::IntrinsicInst;
 using llvm::LoopInfo;
 using llvm::Module;
 using llvm::OptimizationRemarkEmitter;
-using llvm::PassInfoMixin;
 using llvm::PreservedAnalyses;
 using llvm::RegionInfo;
+using llvm::RequiredPassInfoMixin;
 using llvm::ScalarEvolution;
 using llvm::SCEVUnknown;
 using llvm::SetVector;
@@ -624,7 +624,8 @@ struct ScopAnalysis : AnalysisInfoMixin<ScopAnalysis> {
   Result run(Function &F, FunctionAnalysisManager &FAM);
 };
 
-struct ScopAnalysisPrinterPass final : PassInfoMixin<ScopAnalysisPrinterPass> {
+struct ScopAnalysisPrinterPass final
+    : RequiredPassInfoMixin<ScopAnalysisPrinterPass> {
   ScopAnalysisPrinterPass(raw_ostream &OS) : OS(OS) {}
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);

--- a/src/external/polly/include/polly/ScopInfo.h
+++ b/src/external/polly/include/polly/ScopInfo.h
@@ -52,10 +52,10 @@ using llvm::LoadInst;
 using llvm::make_range;
 using llvm::MapVector;
 using llvm::MemIntrinsic;
-using llvm::PassInfoMixin;
 using llvm::PHINode;
 using llvm::RegionNode;
 using llvm::RegionPass;
+using llvm::RequiredPassInfoMixin;
 using llvm::RGPassManager;
 using llvm::SetVector;
 using llvm::SmallPtrSetImpl;
@@ -2774,7 +2774,7 @@ struct ScopInfoAnalysis : AnalysisInfoMixin<ScopInfoAnalysis> {
   Result run(Function &, FunctionAnalysisManager &);
 };
 
-struct ScopInfoPrinterPass final : PassInfoMixin<ScopInfoPrinterPass> {
+struct ScopInfoPrinterPass final : RequiredPassInfoMixin<ScopInfoPrinterPass> {
   ScopInfoPrinterPass(raw_ostream &OS) : Stream(OS) {}
 
   PreservedAnalyses run(Function &, FunctionAnalysisManager &);

--- a/src/external/polly/include/polly/ScopPass.h
+++ b/src/external/polly/include/polly/ScopPass.h
@@ -94,7 +94,7 @@ private:
 template <typename AnalysisT>
 struct RequireAnalysisPass<AnalysisT, Scop, ScopAnalysisManager,
                            ScopStandardAnalysisResults &, SPMUpdater &>
-    : PassInfoMixin<
+    : RequiredPassInfoMixin<
           RequireAnalysisPass<AnalysisT, Scop, ScopAnalysisManager,
                               ScopStandardAnalysisResults &, SPMUpdater &>> {
   PreservedAnalyses run(Scop &L, ScopAnalysisManager &AM,
@@ -217,7 +217,7 @@ private:
 
 template <typename ScopPassT>
 struct FunctionToScopPassAdaptor final
-    : PassInfoMixin<FunctionToScopPassAdaptor<ScopPassT>> {
+    : OptionalPassInfoMixin<FunctionToScopPassAdaptor<ScopPassT>> {
   explicit FunctionToScopPassAdaptor(ScopPassT Pass) : Pass(std::move(Pass)) {}
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) {

--- a/src/external/polly/include/polly/ScopPass.h
+++ b/src/external/polly/include/polly/ScopPass.h
@@ -217,7 +217,7 @@ private:
 
 template <typename ScopPassT>
 struct FunctionToScopPassAdaptor final
-    : OptionalPassInfoMixin<FunctionToScopPassAdaptor<ScopPassT>> {
+    : llvm::OptionalPassInfoMixin<FunctionToScopPassAdaptor<ScopPassT>> {
   explicit FunctionToScopPassAdaptor(ScopPassT Pass) : Pass(std::move(Pass)) {}
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) {


### PR DESCRIPTION
Normal PassInfoMixin is going away. It seems like this file is already mostly gone in upstream, but we need to still compile with newer versions of LLVM here.