### PR TITLE
Fix affine.if yield captures in isValidSymbolInt (+ then/else guard)

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2451,7 +2451,7 @@ struct MoveSelectToAffine : public OpRewritePattern<arith::SelectOp> {
           auto idx = cast<OpResult>(opv.get()).getResultNumber();
           auto tval = cast<AffineYieldOp>(midIf.getThenBlock()->getTerminator())
                           .getOperand(idx);
-          auto fval = cast<AffineYieldOp>(midIf.getThenBlock()->getTerminator())
+          auto fval = cast<AffineYieldOp>(midIf.getElseBlock()->getTerminator())
                           .getOperand(idx);
           if (matchPattern(tval, m_One()) && matchPattern(fval, m_Zero()))
             continue;

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -100,15 +100,7 @@ bool isValidSymbolInt(Operation *defOp, bool recur, Region *scope) {
     }
     if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
       if (isValidSymbolInt(ifOp.getCondition(), recur, scope)) {
-        if (llvm::all_of(ifOp.thenBlock()->without_terminator(),
-                         [&](Operation &o) {
-                           return isValidSymbolInt(&o, recur, scope);
-                         }) &&
-            llvm::all_of(ifOp.elseBlock()->without_terminator(),
-                         [&](Operation &o) {
-                           return isValidSymbolInt(&o, recur, scope);
-                         }) &&
-            llvm::all_of(
+        if (llvm::all_of(
                 ifOp.thenBlock()->getTerminator()->getOperands(),
                 [&](Value v) { return isValidSymbolInt(v, recur, scope); }) &&
             llvm::all_of(
@@ -121,15 +113,7 @@ bool isValidSymbolInt(Operation *defOp, bool recur, Region *scope) {
       if (llvm::all_of(ifOp.getOperands(), [&](Value o) {
             return isValidSymbolInt(o, recur, scope);
           }))
-        if (llvm::all_of(ifOp.getThenBlock()->without_terminator(),
-                         [&](Operation &o) {
-                           return isValidSymbolInt(&o, recur, scope);
-                         }) &&
-            llvm::all_of(ifOp.getElseBlock()->without_terminator(),
-                         [&](Operation &o) {
-                           return isValidSymbolInt(&o, recur, scope);
-                         }) &&
-            llvm::all_of(
+        if (llvm::all_of(
                 ifOp.getThenBlock()->getTerminator()->getOperands(),
                 [&](Value v) { return isValidSymbolInt(v, recur, scope); }) &&
             llvm::all_of(

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -107,7 +107,13 @@ bool isValidSymbolInt(Operation *defOp, bool recur, Region *scope) {
             llvm::all_of(ifOp.elseBlock()->without_terminator(),
                          [&](Operation &o) {
                            return isValidSymbolInt(&o, recur, scope);
-                         }))
+                         }) &&
+            llvm::all_of(
+                ifOp.thenBlock()->getTerminator()->getOperands(),
+                [&](Value v) { return isValidSymbolInt(v, recur, scope); }) &&
+            llvm::all_of(
+                ifOp.elseBlock()->getTerminator()->getOperands(),
+                [&](Value v) { return isValidSymbolInt(v, recur, scope); }))
           return true;
       }
     }
@@ -122,7 +128,13 @@ bool isValidSymbolInt(Operation *defOp, bool recur, Region *scope) {
             llvm::all_of(ifOp.getElseBlock()->without_terminator(),
                          [&](Operation &o) {
                            return isValidSymbolInt(&o, recur, scope);
-                         }))
+                         }) &&
+            llvm::all_of(
+                ifOp.getThenBlock()->getTerminator()->getOperands(),
+                [&](Value v) { return isValidSymbolInt(v, recur, scope); }) &&
+            llvm::all_of(
+                ifOp.getElseBlock()->getTerminator()->getOperands(),
+                [&](Value v) { return isValidSymbolInt(v, recur, scope); }))
           return true;
     }
   }

--- a/test/lit_tests/raising/affinecfg_select_hoist_capture.mlir
+++ b/test/lit_tests/raising/affinecfg_select_hoist_capture.mlir
@@ -49,28 +49,19 @@ module attributes {gpu.container_module} {
   }
 }
 
+// The selects become an affine.if whose yields capture %247, an scf.if defined
+// inside the parallel and keyed off a non-affine ptrtoint.  It must neither be
+// treated as a valid affine symbol nor hoisted above the values it yields.
+
 // CHECK:       #set = affine_set<()[s0] : (s0 == 0)>
 // CHECK-LABEL:   func.func @test(
 // CHECK-SAME:                    %[[PTR:.+]]: !llvm.ptr, %[[N:.+]]: i64, %[[V:.+]]: i32, %[[PTR2:.+]]: !llvm.ptr) {
-// CHECK-NEXT:      %[[C0_I64:.+]] = arith.constant 0 : i64
-// CHECK-NEXT:      %[[C0_I32:.+]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[C1_I32:.+]] = arith.constant 1 : i32
-// CHECK-NEXT:      %[[C31_I32:.+]] = arith.constant 31 : i32
 // CHECK-NEXT:      %[[CM1_I32:.+]] = arith.constant -1 : i32
-// CHECK-NEXT:      %[[PI:.+]] = llvm.ptrtoint %[[PTR]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[PZ:.+]] = arith.cmpi eq, %[[PI]], %[[C0_I64]] : i64
-// CHECK-NEXT:      %[[IF:.+]]:4 = scf.if %[[PZ]] -> (i32, i32, i32, i32) {
-// CHECK-NEXT:        scf.yield %[[C0_I32]], %[[C0_I32]], %[[C0_I32]], %[[C0_I32]] : i32, i32, i32, i32
-// CHECK-NEXT:      } else {
-// CHECK-NEXT:        scf.yield %[[C0_I32]], %[[C0_I32]], %[[C0_I32]], %[[C0_I32]] : i32, i32, i32, i32
-// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[C31_I32:.+]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[C1_I32:.+]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[C0_I64:.+]] = arith.constant 0 : i64
 // CHECK-NEXT:      %[[NIDX:.+]] = arith.index_cast %[[N]] : i64 to index
-// CHECK-NEXT:      %[[SEL:.+]] = affine.if #set()[%[[NIDX]]] -> i32 {
-// CHECK-NEXT:        affine.yield %[[IF]]#1 : i32
-// CHECK-NEXT:      } else {
-// CHECK-NEXT:        affine.yield %[[IF]]#3 : i32
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %[[SELIDX:.+]] = arith.index_cast %[[SEL]] : i32 to index
 // CHECK-NEXT:      %[[NZ:.+]] = arith.cmpi eq, %[[N]], %[[C0_I64]] : i64
 // CHECK-NEXT:      %[[IF2:.+]]:3 = scf.if %[[NZ]] -> (i32, i32, i32) {
 // CHECK-NEXT:        scf.yield %[[V]], %[[V]], %[[V]] : i32, i32, i32
@@ -79,20 +70,28 @@ module attributes {gpu.container_module} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[IF2IDX:.+]] = arith.index_cast %[[IF2]]#0 : i32 to index
 // CHECK-NEXT:      affine.parallel (%[[TID:.+]]) = (0) to (256) {
-// CHECK-NEXT:        %[[SEL2:.+]] = affine.if #set()[%[[NIDX]]] -> i32 {
-// CHECK-NEXT:          affine.yield %[[IF]]#0 : i32
+// CHECK-NEXT:        %[[PI:.+]] = llvm.ptrtoint %[[PTR]] : !llvm.ptr to i64
+// CHECK-NEXT:        %[[PZ:.+]] = arith.cmpi eq, %[[PI]], %[[C0_I64]] : i64
+// CHECK-NEXT:        %[[IF:.+]]:4 = scf.if %[[PZ]] -> (i32, i32, i32, i32) {
+// CHECK-NEXT:          scf.yield %[[C0_I32]], %[[C0_I32]], %[[C0_I32]], %[[C0_I32]] : i32, i32, i32, i32
 // CHECK-NEXT:        } else {
-// CHECK-NEXT:          affine.yield %[[IF]]#2 : i32
+// CHECK-NEXT:          scf.yield %[[C0_I32]], %[[C0_I32]], %[[C0_I32]], %[[C0_I32]] : i32, i32, i32, i32
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[SEL:.+]]:2 = affine.if #set()[%[[NIDX]]] -> (i32, i32) {
+// CHECK-NEXT:          affine.yield %[[IF]]#0, %[[IF]]#1 : i32, i32
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          affine.yield %[[IF]]#2, %[[IF]]#3 : i32, i32
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %{{.+}}:2 = affine.if #set()[%[[IF2IDX]]] -> (i32, i32) {
-// CHECK-NEXT:          %[[ASM:.+]] = llvm.inline_asm has_side_effects tail_call_kind = <tail> asm_dialect = att "shfl.sync.down.b32 $0, $1, $2, $3, $4;", "=r,r,r,r,r" %[[SEL2]], %[[C1_I32]], %[[C31_I32]], %[[CM1_I32]] : (i32, i32, i32, i32) -> i32
-// CHECK-NEXT:          %[[ADD:.+]] = arith.addi %[[SEL2]], %[[ASM]] : i32
-// CHECK-NEXT:          %[[INNER:.+]] = affine.if #set()[%[[SELIDX]]] -> i32 {
+// CHECK-NEXT:          %[[ASM:.+]] = llvm.inline_asm has_side_effects tail_call_kind = <tail> asm_dialect = att "shfl.sync.down.b32 $0, $1, $2, $3, $4;", "=r,r,r,r,r" %[[SEL]]#0, %[[C1_I32]], %[[C31_I32]], %[[CM1_I32]] : (i32, i32, i32, i32) -> i32
+// CHECK-NEXT:          %[[ADD:.+]] = arith.addi %[[SEL]]#0, %[[ASM]] : i32
+// CHECK-NEXT:          %[[SELZ:.+]] = arith.cmpi eq, %[[SEL]]#1, %[[C0_I32]] : i32
+// CHECK-NEXT:          %[[INNER:.+]] = scf.if %[[SELZ]] -> (i32) {
 // CHECK-NEXT:            %[[LOAD:.+]] = llvm.load %[[PTR2]] : !llvm.ptr -> i32
 // CHECK-NEXT:            %[[ADD2:.+]] = arith.addi %[[LOAD]], %[[ADD]] : i32
-// CHECK-NEXT:            affine.yield %[[ADD2]] : i32
+// CHECK-NEXT:            scf.yield %[[ADD2]] : i32
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            affine.yield %[[V]] : i32
+// CHECK-NEXT:            scf.yield %[[V]] : i32
 // CHECK-NEXT:          }
 // CHECK-NEXT:          affine.yield %[[INNER]], %[[C0_I32]] : i32, i32
 // CHECK-NEXT:        } else {

--- a/test/lit_tests/raising/affinecfg_select_yield_dim.mlir
+++ b/test/lit_tests/raising/affinecfg_select_yield_dim.mlir
@@ -1,0 +1,64 @@
+// RUN: enzymexlamlir-opt %s --affine-cfg | FileCheck %s
+
+module {
+  func.func @select_yield_dim(%ptr: !llvm.ptr, %n: i64, %v: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
+    %c0_i32 = arith.constant 0 : i32
+    scf.parallel (%tid) = (%c0) to (%c256) step (%c1) {
+      %tidi = arith.index_castui %tid : index to i32
+      %inner = arith.cmpi eq, %tidi, %c0_i32 : i32
+      %if:2 = scf.if %inner -> (i32, i32) {
+        scf.yield %c0_i32, %v : i32, i32
+      } else {
+        scf.yield %v, %c0_i32 : i32, i32
+      }
+      %ni = arith.index_castui %n : i64 to index
+      %outer = arith.cmpi eq, %ni, %c0 : index
+      %sel = arith.select %outer, %if#0, %if#1 : i32
+      %selz = arith.cmpi eq, %sel, %c0_i32 : i32
+      %res = scf.if %selz -> (i32) {
+        %l = llvm.load %ptr : !llvm.ptr -> i32
+        scf.yield %l : i32
+      } else {
+        scf.yield %v : i32
+      }
+      llvm.store %res, %ptr : i32, !llvm.ptr
+    }
+    return
+  }
+}
+
+// %sel yields out of an if keyed off the induction variable, so it is a dim and
+// never a valid affine symbol; the conditional using it must stay an scf.if
+// rather than be raised and hoisted.
+
+// CHECK:       #set = affine_set<(d0) : (d0 == 0)>
+// CHECK:       #set1 = affine_set<()[s0] : (s0 == 0)>
+// CHECK-LABEL:   func.func @select_yield_dim(
+// CHECK-SAME:                                %[[PTR:.+]]: !llvm.ptr, %[[N:.+]]: i64, %[[V:.+]]: i32) {
+// CHECK-NEXT:      %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[NIDX:.+]] = arith.index_cast %[[N]] : i64 to index
+// CHECK-NEXT:      affine.parallel (%[[TID:.+]]) = (0) to (256) {
+// CHECK-NEXT:        %[[IF:.+]]:2 = affine.if #set(%[[TID]]) -> (i32, i32) {
+// CHECK-NEXT:          affine.yield %[[C0_I32]], %[[V]] : i32, i32
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          affine.yield %[[V]], %[[C0_I32]] : i32, i32
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[SEL:.+]] = affine.if #set1()[%[[NIDX]]] -> i32 {
+// CHECK-NEXT:          affine.yield %[[IF]]#0 : i32
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          affine.yield %[[IF]]#1 : i32
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[SELZ:.+]] = arith.cmpi eq, %[[SEL]], %[[C0_I32]] : i32
+// CHECK-NEXT:        %[[RES:.+]] = scf.if %[[SELZ]] -> (i32) {
+// CHECK-NEXT:          %[[LOAD:.+]] = llvm.load %[[PTR]] : !llvm.ptr -> i32
+// CHECK-NEXT:          scf.yield %[[LOAD]] : i32
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[V]] : i32
+// CHECK-NEXT:        }
+// CHECK-NEXT:        llvm.store %[[RES]], %[[PTR]] : i32, !llvm.ptr
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }


### PR DESCRIPTION
Follow-up to #2712, which made `getAllOps` see the captures on an if's terminator when choosing where to hoist. That exposed a latent crash on a neighbouring input. Two commits.

### 1. Read the else yield in `MoveSelectToAffine`'s and-operand guard

The guard that skips already-canonical `affine.if` booleans when splitting an `and`/`or` condition read both `tval` and `fval` from `getThenBlock()`, so `tval == fval` always and neither `continue` condition (One/Zero, Zero/One) could ever hold. Such operands got rewritten on every sweep, so `applyPatternsGreedily` never converges — a silent `signalPassFailure()` with no diagnostic (bare `exit 1`, no output).

Latent on `main`: the first conversion loop handles these conditions whole, so the and/or fallback is not reached with `affine.if` operands. Commit 2 makes it reachable.

### 2. Account for terminator captures in `isValidSymbolInt`

`isValidSymbolInt` judges an `scf.if`/`affine.if` by its condition/operands plus its body ops via `without_terminator()` — the same blind spot #2712 fixed in `getAllOps`. An `affine.if` whose only outside references are on its `affine.yield` therefore looks like a valid affine symbol, so `legalCondition`/`isValidIndex` green-light raising a conditional keyed off it. `AffineApplyNormalizer::fix` then correctly reports it cannot legalize that symbol by returning null, but the caller routes null through `llvm_unreachable("cannot move")` — UB under `-c opt`, where the compiler drops the null check and passes a null `Value` straight to `isValidSymbolInt`:

```
Program received signal SIGSEGV
0x... in isValidSymbolInt(mlir::Value, bool, mlir::Region*)
rdi 0x0     <- null Value
#1  AffineApplyNormalizer::AffineApplyNormalizer(...)
#4  MoveIfToAffine::matchAndRewrite(mlir::scf::IfOp, mlir::PatternRewriter&)
```

This checks the yielded values too, so the legality predicate and the hoister agree. The conditional is then left as an `scf.if`, which is correct — in the new test it is keyed off a value yielded out of an `if` on the induction variable, i.e. a dim, never a symbol.

Note dropping `without_terminator()` outright does not work: the body loop uses the `Operation*` overload, which means "is this op's result a symbol", and a yield has no results and is not in the whitelist — every `scf.if`/`affine.if` would fail the check. Confirmed: that variant regresses `affinecfg_noselect` and `raiseimmerse`.

### Behaviour on the two reduced inputs

| build | `select_hoist_capture` | `select_yield_dim` |
|---|---|---|
| before #2712 | dominance error | dominance error |
| #2712 only | ok | **segfault** |
| with this | ok | ok |

`affinecfg_select_hoist_capture`'s expectations are updated: the two selects now merge into one `affine.if` that stays beside the `scf.if` it yields, and the inner conditional stays an `scf.if` since its `scf.if` is keyed off a non-affine `ptrtoint`.

### Testing

`bazel test //test/lit_tests/... --cache_test_results=no`: 1083/1086, and 1082/1085 for commit 1 alone. The 3 failures are pre-existing on `main` and unrelated (uncommitted WIP tests in my working tree: `communication_dusN`, `communication_dusS`, `raising_affine_to_stablehlo_ab_tend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
