### PR TITLE
[Polymer] Bound the scf.if ancestor check to the scop in IslScopBuilder

### DIFF
--- a/src/enzyme_ad/jax/polymer/mlir/lib/Conversion/Polymer/Support/IslScop.cc
+++ b/src/enzyme_ad/jax/polymer/mlir/lib/Conversion/Polymer/Support/IslScop.cc
@@ -1845,9 +1845,13 @@ IslScopBuilder::build(Operation *f, bool allowScfIfConditionalWritesAsMay) {
 
   if (allowScfIfConditionalWritesAsMay) {
     // The enclosing scf.if statement models effects for its nested ops.
-    // Drop nested statements here to avoid double-counting accesses.
+    // Drop nested statements here to avoid double-counting accesses. Only an
+    // scf.if inside the scop has a statement of its own to do that modelling:
+    // one enclosing the whole scop is not part of it, and treating it as the
+    // modelling statement would drop every statement we just gathered.
     llvm::erase_if(scop->stmts, [&](ScopStmt &stmt) {
-      return stmt.getOperation()->getParentOfType<scf::IfOp>() != nullptr;
+      auto ifOp = stmt.getOperation()->getParentOfType<scf::IfOp>();
+      return ifOp && f->isProperAncestor(ifOp);
     });
   }
 

--- a/test/lit_tests/remove_atomic_rmw.mlir
+++ b/test/lit_tests/remove_atomic_rmw.mlir
@@ -1110,3 +1110,39 @@ module {
     return
   }
 }
+
+// -----
+
+// An scf.if enclosing the whole gpu_wrapper is outside the scop and has no
+// statement of its own to model nested effects, so it must not drop the
+// statements gathered inside the wrapper. Dropping them left the stale
+// polymer.stmt.name attributes behind and crashed schedule construction with
+// "stmt not found".
+
+#map = affine_map<(d0) -> (d0)>
+module {
+// CHECK-LABEL:   func.func @gpu_wrapper_enclosed_by_scf_if(
+// CHECK:           scf.if
+// CHECK:             scf.for
+// CHECK:               affine.parallel (%[[I:.*]]) = (0) to (4) {
+// CHECK:                 %[[OLD:.*]] = affine.load %[[ARR:.*]]{{\[}}%[[I]]] : memref<?xf32>
+// CHECK:                 %[[NEW:.*]] = arith.addf %[[OLD]], %[[V:.*]] : f32
+// CHECK:                 affine.store %[[NEW]], %[[ARR]]{{\[}}%[[I]]] : memref<?xf32>
+// CHECK-NOT:       enzyme.affine_atomic_rmw
+  func.func @gpu_wrapper_enclosed_by_scf_if(%pred: i1, %v: f32, %arr: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    scf.if %pred {
+      scf.for %t = %c0 to %c4 step %c1 {
+        %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+          affine.parallel (%i) = (0) to (4) {
+            %r = enzyme.affine_atomic_rmw addf %v, %arr, (#map) [%i] : (f32, memref<?xf32>) -> f32
+          }
+          "enzymexla.polygeist_yield"() : () -> ()
+        }) : (index, index, index, index, index, index) -> index
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
Fixes #2724.

`--remove-atomics` crashed with `stmt not found` / `UNREACHABLE executed at IslScop.cc:347` on the LBM kernel from the issue.

### Root cause

`IslScopBuilder::build`, under `allowScfIfConditionalWritesAsMay` (which `--remove-atomics` passes as `true`), drops statements nested in an `scf.if` — the `scf.if` has a `ScopStmt` of its own that models their effects, and counting both would double-count the accesses:

```cpp
llvm::erase_if(scop->stmts, [&](ScopStmt &stmt) {
  return stmt.getOperation()->getParentOfType<scf::IfOp>() != nullptr;
});
```

`getParentOfType<scf::IfOp>()` walks ancestors **without stopping at the scop root**. In the reported module the scop root — the `enzymexla.gpu_wrapper` — is itself nested:

```
func.func -> scf.if -> scf.for -> enzymexla.gpu_wrapper   <- scop root
```

so every statement reported an `scf.if` ancestor: the one wrapping the entire kernel, which is outside the scop and has no `ScopStmt`. `gatherStmts` built 454 statements and `erase_if` deleted all 454.

The crash is the downstream symptom. `ScopStmt`s constructor stamps `polymer.stmt.name` onto its op, and erasing from the `stmts` vector does not remove that attribute. `buildSequenceSchedule` dispatches on exactly that attribute, so it called `buildLeafSchedule` on an op whose statement no longer existed, and `getIslStmt` hit the `llvm_unreachable`.

### Fix

Bound the ancestor search to the scop, so an `scf.if` only suppresses nested statements when it is itself inside the scop.

On the reported kernel the scop goes from 0 statements back to 64 (the genuinely `scf.if`-nested ones are still dropped, as intended), so the dependence analysis runs on real data instead of crashing, and all 38 `atomic_rmw`s are removed.

### Test

New case in `test/lit_tests/remove_atomic_rmw.mlir` — a `gpu_wrapper` inside `scf.for` inside `scf.if`, mirroring the nesting from the issue. Verified it is a real regression test: with the fix reverted it fails with exactly `stmt not found` / `UNREACHABLE ... IslScop.cc:347`. It also asserts the atomic is still removed, so it would catch a "fix" that dodged the crash by leaving the scop empty.

Full `bazel test -c dbg //test/lit_tests/...` shows no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)