### PR TITLE
[CanonicalizeFor] Perform the final before-region evaluation in while->for

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1562,6 +1562,17 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
       }
     }
 
+    // With an extra condition the loop may also exit by exhausting the trip
+    // count. In that case the while still evaluates the before region one final
+    // time -- the evaluation whose comparison fails -- and it is that
+    // evaluation's condition args which become the loop results. That final
+    // evaluation is only observable through its side effects, which already
+    // force the extra iteration above, and through the loop results, so it is
+    // only needed here if the results are actually used. The after region stays
+    // guarded by the original bound, so it does not run an extra time.
+    if (lookThrough && !loop->use_empty())
+      doWhile = true;
+
     bool mutableAfter = false;
     if (doWhile) {
       for (auto &blk : loop.getAfter()) {

--- a/test/lit_tests/canonicalizefor/andi_while_to_for.mlir
+++ b/test/lit_tests/canonicalizefor/andi_while_to_for.mlir
@@ -31,7 +31,9 @@ module {
 // CHECK-DAG:   %[[CM2560:.*]] = arith.constant -2560 : i32
 // CHECK:       %[[BOUND0:.*]] = arith.addi %arg0, %[[CM2560]] : i32
 // CHECK:       %[[BOUND:.*]] = arith.addi %[[BOUND0]], %[[C1]] : i32
-// CHECK:       %[[FOR:.*]]:5 = scf.for %[[IV:.*]] = %[[C2560]] to %[[BOUND]] step %[[C2560]]
+// CHECK:       %[[MAX:.*]] = arith.maxsi %[[BOUND]], %[[C2560]] : i32
+// CHECK:       %[[TRIP:.*]] = arith.addi %[[MAX]], %[[C2560]] : i32
+// CHECK:       %[[FOR:.*]]:5 = scf.for %[[IV:.*]] = %[[C2560]] to %[[TRIP]] step %[[C2560]]
 // CHECK-SAME:    iter_args(%[[A0:.*]] = %[[C2560]], %[[A1:.*]] = %arg1, %[[A2:.*]] = %[[POISON_I32]], %[[A3:.*]] = %arg1, %[[A4:.*]] = %[[TRUE]])
 // CHECK-SAME:    -> (i32, i64, i32, i64, i1)  : i32 {
 // CHECK:         %[[IF1:.*]]:3 = scf.if %[[A4]] -> (i32, i64, i1) {

--- a/test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir
+++ b/test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir
@@ -1,0 +1,253 @@
+// RUN: enzymexlamlir-opt --canonicalize-scf-for --split-input-file %s | FileCheck %s
+
+// A while with an extra condition can exit either early (the extra condition
+// goes false) or by exhausting the trip count. In the latter case the while
+// still evaluates the before region one final time -- the evaluation whose
+// comparison fails -- and it is that evaluation's condition args which become
+// the loop results. With %p true the loop below runs the body for i = 0, 1, 2
+// and then exits on the evaluation with i = 3, yielding 4.
+//
+// So the for must run one iteration past the bound to compute those results,
+// while the after region stays guarded by the original bound so that it does
+// not execute an extra time.
+
+func.func @trip_count_exit(%p: i1) -> i64 {
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %c3 = arith.constant 3 : i64
+  %r = scf.while (%i = %c0) : (i64) -> i64 {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    %next = arith.addi %i, %c1 : i64
+    %c = arith.andi %cmp, %p : i1
+    scf.condition(%c) %next : i64
+  } do {
+  ^bb0(%a: i64):
+    scf.yield %a : i64
+  }
+  return %r : i64
+}
+
+// CHECK-LABEL:   func.func @trip_count_exit(
+// CHECK-SAME:                               %[[P:.*]]: i1) -> i64 {
+// CHECK-NEXT:      %[[FALSE:.*]] = arith.constant false
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : i64
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[C3:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:      %[[POISON:.*]] = ub.poison : i64
+// CHECK-NEXT:      %[[TRUE:.*]] = arith.constant true
+// The trip count is one past the bound, so that the final evaluation of the
+// before region -- the one producing the results -- is performed.
+// CHECK-NEXT:      %[[C4:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:      %[[FOR:.*]]:3 = scf.for %[[IV:.*]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[CUR:.*]] = %[[C0]], %[[RES:.*]] = %[[POISON]], %[[FLAG:.*]] = %[[TRUE]]) -> (i64, i64, i1)  : i64 {
+// Once the loop is done the before region is no longer evaluated and the
+// results stay frozen at the evaluation which ended it.
+// CHECK-NEXT:        %[[BEFORE:.*]]:2 = scf.if %[[FLAG]] -> (i64, i1) {
+// CHECK-NEXT:          %[[NEXT:.*]] = arith.addi %[[CUR]], %[[C1]] : i64
+// CHECK-NEXT:          scf.yield %[[NEXT]], %[[P]] : i64, i1
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[RES]], %[[FALSE]] : i64, i1
+// CHECK-NEXT:        }
+// The after region keeps the original bound, so it does not run an extra time.
+// CHECK-NEXT:        %[[INBOUNDS:.*]] = arith.cmpi slt, %[[IV]], %[[C3]] : i64
+// CHECK-NEXT:        %[[GUARD:.*]] = arith.andi %[[INBOUNDS]], %[[BEFORE]]#1 : i1
+// CHECK-NEXT:        %[[AFTER:.*]] = scf.if %[[GUARD]] -> (i64) {
+// CHECK-NEXT:          scf.yield %[[BEFORE]]#0 : i64
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[POISON]] : i64
+// CHECK-NEXT:        }
+// CHECK-NEXT:        scf.yield %[[AFTER]], %[[BEFORE]]#0, %[[BEFORE]]#1 : i64, i64, i1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return %[[FOR]]#1 : i64
+// CHECK-NEXT:    }
+
+// -----
+
+// Without an extra condition the loop can only exit by trip count, the before
+// region is just the comparison, and the results are plain block arguments, so
+// no extra iteration is needed.
+
+func.func @no_extra_condition(%ub: i64) -> i64 {
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %r = scf.while (%i = %c0) : (i64) -> i64 {
+    %cmp = arith.cmpi slt, %i, %ub : i64
+    scf.condition(%cmp) %i : i64
+  } do {
+  ^bb0(%a: i64):
+    %next = arith.addi %a, %c1 : i64
+    scf.yield %next : i64
+  }
+  return %r : i64
+}
+
+// CHECK-LABEL:   func.func @no_extra_condition(
+// CHECK-SAME:                                  %[[UB:.*]]: i64) -> i64 {
+// CHECK-NEXT:      %[[LB:.*]] = arith.constant 0 : i64
+// CHECK-NEXT:      %[[STEP:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[LOOP:.*]] = scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%[[ITER:.*]] = %[[LB]]) -> (i64)  : i64 {
+// CHECK-NEXT:        scf.yield %[[I]] : i64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return %[[LOOP]] : i64
+// CHECK-NEXT:    }
+
+// -----
+
+// The final evaluation of the before region is only observable through its side
+// effects or through the loop results. The next three functions share the same
+// loop and vary exactly one of those two properties at a time.
+//
+// Baseline: pure before region, result used, so the extra iteration is needed.
+
+func.func @used_results(%p: i1, %ptr: memref<i64>) -> i64 {
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %c3 = arith.constant 3 : i64
+  %r = scf.while (%i = %c0) : (i64) -> i64 {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    %next = arith.addi %i, %c1 : i64
+    %c = arith.andi %cmp, %p : i1
+    scf.condition(%c) %next : i64
+  } do {
+  ^bb0(%a: i64):
+    memref.store %a, %ptr[] : memref<i64>
+    scf.yield %a : i64
+  }
+  return %r : i64
+}
+
+// CHECK-LABEL:   func.func @used_results(
+// CHECK-SAME:                            %[[P:.*]]: i1,
+// CHECK-SAME:                            %[[PTR:.*]]: memref<i64>) -> i64 {
+// CHECK-NEXT:      %[[FALSE:.*]] = arith.constant false
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : i64
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[C3:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:      %[[POISON:.*]] = ub.poison : i64
+// CHECK-NEXT:      %[[TRUE:.*]] = arith.constant true
+// The bound is extended by one step.
+// CHECK-NEXT:      %[[C4:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:      %[[FOR:.*]]:3 = scf.for %[[IV:.*]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[CUR:.*]] = %[[C0]], %[[RES:.*]] = %[[POISON]], %[[FLAG:.*]] = %[[TRUE]]) -> (i64, i64, i1)  : i64 {
+// CHECK-NEXT:        %[[BEFORE:.*]]:2 = scf.if %[[FLAG]] -> (i64, i1) {
+// CHECK-NEXT:          %[[NEXT:.*]] = arith.addi %[[CUR]], %[[C1]] : i64
+// CHECK-NEXT:          scf.yield %[[NEXT]], %[[P]] : i64, i1
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[RES]], %[[FALSE]] : i64, i1
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[INBOUNDS:.*]] = arith.cmpi slt, %[[IV]], %[[C3]] : i64
+// CHECK-NEXT:        %[[GUARD:.*]] = arith.andi %[[INBOUNDS]], %[[BEFORE]]#1 : i1
+// CHECK-NEXT:        %[[AFTER:.*]] = scf.if %[[GUARD]] -> (i64) {
+// CHECK-NEXT:          memref.store %[[BEFORE]]#0, %[[PTR]][] : memref<i64>
+// CHECK-NEXT:          scf.yield %[[BEFORE]]#0 : i64
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[POISON]] : i64
+// CHECK-NEXT:        }
+// CHECK-NEXT:        scf.yield %[[AFTER]], %[[BEFORE]]#0, %[[BEFORE]]#1 : i64, i64, i1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return %[[FOR]]#1 : i64
+// CHECK-NEXT:    }
+
+// -----
+
+// Differs from @used_results only in that the result is unused, so the final
+// evaluation is unobservable and no extra iteration is needed.
+
+func.func @unused_results(%p: i1, %ptr: memref<i64>) {
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %c3 = arith.constant 3 : i64
+  %r = scf.while (%i = %c0) : (i64) -> i64 {
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    %next = arith.addi %i, %c1 : i64
+    %c = arith.andi %cmp, %p : i1
+    scf.condition(%c) %next : i64
+  } do {
+  ^bb0(%a: i64):
+    memref.store %a, %ptr[] : memref<i64>
+    scf.yield %a : i64
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @unused_results(
+// CHECK-SAME:                              %[[P:.*]]: i1,
+// CHECK-SAME:                              %[[PTR:.*]]: memref<i64>) {
+// CHECK-NEXT:      %[[FALSE:.*]] = arith.constant false
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : i64
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[C3:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:      %[[POISON:.*]] = ub.poison : i64
+// CHECK-NEXT:      %[[TRUE:.*]] = arith.constant true
+// The bound is not extended: no extra iteration.
+// CHECK-NEXT:      %[[FOR:.*]]:3 = scf.for %[[IV:.*]] = %[[C0]] to %[[C3]] step %[[C1]] iter_args(%[[CUR:.*]] = %[[C0]], %[[RES:.*]] = %[[POISON]], %[[FLAG:.*]] = %[[TRUE]]) -> (i64, i64, i1)  : i64 {
+// CHECK-NEXT:        %[[BEFORE:.*]]:2 = scf.if %[[FLAG]] -> (i64, i1) {
+// CHECK-NEXT:          %[[NEXT:.*]] = arith.addi %[[CUR]], %[[C1]] : i64
+// CHECK-NEXT:          scf.yield %[[NEXT]], %[[P]] : i64, i1
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[RES]], %[[FALSE]] : i64, i1
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[INBOUNDS:.*]] = arith.cmpi slt, %[[IV]], %[[C3]] : i64
+// CHECK-NEXT:        %[[GUARD:.*]] = arith.andi %[[INBOUNDS]], %[[BEFORE]]#1 : i1
+// CHECK-NEXT:        %[[AFTER:.*]] = scf.if %[[GUARD]] -> (i64) {
+// CHECK-NEXT:          memref.store %[[BEFORE]]#0, %[[PTR]][] : memref<i64>
+// CHECK-NEXT:          scf.yield %[[BEFORE]]#0 : i64
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[POISON]] : i64
+// CHECK-NEXT:        }
+// CHECK-NEXT:        scf.yield %[[AFTER]], %[[BEFORE]]#0, %[[BEFORE]]#1 : i64, i64, i1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// -----
+
+// Differs from @unused_results only in that the store sits in the before region
+// rather than the after region. The final evaluation is now observable through
+// that side effect, so the existing purity check forces the extra iteration even
+// though the result is still unused.
+
+func.func @impure_before(%p: i1, %ptr: memref<i64>) {
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %c3 = arith.constant 3 : i64
+  %r = scf.while (%i = %c0) : (i64) -> i64 {
+    memref.store %i, %ptr[] : memref<i64>
+    %cmp = arith.cmpi slt, %i, %c3 : i64
+    %next = arith.addi %i, %c1 : i64
+    %c = arith.andi %cmp, %p : i1
+    scf.condition(%c) %next : i64
+  } do {
+  ^bb0(%a: i64):
+    scf.yield %a : i64
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @impure_before(
+// CHECK-SAME:                             %[[P:.*]]: i1,
+// CHECK-SAME:                             %[[PTR:.*]]: memref<i64>) {
+// CHECK-NEXT:      %[[FALSE:.*]] = arith.constant false
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : i64
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[C3:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:      %[[POISON:.*]] = ub.poison : i64
+// CHECK-NEXT:      %[[TRUE:.*]] = arith.constant true
+// CHECK-NEXT:      %[[C4:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:      %[[FOR:.*]]:3 = scf.for %[[IV:.*]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[CUR:.*]] = %[[C0]], %[[RES:.*]] = %[[POISON]], %[[FLAG:.*]] = %[[TRUE]]) -> (i64, i64, i1)  : i64 {
+// CHECK-NEXT:        %[[BEFORE:.*]]:2 = scf.if %[[FLAG]] -> (i64, i1) {
+// CHECK-NEXT:          memref.store %[[CUR]], %[[PTR]][] : memref<i64>
+// CHECK-NEXT:          %[[NEXT:.*]] = arith.addi %[[CUR]], %[[C1]] : i64
+// CHECK-NEXT:          scf.yield %[[NEXT]], %[[P]] : i64, i1
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[RES]], %[[FALSE]] : i64, i1
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[INBOUNDS:.*]] = arith.cmpi slt, %[[IV]], %[[C3]] : i64
+// CHECK-NEXT:        %[[GUARD:.*]] = arith.andi %[[INBOUNDS]], %[[BEFORE]]#1 : i1
+// CHECK-NEXT:        %[[AFTER:.*]] = scf.if %[[GUARD]] -> (i64) {
+// CHECK-NEXT:          scf.yield %[[BEFORE]]#0 : i64
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.yield %[[POISON]] : i64
+// CHECK-NEXT:        }
+// CHECK-NEXT:        scf.yield %[[AFTER]], %[[BEFORE]]#0, %[[BEFORE]]#1 : i64, i64, i1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/test/lit_tests/canonicalizefor/whiletofor2.mlir
+++ b/test/lit_tests/canonicalizefor/whiletofor2.mlir
@@ -32,7 +32,9 @@ module {
 // CHECK-DAG:           %[[cst1:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK-DAG:           %[[c0:.*]] = arith.constant 0 : i32
 // CHECK-DAG:           %[[c1:.*]] = arith.constant 1 : i32
-// CHECK:           %[[FOR:.*]]:6 = scf.for %[[arg:.+]] = %[[c0]] to %[[ub]] step %[[c1]] iter_args(%[[VAL_1:.*]] = %[[c0]], %[[VAL_2:.*]] = %[[cst0]], %[[VAL_3:.*]] = %[[true]], %[[VAL_11:.*]] = %[[c0]], %[[VAL_12:.*]] = %[[cst0]], %[[VAL_13:.*]] = %[[true]])
+// CHECK:           %[[MAX:.*]] = arith.maxsi %[[ub]], %[[c0]] : i32
+// CHECK:           %[[BOUND:.*]] = arith.addi %[[MAX]], %[[c1]] : i32
+// CHECK:           %[[FOR:.*]]:6 = scf.for %[[arg:.+]] = %[[c0]] to %[[BOUND]] step %[[c1]] iter_args(%[[VAL_1:.*]] = %[[c0]], %[[VAL_2:.*]] = %[[cst0]], %[[VAL_3:.*]] = %[[true]], %[[VAL_11:.*]] = %[[c0]], %[[VAL_12:.*]] = %[[cst0]], %[[VAL_13:.*]] = %[[true]])
 // CHECK:             %[[IF1:.*]]:3 = scf.if %[[VAL_13]] -> (i32, f32, i1) {
 // CHECK:               scf.yield %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : i32, f32, i1
 // CHECK:             } else {
@@ -89,7 +91,9 @@ module {
 // CHECK-DAG:           %[[cst1:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK-DAG:           %[[c0:.*]] = arith.constant 0 : i32
 // CHECK-DAG:           %[[c1:.*]] = arith.constant 1 : i32
-// CHECK:           %[[FOR:.*]]:6 = scf.for %[[arg:.+]] = %[[c0]] to %[[VAL_0]] step %[[c1]] iter_args(%[[VAL_1:.*]] = %[[c0]], %[[VAL_2:.*]] = %[[cst0]], %[[VAL_3:.*]] = %[[true]], %[[VAL_11:.*]] = %[[c0]], %[[VAL_12:.*]] = %[[cst0]], %[[VAL_13:.*]] = %[[true]])
+// CHECK:           %[[MAX:.*]] = arith.maxsi %[[VAL_0]], %[[c0]] : i32
+// CHECK:           %[[BOUND:.*]] = arith.addi %[[MAX]], %[[c1]] : i32
+// CHECK:           %[[FOR:.*]]:6 = scf.for %[[arg:.+]] = %[[c0]] to %[[BOUND]] step %[[c1]] iter_args(%[[VAL_1:.*]] = %[[c0]], %[[VAL_2:.*]] = %[[cst0]], %[[VAL_3:.*]] = %[[true]], %[[VAL_11:.*]] = %[[c0]], %[[VAL_12:.*]] = %[[cst0]], %[[VAL_13:.*]] = %[[true]])
 // CHECK:             %[[IF1:.*]]:3 = scf.if %[[VAL_13]] -> (i32, f32, i1) {
 // CHECK:               scf.yield %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : i32, f32, i1
 // CHECK:             } else {
@@ -148,7 +152,9 @@ module {
 // CHECK-DAG:           %[[undef_i8:.*]] = ub.poison : i8
 // CHECK-DAG:           %[[undef_i32:.+]] = ub.poison : i32
 // CHECK-DAG:           %[[undef_i1:.+]] = ub.poison : i1
-// CHECK:           %[[FOR:.*]]:6 = scf.for %[[arg:.*]] = %[[c0_i32]] to %[[ub]] step %[[c1_i32]] iter_args(%[[VAL_13:.*]] = %[[c0_i32]], %[[VAL_14:.*]] = %[[VAL_0]], %[[VAL_16:.*]] = %[[true]], %[[VAL_15:.*]] = %[[VAL_0]], %[[VAL_5:.*]] = %[[c0_i32]], %[[VAL_6:.*]] = %[[true]]) -> (i32, i8, i1, i8, i32, i1)  : i32 {
+// CHECK:           %[[MAX:.*]] = arith.maxsi %[[ub]], %[[c0_i32]] : i32
+// CHECK:           %[[BOUND:.*]] = arith.addi %[[MAX]], %[[c1_i32]] : i32
+// CHECK:           %[[FOR:.*]]:6 = scf.for %[[arg:.*]] = %[[c0_i32]] to %[[BOUND]] step %[[c1_i32]] iter_args(%[[VAL_13:.*]] = %[[c0_i32]], %[[VAL_14:.*]] = %[[VAL_0]], %[[VAL_16:.*]] = %[[true]], %[[VAL_15:.*]] = %[[VAL_0]], %[[VAL_5:.*]] = %[[c0_i32]], %[[VAL_6:.*]] = %[[true]]) -> (i32, i8, i1, i8, i32, i1)  : i32 {
 // CHECK:             %[[IF1:.*]]:3 = scf.if %[[VAL_6]] -> (i8, i32, i1) {
 // CHECK:               scf.yield %[[VAL_14]], %[[VAL_13]], %[[VAL_16]] : i8, i32, i1
 // CHECK:             } else {


### PR DESCRIPTION
Follow-up to #2714.

A `scf.while` whose condition is a comparison and'd with an extra condition can exit two ways: early, when the extra condition goes false, or by exhausting the trip count. In the latter case the while still evaluates the before region one final time — the evaluation whose comparison fails — and it is *that* evaluation's `scf.condition` args which become the loop results.

`MoveWhileToFor` only ran that extra iteration when the before region was impure (`ub = max(ub, lb) + step`), but the results are observable regardless of purity. With a pure before region the results were therefore taken one evaluation too early.

### Example

`@w2f` from `whiletofor2.mlir`, whose condition args are both plain before-block arguments:

```
ub = 3, test.something always true
  cur = (0, 0.0)  0<3 -> body -> cur = (1, 1.0)
  cur = (1, 1.0)  1<3 -> body -> cur = (2, 2.0)
  cur = (2, 2.0)  2<3 -> body -> cur = (3, 3.0)
  cur = (3, 3.0)  3<3 false -> exit, results = (3, 3.0)
```

The generated `for` ran `iv = 0..2` and froze the result slots at the `iv=2` evaluation, yielding `(2, 2.0)`.

Note this is not fixed by the existing seeding of the result iter_args. Those seeds (the loop inits for block-arg condition args, poison otherwise) only apply when the loop runs zero times; here they are overwritten on the first iteration. The fourth evaluation simply never happens.

The zero-trip case is additionally wrong for *computed* condition args, which seed to poison rather than to their value at the initial evaluation: in `andi_while_to_for.mlir` with `%arg0 <= 5119` the while returns `(5120, %arg1)` and the old for returned `(poison, %arg1)`.

### Fix

That final evaluation is observable in exactly two ways: through its side effects, and through the loop results. The first is already handled — an impure before region forces the extra iteration. So it suffices to also force it when there is an extra condition **and** the loop results are used:

```cpp
if (lookThrough && !loop->use_empty())
  doWhile = true;
```

(`Operation::use_empty()` is `getResults().use_empty()`, i.e. all results have no uses.) A pure before region whose results are unused still needs no extra iteration.

The after region stays guarded by the original bound (`cmpi slt, %iv, %helper.ub`), so it does not execute an extra time, and the `flag` iter-arg already freezes the results on early exit.

### Tests

- New `test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir`, checking every emitted line: the trip-count-exit case (bound is now one past `ub`, after region still guarded by `ub`), plus a case with no extra condition, and a controlled series covering both sides of the `!use_empty()` refinement — `@used_results` / `@unused_results` are identical loops differing only in whether the result is returned (bound extended vs not), and `@impure_before` differs from `@unused_results` only in moving the store into the before region (extra iteration forced by the existing purity check despite the unused result).

Both directions were confirmed load-bearing by temporarily weakening the predicate: dropping `!use_empty()` fails `@unused_results`, and dropping the forcing entirely fails `@used_results`, `@trip_count_exit`, `andi_while_to_for.mlir` and `whiletofor2.mlir`.
- `andi_while_to_for.mlir` and `whiletofor2.mlir` updated — all three of their loops were pinning the off-by-one output; the only change in each is the loop bound.

Full lit suite passes.
