### PR TITLE
[AffineCFG] Rewrite unhoistable conditionals in fix()

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -98,6 +98,10 @@ bool isValidSymbolInt(Operation *defOp, bool recur, Region *scope) {
           matchPattern(shiftOp.getRhs(), m_ConstantInt(&intValue)))
         return true;
     }
+    // A conditional whose regions yield valid symbols produces one: the value
+    // is select(cond, thenYield, elseYield) regardless of what else the regions
+    // do.  Materializing that is AffineApplyNormalizer::fix's job -- see the
+    // scf.if case there -- so a side-effecting body is no obstacle here.
     if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
       if (isValidSymbolInt(ifOp.getCondition(), recur, scope)) {
         if (llvm::all_of(
@@ -306,6 +310,23 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
             op = newV;
   };
 
+  // Whether `v` can be computed outside the conditional `guard` that currently
+  // guards it.  Values already defined outside are free; anything still inside
+  // has to be speculatable, since hoisting it means evaluating it on paths that
+  // previously skipped it.
+  std::function<bool(Value, Operation *)> speculatableOutOf =
+      [&](Value v, Operation *guard) -> bool {
+    if (llvm::none_of(guard->getRegions(), [&](Region &r) {
+          return r.isAncestor(v.getParentRegion());
+        }))
+      return true;
+    auto *defOp = v.getDefiningOp();
+    if (!defOp || !isSpeculatable(defOp))
+      return false;
+    return llvm::all_of(defOp->getOperands(),
+                        [&](Value o) { return speculatableOutOf(o, guard); });
+  };
+
   SmallVector<Operation **> operationContext;
   std::function<Value(Value, bool)> fix = [&](Value v,
                                               bool index) -> Value /*legal*/ {
@@ -322,8 +343,38 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
     if (!op)
       llvm::errs() << v << "\n";
     assert(op);
+    // A conditional cannot be cloned out of the control flow that guards it
+    // once its regions have side effects, but the value it produces is still
+    // the then/else pair selected by the condition -- which is what
+    // isValidSymbolInt accepted it on.  Rewrite to just that, leaving the side
+    // effects where they are: an arith.select for scf.if, and a bodiless
+    // affine.if over the same integer set for affine.if, whose condition is a
+    // set rather than an i1 value.  Evaluating both arms unconditionally means
+    // everything hoisted out of a region has to be speculatable.
+    Operation *condIf = nullptr;
+    Value selTrue, selFalse;
+    // Leading entries of `ops` holding the condition: one i1 for scf.if, the
+    // integer set's dim and symbol operands for affine.if.
+    unsigned numCondOperands = 0;
     if (!isReadOnly(op)) {
-      return nullptr;
+      unsigned idx = cast<OpResult>(v).getResultNumber();
+      if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        if (ifOp.getElseRegion().empty())
+          return nullptr;
+        selTrue = ifOp.thenYield().getOperand(idx);
+        selFalse = ifOp.elseYield().getOperand(idx);
+        numCondOperands = 1;
+      } else if (auto ifOp = dyn_cast<affine::AffineIfOp>(op)) {
+        if (!ifOp.hasElse())
+          return nullptr;
+        selTrue = ifOp.getThenBlock()->getTerminator()->getOperand(idx);
+        selFalse = ifOp.getElseBlock()->getTerminator()->getOperand(idx);
+        numCondOperands = ifOp.getNumOperands();
+      } else
+        return nullptr;
+      condIf = op;
+      if (!speculatableOutOf(selTrue, op) || !speculatableOutOf(selFalse, op))
+        return nullptr;
     }
     Operation *front = nullptr;
     operationContext.push_back(&front);
@@ -348,7 +399,17 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
 
     if (front)
       assert(front->getBlock());
-    getAllOps(op);
+    if (condIf) {
+      // Only the condition and the two arms have to be legalized; the rest of
+      // the conditional stays put.
+      if (auto ifOp = dyn_cast<scf::IfOp>(condIf))
+        ops.push_back(ifOp.getCondition());
+      else
+        llvm::append_range(ops, condIf->getOperands());
+      ops.push_back(selTrue);
+      ops.push_back(selFalse);
+    } else
+      getAllOps(op);
 
     if (front)
       assert(front->getBlock());
@@ -404,6 +465,53 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
     if (!front)
       op->dump();
     assert(front);
+    if (condIf) {
+      // ops now holds the legalized condition and arms: replaceOp rewrote the
+      // entries as their defining ops were hoisted.
+      if (!rewriter) {
+        operationContext.pop_back();
+        return v;
+      }
+      Value selTrueFixed = ops[numCondOperands];
+      Value selFalseFixed = ops[numCondOperands + 1];
+      Value sel;
+      {
+        PatternRewriter::InsertionGuard B(*rewriter);
+        rewriter->setInsertionPoint(front);
+        if (auto ifOp = dyn_cast<scf::IfOp>(condIf)) {
+          sel = arith::SelectOp::create(*rewriter, ifOp.getLoc(), ops[0],
+                                        selTrueFixed, selFalseFixed);
+        } else {
+          auto affIfOp = cast<affine::AffineIfOp>(condIf);
+          // isValidDim accepts valid symbols, so the legalized operands remain
+          // legal in the set wherever this lands.
+          SmallVector<Value> setOperands(ops.begin(),
+                                         ops.begin() + numCondOperands);
+          auto newIf = affine::AffineIfOp::create(
+              *rewriter, affIfOp.getLoc(), TypeRange{v.getType()},
+              affIfOp.getIntegerSet(), setOperands, /*withElseRegion=*/true);
+          PatternRewriter::InsertionGuard B2(*rewriter);
+          rewriter->setInsertionPointToStart(newIf.getThenBlock());
+          affine::AffineYieldOp::create(*rewriter, affIfOp.getLoc(),
+                                        ValueRange{selTrueFixed});
+          rewriter->setInsertionPointToStart(newIf.getElseBlock());
+          affine::AffineYieldOp::create(*rewriter, affIfOp.getLoc(),
+                                        ValueRange{selFalseFixed});
+          sel = newIf.getResult(0);
+        }
+      }
+      // Point existing uses at the hoisted value, the way the clone path below
+      // does with replaceOp: an op cloned above this conditional must not keep
+      // referring to a result defined inside it.
+      rewriter->replaceAllUsesWith(v, sel);
+      for (auto todo : opsTodos)
+        for (auto &o : *todo)
+          if (o == v)
+            o = sel;
+      operationContext.pop_back();
+      assert(isValidSymbolInt(sel, /*recur*/ false, scope));
+      return sel;
+    }
     if (!rewriter) {
       operationContext.pop_back();
       assert(isValidSymbolInt(op->getResult(0), /*recur*/ false, scope));
@@ -737,6 +845,7 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
         dimReplacements.push_back(affineApplyMap.getResult(0));
     } else {
       if (!isValidSymbolInt(t, /*recur*/ false, scope)) {
+        Value orig = t;
         if (t.getDefiningOp()) {
           if ((t = fix(t, false))) {
             if (!isValidSymbolInt(t, /*recur*/ false, scope)) {
@@ -748,8 +857,22 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
                            << " to become valid symbol\n";
               llvm_unreachable("cannot move");
             }
-          } else
-            llvm_unreachable("cannot move");
+          } else {
+            // Reaching here means a pattern committed to a rewrite whose
+            // operand cannot be made a valid affine symbol.  llvm_unreachable
+            // is UB in a release build and lets execution fall through into
+            // renumberOne{Dim,Symbol} with a null Value, which segfaults far
+            // from the actual mistake; fail loudly instead.
+            llvm::errs() << " operand " << i << " of " << e
+                         << " could not be moved to become a valid symbol: "
+                         << orig << "\n";
+            if (auto *dop = orig.getDefiningOp())
+              if (auto fop = dop->getParentOfType<FunctionOpInterface>())
+                llvm::errs() << " in function: " << fop.getName() << "\n";
+            llvm::report_fatal_error(
+                "AffineApplyNormalizer: cannot move operand to become a valid "
+                "affine symbol");
+          }
         } else
           llvm_unreachable("cannot move2");
       }

--- a/test/lit_tests/raising/affinecfg_affine_if_side_effect_symbol.mlir
+++ b/test/lit_tests/raising/affinecfg_affine_if_side_effect_symbol.mlir
@@ -1,0 +1,65 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access)" | FileCheck %s
+
+#set = affine_set<()[s0] : (s0 - 1 >= 0)>
+module {
+  func.func @affine_if_side_effect_symbol(%ptr: !llvm.ptr, %n: i32, %c2: i1) -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %m = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr) -> memref<?xi32>
+    %ni = arith.index_cast %n : i32 to index
+    %outer = scf.if %c2 -> (i32) {
+      %if = affine.if #set()[%ni] -> i32 {
+        affine.yield %c0_i32 : i32
+      } else {
+        %sq = arith.muli %n, %n : i32
+        %si = arith.index_cast %sq : i32 to index
+        memref.store %sq, %m[%si] : memref<?xi32>
+        affine.yield %sq : i32
+      }
+      %ifi = arith.index_cast %if : i32 to index
+      %idx = arith.subi %ni, %ifi : index
+      %l = memref.load %m[%idx] : memref<?xi32>
+      scf.yield %l : i32
+    } else {
+      scf.yield %c0_i32 : i32
+    }
+    return %outer : i32
+  }
+}
+
+// The affine.if counterpart of affinecfg_if_side_effect_symbol.mlir.  Its
+// condition is an integer set rather than an i1, so fix() cannot rewrite the
+// value as an arith.select; it materializes a bodiless affine.if over the same
+// set instead, yielding the two hoisted arms.  isValidDim accepts valid
+// symbols, so the legalized set operands stay legal at the new location.  The
+// storing affine.if is left where it is.
+
+// CHECK:         #map = affine_map<()[s0, s1] -> (s0 - s1)>
+// CHECK:         #set = affine_set<()[s0] : (s0 - 1 >= 0)>
+// CHECK-LABEL:   func.func @affine_if_side_effect_symbol(
+// CHECK-SAME:                                            %[[PTR:.+]]: !llvm.ptr, %[[N:.+]]: i32, %[[C2:.+]]: i1) -> i32 {
+// CHECK:           %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK:           %[[SQ:.+]] = arith.muli %[[N]], %[[N]] : i32
+// CHECK:           %[[MEM:.+]] = "enzymexla.pointer2memref"(%[[PTR]]) : (!llvm.ptr) -> memref<?xi32>
+// CHECK:           %[[NI:.+]] = arith.index_cast %[[N]] : i32 to index
+// CHECK:           %[[HOISTED:.+]] = affine.if #set(){{\[}}%[[NI]]] -> i32 {
+// CHECK:             affine.yield %[[C0_I32]] : i32
+// CHECK:           } else {
+// CHECK:             affine.yield %[[SQ]] : i32
+// CHECK:           }
+// CHECK:           %[[HOISTEDI:.+]] = arith.index_cast %[[HOISTED]] : i32 to index
+// CHECK:           %[[OUTER:.+]] = scf.if %[[C2]] -> (i32) {
+// CHECK:             %{{.+}} = affine.if #set(){{\[}}%[[NI]]] -> i32 {
+// CHECK:               affine.yield %[[C0_I32]] : i32
+// CHECK:             } else {
+// CHECK:               %[[SI:.+]] = arith.index_cast %[[SQ]] : i32 to index
+// CHECK:               memref.store %[[SQ]], %[[MEM]]{{\[}}%[[SI]]] : memref<?xi32>
+// CHECK:               affine.yield %[[SQ]] : i32
+// CHECK:             }
+// CHECK:             %[[APP:.+]] = affine.apply #map(){{\[}}%[[NI]], %[[HOISTEDI]]]
+// CHECK:             %[[LOAD:.+]] = memref.load %[[MEM]]{{\[}}%[[APP]]] : memref<?xi32>
+// CHECK:             scf.yield %[[LOAD]] : i32
+// CHECK:           } else {
+// CHECK:             scf.yield %[[C0_I32]] : i32
+// CHECK:           }
+// CHECK:           return %[[OUTER]] : i32
+// CHECK:         }

--- a/test/lit_tests/raising/affinecfg_if_pure_symbol.mlir
+++ b/test/lit_tests/raising/affinecfg_if_pure_symbol.mlir
@@ -1,0 +1,52 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access)" | FileCheck %s
+
+module {
+  func.func @if_pure_symbol(%ptr: !llvm.ptr, %n: i32, %c: i1, %c2: i1) -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %m = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr) -> memref<?xi32>
+    %outer = scf.if %c2 -> (i32) {
+      %if = scf.if %c -> (i32) {
+        scf.yield %c0_i32 : i32
+      } else {
+        %sq = arith.muli %n, %n : i32
+        scf.yield %sq : i32
+      }
+      %ni = arith.index_cast %n : i32 to index
+      %ifi = arith.index_cast %if : i32 to index
+      %idx = arith.subi %ni, %ifi : index
+      %l = memref.load %m[%idx] : memref<?xi32>
+      scf.yield %l : i32
+    } else {
+      scf.yield %c0_i32 : i32
+    }
+    return %outer : i32
+  }
+}
+
+// Companion to affinecfg_if_side_effect_symbol.mlir: with a read-only body the
+// conditional itself is hoistable, so fix() takes its usual path and clones the
+// whole scf.if to the top level of the affine scope rather than materializing a
+// select.  Either way the load is raised.
+
+// CHECK:         #map = affine_map<()[s0, s1] -> (s0 - s1)>
+// CHECK-LABEL:   func.func @if_pure_symbol(
+// CHECK-SAME:                              %[[PTR:.+]]: !llvm.ptr, %[[N:.+]]: i32, %[[C:.+]]: i1, %[[C2:.+]]: i1) -> i32 {
+// CHECK:           %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK:           %[[NI:.+]] = arith.index_cast %[[N]] : i32 to index
+// CHECK:           %[[IF:.+]] = scf.if %[[C]] -> (i32) {
+// CHECK:             scf.yield %[[C0_I32]] : i32
+// CHECK:           } else {
+// CHECK:             %[[SQ:.+]] = arith.muli %[[N]], %[[N]] : i32
+// CHECK:             scf.yield %[[SQ]] : i32
+// CHECK:           }
+// CHECK:           %[[IFI:.+]] = arith.index_cast %[[IF]] : i32 to index
+// CHECK:           %[[MEM:.+]] = "enzymexla.pointer2memref"(%[[PTR]]) : (!llvm.ptr) -> memref<?xi32>
+// CHECK:           %[[OUTER:.+]] = scf.if %[[C2]] -> (i32) {
+// CHECK:             %[[APP:.+]] = affine.apply #map(){{\[}}%[[NI]], %[[IFI]]]
+// CHECK:             %[[LOAD:.+]] = memref.load %[[MEM]]{{\[}}%[[APP]]] : memref<?xi32>
+// CHECK:             scf.yield %[[LOAD]] : i32
+// CHECK:           } else {
+// CHECK:             scf.yield %[[C0_I32]] : i32
+// CHECK:           }
+// CHECK:           return %[[OUTER]] : i32
+// CHECK:         }

--- a/test/lit_tests/raising/affinecfg_if_side_effect_symbol.mlir
+++ b/test/lit_tests/raising/affinecfg_if_side_effect_symbol.mlir
@@ -1,0 +1,60 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access)" | FileCheck %s
+
+module {
+  func.func @if_side_effect_symbol(%ptr: !llvm.ptr, %n: i32, %c: i1, %c2: i1) -> i32 {
+    %c0_i32 = arith.constant 0 : i32
+    %m = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr) -> memref<?xi32>
+    %outer = scf.if %c2 -> (i32) {
+      %if = scf.if %c -> (i32) {
+        scf.yield %c0_i32 : i32
+      } else {
+        %sq = arith.muli %n, %n : i32
+        %si = arith.index_cast %sq : i32 to index
+        memref.store %sq, %m[%si] : memref<?xi32>
+        scf.yield %sq : i32
+      }
+      %ni = arith.index_cast %n : i32 to index
+      %ifi = arith.index_cast %if : i32 to index
+      %idx = arith.subi %ni, %ifi : index
+      %l = memref.load %m[%idx] : memref<?xi32>
+      scf.yield %l : i32
+    } else {
+      scf.yield %c0_i32 : i32
+    }
+    return %outer : i32
+  }
+}
+
+// The inner scf.if yields valid symbols, so its result is one -- but the else
+// region stores to memory, so AffineApplyNormalizer::fix cannot hoist the
+// conditional itself out of the control flow guarding it.  It rewrites the
+// value instead, as select(%c, 0, %n * %n), and the stores stay put.  Cloning
+// the conditional wholesale was the only strategy fix() had, so it returned
+// null and the caller's llvm_unreachable -- UB under NDEBUG -- fell through
+// into renumberOneSymbol with a null Value and segfaulted.
+
+// CHECK:         #map = affine_map<()[s0, s1] -> (s0 - s1)>
+// CHECK-LABEL:   func.func @if_side_effect_symbol(
+// CHECK-SAME:                                     %[[PTR:.+]]: !llvm.ptr, %[[N:.+]]: i32, %[[C:.+]]: i1, %[[C2:.+]]: i1) -> i32 {
+// CHECK:           %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK:           %[[NI:.+]] = arith.index_cast %[[N]] : i32 to index
+// CHECK:           %[[SQ:.+]] = arith.muli %[[N]], %[[N]] : i32
+// CHECK:           %[[SEL:.+]] = arith.select %[[C]], %[[C0_I32]], %[[SQ]] : i32
+// CHECK:           %[[SELI:.+]] = arith.index_cast %[[SEL]] : i32 to index
+// CHECK:           %[[MEM:.+]] = "enzymexla.pointer2memref"(%[[PTR]]) : (!llvm.ptr) -> memref<?xi32>
+// CHECK:           %[[OUTER:.+]] = scf.if %[[C2]] -> (i32) {
+// CHECK:             %{{.+}} = scf.if %[[C]] -> (i32) {
+// CHECK:               scf.yield %[[C0_I32]] : i32
+// CHECK:             } else {
+// CHECK:               %[[SI:.+]] = arith.index_cast %[[SQ]] : i32 to index
+// CHECK:               memref.store %[[SQ]], %[[MEM]]{{\[}}%[[SI]]] : memref<?xi32>
+// CHECK:               scf.yield %[[SQ]] : i32
+// CHECK:             }
+// CHECK:             %[[APP:.+]] = affine.apply #map(){{\[}}%[[NI]], %[[SELI]]]
+// CHECK:             %[[LOAD:.+]] = memref.load %[[MEM]]{{\[}}%[[APP]]] : memref<?xi32>
+// CHECK:             scf.yield %[[LOAD]] : i32
+// CHECK:           } else {
+// CHECK:             scf.yield %[[C0_I32]] : i32
+// CHECK:           }
+// CHECK:           return %[[OUTER]] : i32
+// CHECK:         }


### PR DESCRIPTION
Fixes #2716.

`isValidSymbolInt` is a "could this become a symbol, after hoisting **or rewriting**" predicate, and it accepts an `scf.if` whose regions yield valid symbols. `AffineApplyNormalizer::fix` only implemented the hoisting half — its single strategy is to clone the defining op above the affine scope — so it bailed at its `isReadOnly()` guard on this LULESH conditional:

```mlir
%37 = scf.if %36 -> (i32) {
  scf.yield %c0_i32 : i32
} else {
  %90 = arith.muli %arg1, %arg1 : i32
  ...
  scf.for %arg2 = %c1_i64 to %95 step %c1_i64 : i64 {
    memref.store %97, %98[%100] : memref<?xi32>
    ...
  }
  scf.yield %90 : i32
}
```

The caller routes that null through `llvm_unreachable("cannot move")` — `__builtin_unreachable()` under `-DNDEBUG` — so execution fell through into `renumberOne{Dim,Symbol}` with a null `Value`:

```
isValidSymbolInt(mlir::Value, bool, mlir::Region*)          <-- SIGSEGV, %rdi = 0
AffineApplyNormalizer::AffineApplyNormalizer(...)
fully2ComposeAffineMapAndOperands(...)
MemrefLoadAffineApply::matchAndRewrite(mlir::memref::LoadOp, ...)
mlir::convertLLVMToAffineAccess(...)
```

## The fix

The conditional cannot move, but its value can: whatever else the regions do, the result is the then/else pair selected by the condition. `fix()` now rewrites to just that when the op itself is unhoistable, legalizing only the condition and the two yielded values through the existing machinery and leaving the side effects where they are.

- **`scf.if`** becomes an `arith.select`.
- **`affine.if`** is conditioned on an integer set rather than an i1 value, so it gets a bodiless `affine.if` over the same set, yielding the two hoisted arms. That is legal at the new location because `isValidDim` accepts valid symbols (`AffineOps.cpp:320`), so the legalized set operands stay legal.

So the load is **raised**, not merely left alone:

```mlir
%sq  = arith.muli %n, %n : i32
%sel = arith.select %c, %c0_i32, %sq : i32
%i   = arith.index_cast %sel : i32 to index
...
%app = affine.apply #map()[%ni, %i]
%l   = memref.load %mem[%app] : memref<?xi32>
```

with the storing `scf.if` untouched.

Two details this needs:

- **Speculation.** Evaluating both arms unconditionally means anything hoisted out of a region has to be speculatable; `speculatableOutOf` checks that transitively, and values already defined outside the conditional are free.
- **Use repointing.** Uses of the result are redirected to the select, the way the clone path does through `replaceOp`. Without it an op cloned above the conditional keeps referring to a result defined inside it and trips the dominance verifier — which is what my first attempt at this did on the LULESH module.

Also replaces the `llvm_unreachable` on the `fix()`-failed path with a `report_fatal_error` naming the operand and function, so a remaining gap between what the patterns accept and what `fix()` can legalize aborts diagnosably rather than corrupting state.

## Tests

- `test/lit_tests/raising/affinecfg_if_side_effect_symbol.mlir` — side-effecting body, exercising the new select path. Segfaults `enzymexlamlir-opt` at `8b2b29601` (exit 139); passes here. The `if` has to be nested inside another region, otherwise it is trivially a top-level value and the recursive analysis never runs.
- `test/lit_tests/raising/affinecfg_affine_if_side_effect_symbol.mlir` — the `affine.if` counterpart, exercising the bodiless-`affine.if` rewrite.
- `test/lit_tests/raising/affinecfg_if_pure_symbol.mlir` — read-only body still takes the clone path, with the whole `scf.if` hoisted.

## Verification

- Full `//test/lit_tests:all` → 1088/1091. The three failures (`raising_affine_to_stablehlo_ab_tend`, `communication_dusN`, `communication_dusS`) are unrelated: the first reproduces on unmodified `main`, the latter two are untracked local WIP files exercising `--optimize-communication`.
- The LULESH reproducer from #2716 → clean 3/3 (was 5/5 segfault), and the surrounding pipeline segment runs to completion.
- Previously this segfaulted inside `reactant-clang` and broke the LULESH job in EnzymeAD/Reactant#56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
