### PR TITLE
Adds cuda backend support to MPI Allreduce via NCCL

### DIFF
--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
@@ -1,5 +1,6 @@
 // #include "mhlo/IR/hlo_ops.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -26,6 +27,44 @@ namespace enzyme {
 } // namespace mlir
 
 using namespace mlir;
+
+static FailureOr<int32_t> mapMPIToNCCLDatatype(enzymexla::MPIDatatype dt) {
+  switch (dt) {
+  case enzymexla::MPIDatatype::MPI_INT32_T:
+  case enzymexla::MPIDatatype::MPI_INT:
+    return 2; // ncclInt32
+  case enzymexla::MPIDatatype::MPI_UINT32_T:
+  case enzymexla::MPIDatatype::MPI_UNSIGNED:
+    return 3; // ncclUint32
+  case enzymexla::MPIDatatype::MPI_INT64_T:
+  case enzymexla::MPIDatatype::MPI_LONG_LONG_INT:
+    return 4; // ncclInt64
+  case enzymexla::MPIDatatype::MPI_UINT64_T:
+  case enzymexla::MPIDatatype::MPI_UNSIGNED_LONG_LONG:
+    return 5; // ncclUint64
+  case enzymexla::MPIDatatype::MPI_FLOAT:
+    return 7; // ncclFloat32
+  case enzymexla::MPIDatatype::MPI_DOUBLE:
+    return 8; // ncclFloat64
+  default:
+    return failure();
+  }
+}
+
+static FailureOr<int32_t> mapMPIToNCCLRedOp(enzymexla::MPIOp op) {
+  switch (op) {
+  case enzymexla::MPIOp::MPI_SUM:
+    return 0; // ncclSum
+  case enzymexla::MPIOp::MPI_PROD:
+    return 1; // ncclProd
+  case enzymexla::MPIOp::MPI_MAX:
+    return 2; // ncclMax
+  case enzymexla::MPIOp::MPI_MIN:
+    return 3; // ncclMin
+  default:
+    return failure();
+  }
+}
 
 struct MPICommRankOpLowering
     : public OpRewritePattern<enzymexla::MPICommRankOp> {
@@ -1374,9 +1413,10 @@ struct MPIAllreduceOpLowering
     : public OpRewritePattern<enzymexla::MPIAllreduceOp> {
 
   std::string backend;
-  MPIAllreduceOpLowering(std::string backend, MLIRContext *context,
+  size_t ncclCommPtr;
+  MPIAllreduceOpLowering(std::string backend, size_t ncclCommPtr, MLIRContext *context,
                          PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit), backend(backend) {}
+      : OpRewritePattern(context, benefit), backend(backend), ncclCommPtr(ncclCommPtr) {}
 
   LogicalResult matchAndRewrite(enzymexla::MPIAllreduceOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1551,6 +1591,161 @@ struct MPIAllreduceOpLowering
       rewriter.replaceOp(op, jitCall);
 
       return success();
+
+    } else if (backend == "cuda") {
+
+      auto moduleOp = op->getParentOfType<ModuleOp>();
+      auto sendbufType = dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+      auto recvbufType = dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+      if (!sendbufType || !sendbufType.hasStaticShape())
+        return rewriter.notifyMatchFailure(
+            op, "CUDA NCCL allreduce lowering requires statically shaped "
+                "sendbuf to derive the element count");
+      if (!recvbufType || !recvbufType.hasStaticShape())
+        return rewriter.notifyMatchFailure(
+            op, "CUDA NCCL allreduce lowering requires statically shaped "
+                "recvbuf to validate the element count");
+      if (sendbufType.getShape() != recvbufType.getShape())
+        return rewriter.notifyMatchFailure(
+            op, "CUDA NCCL allreduce lowering requires sendbuf and recvbuf to "
+                "have the same shape");
+
+      auto llvmPtrType = LLVM::LLVMPointerType::get(context);
+      auto llvmVoidType = LLVM::LLVMVoidType::get(context);
+      auto i32Type = IntegerType::get(context, 32);
+      auto i64Type = IntegerType::get(context, 64);
+
+      std::string ncclFunctionName = "ncclAllReduce";
+
+      auto datatype = op.getDatatype();
+      StringRef datatypeName = stringifyMPIDatatype(datatype);
+      auto ncclDatatype = mapMPIToNCCLDatatype(datatype);
+      if (failed(ncclDatatype))
+        return rewriter.notifyMatchFailure(
+            op, "MPI datatype not supported by NCCL lowering: " +
+                    datatypeName.str());
+
+      auto mpiOp = op.getOp();
+      StringRef mpiOpName = stringifyMPIOp(mpiOp);
+      auto ncclRedOp = mapMPIToNCCLRedOp(mpiOp);
+      if (failed(ncclRedOp))
+        return rewriter.notifyMatchFailure(
+            op, "MPI reduction op not supported by NCCL lowering: " +
+                    mpiOpName.str());
+
+      // Generate the enzymexla_wrapper LLVM function body
+      std::string wrapperFunctionName = "enzymexla_wrapper_" + ncclFunctionName +
+                                        "_" + mpiOpName.str() + "_" +
+                                        datatypeName.str();
+
+      if (!moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(wrapperFunctionName)) {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(moduleOp.getBody());
+
+        // Create the wrapper function decl
+        auto funcType = LLVM::LLVMFunctionType::get(
+            llvmVoidType, {llvmPtrType, llvmPtrType}, false);
+
+        auto wrapperFunc = rewriter.create<LLVM::LLVMFuncOp>(
+            op.getLoc(), wrapperFunctionName, funcType);
+
+        // Add function-level memory effects attribute
+        auto memoryEffectsAttr = rewriter.getArrayAttr(
+            {rewriter.getStringAttr("read"), rewriter.getStringAttr("write"),
+             rewriter.getStringAttr("allocate"),
+             rewriter.getStringAttr("free")});
+        wrapperFunc->setAttr("enzymexla.memory_effects", memoryEffectsAttr);
+
+        Block *entryBlock = wrapperFunc.addEntryBlock(rewriter);
+        rewriter.setInsertionPointToStart(entryBlock);
+
+        // Add argument-level memory effects attribute to all arguments
+        for (unsigned i = 0; i < 2; ++i) {
+          wrapperFunc.setArgAttr(i, "enzymexla.memory_effects",
+                                 memoryEffectsAttr);
+        }
+
+        // Get the function arguments
+        Value sendbufPtr = entryBlock->getArgument(0);
+        Value recvbufPtr = entryBlock->getArgument(1);
+
+        Value count = rewriter.create<LLVM::ConstantOp>(
+            op.getLoc(), i64Type,
+            rewriter.getI64IntegerAttr(sendbufType.getNumElements()));
+
+        Value dtype = rewriter.create<LLVM::ConstantOp>(
+            op.getLoc(), i32Type,
+            rewriter.getI32IntegerAttr(*ncclDatatype));
+
+        // Get the address of the communicator
+        Value ncclCommInt = rewriter.create<LLVM::ConstantOp>(
+            op.getLoc(), i64Type, rewriter.getI64IntegerAttr(ncclCommPtr));
+        Value ncclComm = rewriter.create<LLVM::IntToPtrOp>(
+            op.getLoc(), llvmPtrType, ncclCommInt);
+
+        Value redOp = rewriter.create<LLVM::ConstantOp>(
+            op.getLoc(), i32Type,
+            rewriter.getI32IntegerAttr(*ncclRedOp));
+
+        Value stream =
+            enzymexla::GetStreamOp::create(rewriter, op.getLoc(), llvmPtrType);
+
+        Value sendDataPtr =
+            rewriter.create<LLVM::LoadOp>(op.getLoc(), llvmPtrType, sendbufPtr);
+        Value recvDataPtr =
+            rewriter.create<LLVM::LoadOp>(op.getLoc(), llvmPtrType, recvbufPtr);
+
+        // Call ncclAllReduce
+        // TODO error handling
+        rewriter.create<LLVM::CallOp>(
+            op.getLoc(), TypeRange{i32Type},
+            SymbolRefAttr::get(context, ncclFunctionName),
+            ValueRange{sendDataPtr, recvDataPtr, count, dtype, redOp, ncclComm,
+                       stream});
+
+        rewriter.create<LLVM::ReturnOp>(op.getLoc(), ValueRange{});
+      }
+
+      // Insert ncclAllReduce function declaration if not already present
+      if (!moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(ncclFunctionName)) {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(moduleOp.getBody());
+
+        auto funcType = LLVM::LLVMFunctionType::get(
+            i32Type,
+            {llvmPtrType, llvmPtrType, i64Type, i32Type, i32Type, llvmPtrType,
+             llvmPtrType},
+            false);
+
+        rewriter.create<LLVM::LLVMFuncOp>(op.getLoc(), ncclFunctionName,
+                                          funcType, LLVM::Linkage::External);
+      }
+
+      Value operands[] = {op.getOperand(0), op.getOperand(1)};
+
+      // Add inbuf to output operand aliases
+      SmallVector<Attribute> aliases;
+      aliases.push_back(stablehlo::OutputOperandAliasAttr::get(
+          context,
+          /*output_operand_aliases=*/std::vector<int64_t>{},
+          /*operand_index=*/1,
+          /*operand_tuple_indices=*/std::vector<int64_t>{}));
+
+      auto jitCall = rewriter.create<enzymexla::JITCallOp>(
+          op.getLoc(), op->getResultTypes(),
+          mlir::FlatSymbolRefAttr::get(context, wrapperFunctionName),
+          ValueRange{operands}, rewriter.getStringAttr(""),
+          /*operand_layouts=*/nullptr,
+          /*result_layouts=*/nullptr,
+          /*arg_attrs=*/nullptr,
+          /*res_attrs=*/nullptr,
+          /*output_operand_aliases=*/rewriter.getArrayAttr(aliases),
+          /*xla_side_effect_free=*/nullptr);
+
+      rewriter.replaceOp(op, jitCall);
+
+      return success();
+
     } else {
       return rewriter.notifyMatchFailure(op,
                                          "Backend not supported: " + backend);
@@ -1729,7 +1924,39 @@ struct LowerEnzymeXLAMPIPass
   using Base::Base;
 
   void runOnOperation() override {
-    auto context = getOperation()->getContext();
+    // TODO: declare LowerEnzymeXLAMPIPass as a ModuleOp pass in Passes.td
+    // so getOperation() has the right static type here.
+    ModuleOp module = dyn_cast<ModuleOp>(getOperation());
+    if (!module) {
+      getOperation()->emitError()
+          << "lower-enzymexla-mpi must run on a builtin.module";
+      signalPassFailure();
+      return;
+    }
+
+    auto context = module->getContext();
+
+    // fail if no nccl communicator was provided, but backend==cuda and we're trying
+    // to lower an MPI ops which needs a communicator
+    if (backend == "cuda" && !ncclCommPtr) {
+      bool hasLowerableMPIOp = false;
+      module.walk([&](Operation *op) {
+        if (isa<enzymexla::MPIBarrierOp, enzymexla::MPISendOp,
+                enzymexla::MPIRecvOp, enzymexla::MPIIsendOp,
+                enzymexla::MPIIrecvOp, enzymexla::MPIWaitOp,
+                enzymexla::MPIWaitallOp, enzymexla::MPIAllreduceOp,
+                enzymexla::MPIBcastOp>(op)) {
+          hasLowerableMPIOp = true;
+        }
+      });
+      if (hasLowerableMPIOp) {
+        module.emitError()
+            << "lower-enzymexla-mpi with backend=cuda requires a valid NCCL communicator pointer";
+        signalPassFailure();
+        return;
+      }
+    }
+    
     RewritePatternSet patterns(context);
 
     patterns.add<MPICommRankOpLowering>(backend, context);
@@ -1741,12 +1968,12 @@ struct LowerEnzymeXLAMPIPass
     patterns.add<MPIIrecvOpLowering>(backend, context);
     patterns.add<MPIWaitOpLowering>(backend, context);
     patterns.add<MPIWaitallOpLowering>(backend, context);
-    patterns.add<MPIAllreduceOpLowering>(backend, context);
+    patterns.add<MPIAllreduceOpLowering>(backend, ncclCommPtr, context);
     patterns.add<MPIBcastOpLowering>(backend, context);
 
     GreedyRewriteConfig config;
     config.enableFolding();
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
+    if (failed(applyPatternsGreedily(module, std::move(patterns),
                                      config))) {
       signalPassFailure();
     }

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
@@ -1916,17 +1916,18 @@ struct LowerEnzymeXLAMPIPass
     auto context = module->getContext();
 
     if (backend == "cuda" && !ncclCommPtr) {
-      bool hasLowerableMPIOp = false;
-      module.walk([&](Operation *op) {
-        if (isa<enzymexla::MPIBarrierOp, enzymexla::MPISendOp,
-                enzymexla::MPIRecvOp, enzymexla::MPIIsendOp,
-                enzymexla::MPIIrecvOp, enzymexla::MPIWaitOp,
-                enzymexla::MPIWaitallOp, enzymexla::MPIAllreduceOp,
-                enzymexla::MPIBcastOp>(op)) {
-          hasLowerableMPIOp = true;
-        }
-      });
-      if (hasLowerableMPIOp) {
+      if (module
+              .walk([&](Operation *op) -> WalkResult {
+                if (isa<enzymexla::MPIBarrierOp, enzymexla::MPISendOp,
+                        enzymexla::MPIRecvOp, enzymexla::MPIIsendOp,
+                        enzymexla::MPIIrecvOp, enzymexla::MPIWaitOp,
+                        enzymexla::MPIWaitallOp, enzymexla::MPIAllreduceOp,
+                        enzymexla::MPIBcastOp>(op)) {
+                  return WalkResult::interrupt();
+                }
+                return WalkResult::advance();
+              })
+              .wasInterrupted()) {
         module.emitError() << "lower-enzymexla-mpi with backend=cuda requires "
                               "a valid NCCL communicator pointer";
         signalPassFailure();

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
@@ -1634,8 +1634,8 @@ struct MPIAllreduceOpLowering
              rewriter.getStringAttr("allocate"),
              rewriter.getStringAttr("free")});
         wrapperFunc->setAttr("enzymexla.memory_effects", memoryEffectsAttr);
-        wrapperFunc->setAttr("enzymexla.requires_cuda_abi",
-                             rewriter.getUnitAttr());
+        wrapperFunc->setAttr("enzymexla.device_abi",
+                             rewriter.getStringAttr("cuda"));
 
         Block *entryBlock = wrapperFunc.addEntryBlock(rewriter);
         rewriter.setInsertionPointToStart(entryBlock);

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
@@ -1915,12 +1915,6 @@ struct LowerEnzymeXLAMPIPass
 
     auto context = module->getContext();
 
-    if (backend != "cpu" && backend != "cuda") {
-      module.emitError() << "Backend not supported: " << backend;
-      signalPassFailure();
-      return;
-    }
-
     if (backend == "cuda" && !ncclCommPtr) {
       bool hasLowerableMPIOp = false;
       module.walk([&](Operation *op) {

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
@@ -1596,21 +1596,7 @@ struct MPIAllreduceOpLowering
     } else if (backend == "cuda") {
 
       auto moduleOp = op->getParentOfType<ModuleOp>();
-      auto sendbufType = dyn_cast<RankedTensorType>(op.getOperand(0).getType());
-      auto recvbufType = dyn_cast<RankedTensorType>(op.getOperand(1).getType());
-      if (!sendbufType || !sendbufType.hasStaticShape())
-        return rewriter.notifyMatchFailure(
-            op, "CUDA NCCL allreduce lowering requires statically shaped "
-                "sendbuf to derive the element count");
-      if (!recvbufType || !recvbufType.hasStaticShape())
-        return rewriter.notifyMatchFailure(
-            op, "CUDA NCCL allreduce lowering requires statically shaped "
-                "recvbuf to validate the element count");
-      if (sendbufType.getShape() != recvbufType.getShape())
-        return rewriter.notifyMatchFailure(
-            op, "CUDA NCCL allreduce lowering requires sendbuf and recvbuf to "
-                "have the same shape");
-
+      auto sendbufType = cast<RankedTensorType>(op.getOperand(0).getType());
       auto llvmPtrType = LLVM::LLVMPointerType::get(context);
       auto llvmVoidType = LLVM::LLVMVoidType::get(context);
       auto i32Type = IntegerType::get(context, 32);
@@ -1621,18 +1607,10 @@ struct MPIAllreduceOpLowering
       auto datatype = op.getDatatype();
       StringRef datatypeName = stringifyMPIDatatype(datatype);
       auto ncclDatatype = mapMPIToNCCLDatatype(datatype);
-      if (failed(ncclDatatype))
-        return rewriter.notifyMatchFailure(
-            op, "MPI datatype not supported by NCCL lowering: " +
-                    datatypeName.str());
 
       auto mpiOp = op.getOp();
       StringRef mpiOpName = stringifyMPIOp(mpiOp);
       auto ncclRedOp = mapMPIToNCCLRedOp(mpiOp);
-      if (failed(ncclRedOp))
-        return rewriter.notifyMatchFailure(
-            op, "MPI reduction op not supported by NCCL lowering: " +
-                    mpiOpName.str());
 
       // Generate the enzymexla_wrapper LLVM function body
       std::string wrapperFunctionName =
@@ -1937,8 +1915,6 @@ struct LowerEnzymeXLAMPIPass
 
     auto context = module->getContext();
 
-    // fail if no nccl communicator was provided, but backend==cuda and we're
-    // trying to lower an MPI ops which needs a communicator
     if (backend == "cuda" && !ncclCommPtr) {
       bool hasLowerableMPIOp = false;
       module.walk([&](Operation *op) {
@@ -1953,6 +1929,53 @@ struct LowerEnzymeXLAMPIPass
       if (hasLowerableMPIOp) {
         module.emitError() << "lower-enzymexla-mpi with backend=cuda requires "
                               "a valid NCCL communicator pointer";
+        signalPassFailure();
+        return;
+      }
+    }
+
+    if (backend == "cuda") {
+      bool hasUnsupportedAllreduce = false;
+      module.walk([&](enzymexla::MPIAllreduceOp op) {
+        auto sendbufType =
+            dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+        auto recvbufType =
+            dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+        if (!sendbufType || !sendbufType.hasStaticShape()) {
+          op.emitError() << "CUDA NCCL allreduce lowering requires statically "
+                            "shaped sendbuf to derive the element count";
+          hasUnsupportedAllreduce = true;
+          return;
+        }
+        if (!recvbufType || !recvbufType.hasStaticShape()) {
+          op.emitError() << "CUDA NCCL allreduce lowering requires statically "
+                            "shaped recvbuf to validate the element count";
+          hasUnsupportedAllreduce = true;
+          return;
+        }
+        if (sendbufType.getShape() != recvbufType.getShape()) {
+          op.emitError() << "CUDA NCCL allreduce lowering requires sendbuf and "
+                            "recvbuf to have the same shape";
+          hasUnsupportedAllreduce = true;
+          return;
+        }
+
+        auto datatype = op.getDatatype();
+        if (failed(mapMPIToNCCLDatatype(datatype))) {
+          op.emitError() << "MPI datatype not supported by NCCL lowering: "
+                         << stringifyMPIDatatype(datatype);
+          hasUnsupportedAllreduce = true;
+          return;
+        }
+
+        auto mpiOp = op.getOp();
+        if (failed(mapMPIToNCCLRedOp(mpiOp))) {
+          op.emitError() << "MPI reduction op not supported by NCCL lowering: "
+                         << stringifyMPIOp(mpiOp);
+          hasUnsupportedAllreduce = true;
+        }
+      });
+      if (hasUnsupportedAllreduce) {
         signalPassFailure();
         return;
       }

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
@@ -1915,6 +1915,12 @@ struct LowerEnzymeXLAMPIPass
 
     auto context = module->getContext();
 
+    if (backend != "cpu" && backend != "cuda") {
+      module.emitError() << "Backend not supported: " << backend;
+      signalPassFailure();
+      return;
+    }
+
     if (backend == "cuda" && !ncclCommPtr) {
       bool hasLowerableMPIOp = false;
       module.walk([&](Operation *op) {
@@ -1935,6 +1941,22 @@ struct LowerEnzymeXLAMPIPass
     }
 
     if (backend == "cuda") {
+      bool hasUnsupportedMPIOp = false;
+      module.walk([&](Operation *op) {
+        if (isa<enzymexla::MPICommRankOp, enzymexla::MPICommSizeOp,
+                enzymexla::MPIBarrierOp, enzymexla::MPISendOp,
+                enzymexla::MPIRecvOp, enzymexla::MPIIsendOp,
+                enzymexla::MPIIrecvOp, enzymexla::MPIWaitOp,
+                enzymexla::MPIWaitallOp, enzymexla::MPIBcastOp>(op)) {
+          op->emitError() << "MPI operation not supported by backend cuda";
+          hasUnsupportedMPIOp = true;
+        }
+      });
+      if (hasUnsupportedMPIOp) {
+        signalPassFailure();
+        return;
+      }
+
       bool hasUnsupportedAllreduce = false;
       module.walk([&](enzymexla::MPIAllreduceOp op) {
         auto sendbufType =

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
@@ -1655,6 +1655,8 @@ struct MPIAllreduceOpLowering
              rewriter.getStringAttr("allocate"),
              rewriter.getStringAttr("free")});
         wrapperFunc->setAttr("enzymexla.memory_effects", memoryEffectsAttr);
+        wrapperFunc->setAttr("enzymexla.requires_cuda_abi",
+                             rewriter.getUnitAttr());
 
         Block *entryBlock = wrapperFunc.addEntryBlock(rewriter);
         rewriter.setInsertionPointToStart(entryBlock);

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLAMPI.cpp
@@ -1414,9 +1414,10 @@ struct MPIAllreduceOpLowering
 
   std::string backend;
   size_t ncclCommPtr;
-  MPIAllreduceOpLowering(std::string backend, size_t ncclCommPtr, MLIRContext *context,
-                         PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit), backend(backend), ncclCommPtr(ncclCommPtr) {}
+  MPIAllreduceOpLowering(std::string backend, size_t ncclCommPtr,
+                         MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern(context, benefit), backend(backend),
+        ncclCommPtr(ncclCommPtr) {}
 
   LogicalResult matchAndRewrite(enzymexla::MPIAllreduceOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1634,9 +1635,9 @@ struct MPIAllreduceOpLowering
                     mpiOpName.str());
 
       // Generate the enzymexla_wrapper LLVM function body
-      std::string wrapperFunctionName = "enzymexla_wrapper_" + ncclFunctionName +
-                                        "_" + mpiOpName.str() + "_" +
-                                        datatypeName.str();
+      std::string wrapperFunctionName =
+          "enzymexla_wrapper_" + ncclFunctionName + "_" + mpiOpName.str() +
+          "_" + datatypeName.str();
 
       if (!moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(wrapperFunctionName)) {
         OpBuilder::InsertionGuard guard(rewriter);
@@ -1676,8 +1677,7 @@ struct MPIAllreduceOpLowering
             rewriter.getI64IntegerAttr(sendbufType.getNumElements()));
 
         Value dtype = rewriter.create<LLVM::ConstantOp>(
-            op.getLoc(), i32Type,
-            rewriter.getI32IntegerAttr(*ncclDatatype));
+            op.getLoc(), i32Type, rewriter.getI32IntegerAttr(*ncclDatatype));
 
         // Get the address of the communicator
         Value ncclCommInt = rewriter.create<LLVM::ConstantOp>(
@@ -1686,8 +1686,7 @@ struct MPIAllreduceOpLowering
             op.getLoc(), llvmPtrType, ncclCommInt);
 
         Value redOp = rewriter.create<LLVM::ConstantOp>(
-            op.getLoc(), i32Type,
-            rewriter.getI32IntegerAttr(*ncclRedOp));
+            op.getLoc(), i32Type, rewriter.getI32IntegerAttr(*ncclRedOp));
 
         Value stream =
             enzymexla::GetStreamOp::create(rewriter, op.getLoc(), llvmPtrType);
@@ -1713,11 +1712,11 @@ struct MPIAllreduceOpLowering
         OpBuilder::InsertionGuard guard(rewriter);
         rewriter.setInsertionPointToStart(moduleOp.getBody());
 
-        auto funcType = LLVM::LLVMFunctionType::get(
-            i32Type,
-            {llvmPtrType, llvmPtrType, i64Type, i32Type, i32Type, llvmPtrType,
-             llvmPtrType},
-            false);
+        auto funcType = LLVM::LLVMFunctionType::get(i32Type,
+                                                    {llvmPtrType, llvmPtrType,
+                                                     i64Type, i32Type, i32Type,
+                                                     llvmPtrType, llvmPtrType},
+                                                    false);
 
         rewriter.create<LLVM::LLVMFuncOp>(op.getLoc(), ncclFunctionName,
                                           funcType, LLVM::Linkage::External);
@@ -1938,8 +1937,8 @@ struct LowerEnzymeXLAMPIPass
 
     auto context = module->getContext();
 
-    // fail if no nccl communicator was provided, but backend==cuda and we're trying
-    // to lower an MPI ops which needs a communicator
+    // fail if no nccl communicator was provided, but backend==cuda and we're
+    // trying to lower an MPI ops which needs a communicator
     if (backend == "cuda" && !ncclCommPtr) {
       bool hasLowerableMPIOp = false;
       module.walk([&](Operation *op) {
@@ -1952,13 +1951,13 @@ struct LowerEnzymeXLAMPIPass
         }
       });
       if (hasLowerableMPIOp) {
-        module.emitError()
-            << "lower-enzymexla-mpi with backend=cuda requires a valid NCCL communicator pointer";
+        module.emitError() << "lower-enzymexla-mpi with backend=cuda requires "
+                              "a valid NCCL communicator pointer";
         signalPassFailure();
         return;
       }
     }
-    
+
     RewritePatternSet patterns(context);
 
     patterns.add<MPICommRankOpLowering>(backend, context);
@@ -1975,8 +1974,7 @@ struct LowerEnzymeXLAMPIPass
 
     GreedyRewriteConfig config;
     config.enableFolding();
-    if (failed(applyPatternsGreedily(module, std::move(patterns),
-                                     config))) {
+    if (failed(applyPatternsGreedily(module, std::move(patterns), config))) {
       signalPassFailure();
     }
   }

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -240,14 +240,6 @@ struct CallInfo {
   void *(*init)();
 };
 
-struct CuFuncWrapper {
-  void *func;
-};
-
-extern "C" MLIR_CAPI_EXPORTED void *EnzymeJaXEmptyGPUInit() {
-  return new CuFuncWrapper{nullptr};
-}
-
 llvm::StringMap<CallInfo> jitkernels;
 llvm::sys::SmartRWMutex<true> jit_kernel_mutex;
 std::unique_ptr<llvm::orc::LLJIT> JIT = nullptr;
@@ -338,11 +330,6 @@ bool initJIT() {
     JIT = std::move(tJIT.get());
     assert(JIT);
     auto GlobalPrefix = JIT->getDataLayout().getGlobalPrefix();
-
-    MappedSymbols[JIT->mangleAndIntern("EnzymeJaXEmptyGPUInit")] =
-        llvm::orc::ExecutorSymbolDef(
-            llvm::orc::ExecutorAddr::fromPtr((void *)&EnzymeJaXEmptyGPUInit),
-            llvm::JITSymbolFlags());
 
     llvm::orc::DynamicLibrarySearchGenerator::SymbolPredicate Pred;
 
@@ -466,17 +453,14 @@ static void insertEmptyGPUInit(mlir::ModuleOp &submod, mlir::Location loc) {
 
   auto ptrty = LLVM::LLVMPointerType::get(builder.getContext());
   auto initTy = LLVM::LLVMFunctionType::get(ptrty, {}, false);
-  auto helper = LLVM::LLVMFuncOp::create(builder, loc, "EnzymeJaXEmptyGPUInit",
-                                         initTy, LLVM::Linkage::External);
   auto initfn = LLVM::LLVMFuncOp::create(builder, loc, "nv_func_init", initTy,
                                          LLVM::Linkage::External);
 
   auto blk = new Block();
   initfn.getRegion().push_back(blk);
   builder.setInsertionPointToEnd(blk);
-  SmallVector<mlir::Value> args;
-  auto cufunc = LLVM::CallOp::create(builder, loc, helper, args)->getResult(0);
-  LLVM::ReturnOp::create(builder, loc, ValueRange(cufunc));
+  auto null = LLVM::ZeroOp::create(builder, loc, ptrty);
+  LLVM::ReturnOp::create(builder, loc, ValueRange(null));
 }
 
 void rewriteKernelCallABI(

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -780,7 +780,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
                      const std::string &toolkitPath,
                      const llvm::SmallVectorImpl<std::string> &linkFiles,
                      bool debug, bool returnPtr, bool dump_final_module,
-                     bool useCudaABI) {
+                     bool requiresCudaABI) {
 
   OpBuilder builder(op);
 
@@ -863,7 +863,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
   builder.setInsertionPointToEnd(&submod.getBodyRegion().front());
 
   SmallVector<mlir::Type, 1> intys = {ptrty};
-  if (useCudaABI) {
+  if (numGPUModule != 0 || requiresCudaABI) {
     intys.push_back(ptrty);
     intys.push_back(ptrty);
   }
@@ -983,7 +983,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
         submod.erase();
         return {};
       }
-      if (useCudaABI) {
+      if (requiresCudaABI) {
         replaceGetStreamOpsWithCudaABIStreamArg(submod);
         insertEmptyGPUInit(submod, loc);
       }
@@ -1033,7 +1033,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
     }
 
     auto ptr = CompileHostModule(ss.str(), submod,
-                                 numGPUModule != 0 || useCudaABI,
+                                 numGPUModule != 0 || requiresCudaABI,
                                  dump_final_module);
     jitkernels[ss.str()] = ptr;
     submod.erase();
@@ -1139,7 +1139,8 @@ struct LowerJITPass
           symbolTable, op.getLoc(), fn, jit, op, openmp, cuResultHandlerPtr,
           cuStreamSynchronizePtr, indexBitWidth, cubinTriple, cubinChip,
           cubinFeatures, cubinFormat, cuOptLevel, toolkitPath, linkFilesArray,
-          debug, hasReturn, dump_final_module, backend == "cuda");
+          debug, hasReturn, dump_final_module,
+          fn->hasAttr("enzymexla.requires_cuda_abi"));
 
       std::string backendinfo((char *)&cdata, sizeof(CallInfo));
       if (jit) {

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -240,14 +240,6 @@ struct CallInfo {
   void *(*init)();
 };
 
-struct CuFuncWrapper {
-  void *func;
-};
-
-extern "C" MLIR_CAPI_EXPORTED void *EnzymeJaXEmptyGPUInit() {
-  return new CuFuncWrapper{nullptr};
-}
-
 llvm::StringMap<CallInfo> jitkernels;
 llvm::sys::SmartRWMutex<true> jit_kernel_mutex;
 std::unique_ptr<llvm::orc::LLJIT> JIT = nullptr;
@@ -338,11 +330,6 @@ bool initJIT() {
     JIT = std::move(tJIT.get());
     assert(JIT);
     auto GlobalPrefix = JIT->getDataLayout().getGlobalPrefix();
-
-    MappedSymbols[JIT->mangleAndIntern("EnzymeJaXEmptyGPUInit")] =
-        llvm::orc::ExecutorSymbolDef(
-            llvm::orc::ExecutorAddr::fromPtr((void *)&EnzymeJaXEmptyGPUInit),
-            llvm::JITSymbolFlags());
 
     llvm::orc::DynamicLibrarySearchGenerator::SymbolPredicate Pred;
 
@@ -466,17 +453,18 @@ static void insertEmptyGPUInit(mlir::ModuleOp &submod, mlir::Location loc) {
 
   auto ptrty = LLVM::LLVMPointerType::get(builder.getContext());
   auto initTy = LLVM::LLVMFunctionType::get(ptrty, {}, false);
-  auto helper = LLVM::LLVMFuncOp::create(builder, loc, "EnzymeJaXEmptyGPUInit",
-                                         initTy, LLVM::Linkage::External);
   auto initfn = LLVM::LLVMFuncOp::create(builder, loc, "nv_func_init", initTy,
                                          LLVM::Linkage::External);
 
   auto blk = new Block();
   initfn.getRegion().push_back(blk);
   builder.setInsertionPointToEnd(blk);
-  SmallVector<mlir::Value> args;
-  auto cufunc = LLVM::CallOp::create(builder, loc, helper, args)->getResult(0);
-  LLVM::ReturnOp::create(builder, loc, ValueRange(cufunc));
+  auto i64 = builder.getIntegerType(64);
+  auto one = LLVM::ConstantOp::create(builder, loc, i64,
+                                      builder.getI64IntegerAttr(1));
+  auto sentinel =
+      LLVM::IntToPtrOp::create(builder, loc, ptrty, one.getResult());
+  LLVM::ReturnOp::create(builder, loc, ValueRange(sentinel));
 }
 
 void rewriteKernelCallABI(

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -769,18 +769,16 @@ void rewriteKernelCallABI(
   });
 }
 
-CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
-                     FunctionOpInterface op, bool jit,
-                     enzymexla::JITCallOp jcall, bool openmp,
-                     size_t cuResultHandlerPtr, size_t cuStreamSynchronizePtr,
-                     int indexBitWidth, const std::string &cubinTriple,
-                     const std::string &cubinChip,
-                     const std::string &cubinFeatures,
-                     const std::string &cubinFormat, int cuOptLevel,
-                     const std::string &toolkitPath,
-                     const llvm::SmallVectorImpl<std::string> &linkFiles,
-                     bool debug, bool returnPtr, bool dump_final_module,
-                     bool requiresCudaABI) {
+CallInfo
+CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
+            FunctionOpInterface op, bool jit, enzymexla::JITCallOp jcall,
+            bool openmp, size_t cuResultHandlerPtr,
+            size_t cuStreamSynchronizePtr, int indexBitWidth,
+            const std::string &cubinTriple, const std::string &cubinChip,
+            const std::string &cubinFeatures, const std::string &cubinFormat,
+            int cuOptLevel, const std::string &toolkitPath,
+            const llvm::SmallVectorImpl<std::string> &linkFiles, bool debug,
+            bool returnPtr, bool dump_final_module, bool requiresCudaABI) {
 
   OpBuilder builder(op);
 

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -240,6 +240,14 @@ struct CallInfo {
   void *(*init)();
 };
 
+struct CuFuncWrapper {
+  void *func;
+};
+
+extern "C" MLIR_CAPI_EXPORTED void *EnzymeJaXEmptyGPUInit() {
+  return new CuFuncWrapper{nullptr};
+}
+
 llvm::StringMap<CallInfo> jitkernels;
 llvm::sys::SmartRWMutex<true> jit_kernel_mutex;
 std::unique_ptr<llvm::orc::LLJIT> JIT = nullptr;
@@ -330,6 +338,11 @@ bool initJIT() {
     JIT = std::move(tJIT.get());
     assert(JIT);
     auto GlobalPrefix = JIT->getDataLayout().getGlobalPrefix();
+
+    MappedSymbols[JIT->mangleAndIntern("EnzymeJaXEmptyGPUInit")] =
+        llvm::orc::ExecutorSymbolDef(
+            llvm::orc::ExecutorAddr::fromPtr((void *)&EnzymeJaXEmptyGPUInit),
+            llvm::JITSymbolFlags());
 
     llvm::orc::DynamicLibrarySearchGenerator::SymbolPredicate Pred;
 
@@ -445,6 +458,25 @@ static void replaceGetStreamOpsWithCudaABIStreamArg(mlir::ModuleOp &submod) {
     }
     op.erase();
   }
+}
+
+static void insertEmptyGPUInit(mlir::ModuleOp &submod, mlir::Location loc) {
+  OpBuilder builder(submod);
+  builder.setInsertionPointToStart(&submod.getBodyRegion().front());
+
+  auto ptrty = LLVM::LLVMPointerType::get(builder.getContext());
+  auto initTy = LLVM::LLVMFunctionType::get(ptrty, {}, false);
+  auto helper = LLVM::LLVMFuncOp::create(builder, loc, "EnzymeJaXEmptyGPUInit",
+                                         initTy, LLVM::Linkage::External);
+  auto initfn = LLVM::LLVMFuncOp::create(builder, loc, "nv_func_init", initTy,
+                                         LLVM::Linkage::External);
+
+  auto blk = new Block();
+  initfn.getRegion().push_back(blk);
+  builder.setInsertionPointToEnd(blk);
+  SmallVector<mlir::Value> args;
+  auto cufunc = LLVM::CallOp::create(builder, loc, helper, args)->getResult(0);
+  LLVM::ReturnOp::create(builder, loc, ValueRange(cufunc));
 }
 
 void rewriteKernelCallABI(
@@ -951,8 +983,10 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
         submod.erase();
         return {};
       }
-      if (useCudaABI)
+      if (useCudaABI) {
         replaceGetStreamOpsWithCudaABIStreamArg(submod);
+        insertEmptyGPUInit(submod, loc);
+      }
     } else {
       submod->walk([](gpu::GPUModuleOp gmod) {
         auto str = gmod.getName();
@@ -1005,7 +1039,8 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
                            cubinFormat, cuOptLevel, toolkitPath, linkFiles);
     }
 
-    auto ptr = CompileHostModule(ss.str(), submod, numGPUModule != 0,
+    auto ptr = CompileHostModule(ss.str(), submod,
+                                 numGPUModule != 0 || useCudaABI,
                                  dump_final_module);
     jitkernels[ss.str()] = ptr;
     submod.erase();

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -426,6 +426,27 @@ CallInfo CompileHostModule(std::string &key, mlir::ModuleOp modOp,
   return CallInfo{(void (*)(void *, void *, void **))ptr, (void *(*)())nvptr};
 }
 
+static void replaceGetStreamOpsWithCudaABIStreamArg(mlir::ModuleOp &submod) {
+  SmallVector<enzymexla::GetStreamOp> streams;
+  submod.walk([&](enzymexla::GetStreamOp op) { streams.push_back(op); });
+  for (auto op : streams) {
+    auto pfunc = op->getParentOfType<LLVM::LLVMFuncOp>();
+    assert(pfunc && "expected get_stream to be inside an LLVM function");
+    mlir::Value stream = pfunc.getBody().begin()->getArgument(1);
+    for (auto u : llvm::make_early_inc_range(op.getResult().getUsers())) {
+      if (auto ur = dyn_cast<UnrealizedConversionCastOp>(u)) {
+        assert(ur->getResult(0).getType() == stream.getType());
+        ur->getResult(0).replaceAllUsesWith(stream);
+        ur.erase();
+        continue;
+      }
+      assert(op.getResult().getType() == stream.getType());
+      u->replaceUsesOfWith(op.getResult(), stream);
+    }
+    op.erase();
+  }
+}
+
 void rewriteKernelCallABI(
     mlir::ModuleOp &submod, mlir::Location loc, const std::string &legalName,
     bool debug, enzymexla::JITCallOp jitCallOp, const std::string &modstr,
@@ -628,20 +649,7 @@ void rewriteKernelCallABI(
     LLVM::ReturnOp::create(builder, loc, ValueRange(func));
   }
 
-  SmallVector<enzymexla::GetStreamOp> streams;
-  submod.walk([&](enzymexla::GetStreamOp op) { streams.push_back(op); });
-  for (auto op : streams) {
-    OpBuilder builder(op);
-    auto pfunc = op->getParentOfType<LLVM::LLVMFuncOp>();
-    mlir::Value stream = pfunc.getBody().begin()->getArgument(1);
-    for (auto u : llvm::make_early_inc_range(op->getResult(0).getUsers())) {
-      auto ur = cast<UnrealizedConversionCastOp>(u);
-      assert(ur->getResult(0).getType() == stream.getType());
-      ur->getResult(0).replaceAllUsesWith(stream);
-      ur.erase();
-    }
-    op.erase();
-  }
+  replaceGetStreamOpsWithCudaABIStreamArg(submod);
 
   submod.walk([&](gpu::LaunchFuncOp op) {
     builder.setInsertionPoint(op);
@@ -739,7 +747,8 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
                      const std::string &cubinFormat, int cuOptLevel,
                      const std::string &toolkitPath,
                      const llvm::SmallVectorImpl<std::string> &linkFiles,
-                     bool debug, bool returnPtr, bool dump_final_module) {
+                     bool debug, bool returnPtr, bool dump_final_module,
+                     bool useCudaABI) {
 
   OpBuilder builder(op);
 
@@ -766,7 +775,6 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
   auto submod = ModuleOp::create(builder, loc);
 
   int numGPUModule = 0;
-
   SmallVector<Operation *> tocopy;
   op->walk([&](gpu::LaunchFuncOp cop) {
     tocopy.push_back(SymbolTable::lookupNearestSymbolFrom<gpu::GPUModuleOp>(
@@ -823,7 +831,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
   builder.setInsertionPointToEnd(&submod.getBodyRegion().front());
 
   SmallVector<mlir::Type, 1> intys = {ptrty};
-  if (numGPUModule != 0) {
+  if (useCudaABI) {
     intys.push_back(ptrty);
     intys.push_back(ptrty);
   }
@@ -943,6 +951,8 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
         submod.erase();
         return {};
       }
+      if (useCudaABI)
+        replaceGetStreamOpsWithCudaABIStreamArg(submod);
     } else {
       submod->walk([](gpu::GPUModuleOp gmod) {
         auto str = gmod.getName();
@@ -1094,7 +1104,7 @@ struct LowerJITPass
           symbolTable, op.getLoc(), fn, jit, op, openmp, cuResultHandlerPtr,
           cuStreamSynchronizePtr, indexBitWidth, cubinTriple, cubinChip,
           cubinFeatures, cubinFormat, cuOptLevel, toolkitPath, linkFilesArray,
-          debug, hasReturn, dump_final_module);
+          debug, hasReturn, dump_final_module, backend == "cuda");
 
       std::string backendinfo((char *)&cdata, sizeof(CallInfo));
       if (jit) {

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -780,7 +780,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
                      const std::string &toolkitPath,
                      const llvm::SmallVectorImpl<std::string> &linkFiles,
                      bool debug, bool returnPtr, bool dump_final_module,
-                     bool useCudaABI) {
+                     bool requiresCudaABI) {
 
   OpBuilder builder(op);
 
@@ -863,7 +863,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
   builder.setInsertionPointToEnd(&submod.getBodyRegion().front());
 
   SmallVector<mlir::Type, 1> intys = {ptrty};
-  if (useCudaABI) {
+  if (numGPUModule != 0 || requiresCudaABI) {
     intys.push_back(ptrty);
     intys.push_back(ptrty);
   }
@@ -983,7 +983,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
         submod.erase();
         return {};
       }
-      if (useCudaABI) {
+      if (requiresCudaABI) {
         replaceGetStreamOpsWithCudaABIStreamArg(submod);
         insertEmptyGPUInit(submod, loc);
       }
@@ -1040,7 +1040,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
     }
 
     auto ptr = CompileHostModule(ss.str(), submod,
-                                 numGPUModule != 0 || useCudaABI,
+                                 numGPUModule != 0 || requiresCudaABI,
                                  dump_final_module);
     jitkernels[ss.str()] = ptr;
     submod.erase();
@@ -1146,7 +1146,8 @@ struct LowerJITPass
           symbolTable, op.getLoc(), fn, jit, op, openmp, cuResultHandlerPtr,
           cuStreamSynchronizePtr, indexBitWidth, cubinTriple, cubinChip,
           cubinFeatures, cubinFormat, cuOptLevel, toolkitPath, linkFilesArray,
-          debug, hasReturn, dump_final_module, backend == "cuda");
+          debug, hasReturn, dump_final_module,
+          fn->hasAttr("enzymexla.requires_cuda_abi"));
 
       std::string backendinfo((char *)&cdata, sizeof(CallInfo));
       if (jit) {

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -1140,12 +1140,14 @@ struct LowerJITPass
         hasReturn = !fnty.getResults().empty();
       }
 
+      auto deviceABI = fn->getAttrOfType<StringAttr>("enzymexla.device_abi");
+
       CallInfo cdata = CompileCall(
           symbolTable, op.getLoc(), fn, jit, op, openmp, cuResultHandlerPtr,
           cuStreamSynchronizePtr, indexBitWidth, cubinTriple, cubinChip,
           cubinFeatures, cubinFormat, cuOptLevel, toolkitPath, linkFilesArray,
           debug, hasReturn, dump_final_module,
-          fn->hasAttr("enzymexla.requires_cuda_abi"));
+          deviceABI && deviceABI.getValue() == "cuda");
 
       std::string backendinfo((char *)&cdata, sizeof(CallInfo));
       if (jit) {

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -426,6 +426,27 @@ CallInfo CompileHostModule(std::string &key, mlir::ModuleOp modOp,
   return CallInfo{(void (*)(void *, void *, void **))ptr, (void *(*)())nvptr};
 }
 
+static void replaceGetStreamOpsWithCudaABIStreamArg(mlir::ModuleOp &submod) {
+  SmallVector<enzymexla::GetStreamOp> streams;
+  submod.walk([&](enzymexla::GetStreamOp op) { streams.push_back(op); });
+  for (auto op : streams) {
+    auto pfunc = op->getParentOfType<LLVM::LLVMFuncOp>();
+    assert(pfunc && "expected get_stream to be inside an LLVM function");
+    mlir::Value stream = pfunc.getBody().begin()->getArgument(1);
+    for (auto u : llvm::make_early_inc_range(op.getResult().getUsers())) {
+      if (auto ur = dyn_cast<UnrealizedConversionCastOp>(u)) {
+        assert(ur->getResult(0).getType() == stream.getType());
+        ur->getResult(0).replaceAllUsesWith(stream);
+        ur.erase();
+        continue;
+      }
+      assert(op.getResult().getType() == stream.getType());
+      u->replaceUsesOfWith(op.getResult(), stream);
+    }
+    op.erase();
+  }
+}
+
 void rewriteKernelCallABI(
     mlir::ModuleOp &submod, mlir::Location loc, const std::string &legalName,
     bool debug, enzymexla::JITCallOp jitCallOp, const std::string &modstr,
@@ -628,20 +649,7 @@ void rewriteKernelCallABI(
     LLVM::ReturnOp::create(builder, loc, ValueRange(func));
   }
 
-  SmallVector<enzymexla::GetStreamOp> streams;
-  submod.walk([&](enzymexla::GetStreamOp op) { streams.push_back(op); });
-  for (auto op : streams) {
-    OpBuilder builder(op);
-    auto pfunc = op->getParentOfType<LLVM::LLVMFuncOp>();
-    mlir::Value stream = pfunc.getBody().begin()->getArgument(1);
-    for (auto u : llvm::make_early_inc_range(op->getResult(0).getUsers())) {
-      auto ur = cast<UnrealizedConversionCastOp>(u);
-      assert(ur->getResult(0).getType() == stream.getType());
-      ur->getResult(0).replaceAllUsesWith(stream);
-      ur.erase();
-    }
-    op.erase();
-  }
+  replaceGetStreamOpsWithCudaABIStreamArg(submod);
 
   submod.walk([&](gpu::LaunchFuncOp op) {
     builder.setInsertionPoint(op);
@@ -739,7 +747,8 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
                      const std::string &cubinFormat, int cuOptLevel,
                      const std::string &toolkitPath,
                      const llvm::SmallVectorImpl<std::string> &linkFiles,
-                     bool debug, bool returnPtr, bool dump_final_module) {
+                     bool debug, bool returnPtr, bool dump_final_module,
+                     bool useCudaABI) {
 
   OpBuilder builder(op);
 
@@ -766,7 +775,6 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
   auto submod = ModuleOp::create(builder, loc);
 
   int numGPUModule = 0;
-
   SmallVector<Operation *> tocopy;
   op->walk([&](gpu::LaunchFuncOp cop) {
     tocopy.push_back(SymbolTable::lookupNearestSymbolFrom<gpu::GPUModuleOp>(
@@ -823,7 +831,7 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
   builder.setInsertionPointToEnd(&submod.getBodyRegion().front());
 
   SmallVector<mlir::Type, 1> intys = {ptrty};
-  if (numGPUModule != 0) {
+  if (useCudaABI) {
     intys.push_back(ptrty);
     intys.push_back(ptrty);
   }
@@ -943,6 +951,8 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
         submod.erase();
         return {};
       }
+      if (useCudaABI)
+        replaceGetStreamOpsWithCudaABIStreamArg(submod);
     } else {
       submod->walk([](gpu::GPUModuleOp gmod) {
         auto str = gmod.getName();
@@ -1101,7 +1111,7 @@ struct LowerJITPass
           symbolTable, op.getLoc(), fn, jit, op, openmp, cuResultHandlerPtr,
           cuStreamSynchronizePtr, indexBitWidth, cubinTriple, cubinChip,
           cubinFeatures, cubinFormat, cuOptLevel, toolkitPath, linkFilesArray,
-          debug, hasReturn, dump_final_module);
+          debug, hasReturn, dump_final_module, backend == "cuda");
 
       std::string backendinfo((char *)&cdata, sizeof(CallInfo));
       if (jit) {

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -460,8 +460,8 @@ static void insertEmptyGPUInit(mlir::ModuleOp &submod, mlir::Location loc) {
   initfn.getRegion().push_back(blk);
   builder.setInsertionPointToEnd(blk);
   auto i64 = builder.getIntegerType(64);
-  auto one = LLVM::ConstantOp::create(builder, loc, i64,
-                                      builder.getI64IntegerAttr(1));
+  auto one =
+      LLVM::ConstantOp::create(builder, loc, i64, builder.getI64IntegerAttr(1));
   auto sentinel =
       LLVM::IntToPtrOp::create(builder, loc, ptrty, one.getResult());
   LLVM::ReturnOp::create(builder, loc, ValueRange(sentinel));

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -240,6 +240,14 @@ struct CallInfo {
   void *(*init)();
 };
 
+struct CuFuncWrapper {
+  void *func;
+};
+
+extern "C" MLIR_CAPI_EXPORTED void *EnzymeJaXEmptyGPUInit() {
+  return new CuFuncWrapper{nullptr};
+}
+
 llvm::StringMap<CallInfo> jitkernels;
 llvm::sys::SmartRWMutex<true> jit_kernel_mutex;
 std::unique_ptr<llvm::orc::LLJIT> JIT = nullptr;
@@ -330,6 +338,11 @@ bool initJIT() {
     JIT = std::move(tJIT.get());
     assert(JIT);
     auto GlobalPrefix = JIT->getDataLayout().getGlobalPrefix();
+
+    MappedSymbols[JIT->mangleAndIntern("EnzymeJaXEmptyGPUInit")] =
+        llvm::orc::ExecutorSymbolDef(
+            llvm::orc::ExecutorAddr::fromPtr((void *)&EnzymeJaXEmptyGPUInit),
+            llvm::JITSymbolFlags());
 
     llvm::orc::DynamicLibrarySearchGenerator::SymbolPredicate Pred;
 
@@ -445,6 +458,25 @@ static void replaceGetStreamOpsWithCudaABIStreamArg(mlir::ModuleOp &submod) {
     }
     op.erase();
   }
+}
+
+static void insertEmptyGPUInit(mlir::ModuleOp &submod, mlir::Location loc) {
+  OpBuilder builder(submod);
+  builder.setInsertionPointToStart(&submod.getBodyRegion().front());
+
+  auto ptrty = LLVM::LLVMPointerType::get(builder.getContext());
+  auto initTy = LLVM::LLVMFunctionType::get(ptrty, {}, false);
+  auto helper = LLVM::LLVMFuncOp::create(builder, loc, "EnzymeJaXEmptyGPUInit",
+                                         initTy, LLVM::Linkage::External);
+  auto initfn = LLVM::LLVMFuncOp::create(builder, loc, "nv_func_init", initTy,
+                                         LLVM::Linkage::External);
+
+  auto blk = new Block();
+  initfn.getRegion().push_back(blk);
+  builder.setInsertionPointToEnd(blk);
+  SmallVector<mlir::Value> args;
+  auto cufunc = LLVM::CallOp::create(builder, loc, helper, args)->getResult(0);
+  LLVM::ReturnOp::create(builder, loc, ValueRange(cufunc));
 }
 
 void rewriteKernelCallABI(
@@ -951,8 +983,10 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
         submod.erase();
         return {};
       }
-      if (useCudaABI)
+      if (useCudaABI) {
         replaceGetStreamOpsWithCudaABIStreamArg(submod);
+        insertEmptyGPUInit(submod, loc);
+      }
     } else {
       submod->walk([](gpu::GPUModuleOp gmod) {
         auto str = gmod.getName();
@@ -998,7 +1032,8 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
                            cubinFormat, cuOptLevel, toolkitPath, linkFiles);
     }
 
-    auto ptr = CompileHostModule(ss.str(), submod, numGPUModule != 0,
+    auto ptr = CompileHostModule(ss.str(), submod,
+                                 numGPUModule != 0 || useCudaABI,
                                  dump_final_module);
     jitkernels[ss.str()] = ptr;
     submod.erase();

--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -240,6 +240,14 @@ struct CallInfo {
   void *(*init)();
 };
 
+struct CuFuncWrapper {
+  void *func;
+};
+
+extern "C" MLIR_CAPI_EXPORTED void *EnzymeJaXEmptyGPUInit() {
+  return new CuFuncWrapper{nullptr};
+}
+
 llvm::StringMap<CallInfo> jitkernels;
 llvm::sys::SmartRWMutex<true> jit_kernel_mutex;
 std::unique_ptr<llvm::orc::LLJIT> JIT = nullptr;
@@ -330,6 +338,11 @@ bool initJIT() {
     JIT = std::move(tJIT.get());
     assert(JIT);
     auto GlobalPrefix = JIT->getDataLayout().getGlobalPrefix();
+
+    MappedSymbols[JIT->mangleAndIntern("EnzymeJaXEmptyGPUInit")] =
+        llvm::orc::ExecutorSymbolDef(
+            llvm::orc::ExecutorAddr::fromPtr((void *)&EnzymeJaXEmptyGPUInit),
+            llvm::JITSymbolFlags());
 
     llvm::orc::DynamicLibrarySearchGenerator::SymbolPredicate Pred;
 
@@ -453,14 +466,17 @@ static void insertEmptyGPUInit(mlir::ModuleOp &submod, mlir::Location loc) {
 
   auto ptrty = LLVM::LLVMPointerType::get(builder.getContext());
   auto initTy = LLVM::LLVMFunctionType::get(ptrty, {}, false);
+  auto helper = LLVM::LLVMFuncOp::create(builder, loc, "EnzymeJaXEmptyGPUInit",
+                                         initTy, LLVM::Linkage::External);
   auto initfn = LLVM::LLVMFuncOp::create(builder, loc, "nv_func_init", initTy,
                                          LLVM::Linkage::External);
 
   auto blk = new Block();
   initfn.getRegion().push_back(blk);
   builder.setInsertionPointToEnd(blk);
-  auto null = LLVM::ZeroOp::create(builder, loc, ptrty);
-  LLVM::ReturnOp::create(builder, loc, ValueRange(null));
+  SmallVector<mlir::Value> args;
+  auto cufunc = LLVM::CallOp::create(builder, loc, helper, args)->getResult(0);
+  LLVM::ReturnOp::create(builder, loc, ValueRange(cufunc));
 }
 
 void rewriteKernelCallABI(

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -529,6 +529,7 @@ def LowerEnzymeXLAMPIPass : Pass<"lower-enzymexla-mpi"> {
   let summary = "Lower MPI Ops to LLVM";
   let dependentDialects = [
     "enzymexla::EnzymeXLADialect",
+    "gpu::GPUDialect", 
     "LLVM::LLVMDialect",
   ];
   let options = [
@@ -538,6 +539,12 @@ def LowerEnzymeXLAMPIPass : Pass<"lower-enzymexla-mpi"> {
         /*type=*/"std::string",
         /*default=*/"\"cpu\"",
         /*description=*/"HW backend">,
+    Option<
+        /*C++ variable name=*/"ncclCommPtr",
+        /*CLI argument=*/"ncclCommPtr",
+        /*type=*/"size_t",
+        /*default=*/"0",
+        /*description=*/"Pointer to nccl communicator instance">,
   ];
 }
 

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -614,6 +614,7 @@ def LowerEnzymeXLAMPIPass : Pass<"lower-enzymexla-mpi"> {
   let summary = "Lower MPI Ops to LLVM";
   let dependentDialects = [
     "enzymexla::EnzymeXLADialect",
+    "gpu::GPUDialect", 
     "LLVM::LLVMDialect",
   ];
   let options = [
@@ -623,6 +624,12 @@ def LowerEnzymeXLAMPIPass : Pass<"lower-enzymexla-mpi"> {
         /*type=*/"std::string",
         /*default=*/"\"cpu\"",
         /*description=*/"HW backend">,
+    Option<
+        /*C++ variable name=*/"ncclCommPtr",
+        /*CLI argument=*/"ncclCommPtr",
+        /*type=*/"size_t",
+        /*default=*/"0",
+        /*description=*/"Pointer to nccl communicator instance">,
   ];
 }
 

--- a/src/enzyme_ad/jax/gpu.cc
+++ b/src/enzyme_ad/jax/gpu.cc
@@ -73,6 +73,10 @@ XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   err = cuCtxPushCurrent (pctx);
   */
 
+  if (cinfo->init == nullptr) {
+    return nullptr;
+  }
+
   void *cufunc = cinfo->init();
 
   /*
@@ -131,10 +135,13 @@ XLA_FFI_Error *execute(XLA_FFI_CallFrame *call_frame) {
         &reinterpret_cast<XLA_FFI_Buffer *>(call_frame->args.args[i])->data;
   }
 
+  void *cufunc = nullptr;
   auto *execution_state = reinterpret_cast<xla::ffi::ExecutionState *>(
       internal_api->XLA_FFI_INTERNAL_ExecutionState_Get(
           ctx, XLA_FFI_ExecutionStage_INITIALIZE));
-  auto cufunc = (void *)execution_state->Get<CuFuncWrapper>().value();
+  if (execution_state != nullptr && execution_state->IsSet()) {
+    cufunc = (void *)execution_state->Get<CuFuncWrapper>().value();
+  }
 
   const void **const_ptrs = const_cast<const void **>(ptrs);
 

--- a/src/enzyme_ad/jax/gpu.cc
+++ b/src/enzyme_ad/jax/gpu.cc
@@ -40,6 +40,14 @@ struct CuFuncWrapper {
   void *func;
 };
 
+// static void *emptyGPUInit() { return new CuFuncWrapper{nullptr}; }
+
+static void emptyGPUFunction() {}
+
+static void *emptyGPUInit() {
+  return (void *)(&emptyGPUFunction);
+}
+
 template <bool withError>
 XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   assert(call_frame->attrs.size == 1);
@@ -73,11 +81,8 @@ XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   err = cuCtxPushCurrent (pctx);
   */
 
-  if (cinfo->init == nullptr) {
-    return nullptr;
-  }
-
-  void *cufunc = cinfo->init();
+  auto init = cinfo->init ? cinfo->init : emptyGPUInit;
+  void *cufunc = init();
 
   /*
   CUcontext tctx;
@@ -135,13 +140,10 @@ XLA_FFI_Error *execute(XLA_FFI_CallFrame *call_frame) {
         &reinterpret_cast<XLA_FFI_Buffer *>(call_frame->args.args[i])->data;
   }
 
-  void *cufunc = nullptr;
   auto *execution_state = reinterpret_cast<xla::ffi::ExecutionState *>(
       internal_api->XLA_FFI_INTERNAL_ExecutionState_Get(
           ctx, XLA_FFI_ExecutionStage_INITIALIZE));
-  if (execution_state != nullptr && execution_state->IsSet()) {
-    cufunc = (void *)execution_state->Get<CuFuncWrapper>().value();
-  }
+  auto cufunc = (void *)execution_state->Get<CuFuncWrapper>().value();
 
   const void **const_ptrs = const_cast<const void **>(ptrs);
 

--- a/src/enzyme_ad/jax/gpu.cc
+++ b/src/enzyme_ad/jax/gpu.cc
@@ -41,6 +41,14 @@ struct CuFuncWrapper {
   void operator delete(void *ptr) noexcept {}
 };
 
+// static void *emptyGPUInit() { return new CuFuncWrapper{nullptr}; }
+
+static void emptyGPUFunction() {}
+
+static void *emptyGPUInit() {
+  return (void *)(&emptyGPUFunction);
+}
+
 template <bool withError>
 XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   assert(call_frame->attrs.size == 1);
@@ -74,11 +82,8 @@ XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   err = cuCtxPushCurrent (pctx);
   */
 
-  if (cinfo->init == nullptr) {
-    return nullptr;
-  }
-
-  void *cufunc = cinfo->init();
+  auto init = cinfo->init ? cinfo->init : emptyGPUInit;
+  void *cufunc = init();
 
   /*
   CUcontext tctx;
@@ -136,13 +141,10 @@ XLA_FFI_Error *execute(XLA_FFI_CallFrame *call_frame) {
         &reinterpret_cast<XLA_FFI_Buffer *>(call_frame->args.args[i])->data;
   }
 
-  void *cufunc = nullptr;
   auto *execution_state = reinterpret_cast<xla::ffi::ExecutionState *>(
       internal_api->XLA_FFI_INTERNAL_ExecutionState_Get(
           ctx, XLA_FFI_ExecutionStage_INITIALIZE));
-  if (execution_state != nullptr && execution_state->IsSet()) {
-    cufunc = (void *)execution_state->Get<CuFuncWrapper>().value();
-  }
+  auto cufunc = (void *)execution_state->Get<CuFuncWrapper>().value();
 
   const void **const_ptrs = const_cast<const void **>(ptrs);
 

--- a/src/enzyme_ad/jax/gpu.cc
+++ b/src/enzyme_ad/jax/gpu.cc
@@ -40,14 +40,6 @@ struct CuFuncWrapper {
   void *func;
 };
 
-// static void *emptyGPUInit() { return new CuFuncWrapper{nullptr}; }
-
-static void emptyGPUFunction() {}
-
-static void *emptyGPUInit() {
-  return (void *)(&emptyGPUFunction);
-}
-
 template <bool withError>
 XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   assert(call_frame->attrs.size == 1);
@@ -81,8 +73,7 @@ XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   err = cuCtxPushCurrent (pctx);
   */
 
-  auto init = cinfo->init ? cinfo->init : emptyGPUInit;
-  void *cufunc = init();
+  void *cufunc = cinfo->init();
 
   /*
   CUcontext tctx;

--- a/src/enzyme_ad/jax/gpu.cc
+++ b/src/enzyme_ad/jax/gpu.cc
@@ -74,6 +74,10 @@ XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   err = cuCtxPushCurrent (pctx);
   */
 
+  if (cinfo->init == nullptr) {
+    return nullptr;
+  }
+
   void *cufunc = cinfo->init();
 
   /*
@@ -132,10 +136,13 @@ XLA_FFI_Error *execute(XLA_FFI_CallFrame *call_frame) {
         &reinterpret_cast<XLA_FFI_Buffer *>(call_frame->args.args[i])->data;
   }
 
+  void *cufunc = nullptr;
   auto *execution_state = reinterpret_cast<xla::ffi::ExecutionState *>(
       internal_api->XLA_FFI_INTERNAL_ExecutionState_Get(
           ctx, XLA_FFI_ExecutionStage_INITIALIZE));
-  auto cufunc = (void *)execution_state->Get<CuFuncWrapper>().value();
+  if (execution_state != nullptr && execution_state->IsSet()) {
+    cufunc = (void *)execution_state->Get<CuFuncWrapper>().value();
+  }
 
   const void **const_ptrs = const_cast<const void **>(ptrs);
 

--- a/src/enzyme_ad/jax/gpu.cc
+++ b/src/enzyme_ad/jax/gpu.cc
@@ -41,14 +41,6 @@ struct CuFuncWrapper {
   void operator delete(void *ptr) noexcept {}
 };
 
-// static void *emptyGPUInit() { return new CuFuncWrapper{nullptr}; }
-
-static void emptyGPUFunction() {}
-
-static void *emptyGPUInit() {
-  return (void *)(&emptyGPUFunction);
-}
-
 template <bool withError>
 XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   assert(call_frame->attrs.size == 1);
@@ -82,8 +74,7 @@ XLA_FFI_Error *initialize(XLA_FFI_CallFrame *call_frame) {
   err = cuCtxPushCurrent (pctx);
   */
 
-  auto init = cinfo->init ? cinfo->init : emptyGPUInit;
-  void *cufunc = init();
+  void *cufunc = cinfo->init();
 
   /*
   CUcontext tctx;

--- a/test/lit_tests/mpi/allreduce.mlir
+++ b/test/lit_tests/mpi/allreduce.mlir
@@ -1,23 +1,24 @@
 // RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-mpi{backend=cpu})" %s | FileCheck %s --check-prefix=CPU
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(lower-enzymexla-mpi{backend=cuda ncclCommPtr=1})" %s | FileCheck %s --check-prefix=CUDA
 
 module {
   func.func @main(%arg0: tensor<i64> {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) -> tensor<i64> attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
     %c = stablehlo.constant dense<0> : tensor<i64>
     %c_0 = stablehlo.constant dense<1> : tensor<i32>
-    %0 = enzymexla.mpi.allreduce(%arg0, %c, %c_0) {datatype = #enzymexla.datatype<MPI_INT>, op = #enzymexla.op<MPI_LAND>} : (tensor<i64>, tensor<i64>, tensor<i32>) -> tensor<i64>
+    %0 = enzymexla.mpi.allreduce(%arg0, %c, %c_0) {datatype = #enzymexla.datatype<MPI_INT64_T>, op = #enzymexla.op<MPI_SUM>} : (tensor<i64>, tensor<i64>, tensor<i32>) -> tensor<i64>
     return %0 : tensor<i64>
   }
 }
 
 // CPU:  module {
-// CPU-NEXT:    llvm.mlir.global external constant @MPI_LAND() {addr_space = 0 : i32} : !llvm.ptr
-// CPU-NEXT:    llvm.mlir.global external constant @MPI_INT() {addr_space = 0 : i32} : !llvm.ptr
+// CPU-NEXT:    llvm.mlir.global external constant @MPI_SUM() {addr_space = 0 : i32} : !llvm.ptr
+// CPU-NEXT:    llvm.mlir.global external constant @MPI_INT64_T() {addr_space = 0 : i32} : !llvm.ptr
 // CPU-NEXT:    llvm.mlir.global external constant @MPI_COMM_WORLD() {addr_space = 0 : i32} : !llvm.ptr
 // CPU-NEXT:    llvm.func @MPI_Allreduce(!llvm.ptr, !llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
-// CPU-NEXT:    llvm.func @enzymexla_wrapper_MPI_Allreduce_MPI_LAND_MPI_INT(%arg0: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg2: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
-// CPU-NEXT:      %0 = llvm.mlir.addressof @MPI_LAND : !llvm.ptr
+// CPU-NEXT:    llvm.func @enzymexla_wrapper_MPI_Allreduce_MPI_SUM_MPI_INT64_T(%arg0: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg2: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// CPU-NEXT:      %0 = llvm.mlir.addressof @MPI_SUM : !llvm.ptr
 // CPU-NEXT:      %1 = llvm.mlir.addressof @MPI_COMM_WORLD : !llvm.ptr
-// CPU-NEXT:      %2 = llvm.mlir.addressof @MPI_INT : !llvm.ptr
+// CPU-NEXT:      %2 = llvm.mlir.addressof @MPI_INT64_T : !llvm.ptr
 // CPU-NEXT:      %3 = llvm.load %arg2 : !llvm.ptr -> i32
 // CPU-NEXT:      %4 = llvm.call @MPI_Allreduce(%arg0, %arg1, %3, %2, %0, %1) : (!llvm.ptr, !llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
 // CPU-NEXT:      llvm.return
@@ -25,7 +26,28 @@ module {
 // CPU-NEXT:    func.func @main(%arg0: tensor<i64> {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) -> tensor<i64> attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
 // CPU-NEXT:      %c = stablehlo.constant dense<0> : tensor<i64>
 // CPU-NEXT:      %c_0 = stablehlo.constant dense<1> : tensor<i32>
-// CPU-NEXT:      %0 = enzymexla.jit_call @enzymexla_wrapper_MPI_Allreduce_MPI_LAND_MPI_INT (%arg0, %c, %c_0) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>]} : (tensor<i64>, tensor<i64>, tensor<i32>) -> tensor<i64>
+// CPU-NEXT:      %0 = enzymexla.jit_call @enzymexla_wrapper_MPI_Allreduce_MPI_SUM_MPI_INT64_T (%arg0, %c, %c_0) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>]} : (tensor<i64>, tensor<i64>, tensor<i32>) -> tensor<i64>
 // CPU-NEXT:      return %0 : tensor<i64>
 // CPU-NEXT:    }
 // CPU-NEXT:  }
+
+
+// CUDA:  module {
+// CUDA-NEXT:    llvm.func @ncclAllReduce(!llvm.ptr, !llvm.ptr, i64, i32, i32, !llvm.ptr, !llvm.ptr) -> i32
+// CUDA-NEXT:    llvm.func @enzymexla_wrapper_ncclAllReduce_MPI_SUM_MPI_INT64_T(%arg0: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// CUDA-NEXT:      %0 = llvm.mlir.constant(0 : i32) : i32
+// CUDA-NEXT:      %1 = llvm.mlir.constant(1 : i64) : i64
+// CUDA-NEXT:      %2 = llvm.mlir.constant(4 : i32) : i32
+// CUDA-NEXT:      %3 = llvm.inttoptr %1 : i64 to !llvm.ptr
+// CUDA-NEXT:      %4 = "enzymexla.get_stream"() : () -> !llvm.ptr
+// CUDA-NEXT:      %5 = llvm.load %arg0 : !llvm.ptr -> !llvm.ptr
+// CUDA-NEXT:      %6 = llvm.load %arg1 : !llvm.ptr -> !llvm.ptr
+// CUDA-NEXT:      %7 = llvm.call @ncclAllReduce(%5, %6, %1, %2, %0, %3, %4) : (!llvm.ptr, !llvm.ptr, i64, i32, i32, !llvm.ptr, !llvm.ptr) -> i32
+// CUDA-NEXT:      llvm.return
+// CUDA-NEXT:    }
+// CUDA-NEXT:    func.func @main(%arg0: tensor<i64> {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) -> tensor<i64> attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// CUDA-NEXT:      %c = stablehlo.constant dense<0> : tensor<i64>
+// CUDA-NEXT:      %0 = enzymexla.jit_call @enzymexla_wrapper_ncclAllReduce_MPI_SUM_MPI_INT64_T (%arg0, %c) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 1, operand_tuple_indices = []>]} : (tensor<i64>, tensor<i64>) -> tensor<i64>
+// CUDA-NEXT:      return %0 : tensor<i64>
+// CUDA-NEXT:    }
+// CUDA-NEXT:  }

--- a/test/lit_tests/mpi/allreduce.mlir
+++ b/test/lit_tests/mpi/allreduce.mlir
@@ -34,7 +34,7 @@ module {
 
 // CUDA:  module {
 // CUDA-NEXT:    llvm.func @ncclAllReduce(!llvm.ptr, !llvm.ptr, i64, i32, i32, !llvm.ptr, !llvm.ptr) -> i32
-// CUDA-NEXT:    llvm.func @enzymexla_wrapper_ncclAllReduce_MPI_SUM_MPI_INT64_T(%arg0: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// CUDA-NEXT:    llvm.func @enzymexla_wrapper_ncclAllReduce_MPI_SUM_MPI_INT64_T(%arg0: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) attributes {{.*}}enzymexla.requires_cuda_abi{{.*}} {
 // CUDA-NEXT:      %0 = llvm.mlir.constant(0 : i32) : i32
 // CUDA-NEXT:      %1 = llvm.mlir.constant(1 : i64) : i64
 // CUDA-NEXT:      %2 = llvm.mlir.constant(4 : i32) : i32

--- a/test/lit_tests/mpi/allreduce.mlir
+++ b/test/lit_tests/mpi/allreduce.mlir
@@ -34,7 +34,7 @@ module {
 
 // CUDA:  module {
 // CUDA-NEXT:    llvm.func @ncclAllReduce(!llvm.ptr, !llvm.ptr, i64, i32, i32, !llvm.ptr, !llvm.ptr) -> i32
-// CUDA-NEXT:    llvm.func @enzymexla_wrapper_ncclAllReduce_MPI_SUM_MPI_INT64_T(%arg0: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) attributes {{.*}}enzymexla.requires_cuda_abi{{.*}} {
+// CUDA-NEXT:    llvm.func @enzymexla_wrapper_ncclAllReduce_MPI_SUM_MPI_INT64_T(%arg0: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: !llvm.ptr {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}) attributes {{.*}}enzymexla.device_abi = "cuda"{{.*}} {
 // CUDA-NEXT:      %0 = llvm.mlir.constant(0 : i32) : i32
 // CUDA-NEXT:      %1 = llvm.mlir.constant(1 : i64) : i64
 // CUDA-NEXT:      %2 = llvm.mlir.constant(4 : i32) : i32


### PR DESCRIPTION
This PR Adds cuda backend support to MPI Allreduce via ncclAllReduce.

We could either merge this PR roughly as is once we're happy with it, or wait until cuda support for the rest of the MPI ops is implemented. But I wanted to check in at this point to make sure we're happy with the design before moving forward.

In particular, changes were made to some core infrastructure:
* `LowerJIT.cpp`: Previously it was assumed that one only needed to replace `GetStreamOp` with the actual cuda stream when there was a kernel call, which were identified with criteria that don't catch the NCCL case. But we also need to make this replacement for the NCCL case, so we generalize the `LowerJITPass` to catch the NCCL case as well.
* `gpu.cc`: Previously it was assumed that there was always a `CuFunc`, which isn't true for the NCCL case. We generalize the `XLA_FFI_Handler`'s `initialize` and `execute` accordingly

A couple other design choices to note:
* Previously, we passed in the count via an op arg. Now we infer the count from the send/recv bufs, but therefore require those bufs to be statically shaped. 
* The address of the nccl communicator comes in via a pass option, which isn't the most robust but is probably ok for now