### PR TITLE
Fix Windows JIT failure on floating point constants

### DIFF
--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -271,8 +271,40 @@ extern "C" void __chkstk(void);
 
 bool initJIT() {
   if (!JIT) {
+    auto tJTMB = llvm::orc::JITTargetMachineBuilder::detectHost();
+    if (!tJTMB) {
+      llvm::errs() << " jit host detection error: " << tJTMB.takeError()
+                   << "\n";
+      return false;
+    }
+
+    // On Windows, compile as if we were mingw rather than MSVC. With an MSVC
+    // environment LLVM emits every mergeable floating point constant into its
+    // own COMDAT section carrying a global `__real@<hex>` (or `__xmm@<hex>`)
+    // symbol -- see TargetLoweringObjectFileCOFF::getSectionForConstant
+    // together with AsmPrinter::GetCPISymbol, which is gated on
+    // isWindowsMSVCEnvironment(). LLJIT links x86-64 COFF objects with
+    // RuntimeDyld, whose COMDAT support cannot resolve those symbols
+    // (llvm.org/PR40074, which RTDyldObjectLinkingLayer::onObjLoad only
+    // partially works around), so a kernel containing a literal such as `0.5`
+    // intermittently fails to materialize:
+    //
+    //   Failed to materialize symbols:
+    //     { (enzymejitdl_12, { __real@3fe0000000000000 }) }
+    //
+    // The GNU environment selects MCAsmInfoGNUCOFF, which sets
+    // HasCOFFComdatConstants = false, so constants are emitted as ordinary
+    // constant-pool entries with local labels that RuntimeDyld handles fine.
+    // Both environments share the same architecture, object format, data
+    // layout and calling convention, so this only changes how constants are
+    // emitted. The one externally visible difference is the name of the stack
+    // probe helper, which is mapped below. See EnzymeAD/Reactant.jl#1673.
+    if (tJTMB->getTargetTriple().isWindowsMSVCEnvironment())
+      tJTMB->getTargetTriple().setEnvironment(llvm::Triple::GNU);
+
     auto tJIT =
         llvm::orc::LLJITBuilder()
+            .setJITTargetMachineBuilder(std::move(*tJTMB))
             .setLinkProcessSymbolsByDefault(true)
             .setObjectLinkingLayerCreator(
                 [](llvm::orc::ExecutionSession &ES,
@@ -316,14 +348,25 @@ bool initJIT() {
 #if defined(_WIN32)
 #ifdef __MINGW32__
 #if defined(__i386__)
-    EnzymeJaXMapSymbol("__chkstk", (void *)&_alloca);
+    void *StackProbe = (void *)&_alloca;
 #elif defined(__x86_64__)
-    EnzymeJaXMapSymbol("__chkstk", (void *)&___chkstk_ms);
+    void *StackProbe = (void *)&___chkstk_ms;
 #else
-    EnzymeJaXMapSymbol("__chkstk", (void *)&__chkstk);
+    void *StackProbe = (void *)&__chkstk;
 #endif
 #else
-    EnzymeJaXMapSymbol("__chkstk", (void *)&__chkstk);
+    void *StackProbe = (void *)&__chkstk;
+#endif
+    EnzymeJaXMapSymbol("__chkstk", StackProbe);
+#if defined(_M_X64) || defined(__x86_64__)
+    // We select the GNU environment above, and x86-64 mingw names the stack
+    // probe ___chkstk_ms rather than __chkstk (see RuntimeLibcalls.td, where
+    // ___chkstk_ms is isCygwinMinGW64 and __chkstk is isWin64NotCygMing). The
+    // two are interchangeable there: both take the allocation size in %rax,
+    // only probe, and leave %rsp and %rax alone (see the comment in
+    // X86FrameLowering::emitStackProbeCall), so whichever one this process was
+    // built with can serve both names.
+    EnzymeJaXMapSymbol("___chkstk_ms", StackProbe);
 #endif
 #endif
   }

--- a/test/lit_tests/lowering/cpujitfpconst.mlir
+++ b/test/lit_tests/lowering/cpujitfpconst.mlir
@@ -1,0 +1,33 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(lower-jit{backend=cpu})" | FileCheck %s
+
+// A CPU jit_call whose body contains a floating point literal. Note that `jit`
+// defaults to true, so unlike cpujit.mlir this actually compiles @scale through
+// the in-process ORC JIT, and lower-jit signals pass failure if the module
+// cannot be materialized.
+//
+// On Windows with an MSVC target triple, LLVM emits the 0.5 below into its own
+// COMDAT section with a global `__real@3fe0000000000000` symbol, which
+// RuntimeDyld cannot resolve (llvm.org/PR40074):
+//
+//   JIT session error: Failed to materialize symbols:
+//     { (enzymejitdl_12, { __real@3fe0000000000000 }) }
+//
+// initJIT() therefore selects the mingw environment on Windows, which does not
+// use COMDAT constants. See EnzymeAD/Reactant.jl#1673.
+
+module {
+  func.func private @scale(%arg0: !llvm.ptr<1>) {
+    %cst = llvm.mlir.constant(5.000000e-01 : f64) : f64
+    %0 = llvm.load %arg0 {alignment = 8 : i64} : !llvm.ptr<1> -> f64
+    %1 = llvm.fmul %cst, %0 : f64
+    llvm.store %1, %arg0 {alignment = 8 : i64} : f64, !llvm.ptr<1>
+    return
+  }
+  func.func @main(%arg0: tensor<64xf64>) -> tensor<64xf64> {
+    %0 = enzymexla.jit_call @scale (%arg0) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 0, operand_tuple_indices = []>]} : (tensor<64xf64>) -> tensor<64xf64>
+    return %0 : tensor<64xf64>
+  }
+}
+
+// CHECK-LABEL: @main
+// CHECK: stablehlo.custom_call @enzymexla_compile_cpu


### PR DESCRIPTION
The in-process ORC JIT builds its TargetMachine from the detected host triple, which on Windows is an MSVC one. LLVM then emits every mergeable floating point constant into its own COMDAT section carrying a global `__real@<hex>` symbol, and RuntimeDyld -- which is what LLJIT links x86-64 COFF objects with -- cannot resolve those (llvm.org/PR40074). Any kernel containing a literal such as `0.5` then intermittently fails:

  JIT session error: Failed to materialize symbols:
    { (enzymejitdl_12, { __real@3fe0000000000000 }) }
   lookupError Failed to materialize symbols: { (enzymejitdl_12, { entry }) }

Select the GNU (mingw) environment instead, which picks MCAsmInfoGNUCOFF (HasCOFFComdatConstants = false) so constants become ordinary constant-pool entries with local labels. The two environments share the same architecture, object format, data layout and calling convention; the one visible difference is that x86-64 mingw names the stack probe ___chkstk_ms rather than __chkstk, so map both names onto whichever probe the host process provides.

Fixes EnzymeAD/Reactant.jl#1673.