### PR TITLE
Add flag to disable speculation of partial if bodies

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
@@ -889,6 +889,7 @@ public:
   }
 };
 
+template <bool Speculate>
 class PartialIfToSelect final : public OpRewritePattern<scf::IfOp> {
 public:
   using OpRewritePattern<scf::IfOp>::OpRewritePattern;
@@ -930,6 +931,12 @@ public:
           return v;
         if (!ifOp->isAncestor(op))
           return v;
+        // If speculation is disabled, transform only if ops that solely contain
+        // yields
+        if (!Speculate && (thenBlock->getOperations().size() != 1 ||
+                           elseBlock->getOperations().size() != 1)) {
+          return std::nullopt;
+        }
         if (op->getNumRegions() > 0)
           return std::nullopt;
         if (!isPure(op))
@@ -1057,13 +1064,17 @@ struct CanonicalizeLoopsPass
     {
       RewritePatternSet patterns(&getContext());
       patterns.add<RemoveAffineParallelSingleIter, SwitchToIf,
-                   SimplifyIfByRemovingEmptyThen, PartialIfToSelect>(
-          &getContext());
+                   SimplifyIfByRemovingEmptyThen>(&getContext());
 
       if (speculate_if) {
         patterns.add<IfToSelect<true>>(&getContext());
       } else {
         patterns.add<IfToSelect<false>>(&getContext());
+      }
+      if (speculate_partial_if) {
+        patterns.add<PartialIfToSelect<true>>(&getContext());
+      } else {
+        patterns.add<PartialIfToSelect<false>>(&getContext());
       }
 
       if (failed(

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -24,7 +24,10 @@ def CanonicalizeLoopsPass : InterfacePass<"canonicalize-loops",
   let options = [
     Option<"speculate_if", "speculate_if", "bool",
            /*default=*/"false",
-	   "Whether to speculate if statement bodies">
+	   "Whether to speculate if statement bodies">,
+    Option<"speculate_partial_if", "speculate_partial_if", "bool",
+           /*default=*/"false",
+	   "Whether to partially speculate if statement bodies">
   ];
 }
 

--- a/test/lit_tests/if_to_select.mlir
+++ b/test/lit_tests/if_to_select.mlir
@@ -1,4 +1,5 @@
-// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(func.func(canonicalize-loops))" --split-input-file | FileCheck %s
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(func.func(canonicalize-loops{speculate_if}))" --split-input-file | FileCheck %s
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(func.func(canonicalize-loops{speculate_partial_if=false}))" --split-input-file | FileCheck %s --check-prefix=NOSPECULATE
 
 func.func @if_to_select(%arg0: i1, %arg1: i32, %arg2: i32) -> i32 {
   %result = scf.if %arg0 -> i32 {
@@ -55,3 +56,32 @@ func.func @if_to_select_nested(%cond: i1, %val1: f64, %val2: f64, %const: f64, %
 // CHECK: %[[COPY:.*]] = math.copysign %[[VAL1]], %[[CONST2]] : f64
 // CHECK: %[[SEL2:.*]] = arith.select %[[COND]], %[[SEL1]], %[[COPY]] : f64
 // CHECK: return %[[SEL2]] : f64   
+
+// -----
+
+func.func @if_to_select_nested(%cond: i1, %val1: f64, %val2: f64, %const: f64, %const2: f64) -> f64 {
+  %result = scf.if %cond -> (f64) {
+    %cmp = arith.cmpf ogt, %val1, %const {fastmathFlags = #llvm.fastmath<none>} : f64
+    %sel = arith.select %cmp, %val1, %val2 {fastmathFlags = #llvm.fastmath<none>} : f64
+    scf.yield %sel : f64
+  } else {
+    %copy = math.copysign %val1, %const2 : f64
+    scf.yield %copy : f64
+  }
+  return %result : f64
+}
+
+// With speculation disabled, the if should be left in place.
+
+// NOSPECULATE-LABEL:   func.func @if_to_select_nested(
+// NOSPECULATE-SAME:      %[[ARG0:.*]]: i1, %[[ARG1:.*]]: f64, %[[ARG2:.*]]: f64, %[[ARG3:.*]]: f64, %[[ARG4:.*]]: f64) -> f64 {
+// NOSPECULATE:           %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f64) {
+// NOSPECULATE:             %[[CMPF_0:.*]] = arith.cmpf ogt, %[[ARG1]], %[[ARG3]] {fastmathFlags = #llvm.fastmath<none>} : f64
+// NOSPECULATE:             %[[SELECT_0:.*]] = arith.select %[[CMPF_0]], %[[ARG1]], %[[ARG2]] {fastmathFlags = #llvm.fastmath<none>} : f64
+// NOSPECULATE:             scf.yield %[[SELECT_0]] : f64
+// NOSPECULATE:           } else {
+// NOSPECULATE:             %[[COPYSIGN_0:.*]] = math.copysign %[[ARG1]], %[[ARG4]] : f64
+// NOSPECULATE:             scf.yield %[[COPYSIGN_0]] : f64
+// NOSPECULATE:           }
+// NOSPECULATE:           return %[[IF_0]] : f64
+// NOSPECULATE:         }

--- a/test/lit_tests/partial-if-to-select.mlir
+++ b/test/lit_tests/partial-if-to-select.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(func.func(canonicalize-loops))" %s | FileCheck %s
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(func.func(canonicalize-loops{speculate_partial_if}))" %s | FileCheck %s
 
 // CHECK-NOT: = scf.yield{{.*}}false
 


### PR DESCRIPTION
Disabling this pattern leads to LBM finding a significantly better min-cut solution. cc: @Pangoraw 