### PR TITLE
Tessera: result/output arguments

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -733,6 +733,7 @@ gentbl_cc_library(
 td_library(
     name = "TesseraDialectTdFiles",
     srcs = [
+        "Dialect/Tessera/Attrs.td",
         "Dialect/Tessera/Dialect.td",
         "Dialect/Tessera/Ops.td",
     ],
@@ -768,6 +769,33 @@ gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "Dialect/Tessera/Dialect.td",
+    deps = [
+        ":TesseraDialectTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "TesseraAttrsIncGen",
+    tbl_outs = {
+        "Dialect/Tessera/TesseraEnums.h.inc": [
+            "--gen-enum-decls",
+            "--attrdefs-dialect=tessera",
+        ],
+        "Dialect/Tessera/TesseraEnums.cpp.inc": [
+            "--gen-enum-defs",
+            "--attrdefs-dialect=tessera",
+        ],
+        "Dialect/Tessera/TesseraAttrs.h.inc": [
+            "--gen-attrdef-decls",
+            "--attrdefs-dialect=tessera",
+        ],
+        "Dialect/Tessera/TesseraAttrs.cpp.inc": [
+            "--gen-attrdef-defs",
+            "--attrdefs-dialect=tessera",
+        ],
+    },
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Dialect/Tessera/Attrs.td",
     deps = [
         ":TesseraDialectTdFiles",
     ],
@@ -1310,6 +1338,7 @@ cc_library(
         ":RaisingTransformOpsIncGen",
         ":RaisingTransformPatternsIncGen",
         ":StablehloOptPatternsIncGen",
+        ":TesseraAttrsIncGen",
         ":TesseraDialectIncGen",
         ":TesseraOpsIncGen",
         ":TesseraPassesIncGen",

--- a/src/enzyme_ad/jax/Dialect/Tessera/Attrs.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Attrs.td
@@ -1,0 +1,21 @@
+#ifndef ENZYME_AD_JAX_DIALECT_TESSERA_ATTRS_TD
+#define ENZYME_AD_JAX_DIALECT_TESSERA_ATTRS_TD
+
+include "Dialect.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+
+def TesseraArgDirection : I64EnumAttr<"ArgDirection", 
+        "direction of a lifted tessera argument",
+        [I64EnumAttrCase<"in", 0>,
+         I64EnumAttrCase<"out", 1>,
+         I64EnumAttrCase<"inout", 2>]> {
+    let genSpecializedAttr = 0;
+    let cppNamespace = "::mlir::enzyme::tessera";
+}
+
+def TesseraArgDirectionAttr : EnumAttr<TesseraDialect, TesseraArgDirection, "dir"> {
+    let assemblyFormat = "`<` $value `>`";
+}
+
+#endif // ENZYME_AD_JAX_DIALECT_TESSERA_ATTRS_TD

--- a/src/enzyme_ad/jax/Dialect/Tessera/Dialect.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Dialect.cpp
@@ -1,12 +1,21 @@
 #include "Dialect.h"
-
 #include "mlir/IR/Builders.h"
 #include "llvm/ADT/TypeSwitch.h"
+
+#include "src/enzyme_ad/jax/Dialect/Tessera/TesseraEnums.cpp.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "src/enzyme_ad/jax/Dialect/Tessera/TesseraAttrs.cpp.inc"
 
 #include "src/enzyme_ad/jax/Dialect/Tessera/TesseraDialect.cpp.inc"
 
 // Initialize the dialect
 void mlir::enzyme::tessera::TesseraDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "src/enzyme_ad/jax/Dialect/Tessera/TesseraAttrs.cpp.inc"
+      >();
+
   addOperations<
 #define GET_OP_LIST
 #include "src/enzyme_ad/jax/Dialect/Tessera/TesseraOps.cpp.inc"

--- a/src/enzyme_ad/jax/Dialect/Tessera/Dialect.h
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Dialect.h
@@ -17,6 +17,11 @@
 // Include the dialect
 #include "src/enzyme_ad/jax/Dialect/Tessera/TesseraDialect.h.inc"
 
+// Attribute declarations
+#include "src/enzyme_ad/jax/Dialect/Tessera/TesseraEnums.h.inc"
+#define GET_ATTRDEF_CLASSES
+#include "src/enzyme_ad/jax/Dialect/Tessera/TesseraAttrs.h.inc"
+
 // Include ops
 #define GET_OP_CLASSES
 #include "src/enzyme_ad/jax/Dialect/Tessera/TesseraOps.h.inc"

--- a/src/enzyme_ad/jax/Dialect/Tessera/Dialect.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Dialect.td
@@ -17,7 +17,7 @@ def TesseraDialect : Dialect {
         semantics and thus enable user-defined optimizations on the DSL their code represents.
     }];
     let cppNamespace = "::mlir::enzyme::tessera";
-    // let useDefaultAttributePrinterParser = 1;
+    let useDefaultAttributePrinterParser = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -10,6 +10,8 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+#include <optional>
+
 using namespace mlir;
 using namespace mlir::enzyme::tessera;
 
@@ -24,8 +26,8 @@ namespace mlir::enzyme::tessera {} // namespace mlir::enzyme::tessera
 
 void DefineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
                      FunctionType type, ArrayAttr byRefTypes, bool pure,
-                     ArrayAttr resultArgTypes,
-                     StringAttr sym_visibility, ArrayRef<NamedAttribute> attrs,
+                     ArrayAttr resultArgTypes, StringAttr sym_visibility,
+                     ArrayRef<NamedAttribute> attrs,
                      ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(SymbolTable::getSymbolAttrName(),
                      builder.getStringAttr(name));
@@ -144,22 +146,44 @@ Attribute DefineOp::getSretAttr() {
   return nullptr;
 }
 
-// Override getArgAttr to map call-side indices to define-side indices.
-// tessera::DefineOp has one extra argument at index 0 for sret, which
-// is not present in tessera::CallOp operands. This allows generic
-// FunctionOpInterface callers to use call-side indices directly.
+// Translate a tessera.call operand index into the corresponding raw
+// tessera.define argument index. tessera.call's operand list excludes the
+// sret argument (if any) and any pure result/output arguments (see
+// CallOpRewrite in LLVMToTessera.cpp), so both must be skipped when mapping
+// back onto the define op's own argument list.
+static std::optional<unsigned> translateCallOperandIndex(DefineOp defineOp,
+                                                         unsigned index) {
+  unsigned offset = defineOp.getSretAttr() != nullptr ? 1 : 0;
+  unsigned seen = 0;
+  for (unsigned i = 0, e = defineOp.getByRefTypesArray().size(); i != e; ++i) {
+    if (defineOp.isResultOnlyArg(i))
+      continue;
+    if (seen == index)
+      return i + offset;
+    ++seen;
+  }
+  return std::nullopt;
+}
+
+// Override getArgAttr to map call-side indices to define-side indices, so
+// that generic FunctionOpInterface callers (e.g. mem2reg) can index by a
+// tessera.call's operand position directly.
 Attribute DefineOp::getArgAttr(unsigned index, StringAttr name) {
-  unsigned offset = getSretAttr() != nullptr ? 1 : 0;
+  auto rawIndex = translateCallOperandIndex(*this, index);
+  if (!rawIndex)
+    return nullptr;
   if (auto dict = mlir::function_interface_impl::getArgAttrDict(
-          cast<FunctionOpInterface>(getOperation()), index + offset))
+          cast<FunctionOpInterface>(getOperation()), *rawIndex))
     return dict.get(name);
   return nullptr;
 }
 
 Attribute DefineOp::getArgAttr(unsigned index, StringRef name) {
-  unsigned offset = getSretAttr() != nullptr ? 1 : 0;
+  auto rawIndex = translateCallOperandIndex(*this, index);
+  if (!rawIndex)
+    return nullptr;
   if (auto dict = mlir::function_interface_impl::getArgAttrDict(
-          cast<FunctionOpInterface>(getOperation()), index + offset))
+          cast<FunctionOpInterface>(getOperation()), *rawIndex))
     return dict.get(name);
   return nullptr;
 }
@@ -209,8 +233,7 @@ unsigned DefineOp::getNumResultArgs() {
 }
 
 bool DefineOp::isResultOnlyArg(unsigned argIdx) {
-  return getResultArgType(argIdx) != nullptr &&
-         getByRefType(argIdx) == nullptr;
+  return getResultArgType(argIdx) != nullptr && getByRefType(argIdx) == nullptr;
 }
 
 unsigned DefineOp::getNumCallOperands() {
@@ -237,20 +260,22 @@ LogicalResult DefineOp::verify() {
   if (auto resultArgTypes = getResultArgTypes()) {
     for (Attribute a : resultArgTypes->getValue())
       if (!isa<TypeAttr>(a) && !isa<UnitAttr>(a))
-        return emitOpError(
-                   "resultArgTypes entry must be TypeAttr or UnitAttr, but got ")
+        return emitOpError("resultArgTypes entry must be TypeAttr or UnitAttr, "
+                           "but got ")
                << a;
     if (resultArgTypes->getValue().size() != getByRefTypes().size())
       return emitOpError("resultArgTypes size (")
-             << resultArgTypes->getValue().size() << ") must match number of byRef types ("
-             << getByRefTypes().size() << ")";
+             << resultArgTypes->getValue().size()
+             << ") must match number of byRef types (" << getByRefTypes().size()
+             << ")";
   }
 
   if (getSretAttr() && getNumResultArgs() > 0)
     return emitOpError("cannot have both sret and resultArgTypes");
 
   if (getSretAttr() && !getFunctionType().getResults().empty())
-    return emitOpError("sret function must have a void (empty) natural result list");
+    return emitOpError(
+        "sret function must have a void (empty) natural result list");
 
   return success();
 }
@@ -281,7 +306,7 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   // Walk the callee's sret-excluded arguments in order, matching each
   // argument to the next tessera.call operand, skipping any pure-output
-  // args are skipped. Allow type mismatch only for byref pointer args 
+  // args are skipped. Allow type mismatch only for byref pointer args
   // that have been converted to values.
   bool has_sret = fn.getSretAttr() != nullptr;
   unsigned argOffset = has_sret ? 1 : 0;
@@ -295,10 +320,11 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
       continue; // operand type matches expected type
     }
     if (isa<LLVM::LLVMPointerType>(expectedType) &&
-        (fn.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName()) ||
+        (fn.getArgAttr(operandIdx, LLVM::LLVMDialect::getByValAttrName()) ||
          fn.getByRefType(i))) {
       operandIdx++;
-      continue; // operand was loaded from a byref pointer, so type mismatch is allowed
+      continue; // operand was loaded from a byref pointer, so type mismatch is
+                // allowed
     }
     return emitOpError("operand type mismatch: expected operand type ")
            << expectedType << ", but provided "

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -24,6 +24,7 @@ namespace mlir::enzyme::tessera {} // namespace mlir::enzyme::tessera
 
 void DefineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
                      FunctionType type, ArrayAttr byRefTypes, bool pure,
+                     ArrayAttr resultArgTypes,
                      StringAttr sym_visibility, ArrayRef<NamedAttribute> attrs,
                      ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(SymbolTable::getSymbolAttrName(),
@@ -31,6 +32,9 @@ void DefineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   state.addAttribute(getFunctionTypeAttrName(state.name), TypeAttr::get(type));
   state.addAttribute("pure", builder.getBoolAttr(pure));
   state.addAttribute("byRefTypes", byRefTypes);
+
+  if (resultArgTypes)
+    state.addAttribute("resultArgTypes", resultArgTypes);
 
   if (sym_visibility)
     state.addAttribute(getSymVisibilityAttrName(state.name), sym_visibility);
@@ -173,6 +177,50 @@ Type DefineOp::getByRefType(unsigned argIdx) {
   return cast<TypeAttr>(attr).getValue();
 }
 
+ArrayRef<Attribute> DefineOp::getResultArgTypesArray() {
+  if (auto resultArgTypes = getResultArgTypes())
+    return resultArgTypes->getValue();
+  else
+    return ArrayRef<Attribute>();
+}
+
+Type DefineOp::getResultArgType(unsigned argIdx) {
+  auto types = getResultArgTypesArray();
+  if (types.empty())
+    return nullptr;
+  assert(argIdx < types.size() && "argIdx out of bounds in getResultArgType");
+  auto attr = types[argIdx];
+  if (!isa<TypeAttr>(attr))
+    return nullptr;
+  return cast<TypeAttr>(attr).getValue();
+}
+
+unsigned DefineOp::getNumResultArgs() {
+  if (auto resultArgTypes = getResultArgTypes()) {
+    unsigned count = 0;
+    for (Attribute a : resultArgTypes->getValue()) {
+      if (isa<TypeAttr>(a))
+        count++;
+    }
+    return count;
+  } else {
+    return 0;
+  }
+}
+
+bool DefineOp::isResultOnlyArg(unsigned argIdx) {
+  return getResultArgType(argIdx) != nullptr &&
+         getByRefType(argIdx) == nullptr;
+}
+
+unsigned DefineOp::getNumCallOperands() {
+  unsigned count = 0;
+  for (unsigned i = 0, e = getByRefTypesArray().size(); i != e; ++i)
+    if (!isResultOnlyArg(i))
+      count++;
+  return count;
+}
+
 LogicalResult DefineOp::verify() {
   for (Attribute a : getByRefTypes())
     if (!isa<TypeAttr>(a) && !isa<UnitAttr>(a))
@@ -185,6 +233,24 @@ LogicalResult DefineOp::verify() {
     return emitOpError("byRefTypes size (")
            << getByRefTypes().size() << ") must match number of args ("
            << getFunctionType().getNumInputs() - offset << ")";
+
+  if (auto resultArgTypes = getResultArgTypes()) {
+    for (Attribute a : resultArgTypes->getValue())
+      if (!isa<TypeAttr>(a) && !isa<UnitAttr>(a))
+        return emitOpError(
+                   "resultArgTypes entry must be TypeAttr or UnitAttr, but got ")
+               << a;
+    if (resultArgTypes->getValue().size() != getByRefTypes().size())
+      return emitOpError("resultArgTypes size (")
+             << resultArgTypes->getValue().size() << ") must match number of byRef types ("
+             << getByRefTypes().size() << ")";
+  }
+
+  if (getSretAttr() && getNumResultArgs() > 0)
+    return emitOpError("cannot have both sret and resultArgTypes");
+
+  if (getSretAttr() && !getFunctionType().getResults().empty())
+    return emitOpError("sret function must have a void (empty) natural result list");
 
   return success();
 }
@@ -205,39 +271,52 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   auto fnType = fn.getFunctionType();
 
-  // Verify that the operand and result types match the callee,
-  // unless callee has attribute to indicate struct return.
+  // tessera.call operand count = every non-sret argument, minus any
+  // pure-output (:result but not :byref) args, which are dropped from the
+  // operand list and added as trailing results.
+  unsigned expectedNumOperands = fn.getNumCallOperands();
+  if (getNumOperands() != expectedNumOperands)
+    return emitOpError("incorrect number of operands for callee: expected ")
+           << expectedNumOperands << ", got " << getNumOperands();
+
+  // Walk the callee's sret-excluded arguments in order, matching each
+  // argument to the next tessera.call operand, skipping any pure-output
+  // args are skipped. Allow type mismatch only for byref pointer args 
+  // that have been converted to values.
   bool has_sret = fn.getSretAttr() != nullptr;
-
-  // If tessera.define has sret attribute,
-  // tessera.call operand count = tessera.define input count - 1
-  if (has_sret && (fnType.getNumInputs() == 0 ||
-                   (fnType.getNumInputs() - 1) != getNumOperands()))
-    return emitOpError("incorrect number of operands for callee");
-  if (!has_sret && fnType.getNumInputs() != getNumOperands())
-    return emitOpError("incorrect number of operands for callee");
-
-  // Allow type mismatch only for byref pointer args that have been converted
-  // to values
   unsigned argOffset = has_sret ? 1 : 0;
-  for (unsigned i = 0, e = getNumOperands(); i != e; ++i) {
-    if (getOperand(i).getType() == fnType.getInput(i + argOffset))
-      continue;
-    if (isa<LLVM::LLVMPointerType>(fnType.getInput(i + argOffset)) &&
+  unsigned operandIdx = 0;
+  for (unsigned i = 0, e = fn.getByRefTypesArray().size(); i != e; ++i) {
+    if (fn.isResultOnlyArg(i))
+      continue; // call operand list does not include pure-output args
+    Type expectedType = fnType.getInput(i + argOffset);
+    if (getOperand(operandIdx).getType() == expectedType) {
+      operandIdx++;
+      continue; // operand type matches expected type
+    }
+    if (isa<LLVM::LLVMPointerType>(expectedType) &&
         (fn.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName()) ||
-         fn.getByRefType(i)))
-      continue;
+         fn.getByRefType(i))) {
+      operandIdx++;
+      continue; // operand was loaded from a byref pointer, so type mismatch is allowed
+    }
     return emitOpError("operand type mismatch: expected operand type ")
-           << fnType.getInput(i + argOffset) << ", but provided "
-           << getOperand(i).getType() << " for operand number " << i;
+           << expectedType << ", but provided "
+           << getOperand(operandIdx).getType() << " for operand number "
+           << operandIdx;
   }
 
-  // If tessera.define has sret attribute,
-  // tessera.call result count = tessera.define result count + 1
-  if (has_sret && getNumResults() != 1)
-    return emitOpError("incorrect number of results for callee");
-  if (!has_sret && fnType.getNumResults() != getNumResults())
-    return emitOpError("incorrect number of results for callee");
+  // tessera.call result count = one leading result per :result-marked
+  // argument (in argument order), followed by the callee's natural
+  // function_type results; if a sret is present, the result count is 1
+  // (the sret-derived value).
+  unsigned calleeNumResults = fnType.getNumResults();
+  unsigned numResultArgs = fn.getNumResultArgs();
+  unsigned expectedNumResults =
+      has_sret ? 1 : (calleeNumResults + numResultArgs);
+  if (getNumResults() != expectedNumResults)
+    return emitOpError("incorrect number of results for callee: expected ")
+           << expectedNumResults << ", got " << getNumResults();
 
   if (has_sret) {
     auto sret = fn.getSretAttr();
@@ -245,16 +324,32 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     if (getResult(0).getType() != sretType)
       return emitOpError("result type mismatch: expected ")
              << sretType << " but got " << getResult(0).getType();
-  }
-
-  unsigned offset = has_sret ? 1 : 0;
-  for (unsigned i = 0, e = fnType.getNumResults(); i != e; ++i)
-    if (getResult(i + offset).getType() != fnType.getResult(i)) {
-      auto diag = emitOpError("result type mismatch at index ") << i + offset;
-      diag.attachNote() << "      op result types: " << getResultTypes();
-      diag.attachNote() << "function result types: " << fnType.getResults();
-      return diag;
+  } else {
+    // Verify leading, :result-arg-derived result types, in argument order.
+    unsigned resultArgIdx = 0;
+    for (unsigned i = 0, e = fn.getByRefTypesArray().size(); i != e; ++i) {
+      Type resultType = fn.getResultArgType(i);
+      if (!resultType)
+        continue;
+      Value result = getResult(resultArgIdx);
+      if (result.getType() != resultType)
+        return emitOpError("result type mismatch for output-param argument ")
+               << i << ": expected " << resultType << " but got "
+               << result.getType();
+      resultArgIdx++;
     }
+
+    // Verify the callee's natural (function_type) results, trailing after
+    // the result-arg-derived ones.
+    for (unsigned i = 0, e = calleeNumResults; i != e; ++i)
+      if (getResult(numResultArgs + i).getType() != fnType.getResult(i)) {
+        auto diag = emitOpError("result type mismatch at index ")
+                    << numResultArgs + i;
+        diag.attachNote() << "      op result types: " << getResultTypes();
+        diag.attachNote() << "function result types: " << fnType.getResults();
+        return diag;
+      }
+  }
 
   return success();
 }

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -25,18 +25,14 @@ namespace mlir::enzyme::tessera {} // namespace mlir::enzyme::tessera
 //===----------------------------------------------------------------------===//
 
 void DefineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
-                     FunctionType type, ArrayAttr byRefTypes, bool pure,
-                     ArrayAttr resultArgTypes, StringAttr sym_visibility,
-                     ArrayRef<NamedAttribute> attrs,
+                     FunctionType type, ArrayAttr argModes, bool pure,
+                     StringAttr sym_visibility, ArrayRef<NamedAttribute> attrs,
                      ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(SymbolTable::getSymbolAttrName(),
                      builder.getStringAttr(name));
   state.addAttribute(getFunctionTypeAttrName(state.name), TypeAttr::get(type));
   state.addAttribute("pure", builder.getBoolAttr(pure));
-  state.addAttribute("byRefTypes", byRefTypes);
-
-  if (resultArgTypes)
-    state.addAttribute("resultArgTypes", resultArgTypes);
+  state.addAttribute("argModes", argModes);
 
   if (sym_visibility)
     state.addAttribute(getSymVisibilityAttrName(state.name), sym_visibility);
@@ -155,8 +151,8 @@ static std::optional<unsigned> translateCallOperandIndex(DefineOp defineOp,
                                                          unsigned index) {
   unsigned offset = defineOp.getSretAttr() != nullptr ? 1 : 0;
   unsigned seen = 0;
-  for (unsigned i = 0, e = defineOp.getByRefTypesArray().size(); i != e; ++i) {
-    if (defineOp.isResultOnlyArg(i))
+  for (unsigned i = 0, e = defineOp.getArgModeEntries().size(); i != e; ++i) {
+    if (defineOp.argIsWritten(i) && !defineOp.argIsRead(i))
       continue;
     if (seen == index)
       return i + offset;
@@ -188,90 +184,129 @@ Attribute DefineOp::getArgAttr(unsigned index, StringRef name) {
   return nullptr;
 }
 
-ArrayRef<Attribute> DefineOp::getByRefTypesArray() {
-  return getByRefTypes().getValue();
+// Field names inside a lifted argument's mode dictionary.
+static constexpr llvm::StringLiteral argModeTypeField = "type";
+static constexpr llvm::StringLiteral argModeDirField = "dir";
+
+ArrayRef<Attribute> DefineOp::getArgModeEntries() {
+  return getArgModes().getValue();
 }
 
-Type DefineOp::getByRefType(unsigned argIdx) {
-  auto types = getByRefTypesArray();
-  assert(argIdx < types.size() && "argIdx out of bounds in getByRefType");
-  auto attr = types[argIdx];
-  if (!isa<TypeAttr>(attr))
+// The mode dictionary for an argument, or null if the argument is not lifted.
+static DictionaryAttr getArgModeDict(DefineOp op, unsigned argIdx) {
+  auto modes = op.getArgModeEntries();
+  assert(argIdx < modes.size() && "argIdx out of bounds in getArgModeDict");
+  return dyn_cast<DictionaryAttr>(modes[argIdx]);
+}
+
+// The direction string of a lifted argument, or empty if it is not lifted.
+static StringRef getArgDir(DefineOp op, unsigned argIdx) {
+  auto dict = getArgModeDict(op, argIdx);
+  if (!dict)
+    return StringRef();
+  if (auto dirAttr = dyn_cast_or_null<StringAttr>(dict.get(argModeDirField)))
+    return dirAttr.getValue();
+  return StringRef();
+}
+
+Type DefineOp::getArgLiftedType(unsigned argIdx) {
+  auto dict = getArgModeDict(*this, argIdx);
+  if (!dict)
     return nullptr;
-  return cast<TypeAttr>(attr).getValue();
-}
-
-ArrayRef<Attribute> DefineOp::getResultArgTypesArray() {
-  if (auto resultArgTypes = getResultArgTypes())
-    return resultArgTypes->getValue();
-  else
-    return ArrayRef<Attribute>();
-}
-
-Type DefineOp::getResultArgType(unsigned argIdx) {
-  auto types = getResultArgTypesArray();
-  if (types.empty())
+  auto typeAttr = dyn_cast_or_null<TypeAttr>(dict.get(argModeTypeField));
+  if (!typeAttr)
     return nullptr;
-  assert(argIdx < types.size() && "argIdx out of bounds in getResultArgType");
-  auto attr = types[argIdx];
-  if (!isa<TypeAttr>(attr))
+  return typeAttr.getValue();
+}
+
+bool DefineOp::isLiftedArg(unsigned argIdx) {
+  return getArgModeDict(*this, argIdx) != nullptr;
+}
+
+bool DefineOp::argIsRead(unsigned argIdx) {
+  StringRef dir = getArgDir(*this, argIdx);
+  return dir == "in" || dir == "inout";
+}
+
+bool DefineOp::argIsWritten(unsigned argIdx) {
+  StringRef dir = getArgDir(*this, argIdx);
+  return dir == "out" || dir == "inout";
+}
+
+unsigned DefineOp::getNumWrittenArgs() {
+  unsigned count = 0;
+  for (unsigned i = 0, e = getArgModeEntries().size(); i != e; ++i)
+    if (argIsWritten(i))
+      count++;
+  return count;
+}
+
+Type DefineOp::getCallOperandPointeeType(unsigned callOperandIdx) {
+  // getArgAttr already maps call-operand indices onto define-argument ones.
+  if (auto byValAttr =
+          getArgAttr(callOperandIdx, LLVM::LLVMDialect::getByValAttrName()))
+    return cast<TypeAttr>(byValAttr).getValue();
+  auto rawIndex = translateCallOperandIndex(*this, callOperandIdx);
+  if (!rawIndex)
     return nullptr;
-  return cast<TypeAttr>(attr).getValue();
-}
-
-unsigned DefineOp::getNumResultArgs() {
-  if (auto resultArgTypes = getResultArgTypes()) {
-    unsigned count = 0;
-    for (Attribute a : resultArgTypes->getValue()) {
-      if (isa<TypeAttr>(a))
-        count++;
-    }
-    return count;
-  } else {
-    return 0;
-  }
-}
-
-bool DefineOp::isResultOnlyArg(unsigned argIdx) {
-  return getResultArgType(argIdx) != nullptr && getByRefType(argIdx) == nullptr;
+  // argModes is indexed sret-exclusive, so undo the sret offset. Only a
+  // read argument reaches the callee through a loaded value; a write-only
+  // ("out") argument has no operand slot to carry one.
+  unsigned offset = getSretAttr() != nullptr ? 1 : 0;
+  if (!argIsRead(*rawIndex - offset))
+    return nullptr;
+  return getArgLiftedType(*rawIndex - offset);
 }
 
 unsigned DefineOp::getNumCallOperands() {
   unsigned count = 0;
-  for (unsigned i = 0, e = getByRefTypesArray().size(); i != e; ++i)
-    if (!isResultOnlyArg(i))
+  for (unsigned i = 0, e = getArgModeEntries().size(); i != e; ++i)
+    if (!argIsWritten(i) || argIsRead(i))
       count++;
   return count;
 }
 
 LogicalResult DefineOp::verify() {
-  for (Attribute a : getByRefTypes())
-    if (!isa<TypeAttr>(a) && !isa<UnitAttr>(a))
-      return emitOpError(
-                 "byRefTypes entry must be TypeAttr or UnitAttr, but got ")
-             << a;
+  // Each entry is either UnitAttr (argument not lifted) or a dictionary
+  // carrying exactly one pointee type and one direction. Storing the type once
+  // is deliberate: the previous representation kept it in two parallel arrays,
+  // which could disagree without any verifier noticing.
+  for (auto [i, a] : llvm::enumerate(getArgModes())) {
+    if (isa<UnitAttr>(a))
+      continue;
+    auto dict = dyn_cast<DictionaryAttr>(a);
+    if (!dict)
+      return emitOpError("argModes entry ")
+             << i << " must be a DictionaryAttr or UnitAttr, but got " << a;
 
-  unsigned offset = getSretAttr() != nullptr ? 1 : 0;
-  if (getByRefTypes().size() != getFunctionType().getNumInputs() - offset)
-    return emitOpError("byRefTypes size (")
-           << getByRefTypes().size() << ") must match number of args ("
-           << getFunctionType().getNumInputs() - offset << ")";
+    auto typeAttr = dyn_cast_or_null<TypeAttr>(dict.get(argModeTypeField));
+    if (!typeAttr)
+      return emitOpError("argModes entry ")
+             << i << " must have a '" << argModeTypeField << "' TypeAttr";
 
-  if (auto resultArgTypes = getResultArgTypes()) {
-    for (Attribute a : resultArgTypes->getValue())
-      if (!isa<TypeAttr>(a) && !isa<UnitAttr>(a))
-        return emitOpError("resultArgTypes entry must be TypeAttr or UnitAttr, "
-                           "but got ")
-               << a;
-    if (resultArgTypes->getValue().size() != getByRefTypes().size())
-      return emitOpError("resultArgTypes size (")
-             << resultArgTypes->getValue().size()
-             << ") must match number of byRef types (" << getByRefTypes().size()
-             << ")";
+    auto dirAttr = dyn_cast_or_null<StringAttr>(dict.get(argModeDirField));
+    if (!dirAttr)
+      return emitOpError("argModes entry ")
+             << i << " must have a '" << argModeDirField << "' StringAttr";
+
+    StringRef dir = dirAttr.getValue();
+    if (dir != "in" && dir != "out" && dir != "inout")
+      return emitOpError("argModes entry ")
+             << i << " has invalid direction '" << dir
+             << "', expected 'in', 'out', or 'inout'";
   }
 
-  if (getSretAttr() && getNumResultArgs() > 0)
-    return emitOpError("cannot have both sret and resultArgTypes");
+  // One entry per sret-excluded argument. Write-only ("out") arguments stay in
+  // the define op's signature -- it is tessera.call's operand list, not this
+  // one, that drops them (see getNumCallOperands).
+  unsigned offset = getSretAttr() != nullptr ? 1 : 0;
+  if (getArgModes().size() != getFunctionType().getNumInputs() - offset)
+    return emitOpError("argModes size (")
+           << getArgModes().size() << ") must match number of args ("
+           << getFunctionType().getNumInputs() - offset << ")";
+
+  if (getSretAttr() && getNumWrittenArgs() > 0)
+    return emitOpError("cannot have both sret and write ('out'/'inout') args");
 
   if (getSretAttr() && !getFunctionType().getResults().empty())
     return emitOpError(
@@ -297,23 +332,23 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto fnType = fn.getFunctionType();
 
   // tessera.call operand count = every non-sret argument, minus any
-  // pure-output (:result but not :byref) args, which are dropped from the
-  // operand list and added as trailing results.
+  // write-only ("out") args, which are dropped from the operand list and
+  // added as trailing results.
   unsigned expectedNumOperands = fn.getNumCallOperands();
   if (getNumOperands() != expectedNumOperands)
     return emitOpError("incorrect number of operands for callee: expected ")
            << expectedNumOperands << ", got " << getNumOperands();
 
   // Walk the callee's sret-excluded arguments in order, matching each
-  // argument to the next tessera.call operand, skipping any pure-output
-  // args are skipped. Allow type mismatch only for byref pointer args
-  // that have been converted to values.
+  // argument to the next tessera.call operand and skipping the write-only
+  // ones. Allow a type mismatch only where the operand carries a pointee
+  // value loaded at the call site rather than the pointer itself.
   bool has_sret = fn.getSretAttr() != nullptr;
   unsigned argOffset = has_sret ? 1 : 0;
   unsigned operandIdx = 0;
-  for (unsigned i = 0, e = fn.getByRefTypesArray().size(); i != e; ++i) {
-    if (fn.isResultOnlyArg(i))
-      continue; // call operand list does not include pure-output args
+  for (unsigned i = 0, e = fn.getArgModeEntries().size(); i != e; ++i) {
+    if (fn.argIsWritten(i) && !fn.argIsRead(i))
+      continue; // call operand list does not include write-only args
     Type expectedType = fnType.getInput(i + argOffset);
     if (getOperand(operandIdx).getType() == expectedType) {
       operandIdx++;
@@ -321,10 +356,10 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     }
     if (isa<LLVM::LLVMPointerType>(expectedType) &&
         (fn.getArgAttr(operandIdx, LLVM::LLVMDialect::getByValAttrName()) ||
-         fn.getByRefType(i))) {
+         fn.argIsRead(i))) {
       operandIdx++;
-      continue; // operand was loaded from a byref pointer, so type mismatch is
-                // allowed
+      continue; // operand was loaded from the pointer, so a type mismatch
+                // against the pointer type is expected here
     }
     return emitOpError("operand type mismatch: expected operand type ")
            << expectedType << ", but provided "
@@ -332,12 +367,12 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
            << operandIdx;
   }
 
-  // tessera.call result count = one leading result per :result-marked
-  // argument (in argument order), followed by the callee's natural
+  // tessera.call result count = one leading result per written ("out" or
+  // "inout") argument, in argument order, followed by the callee's natural
   // function_type results; if a sret is present, the result count is 1
   // (the sret-derived value).
   unsigned calleeNumResults = fnType.getNumResults();
-  unsigned numResultArgs = fn.getNumResultArgs();
+  unsigned numResultArgs = fn.getNumWrittenArgs();
   unsigned expectedNumResults =
       has_sret ? 1 : (calleeNumResults + numResultArgs);
   if (getNumResults() != expectedNumResults)
@@ -351,10 +386,14 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
       return emitOpError("result type mismatch: expected ")
              << sretType << " but got " << getResult(0).getType();
   } else {
-    // Verify leading, :result-arg-derived result types, in argument order.
+    // Verify the leading results derived from written arguments, in argument
+    // order. The direction check is load-bearing: getArgLiftedType is also
+    // non-null for read-only ("in") args, which contribute no result.
     unsigned resultArgIdx = 0;
-    for (unsigned i = 0, e = fn.getByRefTypesArray().size(); i != e; ++i) {
-      Type resultType = fn.getResultArgType(i);
+    for (unsigned i = 0, e = fn.getArgModeEntries().size(); i != e; ++i) {
+      if (!fn.argIsWritten(i))
+        continue;
+      Type resultType = fn.getArgLiftedType(i);
       if (!resultType)
         continue;
       Value result = getResult(resultArgIdx);

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.cpp
@@ -199,14 +199,15 @@ static DictionaryAttr getArgModeDict(DefineOp op, unsigned argIdx) {
   return dyn_cast<DictionaryAttr>(modes[argIdx]);
 }
 
-// The direction string of a lifted argument, or empty if it is not lifted.
-static StringRef getArgDir(DefineOp op, unsigned argIdx) {
+// The direction of a lifted argument, or empty if it is not lifted.
+static std::optional<ArgDirection> getArgDir(DefineOp op, unsigned argIdx) {
   auto dict = getArgModeDict(op, argIdx);
   if (!dict)
-    return StringRef();
-  if (auto dirAttr = dyn_cast_or_null<StringAttr>(dict.get(argModeDirField)))
+    return std::nullopt;
+  if (auto dirAttr =
+          dyn_cast_or_null<ArgDirectionAttr>(dict.get(argModeDirField)))
     return dirAttr.getValue();
-  return StringRef();
+  return std::nullopt;
 }
 
 Type DefineOp::getArgLiftedType(unsigned argIdx) {
@@ -224,13 +225,13 @@ bool DefineOp::isLiftedArg(unsigned argIdx) {
 }
 
 bool DefineOp::argIsRead(unsigned argIdx) {
-  StringRef dir = getArgDir(*this, argIdx);
-  return dir == "in" || dir == "inout";
+  std::optional<ArgDirection> dir = getArgDir(*this, argIdx);
+  return dir == ArgDirection::in || dir == ArgDirection::inout;
 }
 
 bool DefineOp::argIsWritten(unsigned argIdx) {
-  StringRef dir = getArgDir(*this, argIdx);
-  return dir == "out" || dir == "inout";
+  std::optional<ArgDirection> dir = getArgDir(*this, argIdx);
+  return dir == ArgDirection::out || dir == ArgDirection::inout;
 }
 
 unsigned DefineOp::getNumWrittenArgs() {
@@ -284,16 +285,11 @@ LogicalResult DefineOp::verify() {
       return emitOpError("argModes entry ")
              << i << " must have a '" << argModeTypeField << "' TypeAttr";
 
-    auto dirAttr = dyn_cast_or_null<StringAttr>(dict.get(argModeDirField));
+    auto dirAttr =
+        dyn_cast_or_null<ArgDirectionAttr>(dict.get(argModeDirField));
     if (!dirAttr)
       return emitOpError("argModes entry ")
-             << i << " must have a '" << argModeDirField << "' StringAttr";
-
-    StringRef dir = dirAttr.getValue();
-    if (dir != "in" && dir != "out" && dir != "inout")
-      return emitOpError("argModes entry ")
-             << i << " has invalid direction '" << dir
-             << "', expected 'in', 'out', or 'inout'";
+             << i << " must have a '" << argModeDirField << "' attribute";
   }
 
   // One entry per sret-excluded argument. Write-only ("out") arguments stay in

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
@@ -29,9 +29,8 @@ def DefineOp : TesseraOp<"define", [
 
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
-	                     ArrayAttr:$byRefTypes,
+                       ArrayAttr:$argModes,
                        BoolAttr:$pure,
-                       OptionalAttr<ArrayAttr>:$resultArgTypes,
                        OptionalAttr<StrAttr>:$sym_visibility,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs
@@ -40,9 +39,8 @@ def DefineOp : TesseraOp<"define", [
 
   let builders = [OpBuilder<(ins
     "StringRef":$name, "FunctionType":$type,
-    "ArrayAttr":$byRefTypes,
+    "ArrayAttr":$argModes,
     "bool":$pure,
-    CArg<"ArrayAttr", "{}">:$resultArgTypes,
     CArg<"StringAttr", "{}">:$sym_visibility,
     CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
     CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)
@@ -66,39 +64,60 @@ def DefineOp : TesseraOp<"define", [
 
     ::mlir::Attribute getSretAttr();
 
-    // Returns the stored byref-type array as an ArrayRef. Index convention: sret-excluded
-    // argument index, since it is based on the argument list in the annotation string,
-    // which does not include the sret argument. Each entry is either a TypeAttr
-    // (arg is byref) or null (arg is not byref).
-    ::mlir::ArrayRef<Attribute> getByRefTypesArray();
+    // Per-argument lifting mode. Index convention: sret-excluded argument
+    // index, since it is based on the argument list in the annotation string,
+    // which does not include the sret argument.
+    //
+    // A "lifted" argument is one the call site dereferences, so that
+    // tessera.call carries the pointee as an SSA value instead of the pointer.
+    // That is what makes an argument nameable in a PDL rewrite rule: PDL
+    // matches SSA def-use edges and cannot see dependencies carried through
+    // memory, so an argument only participates in rewriting once lifted.
+    //
+    // Each entry is either UnitAttr (not lifted -- a plain scalar, or a
+    // pointer deliberately passed through opaquely) or a DictionaryAttr:
+    //   type : TypeAttr -- the pointee type, stored exactly once
+    //   dir  : StrAttr  -- "in", "out", or "inout"
+    //
+    // The direction records what the callee does to the pointee, which
+    // determines the shape of the call:
+    //   in    -- callee reads it. Takes an operand slot carrying the value
+    //            loaded at the call site; contributes no result.
+    //   out   -- callee only writes it. Takes no operand slot (supplying one
+    //            would load uninitialized memory and pass undef); contributes
+    //            a trailing result.
+    //   inout -- callee reads and writes. Takes an operand slot carrying the
+    //            incoming value AND contributes a trailing result (e.g. MPFR's
+    //            rop).
+    ::mlir::ArrayRef<Attribute> getArgModeEntries();
 
-    // Returns the byref type for a given argument index, or null if the argument is not byref.
-    ::mlir::Type getByRefType(unsigned argIdx);
+    // The pointee type of a lifted argument, or null if it is not lifted.
+    ::mlir::Type getArgLiftedType(unsigned argIdx);
 
-    // Returns the stored result-type array as an ArrayRef. Index convention: sret-excluded
-    // argument index, since it is based on the argument list in the annotation string,
-    // which does not include the sret argument. Each entry is either a TypeAttr
-    // (arg is output/result) or null (arg is not output/result). Function may return null
-    // if the result type array is not present (i.e. the function has no output parameters).
-    ::mlir::ArrayRef<Attribute> getResultArgTypesArray();
+    // True if this argument is lifted into the value domain at all.
+    bool isLiftedArg(unsigned argIdx);
 
-    // Returns the result type for a given argument index, or null if the argument is not 
-    // a result/output.
-    ::mlir::Type getResultArgType(unsigned argIdx);
+    // True if the callee reads the pointee (dir is "in" or "inout"). Such an
+    // argument consumes a tessera.call operand slot carrying the loaded value.
+    bool argIsRead(unsigned argIdx);
 
-    // Number of arguments marked :result, i.e. the number of training results
-    // the tessera.call adds beyond the callee's natural (function_type) results.
-    // Equal to the number of non-unit entries in resultArgTypes array.
-    unsigned getNumResultArgs();
+    // True if the callee writes the pointee (dir is "out" or "inout"). Such an
+    // argument contributes a trailing tessera.call result.
+    bool argIsWritten(unsigned argIdx);
 
-    // True if this argument is marked :result but not :byref, i.e. it is a
-    // pure output param that does NOT consume a tessera.call operand slot
-    // (unlike an inout arg, which is both byref and result and still
-    // consumes an operand).
-    bool isResultOnlyArg(unsigned argIdx);
+    // Number of arguments the callee writes, i.e. how many trailing results
+    // tessera.call adds beyond the callee's natural (function_type) results.
+    unsigned getNumWrittenArgs();
+
+    // The pointee type the callee takes this operand through: an LLVM byVal
+    // attribute if present, otherwise the arg's lifted type, or null if the
+    // callee takes the operand directly. Indexed by tessera.call operand position.
+    // Operands with a pointee type were loaded from memory when entering
+    // tessera.call and must be reconstructed into memory when leaving it.
+    ::mlir::Type getCallOperandPointeeType(unsigned callOperandIdx);
 
     // Number of operands tessera.call should have for this callee: every
-    // sret-excluded argument, minus the pure-output (isResultOnlyArg) ones.
+    // sret-excluded argument, minus the pure-output ("out") ones.
     unsigned getNumCallOperands();
 
     //===------------------------------------------------------------------===//

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
@@ -31,6 +31,7 @@ def DefineOp : TesseraOp<"define", [
                        TypeAttrOf<FunctionType>:$function_type,
 	                     ArrayAttr:$byRefTypes,
                        BoolAttr:$pure,
+                       OptionalAttr<ArrayAttr>:$resultArgTypes,
                        OptionalAttr<StrAttr>:$sym_visibility,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs
@@ -41,6 +42,7 @@ def DefineOp : TesseraOp<"define", [
     "StringRef":$name, "FunctionType":$type,
     "ArrayAttr":$byRefTypes,
     "bool":$pure,
+    CArg<"ArrayAttr", "{}">:$resultArgTypes,
     CArg<"StringAttr", "{}">:$sym_visibility,
     CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
     CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)
@@ -73,6 +75,31 @@ def DefineOp : TesseraOp<"define", [
     // Returns the byref type for a given argument index, or null if the argument is not byref.
     ::mlir::Type getByRefType(unsigned argIdx);
 
+    // Returns the stored result-type array as an ArrayRef. Index convention: sret-excluded
+    // argument index, since it is based on the argument list in the annotation string,
+    // which does not include the sret argument. Each entry is either a TypeAttr
+    // (arg is output/result) or null (arg is not output/result). Function may return null
+    // if the result type array is not present (i.e. the function has no output parameters).
+    ::mlir::ArrayRef<Attribute> getResultArgTypesArray();
+
+    // Returns the result type for a given argument index, or null if the argument is not 
+    // a result/output.
+    ::mlir::Type getResultArgType(unsigned argIdx);
+
+    // Number of arguments marked :result, i.e. the number of training results
+    // the tessera.call adds beyond the callee's natural (function_type) results.
+    // Equal to the number of non-unit entries in resultArgTypes array.
+    unsigned getNumResultArgs();
+
+    // True if this argument is marked :result but not :byref, i.e. it is a
+    // pure output param that does NOT consume a tessera.call operand slot
+    // (unlike an inout arg, which is both byref and result and still
+    // consumes an operand).
+    bool isResultOnlyArg(unsigned argIdx);
+
+    // Number of operands tessera.call should have for this callee: every
+    // sret-excluded argument, minus the pure-output (isResultOnlyArg) ones.
+    unsigned getNumCallOperands();
 
     //===------------------------------------------------------------------===//
     // FunctionOpInterface Methods

--- a/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
+++ b/src/enzyme_ad/jax/Dialect/Tessera/Ops.td
@@ -64,10 +64,6 @@ def DefineOp : TesseraOp<"define", [
 
     ::mlir::Attribute getSretAttr();
 
-    // Per-argument lifting mode. Index convention: sret-excluded argument
-    // index, since it is based on the argument list in the annotation string,
-    // which does not include the sret argument.
-    //
     // A "lifted" argument is one the call site dereferences, so that
     // tessera.call carries the pointee as an SSA value instead of the pointer.
     // That is what makes an argument nameable in a PDL rewrite rule: PDL
@@ -77,7 +73,7 @@ def DefineOp : TesseraOp<"define", [
     // Each entry is either UnitAttr (not lifted -- a plain scalar, or a
     // pointer deliberately passed through opaquely) or a DictionaryAttr:
     //   type : TypeAttr -- the pointee type, stored exactly once
-    //   dir  : StrAttr  -- "in", "out", or "inout"
+    //   dir  : ArgDirectionAttr -- enum representing "in", "out", or "inout"
     //
     // The direction records what the callee does to the pointee, which
     // determines the shape of the call:

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -1184,6 +1184,10 @@ bool isCallNonCapturing(CallOpInterface callOp, Value val) {
     auto operands = callOp.getArgOperands();
     for (int i = 0; i < operands.size(); i++) {
       if (operands[i] == val) {
+        // Operands beyond the callee's declared arguments correspond to
+        // varargs, which have no argument attribute slot to check.
+        if (i >= (int)fn.getNumArguments())
+          continue;
         if (fn.getArgAttr(i, LLVM::LLVMDialect::getNoCaptureAttrName()))
           return true;
       }

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -42,10 +42,11 @@ namespace {
 // Rewrite 'llvm.func' -> 'tessera.define'
 class FuncOpRewrite final : public OpRewritePattern<LLVM::LLVMFuncOp> {
 public:
-  FuncOpRewrite(MLIRContext *ctx,
-                const llvm::DenseMap<unsigned, mlir::Type> &argTypesByIndex)
+  FuncOpRewrite(
+      MLIRContext *ctx,
+      const llvm::DenseMap<unsigned, mlir::Type> &argTypesByGlobalIndices)
       : OpRewritePattern<LLVM::LLVMFuncOp>(ctx),
-        argTypesByIndex(argTypesByIndex) {}
+        argTypesByGlobalIndices(argTypesByGlobalIndices) {}
 
   LogicalResult matchAndRewrite(LLVM::LLVMFuncOp funcOp,
                                 PatternRewriter &rewriter) const override {
@@ -69,13 +70,23 @@ public:
       return failure();
 
     // Parse the tessera op attribute, which is expected to be in the format:
-    // "tessera_op(arg1:byref, arg2, ...):globals=index1,..." or
-    // "pure_tessera_op(arg1:byref, arg2, ...):globals=index1,..." where
-    // index1,... corresponds positionally, in left-to-right order, to the byref
-    // args in the arg list above, and are used to look up the types of the
-    // byref args. The attribute could also contain output arguments marked
-    // with ":result" (e.g. "tessera_op(arg1:result, arg2:byref):globals=0,1"),
-    // whose types are also stored in the map.
+    // "tessera_op(arg1:val=in, arg2, ...):globals=index1,..." or
+    // "pure_tessera_op(arg1:val=in, arg2, ...):globals=index1,...".
+    //
+    // A marker lifts an argument into the value domain: the call site
+    // dereferences the pointer so that tessera.call carries the pointee as an
+    // SSA value. That is what lets a PDL pattern match over calls, since
+    // PDL matches SSA def-use edges and cannot see dependencies through
+    // memory. An unmarked argument is passed through as-is.
+    //
+    // The marker's direction says what the callee does to the pointee:
+    //   :val=in    reads it   -- takes an operand, yields no result
+    //   :val=out   writes it  -- takes no operand, yields a trailing result
+    //   :val=inout both       -- takes an operand and yields a result
+    //
+    // index1,... corresponds positionally, in left-to-right order, to the
+    // marked args, one global counter index per marked arg, and is used to
+    // look up each arg's type in argTypesByGlobalIndices.
     StringRef raw = tesseraOpAttr.getValue();
 
     // Parse op name (everything before the '(')
@@ -84,53 +95,50 @@ public:
     // Parse args in parentheses
     StringRef argList = raw.slice(raw.find('(') + 1, raw.find(')'));
 
-    // Parse indices after ":globals=" (order corresponds to order byref
-    // or result args appear in argList)
+    // Parse indices after ":globals=" (order corresponds to the order marked
+    // args appear in argList)
     SmallVector<StringRef> indexList;
     StringRef indicesStr = raw.substr(raw.find(')') + 1);
     if (!indicesStr.empty() && indicesStr.consume_front(":globals=")) {
       indicesStr.split(indexList, ',');
     }
 
-    // Identify which args are marked byref or result and look up their types
-    // in the argTypesByIndex map. :byref and :result args share a single
-    // :globals= index list, consumed in left-to-right arg order regardless
-    // of which marker each pointer-typed arg uses, so both loops below
-    // advance the same shared counter.
-    SmallVector<Attribute> byRefTypes;
-    SmallVector<Attribute> resultArgTypes;
+    // Identify which args carry a lifting marker and look up their pointee
+    // types in the look up each map. Marked args consume the :globals=
+    // index list in left-to-right arg order, one index each.
+    SmallVector<Attribute> argModes;
     unsigned numIndicesFound = 0;
 
-    // Consumes the next shared global index for a byref/result-marked arg,
-    // looks up its pointee type by that index in argTypesByIndex, and
-    // appends the resolved TypeAttr to `out`.
-    auto consumeMarkedArg =
-        [&](StringRef kindName,
-            SmallVectorImpl<Attribute> &out) -> LogicalResult {
+    // Consumes the next global index for a marked arg, looks up its type
+    // by that index in argTypesByGlobalIndices, and returns the mode dictionary
+    // pairing that type with `dir`.
+    auto consumeMarkedArg = [&](StringRef dir) -> Attribute {
       if (numIndicesFound >= indexList.size()) {
-        funcOp->emitError(
-            "tessera: not enough global indices for byref/result args");
-        return failure();
+        funcOp->emitError("tessera: not enough global indices for marked args");
+        return nullptr;
       }
-      // Find the types of the byref/result arguments by looking for global
+      // Find the pointee types of the marked arguments by looking for global
       // variables with names that match the pattern "__tessera_arg_type_<idx>"
       // where <idx> is a number parsed in the tessera_op attribute after
       // "globals=".
       StringRef indexStr = indexList[numIndicesFound++];
       unsigned idx;
       if (indexStr.trim().getAsInteger(10, idx)) {
-        funcOp->emitError("tessera: invalid ")
-            << kindName << " type index: " << indexStr;
-        return failure();
+        funcOp->emitError("tessera: invalid type index for :val=")
+            << dir << " arg: " << indexStr;
+        return nullptr;
       }
-      auto it = argTypesByIndex.find(idx);
-      if (it == argTypesByIndex.end()) {
-        funcOp->emitError("tessera: no ")
-            << kindName << " type found for index: " << idx;
-        return failure();
+      auto it = argTypesByGlobalIndices.find(idx);
+      if (it == argTypesByGlobalIndices.end()) {
+        funcOp->emitError("tessera: no lifting entry found for :val=")
+            << dir << " arg at index: " << idx;
+        return nullptr;
       }
-      out.push_back(TypeAttr::get(it->second));
-      return success();
+      return DictionaryAttr::get(ctx,
+                                 {NamedAttribute(StringAttr::get(ctx, "type"),
+                                                 TypeAttr::get(it->second)),
+                                  NamedAttribute(StringAttr::get(ctx, "dir"),
+                                                 StringAttr::get(ctx, dir))});
     };
 
     if (!argList.trim().empty()) {
@@ -138,35 +146,41 @@ public:
       argList.split(argParts, ',');
       for (unsigned i = 0, e = argParts.size(); i != e; ++i) {
         StringRef arg = argParts[i].trim();
-
-        // Check if arg is marked as byref and add its type to byRefTypes.
-        if (arg.contains(":byref") || arg.contains(": byref")) {
-          if (failed(consumeMarkedArg("byref", byRefTypes)))
-            return failure();
-        } else {
-          // Push a unit attribute so that the byRefTypes array has the same
-          // size as the number of args.
-          byRefTypes.push_back(UnitAttr::get(ctx));
+        StringRef marker = arg.split(':').second.trim();
+        if (marker.empty()) {
+          // Unmarked: not lifted. Push a unit attribute so that argModes has
+          // the same size as the number of args.
+          argModes.push_back(UnitAttr::get(ctx));
+          continue;
         }
 
-        // Check if arg is marked as an output/result and add its type to
-        // resultArgTypes.
-        if (arg.contains(":result") || arg.contains(": result")) {
-          if (failed(consumeMarkedArg("result", resultArgTypes)))
-            return failure();
-        } else {
-          // Push a unit attribute so that the resultArgTypes array has the
-          // same size as the number of args.
-          resultArgTypes.push_back(UnitAttr::get(ctx));
+        // Expect the form "arg:val=<dir>", disregarding additional spaces.
+        StringRef dir = marker;
+        bool wellFormed = dir.consume_front("val");
+        if (wellFormed) {
+          dir = dir.ltrim();
+          wellFormed = dir.consume_front("=");
+          dir = dir.trim();
         }
+        if (!wellFormed || (dir != "in" && dir != "out" && dir != "inout")) {
+          funcOp->emitError("tessera: argument '")
+              << arg << "' has invalid marker '" << marker
+              << "', expected :val=in, :val=out, or :val=inout";
+          return failure();
+        }
+
+        Attribute mode = consumeMarkedArg(dir);
+        if (!mode)
+          return failure();
+        argModes.push_back(mode);
       }
     }
 
-    // The format guarantees one global index per byref/result arg.
+    // The format guarantees one global index per marked arg.
     // A mismatch means the annotation string is malformed or the Clang
     // plugin's emission order has drifted from this parser's assumption.
     if (numIndicesFound != indexList.size()) {
-      funcOp->emitError("tessera: mismatch between byref/result arg count and "
+      funcOp->emitError("tessera: mismatch between marked arg count and "
                         "global index count");
       return failure();
     }
@@ -187,15 +201,15 @@ public:
             module)))
       return failure();
 
-    bool hasResultArg = llvm::any_of(
-        resultArgTypes, [](Attribute attr) { return isa<TypeAttr>(attr); });
-
-    // Create the tessera.define op with the new name, function type, byRef
-    // args, sizes, and purity (side effect free) attribute
+    // Create the tessera.define op with the new name, function type, per-arg
+    // lifting modes, and purity (side effect free) attribute. External
+    // declarations must be marked private: FunctionOpInterface's verifier
+    // rejects a body-less symbol with public visibility, unlike
+    // llvm.func where a public extern declaration is normal.
     auto tesseraDefineOp = tessera::DefineOp::create(
         rewriter, funcOp.getLoc(), tesseraName.str(), fnType,
-        ArrayAttr::get(ctx, byRefTypes), isPure,
-        hasResultArg ? ArrayAttr::get(ctx, resultArgTypes) : ArrayAttr());
+        ArrayAttr::get(ctx, argModes), isPure,
+        funcOp.isExternal() ? rewriter.getStringAttr("private") : StringAttr());
 
     // Copy over all attributes other than the function name and type
     // and tessera_op / pure_tessera_op attribute.
@@ -222,7 +236,7 @@ public:
   }
 
 private:
-  const llvm::DenseMap<unsigned, mlir::Type> &argTypesByIndex;
+  const llvm::DenseMap<unsigned, mlir::Type> &argTypesByGlobalIndices;
 };
 
 // Rewrite 'llvm.call' -> 'tessera.call'
@@ -264,12 +278,14 @@ public:
 
     // Build newAttrs from the original call's attributes. If arg_attrs is
     // present, filter out the entry for the sret arg (always index 0) or
-    // for any pure result/output arguments, since those operands are
+    // for any write-only ("out") arguments, since those operands are
     // excluded from tessera.call's operand list below and arg_attrs must
     // stay aligned with operand position.
     if (argAttrs) {
       for (unsigned i = 0, e = argAttrs.size(); i != e; ++i) {
-        bool skip = sretPtr ? (i == 0) : defineOp.isResultOnlyArg(i);
+        bool skip = sretPtr
+                        ? (i == 0)
+                        : (defineOp.argIsWritten(i) && !defineOp.argIsRead(i));
         if (!skip)
           newArgAttrs.push_back(argAttrs[i]);
       }
@@ -284,12 +300,11 @@ public:
     }
 
     // Build operands without first element if sretPtr is present.
-    // If a pointer operand has a LLVM byVal attribute or was marked
-    // as byRef by the user, load the value from the pointer and store
-    // that as the new operand. Don't include pure result/output
-    // arguments in the new operand list.
+    // If a pointer operand has a LLVM byVal attribute or was lifted by the
+    // user, load the value from the pointer and store that as the new
+    // operand. Don't include write-only ("out") arguments in the new operand
+    // list.
     SmallVector<Value> newOperands;
-    SmallVector<int32_t> loadedOperands;
     SmallVector<Value> resultArgPtrs;
     SmallVector<Type> resultArgTypes;
     int argOffset = sretPtr ? 1 : 0;
@@ -302,43 +317,39 @@ public:
         continue;
       }
 
-      // Exclude pure result/output arguments from the new operands
-      // list and remember their pointer and pointee types for later
-      // use after the tessera.call is built
-      if (defineOp.isResultOnlyArg(i)) {
+      // Every written arg contributes a trailing tessera.call result, so
+      // remember its pointer and pointee type for use after the call is
+      // built. Whether it also keeps an operand slot depends on the
+      // direction:
+      //   - "out": the callee only writes it, so it is dropped from the
+      //     operand list entirely. Supplying one would load the caller's
+      //     not-yet-written storage and pass undef.
+      //   - "inout": the callee reads the caller's existing object and writes
+      //     back through the same pointer, so it falls through to the load
+      //     below and keeps its operand slot carrying the incoming value.
+      // Recorded in argument order either way, as CallOp's verifier expects.
+      if (defineOp.argIsWritten(i)) {
+        Type resultArgType = defineOp.getArgLiftedType(i);
         resultArgPtrs.push_back(operand);
-        resultArgTypes.push_back(defineOp.getResultArgType(i));
-        continue;
+        resultArgTypes.push_back(resultArgType);
+        if (!defineOp.argIsRead(i))
+          continue; // write-only: drop operand slot entirely
       }
 
-      // Determine whether to load pointer and what type to load based on LLVM
-      // byVal attribute or user-marked byRef attribute on the tessera.define
-      // op. If neither is present, just pass the pointer through.
-      // newOperands.size() is the number of tessera.call operands emitted
-      // so far, i.e. the call-operand index this entry will land at once
-      // pushed below -- getArgAttr expects that stripped index, not the
-      // pre-strip loop index i.
-      Type pointeeType;
-      if (auto byValAttr = defineOp.getArgAttr(
-              newOperands.size(), LLVM::LLVMDialect::getByValAttrName())) {
-        pointeeType = cast<TypeAttr>(byValAttr).getValue();
-      } else if (auto byRefType = defineOp.getByRefType(i)) {
-        pointeeType = byRefType;
-      }
-
-      if (pointeeType) {
+      // If the callee takes this argument through a pointer, load the pointee
+      // so the tessera.call carries a value; otherwise pass the pointer
+      // through. newOperands.size() is the call-operand index this entry
+      // lands at once pushed below, which is the index
+      // getCallOperandPointeeType expects -- not the pre-strip loop index i.
+      if (Type pointeeType =
+              defineOp.getCallOperandPointeeType(newOperands.size())) {
         auto loadedVal = LLVM::LoadOp::create(rewriter, callOp.getLoc(),
                                               pointeeType, operand);
         newOperands.push_back(loadedVal);
-        loadedOperands.push_back(i);
       } else {
         newOperands.push_back(operand);
       }
     }
-
-    newAttrs.push_back(
-        rewriter.getNamedAttr("tessera.loaded_operands",
-                              rewriter.getDenseI32ArrayAttr(loadedOperands)));
 
     // Create tessera.call op with results conveyed as direct SSA values rather
     // than written through pointers -- either the sret-derived value, or the
@@ -421,7 +432,7 @@ struct LLVMToTesseraPass
     // than requiring it at the start). Each tessera.define op's own index
     // list (from its "globals=" attribute) is later resolved against this
     // map, avoiding a full module rescan per op.
-    llvm::DenseMap<unsigned, mlir::Type> argTypesByIndex;
+    llvm::DenseMap<unsigned, mlir::Type> argTypesByGlobalIndices;
     StringRef prefix = "__tessera_arg_type_";
     for (auto global : module.getOps<mlir::LLVM::GlobalOp>()) {
       StringRef name = global.getSymName();
@@ -433,7 +444,8 @@ struct LLVMToTesseraPass
       if (idxStr.getAsInteger(10, idx))
         continue; // not a well-formed index suffix, skip
 
-      auto [it, inserted] = argTypesByIndex.try_emplace(idx, global.getType());
+      auto [it, inserted] =
+          argTypesByGlobalIndices.try_emplace(idx, global.getType());
       if (!inserted) {
         llvm::errs()
             << "Tessera: found multiple globals matching argument type index "
@@ -442,7 +454,7 @@ struct LLVMToTesseraPass
       }
     }
 
-    patterns.add<FuncOpRewrite>(ctx, argTypesByIndex);
+    patterns.add<FuncOpRewrite>(ctx, argTypesByGlobalIndices);
     patterns.add<CallOpRewrite, ReturnOpRewrite>(ctx);
 
     GreedyRewriteConfig config;

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -43,9 +43,9 @@ namespace {
 class FuncOpRewrite final : public OpRewritePattern<LLVM::LLVMFuncOp> {
 public:
   FuncOpRewrite(MLIRContext *ctx,
-                const llvm::DenseMap<unsigned, mlir::Type> &byRefTypesByIndex)
+                const llvm::DenseMap<unsigned, mlir::Type> &argTypesByIndex)
       : OpRewritePattern<LLVM::LLVMFuncOp>(ctx),
-        byRefTypesByIndex(byRefTypesByIndex) {}
+        argTypesByIndex(argTypesByIndex) {}
 
   LogicalResult matchAndRewrite(LLVM::LLVMFuncOp funcOp,
                                 PatternRewriter &rewriter) const override {
@@ -73,7 +73,9 @@ public:
     // "pure_tessera_op(arg1:byref, arg2, ...):globals=index1,..." where
     // index1,... corresponds positionally, in left-to-right order, to the byref
     // args in the arg list above, and are used to look up the types of the
-    // byref args.
+    // byref args. The attribute could also contain output arguments marked
+    // with ":result" (e.g. "tessera_op(arg1:result, arg2:byref):globals=0,1"),
+    // whose types are also stored in the map.
     StringRef raw = tesseraOpAttr.getValue();
 
     // Parse op name (everything before the '(')
@@ -83,61 +85,87 @@ public:
     StringRef argList = raw.slice(raw.find('(') + 1, raw.find(')'));
 
     // Parse indices after ":globals=" (order corresponds to order byref
-    // args appear in argList)
+    // or result args appear in argList)
     SmallVector<StringRef> indexList;
     StringRef indicesStr = raw.substr(raw.find(')') + 1);
     if (!indicesStr.empty() && indicesStr.consume_front(":globals=")) {
       indicesStr.split(indexList, ',');
     }
 
-    // Identify which args are marked byref and look up their types in
-    // byRefTypesByIndex map
+    // Identify which args are marked byref or result and look up their types
+    // in the argTypesByIndex map. :byref and :result args share a single
+    // :globals= index list, consumed in left-to-right arg order regardless
+    // of which marker each pointer-typed arg uses, so both loops below
+    // advance the same shared counter.
     SmallVector<Attribute> byRefTypes;
-    unsigned numByRefFound = 0;
+    SmallVector<Attribute> resultArgTypes;
+    unsigned numIndicesFound = 0;
+
+    // Consumes the next shared global index for a byref/result-marked arg,
+    // looks up its pointee type by that index in argTypesByIndex, and
+    // appends the resolved TypeAttr to `out`.
+    auto consumeMarkedArg = [&](StringRef kindName,
+                                 SmallVectorImpl<Attribute> &out) -> LogicalResult {
+      if (numIndicesFound >= indexList.size()) {
+        funcOp->emitError(
+            "tessera: not enough global indices for byref/result args");
+        return failure();
+      }
+      // Find the types of the byref/result arguments by looking for global
+      // variables with names that match the pattern "__tessera_arg_type_<idx>" 
+      // where <idx> is a number parsed in the tessera_op attribute after "globals=".
+      StringRef indexStr = indexList[numIndicesFound++];
+      unsigned idx;
+      if (indexStr.trim().getAsInteger(10, idx)) {
+        funcOp->emitError("tessera: invalid ")
+            << kindName << " type index: " << indexStr;
+        return failure();
+      }
+      auto it = argTypesByIndex.find(idx);
+      if (it == argTypesByIndex.end()) {
+        funcOp->emitError("tessera: no ")
+            << kindName << " type found for index: " << idx;
+        return failure();
+      }
+      out.push_back(TypeAttr::get(it->second));
+      return success();
+    };
+
     if (!argList.trim().empty()) {
       SmallVector<StringRef> argParts;
       argList.split(argParts, ',');
       for (unsigned i = 0, e = argParts.size(); i != e; ++i) {
         StringRef arg = argParts[i].trim();
 
-        // Check if arg is marked as byref. If not, push a unit attribute so
-        // that the byRefTypes array has the same size as the number of args.
-        if (!arg.contains(":byref") && !arg.contains(": byref")) {
+        // Check if arg is marked as byref and add its type to byRefTypes.
+        if (arg.contains(":byref") || arg.contains(": byref")) {
+          if (failed(consumeMarkedArg("byref", byRefTypes)))
+            return failure();
+        } else {
+          // Push a unit attribute so that the byRefTypes array has the same
+          // size as the number of args.
           byRefTypes.push_back(UnitAttr::get(ctx));
-          continue;
         }
 
-        if (numByRefFound >= indexList.size()) {
-          funcOp->emitError("tessera: not enough byref indices for byref args");
-          return failure();
+        // Check if arg is marked as an output/result and add its type to
+        // resultArgTypes.
+        if (arg.contains(":result") || arg.contains(": result")) {
+          if (failed(consumeMarkedArg("result", resultArgTypes)))
+            return failure();
+        } else {
+          // Push a unit attribute so that the resultArgTypes array has the
+          // same size as the number of args.
+          resultArgTypes.push_back(UnitAttr::get(ctx));
         }
-
-        // Find the types of the byref arguments by looking for global variables
-        // with names that match the pattern "__tessera_byref_arg_type_<idx>"
-        // where <idx> is a number parsed in the tessera_op attribute after
-        // "globals=".
-        auto byRefIndex = indexList[numByRefFound++];
-        unsigned idx;
-        if (byRefIndex.trim().getAsInteger(10, idx)) {
-          funcOp->emitError("tessera: invalid byref type index: ")
-              << byRefIndex;
-          return failure();
-        }
-        auto it = byRefTypesByIndex.find(idx);
-        if (it == byRefTypesByIndex.end()) {
-          funcOp->emitError("tessera: no byref type found for index: ") << idx;
-          return failure();
-        }
-        byRefTypes.push_back(TypeAttr::get(it->second));
       }
     }
 
-    // The format guarantees one global index per byref arg.
+    // The format guarantees one global index per byref/result arg.
     // A mismatch means the annotation string is malformed or the Clang
     // plugin's emission order has drifted from this parser's assumption.
-    if (numByRefFound != indexList.size()) {
+    if (numIndicesFound != indexList.size()) {
       funcOp->emitError(
-          "tessera: mismatch between byref arg count and global index count");
+          "tessera: mismatch between byref/result arg count and global index count");
       return failure();
     }
 
@@ -157,11 +185,16 @@ public:
             module)))
       return failure();
 
+    bool hasResultArg = llvm::any_of(resultArgTypes, [](Attribute attr) {
+      return isa<TypeAttr>(attr);
+    });
+
     // Create the tessera.define op with the new name, function type, byRef
     // args, sizes, and purity (side effect free) attribute
     auto tesseraDefineOp = tessera::DefineOp::create(
         rewriter, funcOp.getLoc(), tesseraName.str(), fnType,
-        ArrayAttr::get(ctx, byRefTypes), isPure);
+        ArrayAttr::get(ctx, byRefTypes), isPure,
+        hasResultArg ? ArrayAttr::get(ctx, resultArgTypes) : ArrayAttr());
 
     // Copy over all attributes other than the function name and type
     // and tessera_op / pure_tessera_op attribute.
@@ -188,7 +221,7 @@ public:
   }
 
 private:
-  const llvm::DenseMap<unsigned, mlir::Type> &byRefTypesByIndex;
+  const llvm::DenseMap<unsigned, mlir::Type> &argTypesByIndex;
 };
 
 // Rewrite 'llvm.call' -> 'tessera.call'
@@ -205,8 +238,8 @@ public:
     if (!calleeAttr)
       return failure();
 
-    auto callee = SymbolTable::lookupSymbolIn(module, calleeAttr);
     // Only rewrite if callee is a tessera.define op
+    auto callee = SymbolTable::lookupSymbolIn(module, calleeAttr);
     auto defineOp = dyn_cast_or_null<tessera::DefineOp>(callee);
     if (!defineOp)
       return failure();
@@ -218,34 +251,48 @@ public:
     SmallVector<Attribute> newArgAttrs;
     SmallVector<NamedAttribute> newAttrs;
 
-    // Check if first operand has sret attribute. If so, use its pointed-to
-    // type as the SSA return type, since tessera.call returns values directly
-    // rather than writing through a pointer.
+    // If the first operand has an sret attribute, use its pointed-to type as
+    // the SSA return type, since tessera.call returns values directly rather
+    // than writing through a pointer.
     if (!operands.empty() && argAttrs) {
       if (auto sretAttr = defineOp.getSretAttr()) {
         sretPtr = callOp.getOperand(0);
         sretType = cast<TypeAttr>(sretAttr).getValue();
-        // Build arg attrs without first element
-        for (int j = 1; j < argAttrs.size(); j++)
-          newArgAttrs.push_back(argAttrs[j]);
-        // Filter out arg_attrs from attributes
-        for (auto attr : callOp->getAttrs()) {
-          if (attr.getName() != callOp.getArgAttrsAttrName())
-            newAttrs.push_back(attr);
-        }
-        newAttrs.push_back(rewriter.getNamedAttr(
-            callOp.getArgAttrsAttrName(), rewriter.getArrayAttr(newArgAttrs)));
       }
     }
 
-    SmallVector<Value> newOperands;
-    SmallVector<int32_t> loadedOperands;
+    // Build newAttrs from the original call's attributes. If arg_attrs is
+    // present, filter out the entry for the sret arg (always index 0) or
+    // for any pure result/output arguments, since those operands are
+    // excluded from tessera.call's operand list below and arg_attrs must
+    // stay aligned with operand position.
+    if (argAttrs) {
+      for (unsigned i = 0, e = argAttrs.size(); i != e; ++i) {
+        bool skip = sretPtr ? (i == 0) : defineOp.isResultOnlyArg(i);
+        if (!skip)
+          newArgAttrs.push_back(argAttrs[i]);
+      }
+      for (auto attr : callOp->getAttrs()) {
+        if (attr.getName() != callOp.getArgAttrsAttrName())
+          newAttrs.push_back(attr);
+      }
+      newAttrs.push_back(rewriter.getNamedAttr(
+          callOp.getArgAttrsAttrName(), rewriter.getArrayAttr(newArgAttrs)));
+    } else {
+      newAttrs.append(callOp->getAttrs().begin(), callOp->getAttrs().end());
+    }
 
     // Build operands without first element if sretPtr is present.
-    // If a pointer operand has a byVal attribute or was marked as
-    // byRef by the user, load the value from the pointer and store
-    // that as the new operand.
+    // If a pointer operand has a LLVM byVal attribute or was marked
+    // as byRef by the user, load the value from the pointer and store
+    // that as the new operand. Don't include pure result/output
+    // arguments in the new operand list.
+    SmallVector<Value> newOperands;
+    SmallVector<int32_t> loadedOperands;
+    SmallVector<Value> resultArgPtrs;
+    SmallVector<Type> resultArgTypes;
     int argOffset = sretPtr ? 1 : 0;
+
     for (unsigned i = 0; i < operands.size() - argOffset; i++) {
       auto operand = callOp.getOperand(i + argOffset);
 
@@ -254,9 +301,18 @@ public:
         continue;
       }
 
-      // Determine whether to load pointer and what type to load based on
-      // byVal attribute or byRef attribute on the tessera.define op.
-      // If neither is present, just pass the pointer through.
+      // Exclude pure result/output arguments from the new operands
+      // list and remember their pointer and pointee types for later
+      // use after the tessera.call is built
+      if (defineOp.isResultOnlyArg(i)) {
+        resultArgPtrs.push_back(operand);
+        resultArgTypes.push_back(defineOp.getResultArgType(i));
+        continue;
+      }
+
+      // Determine whether to load pointer and what type to load based on LLVM
+      // byVal attribute or user-marked byRef attribute on the tessera.define 
+      // op. If neither is present, just pass the pointer through.
       Type pointeeType;
       if (auto byValAttr =
               defineOp.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName())) {
@@ -279,8 +335,12 @@ public:
         rewriter.getNamedAttr("tessera.loaded_operands",
                               rewriter.getDenseI32ArrayAttr(loadedOperands)));
 
-    // Create tessera.call op with SSA return type
+    // Create tessera.call op with results conveyed as direct SSA values rather
+    // than written through pointers -- either the sret-derived value, or the
+    // natural return (if any) plus one trailing value per result/output argument.
     if (sretPtr) {
+      // Set the result type of the new tessera.call op to be the sret pointee type
+      // and store the result back through the sret pointer.
       auto newCall =
           tessera::CallOp::create(rewriter, callOp.getLoc(),
                                   TypeRange{sretType}, newOperands, newAttrs);
@@ -288,10 +348,30 @@ public:
                             sretPtr);
       rewriter.eraseOp(callOp);
     } else {
-      rewriter.replaceOpWithNewOp<tessera::CallOp>(
-          callOp, callOp.getResultTypes(), newOperands, callOp->getAttrs());
+      // Add result argument types to the front of the result type list of
+      // the new tessera.call op -- one leading result per pure-output
+      // argument, in argument order -- followed by the natural (original)
+      // result types. Result-arg-derived results come first so that a PDL
+      // rule referencing result 0 always sees the semantically meaningful
+      // output-param value rather than the natural/ternary return.
+      SmallVector<Type> newResultTypes(resultArgTypes.begin(),
+                                        resultArgTypes.end());
+      newResultTypes.append(callOp.getResultTypes().begin(),
+                            callOp.getResultTypes().end());
+      auto newCall = tessera::CallOp::create(rewriter, callOp.getLoc(),
+                                    newResultTypes, newOperands, newAttrs);
+      // Store each leading result back through its original pointer so any
+      // pre-existing downstream load from that pointer still sees the right
+      // value.
+      for (auto [idx, ptr] : llvm::enumerate(resultArgPtrs)) {
+        LLVM::StoreOp::create(rewriter, callOp.getLoc(),
+                      newCall.getResult(idx), ptr);
+      }
+      // If the original call had any (natural) results, replace them with
+      // the new call's trailing results.
+      unsigned originalNumResults = callOp.getNumResults();
+      rewriter.replaceOp(callOp, newCall.getResults().take_back(originalNumResults));
     }
-
     return success();
   }
 };
@@ -327,15 +407,15 @@ struct LLVMToTesseraPass
     RewritePatternSet patterns(ctx);
     auto module = cast<ModuleOp>(getOperation());
 
-    // Build a lookup of byref argument index -> resolved type by scanning the
-    // module once for globals named "__tessera_byref_arg_type_<index>" (names
+    // Build a lookup of argument index -> resolved type by scanning the
+    // module once for globals named "__tessera_arg_type_<index>" (names
     // may be mangled with compiler-added prefixes, e.g.
-    // "_ZL26__tessera_byref_arg_type_0", so we search for the marker rather
-    // than requiring it at the start). Each tessera.define op's own byref index
-    // list (from its "globals=" attribute) is later resolved against this map,
-    // avoiding a full module rescan per op.
-    llvm::DenseMap<unsigned, mlir::Type> byRefTypesByIndex;
-    StringRef prefix = "__tessera_byref_arg_type_";
+    // "_ZL20__tessera_arg_type_0", so we search for the marker rather
+    // than requiring it at the start). Each tessera.define op's own index
+    // list (from its "globals=" attribute) is later resolved against this
+    // map, avoiding a full module rescan per op.
+    llvm::DenseMap<unsigned, mlir::Type> argTypesByIndex;
+    StringRef prefix = "__tessera_arg_type_";
     for (auto global : module.getOps<mlir::LLVM::GlobalOp>()) {
       StringRef name = global.getSymName();
       size_t pos = name.find(prefix);
@@ -347,16 +427,16 @@ struct LLVMToTesseraPass
         continue; // not a well-formed index suffix, skip
 
       auto [it, inserted] =
-          byRefTypesByIndex.try_emplace(idx, global.getType());
+          argTypesByIndex.try_emplace(idx, global.getType());
       if (!inserted) {
         llvm::errs()
-            << "Tessera: found multiple globals matching byref type index "
+            << "Tessera: found multiple globals matching argument type index "
             << idx << ":\n";
         return signalPassFailure();
       }
     }
 
-    patterns.add<FuncOpRewrite>(ctx, byRefTypesByIndex);
+    patterns.add<FuncOpRewrite>(ctx, argTypesByIndex);
     patterns.add<CallOpRewrite, ReturnOpRewrite>(ctx);
 
     GreedyRewriteConfig config;

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -104,16 +104,18 @@ public:
     // Consumes the next shared global index for a byref/result-marked arg,
     // looks up its pointee type by that index in argTypesByIndex, and
     // appends the resolved TypeAttr to `out`.
-    auto consumeMarkedArg = [&](StringRef kindName,
-                                 SmallVectorImpl<Attribute> &out) -> LogicalResult {
+    auto consumeMarkedArg =
+        [&](StringRef kindName,
+            SmallVectorImpl<Attribute> &out) -> LogicalResult {
       if (numIndicesFound >= indexList.size()) {
         funcOp->emitError(
             "tessera: not enough global indices for byref/result args");
         return failure();
       }
       // Find the types of the byref/result arguments by looking for global
-      // variables with names that match the pattern "__tessera_arg_type_<idx>" 
-      // where <idx> is a number parsed in the tessera_op attribute after "globals=".
+      // variables with names that match the pattern "__tessera_arg_type_<idx>"
+      // where <idx> is a number parsed in the tessera_op attribute after
+      // "globals=".
       StringRef indexStr = indexList[numIndicesFound++];
       unsigned idx;
       if (indexStr.trim().getAsInteger(10, idx)) {
@@ -164,8 +166,8 @@ public:
     // A mismatch means the annotation string is malformed or the Clang
     // plugin's emission order has drifted from this parser's assumption.
     if (numIndicesFound != indexList.size()) {
-      funcOp->emitError(
-          "tessera: mismatch between byref/result arg count and global index count");
+      funcOp->emitError("tessera: mismatch between byref/result arg count and "
+                        "global index count");
       return failure();
     }
 
@@ -185,9 +187,8 @@ public:
             module)))
       return failure();
 
-    bool hasResultArg = llvm::any_of(resultArgTypes, [](Attribute attr) {
-      return isa<TypeAttr>(attr);
-    });
+    bool hasResultArg = llvm::any_of(
+        resultArgTypes, [](Attribute attr) { return isa<TypeAttr>(attr); });
 
     // Create the tessera.define op with the new name, function type, byRef
     // args, sizes, and purity (side effect free) attribute
@@ -311,11 +312,15 @@ public:
       }
 
       // Determine whether to load pointer and what type to load based on LLVM
-      // byVal attribute or user-marked byRef attribute on the tessera.define 
+      // byVal attribute or user-marked byRef attribute on the tessera.define
       // op. If neither is present, just pass the pointer through.
+      // newOperands.size() is the number of tessera.call operands emitted
+      // so far, i.e. the call-operand index this entry will land at once
+      // pushed below -- getArgAttr expects that stripped index, not the
+      // pre-strip loop index i.
       Type pointeeType;
-      if (auto byValAttr =
-              defineOp.getArgAttr(i, LLVM::LLVMDialect::getByValAttrName())) {
+      if (auto byValAttr = defineOp.getArgAttr(
+              newOperands.size(), LLVM::LLVMDialect::getByValAttrName())) {
         pointeeType = cast<TypeAttr>(byValAttr).getValue();
       } else if (auto byRefType = defineOp.getByRefType(i)) {
         pointeeType = byRefType;
@@ -337,10 +342,11 @@ public:
 
     // Create tessera.call op with results conveyed as direct SSA values rather
     // than written through pointers -- either the sret-derived value, or the
-    // natural return (if any) plus one trailing value per result/output argument.
+    // natural return (if any) plus one trailing value per result/output
+    // argument.
     if (sretPtr) {
-      // Set the result type of the new tessera.call op to be the sret pointee type
-      // and store the result back through the sret pointer.
+      // Set the result type of the new tessera.call op to be the sret pointee
+      // type and store the result back through the sret pointer.
       auto newCall =
           tessera::CallOp::create(rewriter, callOp.getLoc(),
                                   TypeRange{sretType}, newOperands, newAttrs);
@@ -355,22 +361,23 @@ public:
       // rule referencing result 0 always sees the semantically meaningful
       // output-param value rather than the natural/ternary return.
       SmallVector<Type> newResultTypes(resultArgTypes.begin(),
-                                        resultArgTypes.end());
+                                       resultArgTypes.end());
       newResultTypes.append(callOp.getResultTypes().begin(),
                             callOp.getResultTypes().end());
-      auto newCall = tessera::CallOp::create(rewriter, callOp.getLoc(),
-                                    newResultTypes, newOperands, newAttrs);
+      auto newCall = tessera::CallOp::create(
+          rewriter, callOp.getLoc(), newResultTypes, newOperands, newAttrs);
       // Store each leading result back through its original pointer so any
       // pre-existing downstream load from that pointer still sees the right
       // value.
       for (auto [idx, ptr] : llvm::enumerate(resultArgPtrs)) {
-        LLVM::StoreOp::create(rewriter, callOp.getLoc(),
-                      newCall.getResult(idx), ptr);
+        LLVM::StoreOp::create(rewriter, callOp.getLoc(), newCall.getResult(idx),
+                              ptr);
       }
       // If the original call had any (natural) results, replace them with
       // the new call's trailing results.
       unsigned originalNumResults = callOp.getNumResults();
-      rewriter.replaceOp(callOp, newCall.getResults().take_back(originalNumResults));
+      rewriter.replaceOp(callOp,
+                         newCall.getResults().take_back(originalNumResults));
     }
     return success();
   }
@@ -426,8 +433,7 @@ struct LLVMToTesseraPass
       if (idxStr.getAsInteger(10, idx))
         continue; // not a well-formed index suffix, skip
 
-      auto [it, inserted] =
-          argTypesByIndex.try_emplace(idx, global.getType());
+      auto [it, inserted] = argTypesByIndex.try_emplace(idx, global.getType());
       if (!inserted) {
         llvm::errs()
             << "Tessera: found multiple globals matching argument type index "

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -73,17 +73,6 @@ public:
     // "tessera_op(arg1:val=in, arg2, ...):globals=index1,..." or
     // "pure_tessera_op(arg1:val=in, arg2, ...):globals=index1,...".
     //
-    // A marker lifts an argument into the value domain: the call site
-    // dereferences the pointer so that tessera.call carries the pointee as an
-    // SSA value. That is what lets a PDL pattern match over calls, since
-    // PDL matches SSA def-use edges and cannot see dependencies through
-    // memory. An unmarked argument is passed through as-is.
-    //
-    // The marker's direction says what the callee does to the pointee:
-    //   :val=in    reads it   -- takes an operand, yields no result
-    //   :val=out   writes it  -- takes no operand, yields a trailing result
-    //   :val=inout both       -- takes an operand and yields a result
-    //
     // index1,... corresponds positionally, in left-to-right order, to the
     // marked args, one global counter index per marked arg, and is used to
     // look up each arg's type in argTypesByGlobalIndices.
@@ -112,7 +101,7 @@ public:
     // Consumes the next global index for a marked arg, looks up its type
     // by that index in argTypesByGlobalIndices, and returns the mode dictionary
     // pairing that type with `dir`.
-    auto consumeMarkedArg = [&](StringRef dir) -> Attribute {
+    auto consumeMarkedArg = [&](ArgDirection dir) -> Attribute {
       if (numIndicesFound >= indexList.size()) {
         funcOp->emitError("tessera: not enough global indices for marked args");
         return nullptr;
@@ -124,21 +113,20 @@ public:
       StringRef indexStr = indexList[numIndicesFound++];
       unsigned idx;
       if (indexStr.trim().getAsInteger(10, idx)) {
-        funcOp->emitError("tessera: invalid type index for :val=")
-            << dir << " arg: " << indexStr;
+        funcOp->emitError("tessera: invalid type index for arg: ") << indexStr;
         return nullptr;
       }
       auto it = argTypesByGlobalIndices.find(idx);
       if (it == argTypesByGlobalIndices.end()) {
-        funcOp->emitError("tessera: no lifting entry found for :val=")
-            << dir << " arg at index: " << idx;
+        funcOp->emitError("tessera: no lifting entry found for arg at index: ")
+            << idx;
         return nullptr;
       }
-      return DictionaryAttr::get(ctx,
-                                 {NamedAttribute(StringAttr::get(ctx, "type"),
-                                                 TypeAttr::get(it->second)),
-                                  NamedAttribute(StringAttr::get(ctx, "dir"),
-                                                 StringAttr::get(ctx, dir))});
+      return DictionaryAttr::get(
+          ctx, {NamedAttribute(StringAttr::get(ctx, "type"),
+                               TypeAttr::get(it->second)),
+                NamedAttribute(StringAttr::get(ctx, "dir"),
+                               ArgDirectionAttr::get(ctx, dir))});
     };
 
     if (!argList.trim().empty()) {
@@ -162,14 +150,16 @@ public:
           wellFormed = dir.consume_front("=");
           dir = dir.trim();
         }
-        if (!wellFormed || (dir != "in" && dir != "out" && dir != "inout")) {
+        std::optional<ArgDirection> argDirection =
+            wellFormed ? symbolizeArgDirection(dir) : std::nullopt;
+        if (!argDirection) {
           funcOp->emitError("tessera: argument '")
               << arg << "' has invalid marker '" << marker
               << "', expected :val=in, :val=out, or :val=inout";
           return failure();
         }
 
-        Attribute mode = consumeMarkedArg(dir);
+        Attribute mode = consumeMarkedArg(*argDirection);
         if (!mode)
           return failure();
         argModes.push_back(mode);
@@ -319,15 +309,9 @@ public:
 
       // Every written arg contributes a trailing tessera.call result, so
       // remember its pointer and pointee type for use after the call is
-      // built. Whether it also keeps an operand slot depends on the
-      // direction:
-      //   - "out": the callee only writes it, so it is dropped from the
-      //     operand list entirely. Supplying one would load the caller's
-      //     not-yet-written storage and pass undef.
-      //   - "inout": the callee reads the caller's existing object and writes
-      //     back through the same pointer, so it falls through to the load
-      //     below and keeps its operand slot carrying the incoming value.
-      // Recorded in argument order either way, as CallOp's verifier expects.
+      // built. Arguments that were marked "out" are dropped from the
+      // operand list while arguments marked "inout" keep their operand
+      // slots carrying their incoming values.
       if (defineOp.argIsWritten(i)) {
         Type resultArgType = defineOp.getArgLiftedType(i);
         resultArgPtrs.push_back(operand);
@@ -426,12 +410,9 @@ struct LLVMToTesseraPass
     auto module = cast<ModuleOp>(getOperation());
 
     // Build a lookup of argument index -> resolved type by scanning the
-    // module once for globals named "__tessera_arg_type_<index>" (names
-    // may be mangled with compiler-added prefixes, e.g.
-    // "_ZL20__tessera_arg_type_0", so we search for the marker rather
-    // than requiring it at the start). Each tessera.define op's own index
-    // list (from its "globals=" attribute) is later resolved against this
-    // map, avoiding a full module rescan per op.
+    // module once for globals named "__tessera_arg_type_<index>".
+    // Each tessera.define op's own index list (from its "globals=" attribute)
+    // is later resolved against this map, avoiding a full module rescan per op.
     llvm::DenseMap<unsigned, mlir::Type> argTypesByGlobalIndices;
     StringRef prefix = "__tessera_arg_type_";
     for (auto global : module.getOps<mlir::LLVM::GlobalOp>()) {

--- a/src/enzyme_ad/jax/Passes/Tessera/ParseOptimizationRules.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/ParseOptimizationRules.cpp
@@ -286,15 +286,20 @@ emitMatchPDL(const Expr &expr, OpBuilder &builder, Location loc,
                 builder, loc,
                 FlatSymbolRefAttr::get(builder.getContext(),
                                        c.dialect + "." + c.opname));
-            auto resultTypeOp = pdl::TypeOp::create(
-                builder, loc, builder.getType<pdl::TypeType>(),
-                /*type=*/TypeAttr());
+            // Use an unbound pdl.types range (rather than a single pdl.type) so the match
+            // doesn't constrain the result count of the tessera.call op since
+            // it may vary (1 for a plain call, 1 + N for a callee with
+            // N output-param arguments).
+            auto resultTypesOp = pdl::TypesOp::create(
+                builder, loc,
+                pdl::RangeType::get(builder.getType<pdl::TypeType>()),
+                /*constantTypes=*/ArrayAttr());
             auto callOp = pdl::OperationOp::create(
                 builder, loc, "tessera.call",
                 /*operands=*/argValues,
                 /*attrNames=*/ArrayRef<StringRef>{"callee"},
                 /*attrs=*/ValueRange{calleeAttr},
-                /*types=*/ValueRange{resultTypeOp});
+                /*types=*/ValueRange{resultTypesOp});
             return {pdl::ResultOp::create(builder, loc,
                                           builder.getType<pdl::ValueType>(),
                                           callOp, builder.getI32IntegerAttr(0)),
@@ -335,15 +340,16 @@ emitRewritePDL(const Expr &expr, OpBuilder &builder, Location loc,
                 builder, loc,
                 FlatSymbolRefAttr::get(builder.getContext(),
                                        c.dialect + "." + c.opname));
-            auto resultTypeOp = pdl::TypeOp::create(
-                builder, loc, builder.getType<pdl::TypeType>(),
-                /*type=*/TypeAttr());
+            auto resultTypesOp = pdl::TypesOp::create(
+                builder, loc,
+                pdl::RangeType::get(builder.getType<pdl::TypeType>()),
+                /*constantTypes=*/ArrayAttr());
             auto callOp = pdl::OperationOp::create(
                 builder, loc, "tessera.call",
                 /*operands=*/argValues,
                 /*attrNames=*/ArrayRef<StringRef>{"callee"},
                 /*attrs=*/ValueRange{calleeAttr},
-                /*types=*/ValueRange{resultTypeOp});
+                /*types=*/ValueRange{resultTypesOp});
             return {pdl::ResultOp::create(builder, loc,
                                           builder.getType<pdl::ValueType>(),
                                           callOp, builder.getI32IntegerAttr(0)),

--- a/src/enzyme_ad/jax/Passes/Tessera/ParseOptimizationRules.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/ParseOptimizationRules.cpp
@@ -286,9 +286,9 @@ emitMatchPDL(const Expr &expr, OpBuilder &builder, Location loc,
                 builder, loc,
                 FlatSymbolRefAttr::get(builder.getContext(),
                                        c.dialect + "." + c.opname));
-            // Use an unbound pdl.types range (rather than a single pdl.type) so the match
-            // doesn't constrain the result count of the tessera.call op since
-            // it may vary (1 for a plain call, 1 + N for a callee with
+            // Use an unbound pdl.types range (rather than a single pdl.type) so
+            // the match doesn't constrain the result count of the tessera.call
+            // op since it may vary (1 for a plain call, 1 + N for a callee with
             // N output-param arguments).
             auto resultTypesOp = pdl::TypesOp::create(
                 builder, loc,

--- a/src/enzyme_ad/jax/Passes/Tessera/ParseOptimizationRules.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/ParseOptimizationRules.cpp
@@ -375,15 +375,20 @@ emitMatchPDL(const Expr &expr, OpBuilder &builder, Location loc,
                 builder, loc,
                 FlatSymbolRefAttr::get(builder.getContext(),
                                        c.dialect + "." + c.opname));
-            auto resultTypeOp = pdl::TypeOp::create(
-                builder, loc, builder.getType<pdl::TypeType>(),
-                /*type=*/TypeAttr());
+            // Use an unbound pdl.types range (rather than a single pdl.type) so the match
+            // doesn't constrain the result count of the tessera.call op since
+            // it may vary (1 for a plain call, 1 + N for a callee with
+            // N output-param arguments).
+            auto resultTypesOp = pdl::TypesOp::create(
+                builder, loc,
+                pdl::RangeType::get(builder.getType<pdl::TypeType>()),
+                /*constantTypes=*/ArrayAttr());
             auto callOp = pdl::OperationOp::create(
                 builder, loc, "tessera.call",
                 /*operands=*/argValues,
                 /*attrNames=*/ArrayRef<StringRef>{"callee"},
                 /*attrs=*/ValueRange{calleeAttr},
-                /*types=*/ValueRange{resultTypeOp});
+                /*types=*/ValueRange{resultTypesOp});
             return {pdl::ResultOp::create(builder, loc,
                                           builder.getType<pdl::ValueType>(),
                                           callOp, builder.getI32IntegerAttr(0)),
@@ -450,15 +455,16 @@ emitRewritePDL(const Expr &expr, OpBuilder &builder, Location loc,
                 builder, loc,
                 FlatSymbolRefAttr::get(builder.getContext(),
                                        c.dialect + "." + c.opname));
-            auto resultTypeOp = pdl::TypeOp::create(
-                builder, loc, builder.getType<pdl::TypeType>(),
-                /*type=*/TypeAttr());
+            auto resultTypesOp = pdl::TypesOp::create(
+                builder, loc,
+                pdl::RangeType::get(builder.getType<pdl::TypeType>()),
+                /*constantTypes=*/ArrayAttr());
             auto callOp = pdl::OperationOp::create(
                 builder, loc, "tessera.call",
                 /*operands=*/argValues,
                 /*attrNames=*/ArrayRef<StringRef>{"callee"},
                 /*attrs=*/ValueRange{calleeAttr},
-                /*types=*/ValueRange{resultTypeOp});
+                /*types=*/ValueRange{resultTypesOp});
             return {pdl::ResultOp::create(builder, loc,
                                           builder.getType<pdl::ValueType>(),
                                           callOp, builder.getI32IntegerAttr(0)),

--- a/src/enzyme_ad/jax/Passes/Tessera/ParseOptimizationRules.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/ParseOptimizationRules.cpp
@@ -375,9 +375,9 @@ emitMatchPDL(const Expr &expr, OpBuilder &builder, Location loc,
                 builder, loc,
                 FlatSymbolRefAttr::get(builder.getContext(),
                                        c.dialect + "." + c.opname));
-            // Use an unbound pdl.types range (rather than a single pdl.type) so the match
-            // doesn't constrain the result count of the tessera.call op since
-            // it may vary (1 for a plain call, 1 + N for a callee with
+            // Use an unbound pdl.types range (rather than a single pdl.type) so
+            // the match doesn't constrain the result count of the tessera.call
+            // op since it may vary (1 for a plain call, 1 + N for a callee with
             // N output-param arguments).
             auto resultTypesOp = pdl::TypesOp::create(
                 builder, loc,

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -78,14 +78,13 @@ public:
     auto funcOp = LLVM::LLVMFuncOp::create(rewriter, defineOp.getLoc(),
                                            funcName, llvmFuncType);
 
-    // Copy over attributes other than the function name and type, byRef args,
-    // argSizes, pure, and other attributes used only for tessera conversion
+    // Copy over attributes other than the function name and type, arg modes,
+    // pure, and other attributes used only for tessera conversion
     for (const auto &namedAttr : defineOp->getAttrs()) {
       if (namedAttr.getName() != SymbolTable::getSymbolAttrName() &&
           namedAttr.getName() != defineOp.getFunctionTypeAttrName() &&
-          namedAttr.getName() != defineOp.getByRefTypesAttrName() &&
+          namedAttr.getName() != defineOp.getArgModesAttrName() &&
           namedAttr.getName() != defineOp.getPureAttrName() &&
-          namedAttr.getName() != defineOp.getResultArgTypesAttrName() &&
           namedAttr.getName() != "tessera.original_name")
         funcOp->setAttr(namedAttr.getName(), namedAttr.getValue());
     }
@@ -120,12 +119,38 @@ public:
     auto callee = SymbolTable::lookupSymbolIn(
         callOp->getParentOfType<ModuleOp>(), calleeAttr);
 
-    // Check if callee's first argument has sret attribute. If so, allocate new
-    // pointer to contain result of tessera.call and insert as first argument in
-    // llvm.call.
     auto defineOp = dyn_cast_or_null<tessera::DefineOp>(callee);
     if (!defineOp)
       return failure();
+
+    // Any operand the callee takes through a pointer was loaded from
+    // memory when converting LLVM to tessera, so put it back: allocate
+    // fresh stack storage, store the operand's value into it, and substitute
+    // that pointer in its place. All other operands pass through unchanged.
+    Value one;
+    SmallVector<Value> reconstructedOperands;
+    for (auto [i, operand] : llvm::enumerate(callOp.getOperands())) {
+      if (!isa<LLVM::LLVMPointerType>(operand.getType()) &&
+          defineOp.getCallOperandPointeeType(i)) {
+        if (!one)
+          one = LLVM::ConstantOp::create(rewriter, callOp.getLoc(),
+                                         rewriter.getI32Type(),
+                                         rewriter.getI32IntegerAttr(1));
+        int64_t alignment = 0;
+        if (auto alignAttr =
+                defineOp.getArgAttr(i, LLVM::LLVMDialect::getAlignAttrName()))
+          alignment = cast<IntegerAttr>(alignAttr).getInt();
+        auto AIOp = LLVM::AllocaOp::create(
+            rewriter, callOp.getLoc(),
+            LLVM::LLVMPointerType::get(callOp->getContext()), operand.getType(),
+            one, alignment);
+        Value AI = AIOp;
+        LLVM::StoreOp::create(rewriter, callOp.getLoc(), operand, AI);
+        reconstructedOperands.push_back(AI);
+      } else {
+        reconstructedOperands.push_back(operand);
+      }
+    }
 
     auto buildNewAttrs = [&](ArrayRef<NamedAttribute> baseAttrs,
                              int32_t numOperands,
@@ -133,7 +158,6 @@ public:
       SmallVector<NamedAttribute> newAttrs;
       for (auto attr : baseAttrs) {
         if (attr.getName() != callOp.getArgAttrsAttrName() &&
-            attr.getName() != "tessera.loaded_operands" &&
             attr.getName() != "operandSegmentSizes" &&
             attr.getName() != "op_bundle_sizes")
           newAttrs.push_back(attr);
@@ -152,48 +176,14 @@ public:
       return newAttrs;
     };
 
-    // For each of callOp's operands marked in "tessera.loaded_operands"
-    // (i.e. it was loaded from a byref/byval pointer when converting from
-    // LLVM to tessera), allocate fresh stack storage, store the operand's
-    // value into it, and substitute that pointer in its place; all other
-    // operands pass through unchanged. This is independent of sret --
-    // byref-loadedness and sret-ness are separate properties of a callee's
-    // arguments, so this reconstruction applies regardless of which branch
-    // below is taken.
-    SmallVector<int32_t> argsToReplace;
-    if (auto loadedOperands =
-            callOp->getAttrOfType<DenseI32ArrayAttr>("tessera.loaded_operands"))
-      argsToReplace = llvm::to_vector(loadedOperands.asArrayRef());
-
-    Value one;
-    SmallVector<Value> reconstructedOperands;
-    for (auto [i, operand] : llvm::enumerate(callOp.getOperands())) {
-      if (llvm::is_contained(argsToReplace, (int32_t)i)) {
-        if (!one)
-          one = LLVM::ConstantOp::create(rewriter, callOp.getLoc(),
-                                         rewriter.getI32Type(),
-                                         rewriter.getI32IntegerAttr(1));
-        int64_t alignment = 0;
-        if (auto alignAttr =
-                defineOp.getArgAttr(i, LLVM::LLVMDialect::getAlignAttrName()))
-          alignment = cast<IntegerAttr>(alignAttr).getInt();
-        Value AI = LLVM::AllocaOp::create(
-            rewriter, callOp.getLoc(),
-            LLVM::LLVMPointerType::get(callOp->getContext()), operand.getType(),
-            one, alignment);
-        LLVM::StoreOp::create(rewriter, callOp.getLoc(), operand, AI);
-        reconstructedOperands.push_back(AI);
-      } else {
-        reconstructedOperands.push_back(operand);
-      }
-    }
-
+    // Check if callee's first argument has sret attribute. If so, allocate new
+    // pointer to contain result of tessera.call and insert as first argument in
+    // llvm.call.
     if (defineOp.getNumArguments() > 0 && defineOp.getSretAttr()) {
-      auto sretArgAttrs = defineOp.getArgAttrDict(0);
       if (callOp.getNumResults() == 0)
         return callOp.emitOpError(
             "tessera.call to sret function must have a result");
-      auto sretType = callOp.getResult(0).getType();
+      auto sretArgAttrs = defineOp.getArgAttrDict(0);
       int64_t sret_alignment = 0;
       if (auto sretAlignAttr =
               sretArgAttrs.get(LLVM::LLVMDialect::getAlignAttrName()))
@@ -204,13 +194,14 @@ public:
                                        rewriter.getI32IntegerAttr(1));
 
       // Allocate stack storage for the sret return value
+      auto sretType = callOp.getResult(0).getType();
       Value sretPtr = LLVM::AllocaOp::create(
           rewriter, callOp.getLoc(),
           LLVM::LLVMPointerType::get(callOp->getContext()), sretType, one,
           sret_alignment);
 
       // Build new operands with sretPtr as first arg, followed by the
-      // reconstructed (byref-resolved) operands
+      // reconstructed operands
       SmallVector<Value> newOperands;
       newOperands.push_back(sretPtr);
       newOperands.append(reconstructedOperands.begin(),
@@ -234,23 +225,29 @@ public:
       auto loadedResult =
           LLVM::LoadOp::create(rewriter, callOp.getLoc(), sretType, sretPtr);
       rewriter.replaceOp(callOp, loadedResult.getResult());
-    } else if (defineOp.getNumResultArgs() == 0) {
-      auto newAttrs = buildNewAttrs(callOp->getAttrs(),
-                                    reconstructedOperands.size(), std::nullopt);
-      rewriter.replaceOpWithNewOp<LLVM::CallOp>(
-          callOp, callOp.getResultTypes(), reconstructedOperands, newAttrs);
-    } else {
-      // Allocate stack storage for each result argument, and splice those
+
+    } else if (defineOp.getNumWrittenArgs() > 0) {
+      // Allocate stack storage for each written argument, and splice those
       // pointers into the operand list in the right positions, so that the
       // LLVM::CallOp can be issued with the callee's real function type
-      // and the result-only arguments passed by pointer.
+      // and the write-only arguments passed by pointer.
       SmallVector<Value> newOperands;
       SmallVector<Attribute> newArgAttrs;
       SmallVector<Value> resultArgPtrs;
       SmallVector<Type> resultArgTypes;
+      auto callArgAttrs = callOp.getArgAttrsAttr();
       unsigned tesseraCallIdx = 0;
+
       for (unsigned i = 0, e = defineOp.getNumArguments(); i != e; ++i) {
-        if (defineOp.isResultOnlyArg(i)) {
+        // Check if argument is write-only
+        if (defineOp.argIsWritten(i) && !defineOp.argIsRead(i)) {
+          Type resultArgType = defineOp.getArgLiftedType(i);
+          if (!resultArgType)
+            return callOp.emitOpError(
+                "tessera.call to function with write-only argument must "
+                "have a result type for that argument");
+
+          // Get alignment from callee's arg attrs
           int64_t alignment = 0;
           auto resultArgAttrs = defineOp.getArgAttrDict(i);
           if (resultArgAttrs) {
@@ -263,27 +260,35 @@ public:
                                            rewriter.getI32Type(),
                                            rewriter.getI32IntegerAttr(1));
 
-          Type resultArgType = defineOp.getResultArgType(i);
-          if (!resultArgType)
-            return callOp.emitOpError(
-                "tessera.call to function with result-only argument must "
-                "have a result type for that argument");
           // Allocate stack storage for the result/output argument
-          Value resultArgPtr = LLVM::AllocaOp::create(
+          auto resultArgPtrOp = LLVM::AllocaOp::create(
               rewriter, callOp.getLoc(),
               LLVM::LLVMPointerType::get(callOp->getContext()), resultArgType,
               one, alignment);
+
+          Value resultArgPtr = resultArgPtrOp;
           newOperands.push_back(resultArgPtr);
           resultArgPtrs.push_back(resultArgPtr);
           resultArgTypes.push_back(resultArgType);
           newArgAttrs.push_back(
               resultArgAttrs ? resultArgAttrs : rewriter.getDictionaryAttr({}));
+
+          // Argument is not written, or is "inout"
         } else {
           if (tesseraCallIdx >= reconstructedOperands.size())
             return callOp.emitOpError(
                 "tessera.call has fewer operands than expected by callee");
-          newOperands.push_back(reconstructedOperands[tesseraCallIdx]);
-          auto callArgAttrs = callOp.getArgAttrsAttr();
+          Value operand = reconstructedOperands[tesseraCallIdx];
+          newOperands.push_back(operand);
+          // If arg is inout, it was already reconstructed into an alloca.
+          // We want to read that same alloca back after the call so the
+          // callee's writes through the pointer become the arg's trailing
+          // tessera.call result. Pushed in argument order, matching the
+          // leading-result order LLVMToTessera built and the verifier checks.
+          if (defineOp.argIsWritten(i)) {
+            resultArgPtrs.push_back(operand);
+            resultArgTypes.push_back(defineOp.getArgLiftedType(i));
+          }
           newArgAttrs.push_back(callArgAttrs ? callArgAttrs[tesseraCallIdx]
                                              : rewriter.getDictionaryAttr({}));
           ++tesseraCallIdx;
@@ -301,7 +306,7 @@ public:
                                           newOperands, newAttrs);
 
       // Load each result arg's value back from its alloca, then replace
-      // callOp's results: one loaded value per result-only argument (the
+      // callOp's results: one loaded value per result argument (the
       // leading results on the tessera.call), in argument order, followed
       // by the natural result (if any), matching the new LLVM call's
       // direct result.
@@ -314,6 +319,13 @@ public:
       if (fnType.getNumResults() > 0)
         replacementValues.push_back(newCall.getResult());
       rewriter.replaceOp(callOp, replacementValues);
+
+      // Callee has no result args
+    } else {
+      auto newAttrs = buildNewAttrs(callOp->getAttrs(),
+                                    reconstructedOperands.size(), std::nullopt);
+      rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+          callOp, callOp.getResultTypes(), reconstructedOperands, newAttrs);
     }
 
     return success();

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -85,6 +85,7 @@ public:
           namedAttr.getName() != defineOp.getFunctionTypeAttrName() &&
           namedAttr.getName() != defineOp.getByRefTypesAttrName() &&
           namedAttr.getName() != defineOp.getPureAttrName() &&
+          namedAttr.getName() != defineOp.getResultArgTypesAttrName() &&
           namedAttr.getName() != "tessera.original_name")
         funcOp->setAttr(namedAttr.getName(), namedAttr.getValue());
     }
@@ -151,6 +152,42 @@ public:
       return newAttrs;
     };
 
+    // For each of callOp's operands marked in "tessera.loaded_operands"
+    // (i.e. it was loaded from a byref/byval pointer when converting from
+    // LLVM to tessera), allocate fresh stack storage, store the operand's
+    // value into it, and substitute that pointer in its place; all other
+    // operands pass through unchanged. This is independent of sret --
+    // byref-loadedness and sret-ness are separate properties of a callee's
+    // arguments, so this reconstruction applies regardless of which branch
+    // below is taken.
+    SmallVector<int32_t> argsToReplace;
+    if (auto loadedOperands = callOp->getAttrOfType<DenseI32ArrayAttr>(
+            "tessera.loaded_operands"))
+      argsToReplace = llvm::to_vector(loadedOperands.asArrayRef());
+
+    Value one;
+    SmallVector<Value> reconstructedOperands;
+    for (auto [i, operand] : llvm::enumerate(callOp.getOperands())) {
+      if (llvm::is_contained(argsToReplace, (int32_t)i)) {
+        if (!one)
+          one = LLVM::ConstantOp::create(rewriter, callOp.getLoc(),
+                                         rewriter.getI32Type(),
+                                         rewriter.getI32IntegerAttr(1));
+        int64_t alignment = 0;
+        if (auto alignAttr =
+                defineOp.getArgAttr(i, LLVM::LLVMDialect::getAlignAttrName()))
+          alignment = cast<IntegerAttr>(alignAttr).getInt();
+        Value AI = LLVM::AllocaOp::create(
+            rewriter, callOp.getLoc(),
+            LLVM::LLVMPointerType::get(callOp->getContext()),
+            operand.getType(), one, alignment);
+        LLVM::StoreOp::create(rewriter, callOp.getLoc(), operand, AI);
+        reconstructedOperands.push_back(AI);
+      } else {
+        reconstructedOperands.push_back(operand);
+      }
+    }
+
     if (defineOp.getNumArguments() > 0 && defineOp.getSretAttr()) {
       auto sretArgAttrs = defineOp.getArgAttrDict(0);
       if (callOp.getNumResults() == 0)
@@ -161,9 +198,10 @@ public:
       if (auto sretAlignAttr =
               sretArgAttrs.get(LLVM::LLVMDialect::getAlignAttrName()))
         sret_alignment = cast<IntegerAttr>(sretAlignAttr).getInt();
-      Value one = LLVM::ConstantOp::create(rewriter, callOp.getLoc(),
-                                           rewriter.getI32Type(),
-                                           rewriter.getI32IntegerAttr(1));
+      if (!one)
+        one = LLVM::ConstantOp::create(rewriter, callOp.getLoc(),
+                                       rewriter.getI32Type(),
+                                       rewriter.getI32IntegerAttr(1));
 
       // Allocate stack storage for the sret return value
       Value sretPtr = LLVM::AllocaOp::create(
@@ -171,31 +209,12 @@ public:
           LLVM::LLVMPointerType::get(callOp->getContext()), sretType, one,
           sret_alignment);
 
-      // Build new operands with sretPtr as first arg and reconstructed pointers
+      // Build new operands with sretPtr as first arg, followed by the
+      // reconstructed (byref-resolved) operands
       SmallVector<Value> newOperands;
       newOperands.push_back(sretPtr);
-
-      SmallVector<int32_t> argsToReplace;
-      if (auto loadedOperands = callOp->getAttrOfType<DenseI32ArrayAttr>(
-              "tessera.loaded_operands"))
-        argsToReplace = llvm::to_vector(loadedOperands.asArrayRef());
-
-      for (auto [i, operand] : llvm::enumerate(callOp.getOperands())) {
-        if (llvm::is_contained(argsToReplace, (int32_t)i)) {
-          int64_t alignment = 0;
-          if (auto alignAttr =
-                  defineOp.getArgAttr(i, LLVM::LLVMDialect::getAlignAttrName()))
-            alignment = cast<IntegerAttr>(alignAttr).getInt();
-          Value AI = LLVM::AllocaOp::create(
-              rewriter, callOp.getLoc(),
-              LLVM::LLVMPointerType::get(callOp->getContext()),
-              operand.getType(), one, alignment);
-          LLVM::StoreOp::create(rewriter, callOp.getLoc(), operand, AI);
-          newOperands.push_back(AI);
-        } else {
-          newOperands.push_back(operand);
-        }
-      }
+      newOperands.append(reconstructedOperands.begin(),
+                         reconstructedOperands.end());
 
       // Reconstruct arg attributes with sret attr first
       SmallVector<Attribute> newArgAttrs;
@@ -215,12 +234,84 @@ public:
       auto loadedResult =
           LLVM::LoadOp::create(rewriter, callOp.getLoc(), sretType, sretPtr);
       rewriter.replaceOp(callOp, loadedResult.getResult());
-    } else {
+    } else if (defineOp.getNumResultArgs() == 0) {
       auto newAttrs = buildNewAttrs(callOp->getAttrs(),
-                                    callOp.getOperands().size(), std::nullopt);
+                                    reconstructedOperands.size(), std::nullopt);
+      rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+          callOp, callOp.getResultTypes(), reconstructedOperands, newAttrs);
+    } else {
+      // Allocate stack storage for each result argument, and splice those
+      // pointers into the operand list in the right positions, so that the
+      // LLVM::CallOp can be issued with the callee's real function type
+      // and the result-only arguments passed by pointer.
+      SmallVector<Value> newOperands;
+      SmallVector<Attribute> newArgAttrs;
+      SmallVector<Value> resultArgPtrs;
+      SmallVector<Type> resultArgTypes;
+      unsigned tesseraCallIdx = 0;
+      for (unsigned i = 0, e = defineOp.getNumArguments(); i != e; ++i) {
+        if (defineOp.isResultOnlyArg(i)) {
+          int64_t alignment = 0;
+          auto resultArgAttrs = defineOp.getArgAttrDict(i);
+          if (resultArgAttrs) {
+            if (auto alignAttr =
+                  resultArgAttrs.get(LLVM::LLVMDialect::getAlignAttrName()))
+            alignment = cast<IntegerAttr>(alignAttr).getInt();
+          }
+          if (!one)
+            one = LLVM::ConstantOp::create(rewriter, callOp.getLoc(),
+                                          rewriter.getI32Type(),
+                                          rewriter.getI32IntegerAttr(1));
 
-      rewriter.replaceOpWithNewOp<LLVM::CallOp>(callOp, callOp.getResultTypes(),
-                                                callOp.getOperands(), newAttrs);
+          Type resultArgType = defineOp.getResultArgType(i);
+          if (!resultArgType)
+            return callOp.emitOpError(
+                "tessera.call to function with result-only argument must "
+                "have a result type for that argument");
+          // Allocate stack storage for the result/output argument
+          Value resultArgPtr = LLVM::AllocaOp::create(
+              rewriter, callOp.getLoc(),
+              LLVM::LLVMPointerType::get(callOp->getContext()), resultArgType, 
+              one, alignment);
+          newOperands.push_back(resultArgPtr);
+          resultArgPtrs.push_back(resultArgPtr);
+          resultArgTypes.push_back(resultArgType);
+          newArgAttrs.push_back(resultArgAttrs ? resultArgAttrs
+                                : rewriter.getDictionaryAttr({}));
+        } else {
+          if (tesseraCallIdx >= reconstructedOperands.size())
+            return callOp.emitOpError(
+                "tessera.call has fewer operands than expected by callee");
+          newOperands.push_back(reconstructedOperands[tesseraCallIdx]);
+          auto callArgAttrs = callOp.getArgAttrsAttr();
+          newArgAttrs.push_back(callArgAttrs ? callArgAttrs[tesseraCallIdx]
+                                : rewriter.getDictionaryAttr({}));
+          ++tesseraCallIdx;
+        }
+      }
+
+      auto newAttrs = buildNewAttrs(callOp->getAttrs(), newOperands.size(),
+                                    rewriter.getArrayAttr(newArgAttrs));
+
+      auto fnType = defineOp.getFunctionType();
+      auto returnType = fnType.getNumResults() == 0
+                        ? TypeRange{} : TypeRange{fnType.getResult(0)};
+      auto newCall = LLVM::CallOp::create(rewriter, callOp.getLoc(), returnType,
+                             newOperands, newAttrs);
+
+      // Load each result arg's value back from its alloca, then replace
+      // callOp's results: one loaded value per result-only argument (the
+      // leading results on the tessera.call), in argument order, followed
+      // by the natural result (if any), matching the new LLVM call's
+      // direct result.
+      SmallVector<Value> replacementValues;
+      for (auto [ptr, type] : llvm::zip(resultArgPtrs, resultArgTypes)) {
+        auto loaded = LLVM::LoadOp::create(rewriter, callOp.getLoc(), type, ptr);
+        replacementValues.push_back(loaded.getResult());
+      }
+      if (fnType.getNumResults() > 0)
+        replacementValues.push_back(newCall.getResult());
+      rewriter.replaceOp(callOp, replacementValues);
     }
 
     return success();

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -161,8 +161,8 @@ public:
     // arguments, so this reconstruction applies regardless of which branch
     // below is taken.
     SmallVector<int32_t> argsToReplace;
-    if (auto loadedOperands = callOp->getAttrOfType<DenseI32ArrayAttr>(
-            "tessera.loaded_operands"))
+    if (auto loadedOperands =
+            callOp->getAttrOfType<DenseI32ArrayAttr>("tessera.loaded_operands"))
       argsToReplace = llvm::to_vector(loadedOperands.asArrayRef());
 
     Value one;
@@ -179,8 +179,8 @@ public:
           alignment = cast<IntegerAttr>(alignAttr).getInt();
         Value AI = LLVM::AllocaOp::create(
             rewriter, callOp.getLoc(),
-            LLVM::LLVMPointerType::get(callOp->getContext()),
-            operand.getType(), one, alignment);
+            LLVM::LLVMPointerType::get(callOp->getContext()), operand.getType(),
+            one, alignment);
         LLVM::StoreOp::create(rewriter, callOp.getLoc(), operand, AI);
         reconstructedOperands.push_back(AI);
       } else {
@@ -255,13 +255,13 @@ public:
           auto resultArgAttrs = defineOp.getArgAttrDict(i);
           if (resultArgAttrs) {
             if (auto alignAttr =
-                  resultArgAttrs.get(LLVM::LLVMDialect::getAlignAttrName()))
-            alignment = cast<IntegerAttr>(alignAttr).getInt();
+                    resultArgAttrs.get(LLVM::LLVMDialect::getAlignAttrName()))
+              alignment = cast<IntegerAttr>(alignAttr).getInt();
           }
           if (!one)
             one = LLVM::ConstantOp::create(rewriter, callOp.getLoc(),
-                                          rewriter.getI32Type(),
-                                          rewriter.getI32IntegerAttr(1));
+                                           rewriter.getI32Type(),
+                                           rewriter.getI32IntegerAttr(1));
 
           Type resultArgType = defineOp.getResultArgType(i);
           if (!resultArgType)
@@ -271,13 +271,13 @@ public:
           // Allocate stack storage for the result/output argument
           Value resultArgPtr = LLVM::AllocaOp::create(
               rewriter, callOp.getLoc(),
-              LLVM::LLVMPointerType::get(callOp->getContext()), resultArgType, 
+              LLVM::LLVMPointerType::get(callOp->getContext()), resultArgType,
               one, alignment);
           newOperands.push_back(resultArgPtr);
           resultArgPtrs.push_back(resultArgPtr);
           resultArgTypes.push_back(resultArgType);
-          newArgAttrs.push_back(resultArgAttrs ? resultArgAttrs
-                                : rewriter.getDictionaryAttr({}));
+          newArgAttrs.push_back(
+              resultArgAttrs ? resultArgAttrs : rewriter.getDictionaryAttr({}));
         } else {
           if (tesseraCallIdx >= reconstructedOperands.size())
             return callOp.emitOpError(
@@ -285,7 +285,7 @@ public:
           newOperands.push_back(reconstructedOperands[tesseraCallIdx]);
           auto callArgAttrs = callOp.getArgAttrsAttr();
           newArgAttrs.push_back(callArgAttrs ? callArgAttrs[tesseraCallIdx]
-                                : rewriter.getDictionaryAttr({}));
+                                             : rewriter.getDictionaryAttr({}));
           ++tesseraCallIdx;
         }
       }
@@ -294,10 +294,11 @@ public:
                                     rewriter.getArrayAttr(newArgAttrs));
 
       auto fnType = defineOp.getFunctionType();
-      auto returnType = fnType.getNumResults() == 0
-                        ? TypeRange{} : TypeRange{fnType.getResult(0)};
+      Type resultType =
+          fnType.getNumResults() > 0 ? fnType.getResult(0) : Type();
+      TypeRange returnType = resultType ? TypeRange(resultType) : TypeRange();
       auto newCall = LLVM::CallOp::create(rewriter, callOp.getLoc(), returnType,
-                             newOperands, newAttrs);
+                                          newOperands, newAttrs);
 
       // Load each result arg's value back from its alloca, then replace
       // callOp's results: one loaded value per result-only argument (the
@@ -306,7 +307,8 @@ public:
       // direct result.
       SmallVector<Value> replacementValues;
       for (auto [ptr, type] : llvm::zip(resultArgPtrs, resultArgTypes)) {
-        auto loaded = LLVM::LoadOp::create(rewriter, callOp.getLoc(), type, ptr);
+        auto loaded =
+            LLVM::LoadOp::create(rewriter, callOp.getLoc(), type, ptr);
         replacementValues.push_back(loaded.getResult());
       }
       if (fnType.getNumResults() > 0)

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -149,10 +149,10 @@ func.func @func_store_to_load_not_forwarded() -> i32 {
 
 // -----
 
-tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture, llvm.readonly}) attributes {byRefTypes = [!llvm.struct<(i32, i32)>], pure = false} {
+tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture, llvm.readonly}) attributes {argModes = [{dir = "in", type = !llvm.struct<(i32, i32)>}], pure = false} {
   tessera.return
 }
-tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {
+tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argModes = [], pure = false} {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
   %val = llvm.mlir.constant(42 : i32) : i32
@@ -162,7 +162,7 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefTypes 
   tessera.return %loaded : i32
 }
 
-// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {
+// CHECK: tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argModes = [], pure = false} {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
@@ -173,10 +173,10 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefTypes 
 
 // -----
 
-tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {byRefTypes = [!llvm.struct<(i32, i32)>], pure = false} {
+tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {argModes = [{dir = "in", type = !llvm.struct<(i32, i32)>}], pure = false} {
   tessera.return
 }
-tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {
+tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {argModes = [], pure = false} {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
   %val = llvm.mlir.constant(42 : i32) : i32
@@ -186,7 +186,7 @@ tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefTy
   tessera.return %loaded : i32
 }
 
-// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {
+// CHECK: tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {argModes = [], pure = false} {
 // CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -149,7 +149,7 @@ func.func @func_store_to_load_not_forwarded() -> i32 {
 
 // -----
 
-tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture, llvm.readonly}) attributes {argModes = [{dir = "in", type = !llvm.struct<(i32, i32)>}], pure = false} {
+tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture, llvm.readonly}) attributes {argModes = [{dir = #tessera.dir<in>, type = !llvm.struct<(i32, i32)>}], pure = false} {
   tessera.return
 }
 tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argModes = [], pure = false} {
@@ -173,7 +173,7 @@ tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {argModes = 
 
 // -----
 
-tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {argModes = [{dir = "in", type = !llvm.struct<(i32, i32)>}], pure = false} {
+tessera.define @tessera_foo_capturing(%arg0: !llvm.ptr) attributes {argModes = [{dir = #tessera.dir<in>, type = !llvm.struct<(i32, i32)>}], pure = false} {
   tessera.return
 }
 tessera.define @tessera_store_to_load_not_forwarded() -> i32 attributes {argModes = [], pure = false} {

--- a/test/lit_tests/tessera/inv_apply_pdl.mlir
+++ b/test/lit_tests/tessera/inv_apply_pdl.mlir
@@ -15,12 +15,12 @@ module {
     pdl.pattern : benefit(1) {
       %0 = operand
       %1 = attribute = @eigen.inv
-      %2 = type
-      %3 = operation "tessera.call"(%0 : !pdl.value)  {"callee" = %1} -> (%2 : !pdl.type)
+      %2 = types
+      %3 = operation "tessera.call"(%0 : !pdl.value)  {"callee" = %1} -> (%2 : !pdl.range<type>)
       %4 = result 0 of %3
       %5 = attribute = @eigen.inv
-      %6 = type
-      %7 = operation "tessera.call"(%4 : !pdl.value)  {"callee" = %5} -> (%6 : !pdl.type)
+      %6 = types
+      %7 = operation "tessera.call"(%4 : !pdl.value)  {"callee" = %5} -> (%6 : !pdl.range<type>)
       %8 = result 0 of %7
       rewrite %7 {
         replace %7 with(%0 : !pdl.value)

--- a/test/lit_tests/tessera/inv_apply_pdl.mlir
+++ b/test/lit_tests/tessera/inv_apply_pdl.mlir
@@ -1,7 +1,7 @@
 // RUN: enzymexlamlir-opt %s -tessera-apply-pdl | FileCheck %s
 
 module {
-  tessera.define @eigen.inv(%arg0 : f32) -> f32 attributes {byRefTypes = [unit], pure = true} {
+  tessera.define @eigen.inv(%arg0 : f32) -> f32 attributes {argModes = [unit], pure = true} {
     tessera.return %arg0 : f32
   }
 
@@ -29,7 +29,7 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {byRefTypes = [unit], pure = true} {
+// CHECK: tessera.define @eigen.inv(%[[ARG0:.*]]: f32) -> f32 attributes {argModes = [unit], pure = true} {
 // CHECK-NEXT: tessera.return %[[ARG0]] : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%[[X:.*]]: f32) -> f32 {

--- a/test/lit_tests/tessera/lift_tessera_annotations.mlir
+++ b/test/lit_tests/tessera/lift_tessera_annotations.mlir
@@ -4,7 +4,7 @@ module {
   llvm.mlir.global internal @__tessera_optimize_rule_0(0 : i32) {addr_space = 0 : i32, alignment = 4 : i64, dso_local} : i32
   llvm.mlir.global private unnamed_addr constant @".str"("tessera_optimize=eigen.inv(eigen.inv(x)) -> x\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
   llvm.mlir.global private unnamed_addr constant @".str.1"("<invalid loc>\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
-  llvm.mlir.global private unnamed_addr constant @".str.2"("tessera_op=eigen.inv(x:byref):globals=4\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
+  llvm.mlir.global private unnamed_addr constant @".str.2"("tessera_op=eigen.inv(x:val=in):globals=4\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
   llvm.mlir.global private unnamed_addr constant @".str.3"("/home/jessicacotturone21/Reactant/enzyme/pragma_test.c\00") {addr_space = 0 : i32, dso_local, section = "llvm.metadata"}
   llvm.mlir.global appending @llvm.global.annotations() {addr_space = 0 : i32, section = "llvm.metadata"} : !llvm.array<2 x struct<(ptr, ptr, ptr, i32, ptr)>> {
     %0 = llvm.mlir.zero : !llvm.ptr
@@ -45,7 +45,7 @@ module {
   }
 }
 
-// CHECK: llvm.func @inverse(%[[ARG0:.*]]: f32) -> f32 attributes {tessera_op = "eigen.inv(x:byref):globals=4"} {
+// CHECK: llvm.func @inverse(%[[ARG0:.*]]: f32) -> f32 attributes {tessera_op = "eigen.inv(x:val=in):globals=4"} {
 // CHECK-NEXT: llvm.return %[[ARG0]] : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%[[X:.*]]: f32) -> f32 {

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -25,7 +25,7 @@ llvm.func @func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {tessera_op 
 
 // -----
 
-llvm.mlir.global internal constant @_ZL26__tessera_byref_arg_type_0() : !llvm.struct<(f32)>
+llvm.mlir.global internal constant @_ZL20__tessera_arg_type_0() : !llvm.struct<(f32)>
 
 llvm.func @pure_func(%arg0: i32, %arg1: !llvm.ptr) -> i32 attributes {pure_tessera_op = "tessera_pure_func(x, y:byref):globals=0"} {
   llvm.return %arg0 : i32
@@ -83,7 +83,7 @@ llvm.func @func_with_indirect_call(%arg0: !llvm.ptr) {
 
 // -----
 
-llvm.mlir.global internal constant @_ZL26__tessera_byref_arg_type_1() : !llvm.struct<(f32, f32)>
+llvm.mlir.global internal constant @_ZL20__tessera_arg_type_1() : !llvm.struct<(f32, f32)>
 
 llvm.func @sret_func(%arg0: !llvm.ptr {llvm.sret = !llvm.struct<(f32, f32)>, llvm.align = 8 : i64, llvm.nonnull}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {pure_tessera_op = "tessera_sret_func(x:byref):globals=1"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -43,7 +43,7 @@ llvm.func @helper() attributes {tessera_op = "tessera_helper()"} {
   llvm.return
 }
 
-llvm.func @func_with_call() attributes {tessera_op = "tessera_func_with_call()"} {
+llvm.func @func_with_call() {
   llvm.call @helper() : () -> ()
   llvm.return
 }
@@ -54,12 +54,9 @@ llvm.func @func_with_call() attributes {tessera_op = "tessera_func_with_call()"}
 // CHECK-SAME: tessera.original_name = "helper"
 // CHECK-NEXT: tessera.return
 
-// CHECK: tessera.define @tessera_func_with_call()
-// CHECK-SAME: byRefTypes = []
-// CHECK-SAME: pure = false
-// CHECK-SAME: tessera.original_name = "func_with_call"
+// CHECK: llvm.func @func_with_call()
 // CHECK-NEXT: tessera.call @tessera_helper()
-// CHECK-NEXT: tessera.return
+// CHECK-NEXT: llvm.return
 
 // -----
 
@@ -118,3 +115,37 @@ llvm.func @caller() {
 // CHECK-SAME: (!llvm.struct<(f32, f32)>) -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: llvm.store %[[RES]], %[[A1]] : !llvm.struct<(f32, f32)>, !llvm.ptr
 // CHECK-NEXT: llvm.return
+
+// -----
+
+llvm.mlir.global internal constant @_ZL20__tessera_arg_type_2() : i32
+
+llvm.func @func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {tessera_op = "tessera_func_with_result_arg(x:result, y):globals=2"} {
+  llvm.store %arg1, %arg0 : i32, !llvm.ptr
+  llvm.return %arg1 : i32
+}
+
+llvm.func @result_arg_func_caller() {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x i32 : (i32) -> !llvm.ptr
+  %2 = llvm.call @func_with_result_arg(%1, %0) : (!llvm.ptr, i32) -> i32
+  %3 = llvm.load %1 : !llvm.ptr -> i32
+  llvm.return
+}
+
+// CHECK: tessera.define @tessera_func_with_result_arg(%[[ARG0:.*]]: !llvm.ptr, %[[ARG1:.*]]: i32) -> i32
+// CHECK-SAME: byRefTypes = [unit, unit]
+// CHECK-SAME: pure = false
+// CHECK-SAME: resultArgTypes = [i32, unit]
+// CHECK-SAME: tessera.original_name = "func_with_result_arg"
+// CHECK-NEXT: llvm.store %[[ARG1]], %[[ARG0]] : i32, !llvm.ptr
+// CHECK-NEXT: tessera.return %[[ARG1]] : i32
+
+// CHECK: llvm.func @result_arg_func_caller() {
+// CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[ONE]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[RES:.*]]:2 = tessera.call @tessera_func_with_result_arg(%[[ONE]])
+// CHECK-SAME: (i32) -> (i32, i32)
+// CHECK-NEXT: llvm.store %[[RES]]#0, %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: llvm.return
+// CHECK-NEXT: }

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -5,7 +5,7 @@ llvm.func @simple_func() attributes {tessera_op = "tessera_simple_func()"} {
 }
 
 // CHECK: tessera.define @tessera_simple_func()
-// CHECK-SAME: byRefTypes = []
+// CHECK-SAME: argModes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "simple_func"
 // CHECK-NEXT: tessera.return
@@ -18,7 +18,7 @@ llvm.func @func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {tessera_op 
 }
 
 // CHECK: tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32)
-// CHECK-SAME: byRefTypes = [unit, unit]
+// CHECK-SAME: argModes = [unit, unit]
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_args"
 // CHECK-NEXT: tessera.return %arg0 : i32
@@ -27,12 +27,12 @@ llvm.func @func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {tessera_op 
 
 llvm.mlir.global internal constant @_ZL20__tessera_arg_type_0() : !llvm.struct<(f32)>
 
-llvm.func @pure_func(%arg0: i32, %arg1: !llvm.ptr) -> i32 attributes {pure_tessera_op = "tessera_pure_func(x, y:byref):globals=0"} {
+llvm.func @pure_func(%arg0: i32, %arg1: !llvm.ptr) -> i32 attributes {pure_tessera_op = "tessera_pure_func(x, y:val=in):globals=0"} {
   llvm.return %arg0 : i32
 }
 
 // CHECK: tessera.define @tessera_pure_func(%arg0: i32, %arg1: !llvm.ptr)
-// CHECK-SAME: byRefTypes = [unit, !llvm.struct<(f32)>]
+// CHECK-SAME: argModes = [unit, {dir = "in", type = !llvm.struct<(f32)>}]
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "pure_func"
 // CHECK-NEXT: tessera.return %arg0 : i32
@@ -49,7 +49,7 @@ llvm.func @func_with_call() {
 }
 
 // CHECK: tessera.define @tessera_helper()
-// CHECK-SAME: byRefTypes = []
+// CHECK-SAME: argModes = []
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "helper"
 // CHECK-NEXT: tessera.return
@@ -82,7 +82,7 @@ llvm.func @func_with_indirect_call(%arg0: !llvm.ptr) {
 
 llvm.mlir.global internal constant @_ZL20__tessera_arg_type_1() : !llvm.struct<(f32, f32)>
 
-llvm.func @sret_func(%arg0: !llvm.ptr {llvm.sret = !llvm.struct<(f32, f32)>, llvm.align = 8 : i64, llvm.nonnull}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {pure_tessera_op = "tessera_sret_func(x:byref):globals=1"} {
+llvm.func @sret_func(%arg0: !llvm.ptr {llvm.sret = !llvm.struct<(f32, f32)>, llvm.align = 8 : i64, llvm.nonnull}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) attributes {pure_tessera_op = "tessera_sret_func(x:val=in):globals=1"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
   llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
   llvm.return
@@ -97,7 +97,7 @@ llvm.func @caller() {
 }
 
 // CHECK: tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly})
-// CHECK-SAME: byRefTypes = [!llvm.struct<(f32, f32)>]
+// CHECK-SAME: argModes = [{dir = "in", type = !llvm.struct<(f32, f32)>}]
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "sret_func"
 // CHECK-NEXT: %[[LOAD:.*]] = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
@@ -111,7 +111,6 @@ llvm.func @caller() {
 // CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[A2]] : !llvm.ptr -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: %[[RES:.*]] = tessera.call @tessera_sret_func(%[[LOADED]])
 // CHECK-SAME: arg_attrs = [{llvm.nonnull, llvm.noundef}]
-// CHECK-SAME: tessera.loaded_operands = array<i32: 0>
 // CHECK-SAME: (!llvm.struct<(f32, f32)>) -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: llvm.store %[[RES]], %[[A1]] : !llvm.struct<(f32, f32)>, !llvm.ptr
 // CHECK-NEXT: llvm.return
@@ -120,7 +119,7 @@ llvm.func @caller() {
 
 llvm.mlir.global internal constant @_ZL20__tessera_arg_type_2() : i32
 
-llvm.func @func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {tessera_op = "tessera_func_with_result_arg(x:result, y):globals=2"} {
+llvm.func @func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {tessera_op = "tessera_func_with_result_arg(x:val=out, y):globals=2"} {
   llvm.store %arg1, %arg0 : i32, !llvm.ptr
   llvm.return %arg1 : i32
 }
@@ -134,9 +133,8 @@ llvm.func @result_arg_func_caller() {
 }
 
 // CHECK: tessera.define @tessera_func_with_result_arg(%[[ARG0:.*]]: !llvm.ptr, %[[ARG1:.*]]: i32) -> i32
-// CHECK-SAME: byRefTypes = [unit, unit]
+// CHECK-SAME: argModes = [{dir = "out", type = i32}, unit]
 // CHECK-SAME: pure = false
-// CHECK-SAME: resultArgTypes = [i32, unit]
 // CHECK-SAME: tessera.original_name = "func_with_result_arg"
 // CHECK-NEXT: llvm.store %[[ARG1]], %[[ARG0]] : i32, !llvm.ptr
 // CHECK-NEXT: tessera.return %[[ARG1]] : i32
@@ -146,6 +144,50 @@ llvm.func @result_arg_func_caller() {
 // CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[ONE]] x i32 : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[RES:.*]]:2 = tessera.call @tessera_func_with_result_arg(%[[ONE]])
 // CHECK-SAME: (i32) -> (i32, i32)
+// CHECK-NEXT: llvm.store %[[RES]]#0, %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: llvm.return
+// CHECK-NEXT: }
+
+// -----
+
+// An :val=inout argument, the counterpart to the :val=out case above. The
+// callee reads the pointee before overwriting it, so unlike a pure output the
+// argument keeps its tessera.call operand slot -- carrying the value loaded at
+// the call site -- as well as contributing a trailing result. Dropping that
+// operand would hand the callee uninitialized stack storage.
+
+llvm.mlir.global internal constant @_ZL20__tessera_arg_type_3() : i32
+
+llvm.func @func_with_inout_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {tessera_op = "tessera_func_with_inout_arg(x:val=inout, y):globals=3"} {
+  %0 = llvm.load %arg0 : !llvm.ptr -> i32
+  %1 = llvm.add %0, %arg1 : i32
+  llvm.store %1, %arg0 : i32, !llvm.ptr
+  llvm.return %1 : i32
+}
+
+llvm.func @inout_arg_func_caller() {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x i32 : (i32) -> !llvm.ptr
+  %2 = llvm.call @func_with_inout_arg(%1, %0) : (!llvm.ptr, i32) -> i32
+  llvm.return
+}
+
+// CHECK: tessera.define @tessera_func_with_inout_arg(%[[ARG0:.*]]: !llvm.ptr, %[[ARG1:.*]]: i32) -> i32
+// CHECK-SAME: argModes = [{dir = "inout", type = i32}, unit]
+// CHECK-SAME: pure = false
+// CHECK-SAME: tessera.original_name = "func_with_inout_arg"
+// CHECK-NEXT: %[[LOAD:.*]] = llvm.load %[[ARG0]] : !llvm.ptr -> i32
+// CHECK-NEXT: %[[SUM:.*]] = llvm.add %[[LOAD]], %[[ARG1]] : i32
+// CHECK-NEXT: llvm.store %[[SUM]], %[[ARG0]] : i32, !llvm.ptr
+// CHECK-NEXT: tessera.return %[[SUM]] : i32
+
+// The call keeps two operands, unlike the single-operand :val=out call above.
+// CHECK: llvm.func @inout_arg_func_caller() {
+// CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[ONE]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[IN:.*]] = llvm.load %[[AL]] : !llvm.ptr -> i32
+// CHECK-NEXT: %[[RES:.*]]:2 = tessera.call @tessera_func_with_inout_arg(%[[IN]], %[[ONE]])
+// CHECK-SAME: (i32, i32) -> (i32, i32)
 // CHECK-NEXT: llvm.store %[[RES]]#0, %[[AL]] : i32, !llvm.ptr
 // CHECK-NEXT: llvm.return
 // CHECK-NEXT: }

--- a/test/lit_tests/tessera/llvm_to_tessera.mlir
+++ b/test/lit_tests/tessera/llvm_to_tessera.mlir
@@ -32,7 +32,7 @@ llvm.func @pure_func(%arg0: i32, %arg1: !llvm.ptr) -> i32 attributes {pure_tesse
 }
 
 // CHECK: tessera.define @tessera_pure_func(%arg0: i32, %arg1: !llvm.ptr)
-// CHECK-SAME: argModes = [unit, {dir = "in", type = !llvm.struct<(f32)>}]
+// CHECK-SAME: argModes = [unit, {dir = #tessera.dir<in>, type = !llvm.struct<(f32)>}]
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "pure_func"
 // CHECK-NEXT: tessera.return %arg0 : i32
@@ -97,7 +97,7 @@ llvm.func @caller() {
 }
 
 // CHECK: tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly})
-// CHECK-SAME: argModes = [{dir = "in", type = !llvm.struct<(f32, f32)>}]
+// CHECK-SAME: argModes = [{dir = #tessera.dir<in>, type = !llvm.struct<(f32, f32)>}]
 // CHECK-SAME: pure = true
 // CHECK-SAME: tessera.original_name = "sret_func"
 // CHECK-NEXT: %[[LOAD:.*]] = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
@@ -133,7 +133,7 @@ llvm.func @result_arg_func_caller() {
 }
 
 // CHECK: tessera.define @tessera_func_with_result_arg(%[[ARG0:.*]]: !llvm.ptr, %[[ARG1:.*]]: i32) -> i32
-// CHECK-SAME: argModes = [{dir = "out", type = i32}, unit]
+// CHECK-SAME: argModes = [{dir = #tessera.dir<out>, type = i32}, unit]
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_result_arg"
 // CHECK-NEXT: llvm.store %[[ARG1]], %[[ARG0]] : i32, !llvm.ptr
@@ -173,7 +173,7 @@ llvm.func @inout_arg_func_caller() {
 }
 
 // CHECK: tessera.define @tessera_func_with_inout_arg(%[[ARG0:.*]]: !llvm.ptr, %[[ARG1:.*]]: i32) -> i32
-// CHECK-SAME: argModes = [{dir = "inout", type = i32}, unit]
+// CHECK-SAME: argModes = [{dir = #tessera.dir<inout>, type = i32}, unit]
 // CHECK-SAME: pure = false
 // CHECK-SAME: tessera.original_name = "func_with_inout_arg"
 // CHECK-NEXT: %[[LOAD:.*]] = llvm.load %[[ARG0]] : !llvm.ptr -> i32

--- a/test/lit_tests/tessera/mag_apply_pdl.mlir
+++ b/test/lit_tests/tessera/mag_apply_pdl.mlir
@@ -19,19 +19,19 @@ module {
     pdl.pattern : benefit(1) {
       %0 = operand
       %1 = attribute = @arith.negf
-      %2 = type
-      %3 = operation "tessera.call"(%0 : !pdl.value)  {"callee" = %1} -> (%2 : !pdl.type)
+      %2 = types
+      %3 = operation "tessera.call"(%0 : !pdl.value)  {"callee" = %1} -> (%2 : !pdl.range<type>)
       %4 = result 0 of %3
       %5 = operand
       %6 = operand
       %7 = attribute = @eigen.mag
-      %8 = type
-      %9 = operation "tessera.call"(%4, %5, %6 : !pdl.value, !pdl.value, !pdl.value)  {"callee" = %7} -> (%8 : !pdl.type)
+      %8 = types
+      %9 = operation "tessera.call"(%4, %5, %6 : !pdl.value, !pdl.value, !pdl.value)  {"callee" = %7} -> (%8 : !pdl.range<type>)
       %10 = result 0 of %9
       rewrite %9 {
         %11 = attribute = @eigen.mag
-        %12 = type
-        %13 = operation "tessera.call"(%0, %5, %6 : !pdl.value, !pdl.value, !pdl.value)  {"callee" = %11} -> (%12 : !pdl.type)
+        %12 = types
+        %13 = operation "tessera.call"(%0, %5, %6 : !pdl.value, !pdl.value, !pdl.value)  {"callee" = %11} -> (%12 : !pdl.range<type>)
         %14 = result 0 of %13
         replace %9 with %13
       }

--- a/test/lit_tests/tessera/mag_apply_pdl.mlir
+++ b/test/lit_tests/tessera/mag_apply_pdl.mlir
@@ -1,11 +1,11 @@
 // RUN: enzymexlamlir-opt %s -tessera-apply-pdl | FileCheck %s
 
 module {
-  tessera.define @eigen.mag(%arg0 : f32, %arg1 : f32, %arg2 : f32) -> f32 attributes {byRefTypes = [unit, unit, unit], pure = true} {
+  tessera.define @eigen.mag(%arg0 : f32, %arg1 : f32, %arg2 : f32) -> f32 attributes {argModes = [unit, unit, unit], pure = true} {
       tessera.return %arg0 : f32
   }
   
-  tessera.define @arith.negf(%arg0 : f32) -> f32 attributes {byRefTypes = [unit], pure = true} {
+  tessera.define @arith.negf(%arg0 : f32) -> f32 attributes {argModes = [unit], pure = true} {
       tessera.return %arg0 : f32
   }
 
@@ -39,10 +39,10 @@ module {
   }
 }
 
-// CHECK: tessera.define @eigen.mag(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 attributes {byRefTypes = [unit, unit, unit], pure = true} {
+// CHECK: tessera.define @eigen.mag(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 attributes {argModes = [unit, unit, unit], pure = true} {
 // CHECK-NEXT: tessera.return %arg0 : f32
 // CHECK-NEXT: }
-// CHECK-NEXT: tessera.define @arith.negf(%arg0: f32) -> f32 attributes {byRefTypes = [unit], pure = true} {
+// CHECK-NEXT: tessera.define @arith.negf(%arg0: f32) -> f32 attributes {argModes = [unit], pure = true} {
 // CHECK-NEXT: tessera.return %arg0 : f32
 // CHECK-NEXT: }
 // CHECK-NEXT: llvm.func @main(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {

--- a/test/lit_tests/tessera/parse_optimization_rules.mlir
+++ b/test/lit_tests/tessera/parse_optimization_rules.mlir
@@ -12,19 +12,19 @@ module {
 // CHECK: pdl.pattern : benefit(1) {
 // CHECK-NEXT:   %[[X0:.*]] = operand
 // CHECK-NEXT:   %[[NEGF:.*]] = attribute = @arith.negf
-// CHECK-NEXT:   %[[T0:.*]] = type
-// CHECK-NEXT:   %[[NEGF_CALL:.*]] = operation "tessera.call"(%[[X0]] : !pdl.value) {"callee" = %[[NEGF]]} -> (%[[T0]] : !pdl.type)
+// CHECK-NEXT:   %[[T0:.*]] = types
+// CHECK-NEXT:   %[[NEGF_CALL:.*]] = operation "tessera.call"(%[[X0]] : !pdl.value) {"callee" = %[[NEGF]]} -> (%[[T0]] : !pdl.range<type>)
 // CHECK-NEXT:   %[[NEGF_RES:.*]] = result 0 of %[[NEGF_CALL]]
 // CHECK-NEXT:   %[[Y:.*]] = operand
 // CHECK-NEXT:   %[[Z:.*]] = operand
 // CHECK-NEXT:   %[[MAG:.*]] = attribute = @eigen.mag
-// CHECK-NEXT:   %[[T1:.*]] = type
-// CHECK-NEXT:   %[[MAG_CALL:.*]] = operation "tessera.call"(%[[NEGF_RES]], %[[Y]], %[[Z]] : !pdl.value, !pdl.value, !pdl.value) {"callee" = %[[MAG]]} -> (%[[T1]] : !pdl.type)
+// CHECK-NEXT:   %[[T1:.*]] = types
+// CHECK-NEXT:   %[[MAG_CALL:.*]] = operation "tessera.call"(%[[NEGF_RES]], %[[Y]], %[[Z]] : !pdl.value, !pdl.value, !pdl.value) {"callee" = %[[MAG]]} -> (%[[T1]] : !pdl.range<type>)
 // CHECK-NEXT:   %{{.*}} = result 0 of %[[MAG_CALL]]
 // CHECK-NEXT:   rewrite %[[MAG_CALL]] {
 // CHECK-NEXT:     %[[MAG2:.*]] = attribute = @eigen.mag
 // CHECK-NEXT:     %[[T2:.*]] = type
-// CHECK-NEXT:     %[[NEW_CALL:.*]] = operation "tessera.call"(%[[X0]], %[[Y]], %[[Z]] : !pdl.value, !pdl.value, !pdl.value) {"callee" = %[[MAG2]]} -> (%[[T2]] : !pdl.type)
+// CHECK-NEXT:     %[[NEW_CALL:.*]] = operation "tessera.call"(%[[X0]], %[[Y]], %[[Z]] : !pdl.value, !pdl.value, !pdl.value) {"callee" = %[[MAG2]]} -> (%[[T2]] : !pdl.range<type>)
 // CHECK-NEXT:     %{{.*}} = result 0 of %[[NEW_CALL]]
 // CHECK-NEXT:     replace %[[MAG_CALL]] with %[[NEW_CALL]]
 // CHECK-NEXT:   }
@@ -33,12 +33,12 @@ module {
 // CHECK: pdl.pattern : benefit(1) {
 // CHECK-NEXT:   %[[X0:.*]] = operand
 // CHECK-NEXT:   %[[INV1:.*]] = attribute = @eigen.inv
-// CHECK-NEXT:   %[[T0:.*]] = type
-// CHECK-NEXT:   %[[INV1_CALL:.*]] = operation "tessera.call"(%[[X0]] : !pdl.value) {"callee" = %[[INV1]]} -> (%[[T0]] : !pdl.type)
+// CHECK-NEXT:   %[[T0:.*]] = types
+// CHECK-NEXT:   %[[INV1_CALL:.*]] = operation "tessera.call"(%[[X0]] : !pdl.value) {"callee" = %[[INV1]]} -> (%[[T0]] : !pdl.range<type>)
 // CHECK-NEXT:   %[[INV1_RES:.*]] = result 0 of %[[INV1_CALL]]
 // CHECK-NEXT:   %[[INV2:.*]] = attribute = @eigen.inv
-// CHECK-NEXT:   %[[T1:.*]] = type
-// CHECK-NEXT:   %[[INV2_CALL:.*]] = operation "tessera.call"(%[[INV1_RES]] : !pdl.value) {"callee" = %[[INV2]]} -> (%[[T1]] : !pdl.type)
+// CHECK-NEXT:   %[[T1:.*]] = types
+// CHECK-NEXT:   %[[INV2_CALL:.*]] = operation "tessera.call"(%[[INV1_RES]] : !pdl.value) {"callee" = %[[INV2]]} -> (%[[T1]] : !pdl.range<type>)
 // CHECK-NEXT:   %{{.*}} = result 0 of %[[INV2_CALL]]
 // CHECK-NEXT:   rewrite %[[INV2_CALL]] {
 // CHECK-NEXT:     replace %[[INV2_CALL]] with(%[[X0]] : !pdl.value)

--- a/test/lit_tests/tessera/parse_optimization_rules.mlir
+++ b/test/lit_tests/tessera/parse_optimization_rules.mlir
@@ -39,19 +39,19 @@ module {
 // CHECK: pdl.pattern : benefit(1) {
 // CHECK-NEXT:   %[[X0:.*]] = operand
 // CHECK-NEXT:   %[[NEGF:.*]] = attribute = @arith.negf
-// CHECK-NEXT:   %[[T0:.*]] = type
-// CHECK-NEXT:   %[[NEGF_CALL:.*]] = operation "tessera.call"(%[[X0]] : !pdl.value) {"callee" = %[[NEGF]]} -> (%[[T0]] : !pdl.type)
+// CHECK-NEXT:   %[[T0:.*]] = types
+// CHECK-NEXT:   %[[NEGF_CALL:.*]] = operation "tessera.call"(%[[X0]] : !pdl.value) {"callee" = %[[NEGF]]} -> (%[[T0]] : !pdl.range<type>)
 // CHECK-NEXT:   %[[NEGF_RES:.*]] = result 0 of %[[NEGF_CALL]]
 // CHECK-NEXT:   %[[Y:.*]] = operand
 // CHECK-NEXT:   %[[Z:.*]] = operand
 // CHECK-NEXT:   %[[MAG:.*]] = attribute = @eigen.mag
-// CHECK-NEXT:   %[[T1:.*]] = type
-// CHECK-NEXT:   %[[MAG_CALL:.*]] = operation "tessera.call"(%[[NEGF_RES]], %[[Y]], %[[Z]] : !pdl.value, !pdl.value, !pdl.value) {"callee" = %[[MAG]]} -> (%[[T1]] : !pdl.type)
+// CHECK-NEXT:   %[[T1:.*]] = types
+// CHECK-NEXT:   %[[MAG_CALL:.*]] = operation "tessera.call"(%[[NEGF_RES]], %[[Y]], %[[Z]] : !pdl.value, !pdl.value, !pdl.value) {"callee" = %[[MAG]]} -> (%[[T1]] : !pdl.range<type>)
 // CHECK-NEXT:   %{{.*}} = result 0 of %[[MAG_CALL]]
 // CHECK-NEXT:   rewrite %[[MAG_CALL]] {
 // CHECK-NEXT:     %[[MAG2:.*]] = attribute = @eigen.mag
 // CHECK-NEXT:     %[[T2:.*]] = type
-// CHECK-NEXT:     %[[NEW_CALL:.*]] = operation "tessera.call"(%[[X0]], %[[Y]], %[[Z]] : !pdl.value, !pdl.value, !pdl.value) {"callee" = %[[MAG2]]} -> (%[[T2]] : !pdl.type)
+// CHECK-NEXT:     %[[NEW_CALL:.*]] = operation "tessera.call"(%[[X0]], %[[Y]], %[[Z]] : !pdl.value, !pdl.value, !pdl.value) {"callee" = %[[MAG2]]} -> (%[[T2]] : !pdl.range<type>)
 // CHECK-NEXT:     %{{.*}} = result 0 of %[[NEW_CALL]]
 // CHECK-NEXT:     replace %[[MAG_CALL]] with %[[NEW_CALL]]
 // CHECK-NEXT:   }
@@ -60,12 +60,12 @@ module {
 // CHECK: pdl.pattern : benefit(1) {
 // CHECK-NEXT:   %[[X0:.*]] = operand
 // CHECK-NEXT:   %[[INV1:.*]] = attribute = @eigen.inv
-// CHECK-NEXT:   %[[T0:.*]] = type
-// CHECK-NEXT:   %[[INV1_CALL:.*]] = operation "tessera.call"(%[[X0]] : !pdl.value) {"callee" = %[[INV1]]} -> (%[[T0]] : !pdl.type)
+// CHECK-NEXT:   %[[T0:.*]] = types
+// CHECK-NEXT:   %[[INV1_CALL:.*]] = operation "tessera.call"(%[[X0]] : !pdl.value) {"callee" = %[[INV1]]} -> (%[[T0]] : !pdl.range<type>)
 // CHECK-NEXT:   %[[INV1_RES:.*]] = result 0 of %[[INV1_CALL]]
 // CHECK-NEXT:   %[[INV2:.*]] = attribute = @eigen.inv
-// CHECK-NEXT:   %[[T1:.*]] = type
-// CHECK-NEXT:   %[[INV2_CALL:.*]] = operation "tessera.call"(%[[INV1_RES]] : !pdl.value) {"callee" = %[[INV2]]} -> (%[[T1]] : !pdl.type)
+// CHECK-NEXT:   %[[T1:.*]] = types
+// CHECK-NEXT:   %[[INV2_CALL:.*]] = operation "tessera.call"(%[[INV1_RES]] : !pdl.value) {"callee" = %[[INV2]]} -> (%[[T1]] : !pdl.range<type>)
 // CHECK-NEXT:   %{{.*}} = result 0 of %[[INV2_CALL]]
 // CHECK-NEXT:   rewrite %[[INV2_CALL]] {
 // CHECK-NEXT:     replace %[[INV2_CALL]] with(%[[X0]] : !pdl.value)

--- a/test/lit_tests/tessera/roundtrip.mlir
+++ b/test/lit_tests/tessera/roundtrip.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-tessera.define @foo() attributes {byRefTypes = [], pure = false} {
+tessera.define @foo() attributes {argModes = [], pure = false} {
   tessera.return
 }
 
@@ -9,7 +9,7 @@ tessera.define @foo() attributes {byRefTypes = [], pure = false} {
 
 // -----
 
-tessera.define @bar() -> i32 attributes {byRefTypes = [], pure = false} {
+tessera.define @bar() -> i32 attributes {argModes = [], pure = false} {
   %0 = arith.constant 42 : i32
   tessera.return %0 : i32
 }
@@ -19,7 +19,7 @@ tessera.define @bar() -> i32 attributes {byRefTypes = [], pure = false} {
 
 // -----
 
-tessera.define @caller() attributes {byRefTypes = [], pure = false} {
+tessera.define @caller() attributes {argModes = [], pure = false} {
   tessera.call @foo() : () -> ()
   tessera.return
 }
@@ -30,7 +30,7 @@ tessera.define @caller() attributes {byRefTypes = [], pure = false} {
 
 // -----
 
-tessera.define @with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefTypes = [unit, unit], pure = false} {
+tessera.define @with_args(%arg0: i32, %arg1: f32) -> i32 attributes {argModes = [unit, unit], pure = false} {
   %0 = tessera.call @bar() : () -> i32
   tessera.return %0 : i32
 }

--- a/test/lit_tests/tessera/tessera_to_llvm.mlir
+++ b/test/lit_tests/tessera/tessera_to_llvm.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s -tessera-to-llvm -split-input-file | FileCheck %s
 
-tessera.define @tessera_simple_func() attributes {byRefTypes = [], pure = false, tessera.original_name = "simple_func"} {
+tessera.define @tessera_simple_func() attributes {argModes = [], pure = false, tessera.original_name = "simple_func"} {
   tessera.return
 }
 
@@ -9,7 +9,7 @@ tessera.define @tessera_simple_func() attributes {byRefTypes = [], pure = false,
 
 // -----
 
-tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {byRefTypes = [unit, unit], pure = false, tessera.original_name = "func_with_args"} {
+tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes {argModes = [unit, unit], pure = false, tessera.original_name = "func_with_args"} {
   tessera.return %arg0 : i32
 }
 
@@ -18,11 +18,11 @@ tessera.define @tessera_func_with_args(%arg0: i32, %arg1: f32) -> i32 attributes
 
 // -----
 
-tessera.define @tessera_helper() attributes {byRefTypes = [], pure = false, tessera.original_name = "helper"} {
+tessera.define @tessera_helper() attributes {argModes = [], pure = false, tessera.original_name = "helper"} {
   tessera.return
 }
 
-tessera.define @tessera_func_with_call() attributes {byRefTypes = [], pure = false, tessera.original_name = "func_with_call"} {
+tessera.define @tessera_func_with_call() attributes {argModes = [], pure = false, tessera.original_name = "func_with_call"} {
   tessera.call @tessera_helper() {op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 0, 0>} : () -> ()
   tessera.return
 }
@@ -37,7 +37,7 @@ tessera.define @tessera_func_with_call() attributes {byRefTypes = [], pure = fal
 // -----
 
 tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) 
-attributes {byRefTypes = [!llvm.struct<(f32, f32)>], linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
+attributes {argModes = [{dir = "in", type = !llvm.struct<(f32, f32)>}], linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
   llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
   tessera.return
@@ -48,7 +48,7 @@ llvm.func @caller() {
   %1 = llvm.alloca %0 x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %2 = llvm.alloca %0 x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %3 = llvm.load %2 : !llvm.ptr -> !llvm.struct<(f32, f32)>
-  %4 = tessera.call @tessera_sret_func(%3) {arg_attrs = [{llvm.nonnull, llvm.noundef}], op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>, tessera.loaded_operands = array<i32: 0>} : (!llvm.struct<(f32, f32)>) -> !llvm.struct<(f32, f32)>
+  %4 = tessera.call @tessera_sret_func(%3) {arg_attrs = [{llvm.nonnull, llvm.noundef}], op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>} : (!llvm.struct<(f32, f32)>) -> !llvm.struct<(f32, f32)>
   llvm.store %4, %1 : !llvm.struct<(f32, f32)>, !llvm.ptr
   llvm.return
 }
@@ -73,7 +73,7 @@ llvm.func @caller() {
 
 // -----
 
-tessera.define @tessera_func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {byRefTypes = [unit, unit], pure = false, resultArgTypes = [i32, unit], tessera.original_name = "func_with_result_arg"} {
+tessera.define @tessera_func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {argModes = [{dir = "out", type = i32}, unit], pure = false, tessera.original_name = "func_with_result_arg"} {
   llvm.store %arg1, %arg0 : i32, !llvm.ptr
   tessera.return %arg1 : i32
 }
@@ -81,7 +81,7 @@ tessera.define @tessera_func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i3
 llvm.func @result_arg_func_caller() {
   %0 = llvm.mlir.constant(1 : i32) : i32
   %1 = llvm.alloca %0 x i32 : (i32) -> !llvm.ptr
-  %2:2 = tessera.call @tessera_func_with_result_arg(%0) {tessera.loaded_operands = array<i32>} : (i32) -> (i32, i32)
+  %2:2 = tessera.call @tessera_func_with_result_arg(%0) : (i32) -> (i32, i32)
   llvm.store %2#0, %1 : i32, !llvm.ptr
   llvm.return
 }

--- a/test/lit_tests/tessera/tessera_to_llvm.mlir
+++ b/test/lit_tests/tessera/tessera_to_llvm.mlir
@@ -63,9 +63,9 @@ llvm.func @caller() {
 // CHECK-NEXT: %[[A1:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[A2:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[A2]] : !llvm.ptr -> !llvm.struct<(f32, f32)>
-// CHECK-NEXT: %[[SRET:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT: %[[A3:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> : (i32) -> !llvm.ptr
 // CHECK-NEXT: llvm.store %[[LOADED]], %[[A3]] : !llvm.struct<(f32, f32)>, !llvm.ptr
+// CHECK-NEXT: %[[SRET:.*]] = llvm.alloca %[[ONE]] x !llvm.struct<(f32, f32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT: llvm.call @sret_func(%[[SRET]], %[[A3]]) : (!llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, !llvm.ptr {llvm.nonnull, llvm.noundef}) -> ()
 // CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[SRET]] : !llvm.ptr -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: llvm.store %[[LOADED]], %[[A1]] : !llvm.struct<(f32, f32)>, !llvm.ptr

--- a/test/lit_tests/tessera/tessera_to_llvm.mlir
+++ b/test/lit_tests/tessera/tessera_to_llvm.mlir
@@ -70,3 +70,33 @@ llvm.func @caller() {
 // CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[SRET]] : !llvm.ptr -> !llvm.struct<(f32, f32)>
 // CHECK-NEXT: llvm.store %[[LOADED]], %[[A1]] : !llvm.struct<(f32, f32)>, !llvm.ptr
 // CHECK-NEXT: llvm.return
+
+// -----
+
+tessera.define @tessera_func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {byRefTypes = [unit, unit], pure = false, resultArgTypes = [i32, unit], tessera.original_name = "func_with_result_arg"} {
+  llvm.store %arg1, %arg0 : i32, !llvm.ptr
+  tessera.return %arg1 : i32
+}
+
+llvm.func @result_arg_func_caller() {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x i32 : (i32) -> !llvm.ptr
+  %2:2 = tessera.call @tessera_func_with_result_arg(%0) {tessera.loaded_operands = array<i32>} : (i32) -> (i32, i32)
+  llvm.store %2#0, %1 : i32, !llvm.ptr
+  llvm.return
+}
+
+// CHECK: llvm.func @func_with_result_arg(%[[ARG0:.*]]: !llvm.ptr, %[[ARG1:.*]]: i32) -> i32 {
+// CHECK-NEXT: llvm.store %[[ARG1]], %[[ARG0]] : i32, !llvm.ptr
+// CHECK-NEXT: llvm.return %[[ARG1]] : i32
+// CHECK-NEXT: }
+
+// CHECK: llvm.func @result_arg_func_caller() {
+// CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[ONE]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[AL2:.*]] = llvm.alloca %[[ONE]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[RES:.*]] = llvm.call @func_with_result_arg(%[[AL2]], %[[ONE]]) : (!llvm.ptr, i32) -> i32
+// CHECK-NEXT: %[[LOAD:.*]] = llvm.load %[[AL2]] : !llvm.ptr -> i32
+// CHECK-NEXT: llvm.store %[[LOAD]], %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: llvm.return
+// CHECK-NEXT: }

--- a/test/lit_tests/tessera/tessera_to_llvm.mlir
+++ b/test/lit_tests/tessera/tessera_to_llvm.mlir
@@ -37,7 +37,7 @@ tessera.define @tessera_func_with_call() attributes {argModes = [], pure = false
 // -----
 
 tessera.define @tessera_sret_func(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.nonnull, llvm.sret = !llvm.struct<(f32, f32)>}, %arg1: !llvm.ptr {llvm.noundef, llvm.readonly}) 
-attributes {argModes = [{dir = "in", type = !llvm.struct<(f32, f32)>}], linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
+attributes {argModes = [{dir = #tessera.dir<in>, type = !llvm.struct<(f32, f32)>}], linkage = #llvm.linkage<external>, pure = true, tessera.original_name = "sret_func"} {
   %0 = llvm.load %arg1 {alignment = 8 : i64} : !llvm.ptr -> f32
   llvm.store %0, %arg0 {alignment = 8 : i64} : f32, !llvm.ptr
   tessera.return
@@ -73,7 +73,7 @@ llvm.func @caller() {
 
 // -----
 
-tessera.define @tessera_func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {argModes = [{dir = "out", type = i32}, unit], pure = false, tessera.original_name = "func_with_result_arg"} {
+tessera.define @tessera_func_with_result_arg(%arg0: !llvm.ptr, %arg1: i32) -> i32 attributes {argModes = [{dir = #tessera.dir<out>, type = i32}, unit], pure = false, tessera.original_name = "func_with_result_arg"} {
   llvm.store %arg1, %arg0 : i32, !llvm.ptr
   tessera.return %arg1 : i32
 }


### PR DESCRIPTION
Add support for output arguments, like those used in MPFR. Can now mark an argument as being a result of the operation in the `tessera_op` annotation and it will be treated as a return value of the tessera.call (in addition to any existing return values) to allow for pattern matching. 

The marking logic has been changed so that instead of just specifying an argument as "byref," we now give an argument the marker `:val` to indicate that the argument needs to be lifted from a pointer to a value in the tessera raising pass, and then we can specify the direction as either in, inout, or out (e.g. `rop:val=out`). Each of these 3 cases have a different behavior in the tessera raising pass.