### PR TITLE
Handle semi-affine integer sets in SimplifyAffineExprs

### DIFF
--- a/patches/llvm.patch
+++ b/patches/llvm.patch
@@ -1,0 +1,178 @@
+diff --git a/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h b/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h
+index e481ef85562b..79fb201935f0 100644
+--- a/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h
++++ b/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h
+@@ -334,8 +334,10 @@ public:
+         setValue(i, *valArgs[i]);
+   }
+ 
+-  /// Creates an affine constraint system from an IntegerSet.
+-  explicit FlatLinearValueConstraints(IntegerSet set, ValueRange operands = {});
++  /// Creates an affine constraint system from an IntegerSet. Returns failure
++  /// if `set` is semi-affine, as flattening is not implemented for those.
++  static FailureOr<FlatLinearValueConstraints>
++  create(IntegerSet set, ValueRange operands = {});
+ 
+   /// Return the kind of this object.
+   Kind getKind() const override { return Kind::FlatLinearValueConstraints; }
+@@ -517,6 +519,12 @@ public:
+   ///    output = {0 <= d0 <= 6, 1 <= d1 <= 15}
+   LogicalResult unionBoundingBox(const FlatLinearValueConstraints &other);
+   using IntegerPolyhedron::unionBoundingBox;
++
++protected:
++  /// Creates an affine constraint system from an IntegerSet. `error` is set to
++  /// true if `set` could not be flattened, in which case the constraint system
++  /// is left without the constraints of `set`. Use `create` instead.
++  FlatLinearValueConstraints(IntegerSet set, ValueRange operands, bool *error);
+ };
+ 
+ /// Flattens 'expr' into 'flattenedExpr', which contains the coefficients of the
+diff --git a/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h b/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
+index e6596f2e010d..49903c3c3f67 100644
+--- a/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
++++ b/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
+@@ -45,6 +45,11 @@ class FlatAffineValueConstraints : public FlatLinearValueConstraints {
+ public:
+   using FlatLinearValueConstraints::FlatLinearValueConstraints;
+ 
++  /// Creates an affine constraint system from an IntegerSet. Returns failure
++  /// if `set` is semi-affine, as flattening is not implemented for those.
++  static FailureOr<FlatAffineValueConstraints>
++  create(IntegerSet set, ValueRange operands = {});
++
+   /// Return the kind of this object.
+   Kind getKind() const override { return Kind::FlatAffineValueConstraints; }
+ 
+diff --git a/mlir/lib/Analysis/FlatLinearValueConstraints.cpp b/mlir/lib/Analysis/FlatLinearValueConstraints.cpp
+index 8e8fcc347b72..6d28387b0e5c 100644
+--- a/mlir/lib/Analysis/FlatLinearValueConstraints.cpp
++++ b/mlir/lib/Analysis/FlatLinearValueConstraints.cpp
+@@ -1145,13 +1145,16 @@ IntegerSet FlatLinearConstraints::getAsIntegerSet(MLIRContext *context) const {
+ 
+ // Construct from an IntegerSet.
+ FlatLinearValueConstraints::FlatLinearValueConstraints(IntegerSet set,
+-                                                       ValueRange operands)
++                                                       ValueRange operands,
++                                                       bool *error)
+     : FlatLinearConstraints(set.getNumInequalities(), set.getNumEqualities(),
+                             set.getNumDims() + set.getNumSymbols() + 1,
+                             set.getNumDims(), set.getNumSymbols(),
+                             /*numLocals=*/0) {
++  assert(error && "expected a valid error flag");
+   assert((operands.empty() || set.getNumInputs() == operands.size()) &&
+          "operand count mismatch");
++  *error = false;
+   // Set the values for the non-local variables.
+   for (unsigned i = 0, e = operands.size(); i < e; ++i)
+     setValue(i, operands[i]);
+@@ -1160,7 +1163,8 @@ FlatLinearValueConstraints::FlatLinearValueConstraints(IntegerSet set,
+   std::vector<SmallVector<int64_t, 8>> flatExprs;
+   FlatLinearConstraints localVarCst;
+   if (failed(getFlattenedAffineExprs(set, &flatExprs, &localVarCst))) {
+-    assert(false && "flattening unimplemented for semi-affine integer sets");
++    // Flattening is unimplemented for semi-affine integer sets.
++    *error = true;
+     return;
+   }
+   assert(flatExprs.size() == set.getNumConstraints());
+@@ -1180,6 +1184,15 @@ FlatLinearValueConstraints::FlatLinearValueConstraints(IntegerSet set,
+   append(localVarCst);
+ }
+ 
++FailureOr<FlatLinearValueConstraints>
++FlatLinearValueConstraints::create(IntegerSet set, ValueRange operands) {
++  bool error = false;
++  FlatLinearValueConstraints cst(set, operands, &error);
++  if (error)
++    return failure();
++  return cst;
++}
++
+ unsigned FlatLinearValueConstraints::appendDimVar(ValueRange vals) {
+   unsigned pos = getNumDimVars();
+   return insertVar(VarKind::SetDim, pos, vals);
+diff --git a/mlir/lib/Dialect/Affine/Analysis/AffineStructures.cpp b/mlir/lib/Dialect/Affine/Analysis/AffineStructures.cpp
+index 8bf773dd817f..209f783bdb50 100644
+--- a/mlir/lib/Dialect/Affine/Analysis/AffineStructures.cpp
++++ b/mlir/lib/Dialect/Affine/Analysis/AffineStructures.cpp
+@@ -29,6 +29,15 @@ using namespace mlir;
+ using namespace affine;
+ using namespace presburger;
+ 
++FailureOr<FlatAffineValueConstraints>
++FlatAffineValueConstraints::create(IntegerSet set, ValueRange operands) {
++  bool error = false;
++  FlatAffineValueConstraints cst(set, operands, &error);
++  if (error)
++    return failure();
++  return cst;
++}
++
+ LogicalResult
+ FlatAffineValueConstraints::addInductionVarOrTerminalSymbol(Value val) {
+   if (containsVar(val))
+@@ -208,13 +217,18 @@ void FlatAffineValueConstraints::addAffineIfOpDomain(AffineIfOp ifOp) {
+   canonicalizeSetAndOperands(&set, &operands);
+ 
+   // Create the base constraints from the integer set attached to ifOp.
+-  FlatAffineValueConstraints cst(set, operands);
++  FailureOr<FlatAffineValueConstraints> cst =
++      FlatAffineValueConstraints::create(set, operands);
++  if (failed(cst)) {
++    assert(false && "semi-affine integer sets are unsupported here");
++    return;
++  }
+ 
+   // Merge the constraints from ifOp to the current domain. We need first merge
+   // and align the IDs from both constraints, and then append the constraints
+   // from the ifOp into the current one.
+-  mergeAndAlignVarsWithOther(0, &cst);
+-  append(cst);
++  mergeAndAlignVarsWithOther(0, &*cst);
++  append(*cst);
+ }
+ 
+ LogicalResult FlatAffineValueConstraints::addBound(BoundType type, unsigned pos,
+diff --git a/mlir/lib/Dialect/Affine/Analysis/Utils.cpp b/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
+index cac305df8ba7..321c8e34d907 100644
+--- a/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
++++ b/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
+@@ -2195,13 +2195,17 @@ void mlir::affine::getSequentialLoops(
+ }
+ 
+ IntegerSet mlir::affine::simplifyIntegerSet(IntegerSet set) {
+-  FlatAffineValueConstraints fac(set);
+-  if (fac.isEmpty())
++  FailureOr<FlatAffineValueConstraints> fac =
++      FlatAffineValueConstraints::create(set);
++  // Semi-affine sets can't be flattened; return them as is.
++  if (failed(fac))
++    return set;
++  if (fac->isEmpty())
+     return IntegerSet::getEmptySet(set.getNumDims(), set.getNumSymbols(),
+                                    set.getContext());
+-  fac.removeTrivialRedundancy();
++  fac->removeTrivialRedundancy();
+ 
+-  auto simplifiedSet = fac.getAsIntegerSet(set.getContext());
++  auto simplifiedSet = fac->getAsIntegerSet(set.getContext());
+   assert(simplifiedSet && "guaranteed to succeed while roundtripping");
+   return simplifiedSet;
+ }
+diff --git a/mlir/unittests/Analysis/Presburger/Parser.h b/mlir/unittests/Analysis/Presburger/Parser.h
+index 75842fb054e2..992e86c8b41a 100644
+--- a/mlir/unittests/Analysis/Presburger/Parser.h
++++ b/mlir/unittests/Analysis/Presburger/Parser.h
+@@ -30,7 +30,10 @@ namespace presburger {
+ /// represents a valid IntegerSet.
+ inline IntegerPolyhedron parseIntegerPolyhedron(StringRef str) {
+   MLIRContext context(MLIRContext::Threading::DISABLED);
+-  return affine::FlatAffineValueConstraints(parseIntegerSet(str, &context));
++  FailureOr<affine::FlatAffineValueConstraints> cst =
++      affine::FlatAffineValueConstraints::create(parseIntegerSet(str, &context));
++  assert(succeeded(cst) && "expected a valid IntegerSet");
++  return *cst;
+ }
+ 
+ /// Parse a list of StringRefs to IntegerRelation and combine them into a

--- a/patches/llvm.patch
+++ b/patches/llvm.patch
@@ -1,5 +1,5 @@
 diff --git a/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h b/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h
-index e481ef85562b..79fb201935f0 100644
+index e481ef85562b..28ad01ed6680 100644
 --- a/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h
 +++ b/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h
 @@ -334,8 +334,10 @@ public:
@@ -10,8 +10,8 @@ index e481ef85562b..79fb201935f0 100644
 -  explicit FlatLinearValueConstraints(IntegerSet set, ValueRange operands = {});
 +  /// Creates an affine constraint system from an IntegerSet. Returns failure
 +  /// if `set` is semi-affine, as flattening is not implemented for those.
-+  static FailureOr<FlatLinearValueConstraints>
-+  create(IntegerSet set, ValueRange operands = {});
++  static FailureOr<FlatLinearValueConstraints> create(IntegerSet set,
++                                                      ValueRange operands = {});
  
    /// Return the kind of this object.
    Kind getKind() const override { return Kind::FlatLinearValueConstraints; }
@@ -29,7 +29,7 @@ index e481ef85562b..79fb201935f0 100644
  
  /// Flattens 'expr' into 'flattenedExpr', which contains the coefficients of the
 diff --git a/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h b/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
-index e6596f2e010d..49903c3c3f67 100644
+index e6596f2e010d..477834156028 100644
 --- a/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
 +++ b/mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h
 @@ -45,6 +45,11 @@ class FlatAffineValueConstraints : public FlatLinearValueConstraints {
@@ -38,8 +38,8 @@ index e6596f2e010d..49903c3c3f67 100644
  
 +  /// Creates an affine constraint system from an IntegerSet. Returns failure
 +  /// if `set` is semi-affine, as flattening is not implemented for those.
-+  static FailureOr<FlatAffineValueConstraints>
-+  create(IntegerSet set, ValueRange operands = {});
++  static FailureOr<FlatAffineValueConstraints> create(IntegerSet set,
++                                                      ValueRange operands = {});
 +
    /// Return the kind of this object.
    Kind getKind() const override { return Kind::FlatAffineValueConstraints; }
@@ -161,16 +161,17 @@ index cac305df8ba7..321c8e34d907 100644
    return simplifiedSet;
  }
 diff --git a/mlir/unittests/Analysis/Presburger/Parser.h b/mlir/unittests/Analysis/Presburger/Parser.h
-index 75842fb054e2..992e86c8b41a 100644
+index 75842fb054e2..39ddc1d8c2e1 100644
 --- a/mlir/unittests/Analysis/Presburger/Parser.h
 +++ b/mlir/unittests/Analysis/Presburger/Parser.h
-@@ -30,7 +30,10 @@ namespace presburger {
+@@ -30,7 +30,11 @@ namespace presburger {
  /// represents a valid IntegerSet.
  inline IntegerPolyhedron parseIntegerPolyhedron(StringRef str) {
    MLIRContext context(MLIRContext::Threading::DISABLED);
 -  return affine::FlatAffineValueConstraints(parseIntegerSet(str, &context));
 +  FailureOr<affine::FlatAffineValueConstraints> cst =
-+      affine::FlatAffineValueConstraints::create(parseIntegerSet(str, &context));
++      affine::FlatAffineValueConstraints::create(
++          parseIntegerSet(str, &context));
 +  assert(succeeded(cst) && "expected a valid IntegerSet");
 +  return *cst;
  }

--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -92,16 +92,23 @@ static LogicalResult addAffineIfOpDomain(AffineIfOp ifOp, bool isElse,
   SmallVector<Value> operands(ifOp.getOperands());
   canonicalizeSetAndOperands(&set, &operands);
 
-  // Create the base constraints from the integer set attached to ifOp.
-  FlatAffineValueConstraints cst(set, operands);
+  // Create the base constraints from the integer set attached to ifOp. This
+  // fails for semi-affine sets, which cannot be flattened.
+  FailureOr<FlatAffineValueConstraints> cst =
+      FlatAffineValueConstraints::create(set, operands);
+  if (failed(cst)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "semi-affine integer sets in 'affine.if' not supported\n");
+    return failure();
+  }
 
   if (!isElse) {
-    domain->mergeAndAlignVarsWithOther(0, &cst);
-    domain->append(cst);
+    domain->mergeAndAlignVarsWithOther(0, &*cst);
+    domain->append(*cst);
     return success();
   }
 
-  presburger::PresburgerRelation pr(cst);
+  presburger::PresburgerRelation pr(*cst);
   pr = pr.complement();
   if (pr.getNumDisjuncts() > 1) {
     // TODO: we can turn the domain into a PresburgerSet that supports
@@ -112,7 +119,7 @@ static LogicalResult addAffineIfOpDomain(AffineIfOp ifOp, bool isElse,
   }
 
   FlatLinearValueConstraints flvc(
-      presburger::IntegerPolyhedron(pr.getDisjunct(0)), cst.getMaybeValues());
+      presburger::IntegerPolyhedron(pr.getDisjunct(0)), cst->getMaybeValues());
 
   domain->mergeAndAlignVarsWithOther(0, &flvc);
   domain->append(flvc);

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -82,8 +82,10 @@ echo " llvm::Error evalPrintOp(PrintOp& op, InterpreterValue operand) {" >> thir
     # Apply our own patches on top of the LLVM pinned by XLA. This lets us use
     # upstream APIs which have not yet made it into the pinned commit. Drop the
     # corresponding hunks from patches/llvm.patch once XLA moves to an LLVM
-    # which already contains them.
-    sed -i.bak0 "s|patches = \\[|patches = [\\\"//:patches/llvm.patch\\\",|g" third_party/llvm/workspace.bzl
+    # which already contains them. The label is written in escaped form so that
+    # downstream users of this file (e.g. Reactant.jl) can rewrite it to
+    # @enzyme_ad//:patches when this repo is not the main one.
+    sed -i.bak0 "s/patches = \\[/patches = [\\\"\\/\\/:patches\\/llvm.patch\\\",/g" third_party/llvm/workspace.bzl
     """,
     """
     sed -i.bak0 "s/Node::Leaf(std::forward<decltype(value)>/Node::Leaf(std::forward<T>/g" xla/tuple_tree.h

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -79,6 +79,13 @@ echo " llvm::Error evalPrintOp(PrintOp& op, InterpreterValue operand) {" >> thir
     sed -i.bak0 "s/patch_file/patch_args = [\\\"-p1\\\"],patches/g" third_party/llvm/workspace.bzl
     """,
     """
+    # Apply our own patches on top of the LLVM pinned by XLA. This lets us use
+    # upstream APIs which have not yet made it into the pinned commit. Drop the
+    # corresponding hunks from patches/llvm.patch once XLA moves to an LLVM
+    # which already contains them.
+    sed -i.bak0 "s|patches = \\[|patches = [\\\"//:patches/llvm.patch\\\",|g" third_party/llvm/workspace.bzl
+    """,
+    """
     sed -i.bak0 "s/Node::Leaf(std::forward<decltype(value)>/Node::Leaf(std::forward<T>/g" xla/tuple_tree.h
     """,
     """


### PR DESCRIPTION
FlatAffineValueConstraints' IntegerSet constructor asserts when the set is semi-affine, so addAffineIfOpDomain crashes on such an affine.if instead of bailing out.

Add patches/llvm.patch, carrying the upstream change which makes that constructor protected and exposes FlatAffineValueConstraints::create returning a FailureOr, and wire it into the LLVM pinned by XLA. Drop it once XLA moves to an LLVM which already contains the change.

With that available, addAffineIfOpDomain now returns failure for semi-affine sets, which its caller already handles.