### PR TITLE
Make IR emission order independent of C++ argument evaluation order

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -428,14 +428,13 @@ public:
     Value c0 = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
     Value c1 = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1);
     SmallVector<Value> idxs;
+    Value lenIdx = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getIndexType(), op.getLen());
+    Value widthCst =
+        arith::ConstantIndexOp::create(rewriter, op.getLoc(), width);
     auto forOp = scf::ForOp::create(
         rewriter, op.getLoc(), c0,
-        arith::DivUIOp::create(
-            rewriter, op.getLoc(),
-            arith::IndexCastOp::create(rewriter, op.getLoc(),
-                                       rewriter.getIndexType(), op.getLen()),
-            arith::ConstantIndexOp::create(rewriter, op.getLoc(), width)),
-        c1);
+        arith::DivUIOp::create(rewriter, op.getLoc(), lenIdx, widthCst), c1);
 
     rewriter.setInsertionPointToStart(&forOp.getRegion().getBlocks().front());
     idxs.push_back(forOp.getInductionVar());
@@ -532,14 +531,13 @@ public:
     Value val = cast<mlir::enzyme::AutoDiffTypeInterface>(elTy).createNullValue(
         rewriter, op.getLoc());
 
+    Value lenIdx = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getIndexType(), op.getLen());
+    Value widthCst =
+        arith::ConstantIndexOp::create(rewriter, op.getLoc(), width);
     auto forOp = scf::ForOp::create(
         rewriter, op.getLoc(), c0,
-        arith::DivUIOp::create(
-            rewriter, op.getLoc(),
-            arith::IndexCastOp::create(rewriter, op.getLoc(),
-                                       rewriter.getIndexType(), op.getLen()),
-            arith::ConstantIndexOp::create(rewriter, op.getLoc(), width)),
-        c1);
+        arith::DivUIOp::create(rewriter, op.getLoc(), lenIdx, widthCst), c1);
 
     rewriter.setInsertionPointToStart(&forOp.getRegion().getBlocks().front());
     idxs.push_back(forOp.getInductionVar());

--- a/src/enzyme_ad/jax/Implementations/SHLOGenericBatchOpInterface.h
+++ b/src/enzyme_ad/jax/Implementations/SHLOGenericBatchOpInterface.h
@@ -213,12 +213,13 @@ inline LogicalResult genericCreateBatch(Operation *src, OpBuilder &builder,
 
     for (int d = 0; d < ndims; ++d) {
       // auto idx = (i / batchStrides[d]) % batchSizes[d];
-      auto idx = RemOp::create(
-          bodyBuilder, src->getLoc(),
-          DivOp::create(bodyBuilder, src->getLoc(), whileBody->getArgument(0),
-                        details::makeI64Constant(src->getLoc(), bodyBuilder,
-                                                 batchStrides[d])),
-          details::makeI64Constant(src->getLoc(), bodyBuilder, batchSizes[d]));
+      Value stride =
+          details::makeI64Constant(src->getLoc(), bodyBuilder, batchStrides[d]);
+      Value quotient = DivOp::create(bodyBuilder, src->getLoc(),
+                                     whileBody->getArgument(0), stride);
+      Value size =
+          details::makeI64Constant(src->getLoc(), bodyBuilder, batchSizes[d]);
+      auto idx = RemOp::create(bodyBuilder, src->getLoc(), quotient, size);
 
       startIndices.push_back(idx);
     }

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -641,16 +641,18 @@ class AutoDiffWhileRev
   static stablehlo::WhileOp makeForLoop(OpBuilder &builder, Location loc,
                                         int64_t start, int64_t limit,
                                         int64_t step, ValueRange operands) {
-    return makeForLoop(builder, loc, makeI64Constant(loc, builder, start),
-                       makeI64Constant(loc, builder, limit),
-                       makeI64Constant(loc, builder, step), operands);
+    Value startVal = makeI64Constant(loc, builder, start);
+    Value limitVal = makeI64Constant(loc, builder, limit);
+    Value stepVal = makeI64Constant(loc, builder, step);
+    return makeForLoop(builder, loc, startVal, limitVal, stepVal, operands);
   }
 
   static stablehlo::WhileOp makeForLoop(OpBuilder &builder, Location loc,
                                         int64_t start, Value limit,
                                         int64_t step, ValueRange operands) {
-    return makeForLoop(builder, loc, makeI64Constant(loc, builder, start),
-                       limit, makeI64Constant(loc, builder, step), operands);
+    Value startVal = makeI64Constant(loc, builder, start);
+    Value stepVal = makeI64Constant(loc, builder, step);
+    return makeForLoop(builder, loc, startVal, limit, stepVal, operands);
   }
 
   static stablehlo::WhileOp makeForLoop(OpBuilder &builder, Location loc,
@@ -1220,15 +1222,14 @@ class AutoDiffWhileRev
 
     Value currentStep =
         stablehlo::AddOp::create(builder, orig.getLoc(), outerStart, innerIV);
+    Value constantStart = makeI64Constant(
+        orig.getLoc(), builder, revInfo.info.getConstantStart().value());
+    Value constantStep = makeI64Constant(
+        orig.getLoc(), builder, revInfo.info.getConstantStep().value());
     Value currentIV = stablehlo::AddOp::create(
-        builder, orig.getLoc(),
-        makeI64Constant(orig.getLoc(), builder,
-                        revInfo.info.getConstantStart().value()),
-        stablehlo::MulOp::create(
-            builder, orig.getLoc(),
-            makeI64Constant(orig.getLoc(), builder,
-                            revInfo.info.getConstantStep().value()),
-            currentStep));
+        builder, orig.getLoc(), constantStart,
+        stablehlo::MulOp::create(builder, orig.getLoc(), constantStep,
+                                 currentStep));
 
     Block *origBody = &orig.getBody().front();
     for (auto &&[origarg, revinnerarg] : llvm::zip_equal(

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2816,20 +2816,20 @@ struct ForOpRaising : public OpRewritePattern<scf::ForOp> {
       if (!loop.getStep().getDefiningOp<ConstantIndexOp>()) {
         if (ubs.size() != 1 || lbs.size() != 1)
           return failure();
-        ubs[0] = DivUIOp::create(
-            rewriter, loop.getLoc(),
-            AddIOp::create(
-                rewriter, loop.getLoc(),
-                SubIOp::create(
-                    rewriter, loop.getLoc(), loop.getStep(),
-                    isa<IndexType>(loop.getStep().getType())
+        Value one = isa<IndexType>(loop.getStep().getType())
                         ? ConstantIndexOp::create(rewriter, loop.getLoc(), 1)
                               .getResult()
                         : ConstantIntOp::create(rewriter, loop.getLoc(),
-                                                loop.getStep().getType(), 1))
-                    .getResult(),
-                SubIOp::create(rewriter, loop.getLoc(), loop.getUpperBound(),
-                               loop.getLowerBound())),
+                                                loop.getStep().getType(), 1);
+        Value stepMinusOne =
+            SubIOp::create(rewriter, loop.getLoc(), loop.getStep(), one)
+                .getResult();
+        Value range =
+            SubIOp::create(rewriter, loop.getLoc(), loop.getUpperBound(),
+                           loop.getLowerBound());
+        ubs[0] = DivUIOp::create(
+            rewriter, loop.getLoc(),
+            AddIOp::create(rewriter, loop.getLoc(), stepMinusOne, range),
             loop.getStep());
         lbs[0] = ConstantIndexOp::create(rewriter, loop.getLoc(), 0);
         rewrittenStep = true;

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -700,14 +700,16 @@ expandAffineExpr(OpBuilder &builder, Location loc, AffineExpr expr,
             makeI64Constant(cast<ShapedType>(lhs.getType()), 0),
             stablehlo::ComparisonDirection::LE);
         Value one = makeI64Constant(cast<ShapedType>(lhs.getType()), 1);
-        Value absolute = stablehlo::SelectOp::create(
-            builder, loc, negative, stablehlo::NegOp::create(builder, loc, lhs),
-            stablehlo::AddOp::create(builder, loc, lhs, one));
+        Value negLhs = stablehlo::NegOp::create(builder, loc, lhs);
+        Value lhsPlusOne = stablehlo::AddOp::create(builder, loc, lhs, one);
+        Value absolute = stablehlo::SelectOp::create(builder, loc, negative,
+                                                     negLhs, lhsPlusOne);
         Value quotient = stablehlo::DivOp::create(builder, loc, absolute, rhs);
-        result = stablehlo::SelectOp::create(
-            builder, loc, negative,
-            stablehlo::NegOp::create(builder, loc, quotient),
-            stablehlo::AddOp::create(builder, loc, quotient, one));
+        Value negQuotient = stablehlo::NegOp::create(builder, loc, quotient);
+        Value quotientPlusOne =
+            stablehlo::AddOp::create(builder, loc, quotient, one);
+        result = stablehlo::SelectOp::create(builder, loc, negative,
+                                             negQuotient, quotientPlusOne);
       };
       break;
     default:

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8179,23 +8179,23 @@ struct NoNanZeroBasePowSimplify final
       // 0 ^ x => x == 0 ? 1 : (x > 0 ? 0 : Inf)
       auto zero = stablehlo::ConstantOp::create(
           rewriter, op.getLoc(), rewriter.getZeroAttr(op.getType()));
-      auto nonZeroCase = stablehlo::SelectOp::create(
-          rewriter, op.getLoc(),
+      auto rhsPositive =
           stablehlo::CompareOp::create(rewriter, op.getLoc(), op.getRhs(), zero,
-                                       stablehlo::ComparisonDirection::GT),
-          zero,
-          stablehlo::ConstantOp::create(
-              rewriter, op.getLoc(), op.getType(),
-              cast<ElementsAttr>(makeAttr(
-                  op.getType(), std::numeric_limits<float>::infinity()))));
-      rewriter.replaceOpWithNewOp<stablehlo::SelectOp>(
-          op,
+                                       stablehlo::ComparisonDirection::GT);
+      auto inf = stablehlo::ConstantOp::create(
+          rewriter, op.getLoc(), op.getType(),
+          cast<ElementsAttr>(
+              makeAttr(op.getType(), std::numeric_limits<float>::infinity())));
+      auto nonZeroCase = stablehlo::SelectOp::create(rewriter, op.getLoc(),
+                                                     rhsPositive, zero, inf);
+      auto rhsIsZero =
           stablehlo::CompareOp::create(rewriter, op.getLoc(), op.getRhs(), zero,
-                                       stablehlo::ComparisonDirection::EQ),
-          stablehlo::ConstantOp::create(
-              rewriter, op.getLoc(), op.getType(),
-              cast<ElementsAttr>(makeAttr(op.getType(), 1))),
-          nonZeroCase);
+                                       stablehlo::ComparisonDirection::EQ);
+      auto one = stablehlo::ConstantOp::create(
+          rewriter, op.getLoc(), op.getType(),
+          cast<ElementsAttr>(makeAttr(op.getType(), 1)));
+      rewriter.replaceOpWithNewOp<stablehlo::SelectOp>(op, rhsIsZero, one,
+                                                       nonZeroCase);
       return success();
     }
 
@@ -13490,14 +13490,14 @@ struct DivideDivideSimplify
           return failure();
 
         // Case III.
-        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
-            op,
-            stablehlo::MulOp::create(rewriter, op.getLoc(),
-                                     lhsDivOp->getOperand(0),
-                                     rhsDivOp->getOperand(1)),
-            stablehlo::MulOp::create(rewriter, op.getLoc(),
-                                     lhsDivOp->getOperand(1),
-                                     rhsDivOp->getOperand(0)));
+        auto numerator = stablehlo::MulOp::create(rewriter, op.getLoc(),
+                                                  lhsDivOp->getOperand(0),
+                                                  rhsDivOp->getOperand(1));
+        auto denominator = stablehlo::MulOp::create(rewriter, op.getLoc(),
+                                                    lhsDivOp->getOperand(1),
+                                                    rhsDivOp->getOperand(0));
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(op, numerator,
+                                                      denominator);
         return success();
       } else {
         // Case II.
@@ -27813,12 +27813,11 @@ struct LogSimplify final
         // is NaN while log(a*a) is finite. Gating on the analysis avoids an abs
         // (possibly slower than the mul). See #2570.
         if (lhs == rhs && guaranteedNonNegativeResult(lhs, rewriter)) {
-          rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
-              op,
-              stablehlo::ConstantOp::create(
-                  rewriter, op.getLoc(), lhs.getType(),
-                  cast<ElementsAttr>(makeAttr(lhs.getType(), 2))),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), lhs));
+          auto two = stablehlo::ConstantOp::create(
+              rewriter, op.getLoc(), lhs.getType(),
+              cast<ElementsAttr>(makeAttr(lhs.getType(), 2)));
+          auto logLhs = stablehlo::LogOp::create(rewriter, op.getLoc(), lhs);
+          rewriter.replaceOpWithNewOp<stablehlo::MulOp>(op, two, logLhs);
           return success();
         }
 
@@ -27830,9 +27829,9 @@ struct LogSimplify final
           // #2570.
           Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
           if (isPositiveFiniteConstant(cst, /*allowZero=*/false)) {
-            rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
-                op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
-                stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
+            auto logLhs = stablehlo::LogOp::create(rewriter, op.getLoc(), lhs);
+            auto logRhs = stablehlo::LogOp::create(rewriter, op.getLoc(), rhs);
+            rewriter.replaceOpWithNewOp<stablehlo::AddOp>(op, logLhs, logRhs);
             return success();
           }
         }
@@ -27845,14 +27844,13 @@ struct LogSimplify final
         auto lhs = defOp.getLhs();
         auto rhs = defOp.getRhs();
         if (lhs == rhs) { // log(add(a, a)) -> log(2) + log(a)
-          rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
-              op,
-              stablehlo::LogOp::create(
-                  rewriter, op.getLoc(),
-                  stablehlo::ConstantOp::create(
-                      rewriter, op.getLoc(), lhs.getType(),
-                      cast<ElementsAttr>(makeAttr(lhs.getType(), 2)))),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), lhs));
+          auto logTwo = stablehlo::LogOp::create(
+              rewriter, op.getLoc(),
+              stablehlo::ConstantOp::create(
+                  rewriter, op.getLoc(), lhs.getType(),
+                  cast<ElementsAttr>(makeAttr(lhs.getType(), 2))));
+          auto logLhs = stablehlo::LogOp::create(rewriter, op.getLoc(), lhs);
+          rewriter.replaceOpWithNewOp<stablehlo::AddOp>(op, logTwo, logLhs);
           return success();
         }
 
@@ -27890,9 +27888,10 @@ struct LogSimplify final
           bool constantIsLhs = matchPattern(lhs, m_Constant());
           Value cst = constantIsLhs ? lhs : rhs;
           if (isPositiveFiniteConstant(cst, /*allowZero=*/!constantIsLhs)) {
-            rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
-                op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
-                stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
+            auto logLhs = stablehlo::LogOp::create(rewriter, op.getLoc(), lhs);
+            auto logRhs = stablehlo::LogOp::create(rewriter, op.getLoc(), rhs);
+            rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(op, logLhs,
+                                                               logRhs);
             return success();
           }
         }
@@ -27903,12 +27902,12 @@ struct LogSimplify final
       auto defOp = op.getOperand().getDefiningOp<stablehlo::SqrtOp>();
       if (defOp &&
           isOnlyUsedInOperation(defOp, op)) { // log(sqrt(x)) -> log(x) / 2
-        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
-            op,
-            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand()),
-            stablehlo::ConstantOp::create(
-                rewriter, op.getLoc(), defOp.getType(),
-                cast<ElementsAttr>(makeAttr(defOp.getType(), 2))));
+        auto logOperand =
+            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand());
+        auto two = stablehlo::ConstantOp::create(
+            rewriter, op.getLoc(), defOp.getType(),
+            cast<ElementsAttr>(makeAttr(defOp.getType(), 2)));
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(op, logOperand, two);
         return success();
       }
     }
@@ -27917,12 +27916,12 @@ struct LogSimplify final
       auto defOp = op.getOperand().getDefiningOp<stablehlo::CbrtOp>();
       if (defOp &&
           isOnlyUsedInOperation(defOp, op)) { // log(cbrt(x)) -> log(x) / 3
-        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
-            op,
-            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand()),
-            stablehlo::ConstantOp::create(
-                rewriter, op.getLoc(), defOp.getType(),
-                cast<ElementsAttr>(makeAttr(defOp.getType(), 3))));
+        auto logOperand =
+            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand());
+        auto three = stablehlo::ConstantOp::create(
+            rewriter, op.getLoc(), defOp.getType(),
+            cast<ElementsAttr>(makeAttr(defOp.getType(), 3)));
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(op, logOperand, three);
         return success();
       }
     }
@@ -27931,12 +27930,12 @@ struct LogSimplify final
       auto defOp = op.getOperand().getDefiningOp<stablehlo::RsqrtOp>();
       if (defOp &&
           isOnlyUsedInOperation(defOp, op)) { // log(rsqrt(x)) -> -log(x) / 2
-        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
-            op,
-            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand()),
-            stablehlo::ConstantOp::create(
-                rewriter, op.getLoc(), defOp.getType(),
-                cast<ElementsAttr>(makeAttr(defOp.getType(), -2))));
+        auto logOperand =
+            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand());
+        auto negTwo = stablehlo::ConstantOp::create(
+            rewriter, op.getLoc(), defOp.getType(),
+            cast<ElementsAttr>(makeAttr(defOp.getType(), -2)));
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(op, logOperand, negTwo);
         return success();
       }
     }
@@ -30500,15 +30499,14 @@ struct DUSToDynamicPad
     for (auto [i, index] : llvm::enumerate(indices)) {
       auto cType = RankedTensorType::get(
           {}, cast<RankedTensorType>(index.getType()).getElementType());
+      auto lowerBound = stablehlo::ConstantOp::create(
+          rewriter, op.getLoc(), cType, cast<ElementsAttr>(makeAttr(cType, 0)));
+      auto upperBound = stablehlo::ConstantOp::create(
+          rewriter, op.getLoc(), cType,
+          cast<ElementsAttr>(
+              makeAttr(cType, operandShape[i] - updateShape[i])));
       auto clampedIndex = stablehlo::ClampOp::create(
-          rewriter, op.getLoc(),
-          stablehlo::ConstantOp::create(rewriter, op.getLoc(), cType,
-                                        cast<ElementsAttr>(makeAttr(cType, 0))),
-          index,
-          stablehlo::ConstantOp::create(
-              rewriter, op.getLoc(), cType,
-              cast<ElementsAttr>(
-                  makeAttr(cType, operandShape[i] - updateShape[i]))));
+          rewriter, op.getLoc(), lowerBound, index, upperBound);
 
       auto reshapedIndex = stablehlo::ReshapeOpCreate(
           rewriter, op.getLoc(), clampedIndex, ArrayRef<int64_t>{1});
@@ -31218,8 +31216,9 @@ struct BinaryNegatedOperandsSimplify
     if (lhsInfo.kind == NegKind::SUB && rhsInfo.kind == NegKind::SUB)
       return failure();
 
-    rewriter.replaceOpWithNewOp<OpTy>(op, negateOperand(lhsInfo, rewriter),
-                                      negateOperand(rhsInfo, rewriter));
+    Value negatedLhs = negateOperand(lhsInfo, rewriter);
+    Value negatedRhs = negateOperand(rhsInfo, rewriter);
+    rewriter.replaceOpWithNewOp<OpTy>(op, negatedLhs, negatedRhs);
     return success();
   }
 
@@ -31533,17 +31532,18 @@ struct DotGeneralToSyrk
         cast<RankedTensorType>(syrkInput.getType()).getElementType();
     auto alphaType = RankedTensorType::get({}, elemType);
 
+    auto cMatrix = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), op.getType(),
+        cast<ElementsAttr>(makeAttr(op.getType(), 0)));
+    auto alpha = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), alphaType,
+        cast<ElementsAttr>(makeAttr(alphaType, 1)));
+    auto beta = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), alphaType,
+        cast<ElementsAttr>(makeAttr(alphaType, 0)));
     auto syrkOp = enzymexla::SyrkOp::create(
-        rewriter, op.getLoc(), op.getResult().getType(), syrkInput,
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), op.getType(),
-            cast<ElementsAttr>(makeAttr(op.getType(), 0))),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), alphaType,
-            cast<ElementsAttr>(makeAttr(alphaType, 1))),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), alphaType,
-            cast<ElementsAttr>(makeAttr(alphaType, 0))),
+        rewriter, op.getLoc(), op.getResult().getType(), syrkInput, cMatrix,
+        alpha, beta,
         enzymexla::LapackUploAttr::get(op.getContext(),
                                        enzymexla::LapackUplo::F),
         enzymexla::LapackUploAttr::get(op.getContext(),
@@ -31620,19 +31620,20 @@ struct DotGeneralToSymm
     auto elemType = cast<RankedTensorType>(lhs.getType()).getElementType();
     auto alphaType = RankedTensorType::get({}, elemType);
 
+    auto cMatrix = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), op.getType(),
+        cast<ElementsAttr>(makeAttr(op.getType(), 0)));
+    auto alpha = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), alphaType,
+        cast<ElementsAttr>(makeAttr(alphaType, 1)));
+    auto beta = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), alphaType,
+        cast<ElementsAttr>(makeAttr(alphaType, 0)));
     auto symmOp = enzymexla::SymmOp::create(
         rewriter, op.getLoc(), op.getResult().getType(),
         symmMatrix, // A (symmetric)
         genMatrix,  // B (general)
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), op.getType(),
-            cast<ElementsAttr>(makeAttr(op.getType(), 0))), // C
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), alphaType,
-            cast<ElementsAttr>(makeAttr(alphaType, 1))), // alpha
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), alphaType,
-            cast<ElementsAttr>(makeAttr(alphaType, 0))), // beta
+        cMatrix, alpha, beta,
         enzymexla::LapackSideAttr::get(op.getContext(), side),
         enzymexla::LapackUploAttr::get(op.getContext(),
                                        enzymexla::LapackUplo::F));

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALapack.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALapack.cpp
@@ -1294,12 +1294,12 @@ struct GemqrtOpLowering : public OpRewritePattern<enzymexla::GemqrtOp> {
 
 Value anyNonFiniteValue(PatternRewriter &rewriter, Location loc, Type outType,
                         Value input, int64_t inputRank) {
-  auto areFinite = stablehlo::AndOp::create(
-      rewriter, loc,
-      stablehlo::IsFiniteOp::create(
-          rewriter, loc, stablehlo::RealOp::create(rewriter, loc, input)),
-      stablehlo::IsFiniteOp::create(
-          rewriter, loc, stablehlo::ImagOp::create(rewriter, loc, input)));
+  auto realFinite = stablehlo::IsFiniteOp::create(
+      rewriter, loc, stablehlo::RealOp::create(rewriter, loc, input));
+  auto imagFinite = stablehlo::IsFiniteOp::create(
+      rewriter, loc, stablehlo::ImagOp::create(rewriter, loc, input));
+  auto areFinite =
+      stablehlo::AndOp::create(rewriter, loc, realFinite, imagFinite);
 
   SmallVector<int64_t> reductionDims;
   for (int i = inputRank - 2; i < inputRank; i++)
@@ -1901,21 +1901,21 @@ private:
 
     // LAPACK returns 1-indexed pivots, while XLA returns 0-indexed pivots.
     // We make it consistent with LAPACK by adding 1 to the pivots.
-    auto pivots1Indexed = stablehlo::AddOp::create(
-        rewriter, op.getLoc(),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), pivotType,
-            cast<ElementsAttr>(makeAttr(pivotType, 1))),
-        stablehlo::ConvertOp::create(rewriter, op.getLoc(), pivotType,
-                                     customCall.getResult(1)));
+    auto pivotOne = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), pivotType,
+        cast<ElementsAttr>(makeAttr(pivotType, 1)));
+    auto pivots = stablehlo::ConvertOp::create(rewriter, op.getLoc(), pivotType,
+                                               customCall.getResult(1));
+    auto pivots1Indexed =
+        stablehlo::AddOp::create(rewriter, op.getLoc(), pivotOne, pivots);
 
+    auto permutationOne = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), permutationType,
+        cast<ElementsAttr>(makeAttr(permutationType, 1)));
+    auto permutation = stablehlo::ConvertOp::create(
+        rewriter, op.getLoc(), permutationType, customCall.getResult(2));
     auto permutation1Indexed = stablehlo::AddOp::create(
-        rewriter, op.getLoc(),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), permutationType,
-            cast<ElementsAttr>(makeAttr(permutationType, 1))),
-        stablehlo::ConvertOp::create(rewriter, op.getLoc(), permutationType,
-                                     customCall.getResult(2)));
+        rewriter, op.getLoc(), permutationOne, permutation);
 
     auto info = anyNonFiniteValue(rewriter, op.getLoc(), infoType,
                                   customCall.getResult(0), inputRank);
@@ -2216,12 +2216,12 @@ LogicalResult lowerSVDAlgorithmCPU(OpTy op, PatternRewriter &rewriter,
         auto NVal = LLVM::LoadOp::create(
             rewriter, op.getLoc(), type_llvm_lapack_int, funcOp.getArgument(1));
 
-        auto const5minMN = LLVM::MulOp::create(
-            rewriter, op.getLoc(),
-            LLVM::ConstantOp::create(
-                rewriter, op.getLoc(), type_llvm_lapack_int,
-                rewriter.getIntegerAttr(type_llvm_lapack_int, 5)),
-            arith::MinSIOp::create(rewriter, op.getLoc(), MVal, NVal));
+        auto const5 = LLVM::ConstantOp::create(
+            rewriter, op.getLoc(), type_llvm_lapack_int,
+            rewriter.getIntegerAttr(type_llvm_lapack_int, 5));
+        auto minMN = arith::MinSIOp::create(rewriter, op.getLoc(), MVal, NVal);
+        auto const5minMN =
+            LLVM::MulOp::create(rewriter, op.getLoc(), const5, minMN);
 
         auto rworkptr =
             LLVM::AllocaOp::create(rewriter, op.getLoc(), type_llvm_ptr,

--- a/src/enzyme_ad/jax/Passes/RaiseTritonCustomCallPass.cpp
+++ b/src/enzyme_ad/jax/Passes/RaiseTritonCustomCallPass.cpp
@@ -87,15 +87,21 @@ replaceWithTritonCall(stablehlo::CustomCallOp callOp, PatternRewriter &rewriter,
                                         outerMod.getSymNameAttr(), nestedRefs);
 
   rewriter.setInsertionPoint(callOp);
+
+  Value gridxVal = TI64(rewriter, callOp->getLoc(), gridx);
+  Value gridyVal = TI64(rewriter, callOp->getLoc(), gridy);
+  Value gridzVal = TI64(rewriter, callOp->getLoc(), gridz);
+
+  Value blockxVal = TI64(rewriter, callOp->getLoc(), 1);
+  Value blockyVal = TI64(rewriter, callOp->getLoc(), 1);
+  Value blockzVal = TI64(rewriter, callOp->getLoc(), 1);
+
   rewriter.replaceOpWithNewOp<enzymexla::triton_ext::TritonCallOp>(
       callOp, callOp->getResultTypes(), fn,
 
-      TI64(rewriter, callOp->getLoc(), gridx),
-      TI64(rewriter, callOp->getLoc(), gridy),
-      TI64(rewriter, callOp->getLoc(), gridz),
+      gridxVal, gridyVal, gridzVal,
 
-      TI64(rewriter, callOp->getLoc(), 1), TI64(rewriter, callOp->getLoc(), 1),
-      TI64(rewriter, callOp->getLoc(), 1),
+      blockxVal, blockyVal, blockzVal,
 
       callOp.getInputs(),
       /* backendConfig */ StringAttr::get(callOp.getContext(), ""),


### PR DESCRIPTION
Several sites build two or more ops directly in the argument list of another op-creating call:

```cpp
Value cond = stablehlo::OrOp::create(
    rewriter, loc,
    stablehlo::CompareOp::create(rewriter, loc, n, one, LE),
    stablehlo::CompareOp::create(rewriter, loc, s, one, LE));
```

C++ leaves the evaluation order of function arguments unspecified, so *which compare is inserted into the block first* is the compiler's choice. The `or`'s operands are fixed, but the textual order of the two compares is not — the same source emits them one way on macOS and the other on Linux.

This is not hypothetical. It is exactly what fails in #2721: the new `binomial_progress` lit test was written against the macOS output and the Linux job reports

```
binomial_progress.mlir:87:16: error: CHECK-NEXT: expected string not found in input
// CHECK-NEXT: %[[NSM:.+]] = stablehlo.compare LE, %[[N]], %[[C1]]
```

because Linux emitted the two compares in the opposite order. Anything that pins emitted order — a `CHECK-NEXT` chain, a diff of dumped IR — is build-dependent wherever this pattern appears.

## Changes

Each op that shares an argument list with another op-creating call is bound to a local first, so the source fixes the insertion order. No semantic change: the same ops with the same operands are created, only the order is now pinned. 17 sites:

| File | Sites |
|---|---|
| `Passes/EnzymeHLOOpt.cpp` | 12 (`LogSimplify` x7, `NoNanZeroBasePowSimplify`, `DivideDivideSimplify`, `DUSToDynamicPad`, `BinaryNegatedOperandsSimplify`, `DotGeneralToSyrk`/`DotGeneralToSymm`) |
| `Passes/LowerEnzymeXLALapack.cpp` | 4 |
| `Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp` | 3 |
| `Dialect/Ops.cpp` | 2 |
| `Passes/AffineToStableHLORaising.cpp` | 2 |
| `Implementations/SHLOGenericBatchOpInterface.h` | 1 |
| `Passes/AffineCFG.cpp` | 1 |
| `Passes/RaiseTritonCustomCallPass.cpp` | 1 |

`Passes/LowerEnzymeXLAMath.cpp` has two more, fixed in a separate commit here so the tree is clean for the lint job in #2727. #2721 rewrites that function; whichever of the two lands second should take the other's version of those lines -- it is the same change.

Found by brace/paren-matching every call expression and flagging argument lists with two or more sibling op emitters, where an emitter is `X::create(...)` / `builder.create<...>(...)` / `rewriter.replaceOpWithNewOp<...>(...)` plus any local lambda or function whose body creates ops (`constOfType`, `makeI64Constant`, `TI64`, `negateOperand`, ...). After this change the scan is clean apart from vendored isl.

## Testing

None locally — I have no build of this tree, so CI is the verification here. Existing lit tests should be unaffected: they run on both macOS and Linux today and pass, so no CHECK line can currently depend on an order that already differs between those two platforms.

## Related, not fixed here

A second class of nondeterministic emission, worse in principle because pointer-keyed hash order can vary run to run rather than build to build: iterating a `DenseMap`/`DenseSet` keyed on an op or value and creating ops in the loop body. Five sites — `GPULaunchRecognition.cpp:434`, `LLVMToMemrefAccess.cpp:73`, `LowerTriton.cpp:85`, `PropagateConstantBound.cpp:153`, `polymer/.../IslScop.cc:1207`. Fixing those means picking a deterministic container or sort key, which deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
