### PR TITLE
Add a lint job for order-dependent IR emission

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - '.github/workflows/lint.yml'
+      - 'scripts/check_emission_order.py'
+      - 'src/**/*.cc'
+      - 'src/**/*.cpp'
+      - 'src/**/*.h'
+      - '!src/external'
+  pull_request:
+    paths:
+      - '.github/workflows/lint.yml'
+      - 'scripts/check_emission_order.py'
+      - 'src/**/*.cc'
+      - 'src/**/*.cpp'
+      - 'src/**/*.h'
+      - '!src/external'
+  merge_group:
+
+jobs:
+  emission-order:
+    name: Deterministic IR emission order
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Check for order-dependent IR emission
+      run: python3 scripts/check_emission_order.py --github src

--- a/scripts/check_emission_order.py
+++ b/scripts/check_emission_order.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Flag IR emission whose order depends on C++ argument evaluation order.
+
+Building an op directly inside the argument list of another op-creating call:
+
+    Value cond = stablehlo::OrOp::create(
+        rewriter, loc,
+        stablehlo::CompareOp::create(rewriter, loc, n, one, LE),
+        stablehlo::CompareOp::create(rewriter, loc, s, one, LE));
+
+is a hazard when *two or more* arguments do it. C++ leaves the evaluation
+order of function arguments unspecified, so which compare is inserted into the
+block first is the compiler's choice. The `or`'s operands are fixed, but the
+textual order of the two compares is not: the same source emits them one way
+on macOS and the other on Linux, which makes generated IR -- and any CHECK
+line pinning it -- build-dependent.
+
+The fix is always the same: bind each op to a local first, so the source
+fixes the order.
+
+    Value nSmall = stablehlo::CompareOp::create(rewriter, loc, n, one, LE);
+    Value sSmall = stablehlo::CompareOp::create(rewriter, loc, s, one, LE);
+    Value cond = stablehlo::OrOp::create(rewriter, loc, nSmall, sSmall);
+
+An "emitter" is a call that inserts an op: `X::create(...)`,
+`builder.create<X>(...)`, `rewriter.replaceOpWithNewOp<X>(...)`, or a call to
+a function or lambda in this tree whose own body does one of those (helpers
+such as `makeI64Constant`). Lambda *literals* passed as arguments do not
+count -- their body runs inside the callee, after argument evaluation.
+
+Suppress a false positive with `// NOLINT(emission-order)` on any line of the
+flagged expression.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# A call that inserts an op into the IR.
+MLIR_EMITTER = r"\b\w+::create\s*(?=\()|\bcreate\s*<|\breplaceOpWithNewOp\s*<"
+# LLVM's IRBuilder has the same hazard; opt in with --include-llvm-builder.
+LLVM_EMITTER = r"\bCreate[A-Z]\w*\s*(?=\()"
+EMITTER_RE = re.compile(MLIR_EMITTER)
+
+# Statements/expressions that are not calls we should look into.
+KEYWORDS = {
+    "if",
+    "for",
+    "while",
+    "switch",
+    "catch",
+    "return",
+    "sizeof",
+    "do",
+    "else",
+    "and",
+    "or",
+    "not",
+    "decltype",
+    "static_assert",
+    "assert",
+    "new",
+    "delete",
+    "throw",
+    "case",
+    "template",
+    "operator",
+    "noexcept",
+    "constexpr",
+    "alignof",
+}
+
+LAMBDA_ASSIGN_RE = re.compile(
+    r"\b(?:auto|const\s+auto)\s*&?\s*(\w+)\s*=\s*\[[^\]]*\]\s*"
+    r"(?:\([^)]*\))?\s*(?:mutable\s*)?(?:->[^{;]*)?\{"
+)
+CALL_RE = re.compile(r"(?<![\w])(\w+(?:::\w+)*)\s*(?:<[^<>;{}]*>)?\s*\(")
+LAMBDA_ARG_RE = re.compile(r"^\s*\[[^\]]*\]\s*(?:\(|\{|mutable|->)")
+SUPPRESS_RE = re.compile(r"NOLINT\(\s*emission-order\s*\)")
+
+SOURCE_SUFFIXES = (".cpp", ".cc", ".h", ".hpp")
+SKIP_DIRS = {".git", "build", "third_party", "external"}
+
+
+def strip_noise(src):
+    """Blank out comments, strings and char literals, preserving offsets."""
+    out = list(src)
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            while i < n and src[i] != "\n":
+                out[i] = " "
+                i += 1
+        elif c == "/" and i + 1 < n and src[i + 1] == "*":
+            out[i] = out[i + 1] = " "
+            i += 2
+            while i + 1 < n and not (src[i] == "*" and src[i + 1] == "/"):
+                if src[i] != "\n":
+                    out[i] = " "
+                i += 1
+            if i + 1 < n:
+                out[i] = out[i + 1] = " "
+                i += 2
+        elif c in "\"'":
+            quote = c
+            out[i] = " "
+            i += 1
+            while i < n and src[i] != quote:
+                if src[i] == "\\":
+                    out[i] = " "
+                    i += 1
+                if i < n and src[i] != "\n":
+                    out[i] = " "
+                i += 1
+            if i < n:
+                out[i] = " "
+                i += 1
+        else:
+            i += 1
+    return "".join(out)
+
+
+def match_paren(src, open_idx):
+    depth = 0
+    for i in range(open_idx, len(src)):
+        if src[i] == "(":
+            depth += 1
+        elif src[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def match_brace(src, open_idx):
+    depth = 0
+    for i in range(open_idx, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def split_args(src, lo, hi):
+    """Split [lo, hi) on top-level commas, ignoring () [] {} and <> nesting."""
+    args, depth, angle, start = [], 0, 0, lo
+    for i in range(lo, hi):
+        c = src[i]
+        if c in "([{":
+            depth += 1
+        elif c in ")]}":
+            depth -= 1
+        elif c == "<" and depth == 0:
+            angle += 1
+        elif c == ">" and depth == 0 and angle > 0:
+            angle -= 1
+        elif c == "," and depth == 0 and angle == 0:
+            args.append((start, i))
+            start = i + 1
+    args.append((start, hi))
+    return args
+
+
+def collect_helpers(src):
+    """Names of functions and lambdas in `src` whose body inserts ops."""
+    names = set()
+    for m in LAMBDA_ASSIGN_RE.finditer(src):
+        open_idx = src.index("{", m.end() - 1)
+        close = match_brace(src, open_idx)
+        if close > 0 and EMITTER_RE.search(src[open_idx:close]):
+            names.add(m.group(1))
+    for m in re.finditer(r"(?<![\w.>])(\w+)\s*\(", src):
+        name = m.group(1)
+        if name in KEYWORDS or len(name) < 3:
+            continue
+        close = match_paren(src, m.end() - 1)
+        if close < 0:
+            continue
+        tail = src[close + 1 : close + 40]
+        if not re.match(r"\s*(?:const\s*)?(?:noexcept\s*)?\{", tail):
+            continue
+        open_idx = close + 1 + tail.index("{")
+        body_end = match_brace(src, open_idx)
+        if body_end > 0 and EMITTER_RE.search(src[open_idx:body_end]):
+            names.add(name)
+    return names
+
+
+def iter_sources(roots):
+    for root in roots:
+        if os.path.isfile(root):
+            yield root
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames if d not in SKIP_DIRS and not d.startswith("bazel-")
+            ]
+            for name in sorted(filenames):
+                if name.endswith(SOURCE_SUFFIXES):
+                    yield os.path.join(dirpath, name)
+
+
+def check_file(path, helper_re):
+    raw = open(path, encoding="utf-8", errors="replace").read()
+    src = strip_noise(raw)
+
+    def emits(text):
+        if LAMBDA_ARG_RE.match(text):
+            return False  # lambda literal: its body runs inside the callee
+        return bool(EMITTER_RE.search(text)) or bool(
+            helper_re and helper_re.search(text)
+        )
+
+    findings, reported_lines = [], set()
+    for m in CALL_RE.finditer(src):
+        if m.group(1).split("::")[-1] in KEYWORDS:
+            continue
+        open_idx = src.index("(", m.end() - 1)
+        close = match_paren(src, open_idx)
+        if close < 0:
+            continue
+        args = split_args(src, open_idx + 1, close)
+        if len(args) < 2:
+            continue
+        emitting = [a for a in args if emits(src[a[0] : a[1]])]
+        if len(emitting) < 2:
+            continue
+        line = src.count("\n", 0, m.start()) + 1
+        end_line = src.count("\n", 0, close) + 1
+        if SUPPRESS_RE.search(raw[m.start() : close + 1]):
+            continue
+        # only report the outermost expression on a given line
+        if line in reported_lines:
+            continue
+        reported_lines.add(line)
+        findings.append(
+            (
+                line,
+                end_line,
+                m.group(1),
+                " ".join(raw[m.start() : close + 1].split())[:200],
+            )
+        )
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("roots", nargs="+", help="directories or files to check")
+    parser.add_argument(
+        "--github",
+        action="store_true",
+        help="also emit GitHub Actions error annotations",
+    )
+    parser.add_argument(
+        "--include-llvm-builder",
+        action="store_true",
+        help="also treat LLVM IRBuilder Create* calls as "
+        "emitters (same hazard, separate cleanup)",
+    )
+    args = parser.parse_args()
+
+    if args.include_llvm_builder:
+        global EMITTER_RE
+        EMITTER_RE = re.compile(MLIR_EMITTER + "|" + LLVM_EMITTER)
+
+    files = list(iter_sources(args.roots))
+    helpers = set()
+    stripped = {}
+    for path in files:
+        stripped[path] = strip_noise(
+            open(path, encoding="utf-8", errors="replace").read()
+        )
+        helpers |= collect_helpers(stripped[path])
+    helpers -= KEYWORDS
+    helper_re = (
+        re.compile(
+            r"(?<![\w.>])(?:" + "|".join(sorted(map(re.escape, helpers))) + r")\s*\("
+        )
+        if helpers
+        else None
+    )
+
+    total = 0
+    for path in files:
+        for line, end_line, callee, snippet in check_file(path, helper_re):
+            total += 1
+            msg = (
+                f"{callee}(...) builds two or more ops in one argument list; "
+                f"evaluation order is unspecified, so the emitted IR order "
+                f"is compiler-dependent. Bind each to a local first."
+            )
+            print(f"{path}:{line}: {msg}\n    {snippet}")
+            if args.github:
+                print(
+                    f"::error file={path},line={line},endLine={end_line},"
+                    f"title=Nondeterministic IR emission order::{msg}"
+                )
+
+    if total:
+        print(
+            f"\n{total} nondeterministic emission site(s). "
+            f"Bind each op to a local before the enclosing call, or add "
+            f"`// NOLINT(emission-order)` if the order provably cannot be "
+            f"observed.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"checked {len(files)} files: no nondeterministic emission sites")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -428,14 +428,13 @@ public:
     Value c0 = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 0);
     Value c1 = arith::ConstantIndexOp::create(rewriter, op.getLoc(), 1);
     SmallVector<Value> idxs;
+    Value lenIdx = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getIndexType(), op.getLen());
+    Value widthCst =
+        arith::ConstantIndexOp::create(rewriter, op.getLoc(), width);
     auto forOp = scf::ForOp::create(
         rewriter, op.getLoc(), c0,
-        arith::DivUIOp::create(
-            rewriter, op.getLoc(),
-            arith::IndexCastOp::create(rewriter, op.getLoc(),
-                                       rewriter.getIndexType(), op.getLen()),
-            arith::ConstantIndexOp::create(rewriter, op.getLoc(), width)),
-        c1);
+        arith::DivUIOp::create(rewriter, op.getLoc(), lenIdx, widthCst), c1);
 
     rewriter.setInsertionPointToStart(&forOp.getRegion().getBlocks().front());
     idxs.push_back(forOp.getInductionVar());
@@ -532,14 +531,13 @@ public:
     Value val = cast<mlir::enzyme::AutoDiffTypeInterface>(elTy).createNullValue(
         rewriter, op.getLoc());
 
+    Value lenIdx = arith::IndexCastOp::create(
+        rewriter, op.getLoc(), rewriter.getIndexType(), op.getLen());
+    Value widthCst =
+        arith::ConstantIndexOp::create(rewriter, op.getLoc(), width);
     auto forOp = scf::ForOp::create(
         rewriter, op.getLoc(), c0,
-        arith::DivUIOp::create(
-            rewriter, op.getLoc(),
-            arith::IndexCastOp::create(rewriter, op.getLoc(),
-                                       rewriter.getIndexType(), op.getLen()),
-            arith::ConstantIndexOp::create(rewriter, op.getLoc(), width)),
-        c1);
+        arith::DivUIOp::create(rewriter, op.getLoc(), lenIdx, widthCst), c1);
 
     rewriter.setInsertionPointToStart(&forOp.getRegion().getBlocks().front());
     idxs.push_back(forOp.getInductionVar());

--- a/src/enzyme_ad/jax/Implementations/SHLOGenericBatchOpInterface.h
+++ b/src/enzyme_ad/jax/Implementations/SHLOGenericBatchOpInterface.h
@@ -213,12 +213,13 @@ inline LogicalResult genericCreateBatch(Operation *src, OpBuilder &builder,
 
     for (int d = 0; d < ndims; ++d) {
       // auto idx = (i / batchStrides[d]) % batchSizes[d];
-      auto idx = RemOp::create(
-          bodyBuilder, src->getLoc(),
-          DivOp::create(bodyBuilder, src->getLoc(), whileBody->getArgument(0),
-                        details::makeI64Constant(src->getLoc(), bodyBuilder,
-                                                 batchStrides[d])),
-          details::makeI64Constant(src->getLoc(), bodyBuilder, batchSizes[d]));
+      Value stride =
+          details::makeI64Constant(src->getLoc(), bodyBuilder, batchStrides[d]);
+      Value quotient = DivOp::create(bodyBuilder, src->getLoc(),
+                                     whileBody->getArgument(0), stride);
+      Value size =
+          details::makeI64Constant(src->getLoc(), bodyBuilder, batchSizes[d]);
+      auto idx = RemOp::create(bodyBuilder, src->getLoc(), quotient, size);
 
       startIndices.push_back(idx);
     }

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -641,16 +641,18 @@ class AutoDiffWhileRev
   static stablehlo::WhileOp makeForLoop(OpBuilder &builder, Location loc,
                                         int64_t start, int64_t limit,
                                         int64_t step, ValueRange operands) {
-    return makeForLoop(builder, loc, makeI64Constant(loc, builder, start),
-                       makeI64Constant(loc, builder, limit),
-                       makeI64Constant(loc, builder, step), operands);
+    Value startVal = makeI64Constant(loc, builder, start);
+    Value limitVal = makeI64Constant(loc, builder, limit);
+    Value stepVal = makeI64Constant(loc, builder, step);
+    return makeForLoop(builder, loc, startVal, limitVal, stepVal, operands);
   }
 
   static stablehlo::WhileOp makeForLoop(OpBuilder &builder, Location loc,
                                         int64_t start, Value limit,
                                         int64_t step, ValueRange operands) {
-    return makeForLoop(builder, loc, makeI64Constant(loc, builder, start),
-                       limit, makeI64Constant(loc, builder, step), operands);
+    Value startVal = makeI64Constant(loc, builder, start);
+    Value stepVal = makeI64Constant(loc, builder, step);
+    return makeForLoop(builder, loc, startVal, limit, stepVal, operands);
   }
 
   static stablehlo::WhileOp makeForLoop(OpBuilder &builder, Location loc,
@@ -1220,15 +1222,14 @@ class AutoDiffWhileRev
 
     Value currentStep =
         stablehlo::AddOp::create(builder, orig.getLoc(), outerStart, innerIV);
+    Value constantStart = makeI64Constant(
+        orig.getLoc(), builder, revInfo.info.getConstantStart().value());
+    Value constantStep = makeI64Constant(
+        orig.getLoc(), builder, revInfo.info.getConstantStep().value());
     Value currentIV = stablehlo::AddOp::create(
-        builder, orig.getLoc(),
-        makeI64Constant(orig.getLoc(), builder,
-                        revInfo.info.getConstantStart().value()),
-        stablehlo::MulOp::create(
-            builder, orig.getLoc(),
-            makeI64Constant(orig.getLoc(), builder,
-                            revInfo.info.getConstantStep().value()),
-            currentStep));
+        builder, orig.getLoc(), constantStart,
+        stablehlo::MulOp::create(builder, orig.getLoc(), constantStep,
+                                 currentStep));
 
     Block *origBody = &orig.getBody().front();
     for (auto &&[origarg, revinnerarg] : llvm::zip_equal(

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2816,20 +2816,20 @@ struct ForOpRaising : public OpRewritePattern<scf::ForOp> {
       if (!loop.getStep().getDefiningOp<ConstantIndexOp>()) {
         if (ubs.size() != 1 || lbs.size() != 1)
           return failure();
-        ubs[0] = DivUIOp::create(
-            rewriter, loop.getLoc(),
-            AddIOp::create(
-                rewriter, loop.getLoc(),
-                SubIOp::create(
-                    rewriter, loop.getLoc(), loop.getStep(),
-                    isa<IndexType>(loop.getStep().getType())
+        Value one = isa<IndexType>(loop.getStep().getType())
                         ? ConstantIndexOp::create(rewriter, loop.getLoc(), 1)
                               .getResult()
                         : ConstantIntOp::create(rewriter, loop.getLoc(),
-                                                loop.getStep().getType(), 1))
-                    .getResult(),
-                SubIOp::create(rewriter, loop.getLoc(), loop.getUpperBound(),
-                               loop.getLowerBound())),
+                                                loop.getStep().getType(), 1);
+        Value stepMinusOne =
+            SubIOp::create(rewriter, loop.getLoc(), loop.getStep(), one)
+                .getResult();
+        Value range =
+            SubIOp::create(rewriter, loop.getLoc(), loop.getUpperBound(),
+                           loop.getLowerBound());
+        ubs[0] = DivUIOp::create(
+            rewriter, loop.getLoc(),
+            AddIOp::create(rewriter, loop.getLoc(), stepMinusOne, range),
             loop.getStep());
         lbs[0] = ConstantIndexOp::create(rewriter, loop.getLoc(), 0);
         rewrittenStep = true;

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -700,14 +700,16 @@ expandAffineExpr(OpBuilder &builder, Location loc, AffineExpr expr,
             makeI64Constant(cast<ShapedType>(lhs.getType()), 0),
             stablehlo::ComparisonDirection::LE);
         Value one = makeI64Constant(cast<ShapedType>(lhs.getType()), 1);
-        Value absolute = stablehlo::SelectOp::create(
-            builder, loc, negative, stablehlo::NegOp::create(builder, loc, lhs),
-            stablehlo::AddOp::create(builder, loc, lhs, one));
+        Value negLhs = stablehlo::NegOp::create(builder, loc, lhs);
+        Value lhsPlusOne = stablehlo::AddOp::create(builder, loc, lhs, one);
+        Value absolute = stablehlo::SelectOp::create(builder, loc, negative,
+                                                     negLhs, lhsPlusOne);
         Value quotient = stablehlo::DivOp::create(builder, loc, absolute, rhs);
-        result = stablehlo::SelectOp::create(
-            builder, loc, negative,
-            stablehlo::NegOp::create(builder, loc, quotient),
-            stablehlo::AddOp::create(builder, loc, quotient, one));
+        Value negQuotient = stablehlo::NegOp::create(builder, loc, quotient);
+        Value quotientPlusOne =
+            stablehlo::AddOp::create(builder, loc, quotient, one);
+        result = stablehlo::SelectOp::create(builder, loc, negative,
+                                             negQuotient, quotientPlusOne);
       };
       break;
     default:

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8179,23 +8179,23 @@ struct NoNanZeroBasePowSimplify final
       // 0 ^ x => x == 0 ? 1 : (x > 0 ? 0 : Inf)
       auto zero = stablehlo::ConstantOp::create(
           rewriter, op.getLoc(), rewriter.getZeroAttr(op.getType()));
-      auto nonZeroCase = stablehlo::SelectOp::create(
-          rewriter, op.getLoc(),
+      auto rhsPositive =
           stablehlo::CompareOp::create(rewriter, op.getLoc(), op.getRhs(), zero,
-                                       stablehlo::ComparisonDirection::GT),
-          zero,
-          stablehlo::ConstantOp::create(
-              rewriter, op.getLoc(), op.getType(),
-              cast<ElementsAttr>(makeAttr(
-                  op.getType(), std::numeric_limits<float>::infinity()))));
-      rewriter.replaceOpWithNewOp<stablehlo::SelectOp>(
-          op,
+                                       stablehlo::ComparisonDirection::GT);
+      auto inf = stablehlo::ConstantOp::create(
+          rewriter, op.getLoc(), op.getType(),
+          cast<ElementsAttr>(
+              makeAttr(op.getType(), std::numeric_limits<float>::infinity())));
+      auto nonZeroCase = stablehlo::SelectOp::create(rewriter, op.getLoc(),
+                                                     rhsPositive, zero, inf);
+      auto rhsIsZero =
           stablehlo::CompareOp::create(rewriter, op.getLoc(), op.getRhs(), zero,
-                                       stablehlo::ComparisonDirection::EQ),
-          stablehlo::ConstantOp::create(
-              rewriter, op.getLoc(), op.getType(),
-              cast<ElementsAttr>(makeAttr(op.getType(), 1))),
-          nonZeroCase);
+                                       stablehlo::ComparisonDirection::EQ);
+      auto one = stablehlo::ConstantOp::create(
+          rewriter, op.getLoc(), op.getType(),
+          cast<ElementsAttr>(makeAttr(op.getType(), 1)));
+      rewriter.replaceOpWithNewOp<stablehlo::SelectOp>(op, rhsIsZero, one,
+                                                       nonZeroCase);
       return success();
     }
 
@@ -13490,14 +13490,14 @@ struct DivideDivideSimplify
           return failure();
 
         // Case III.
-        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
-            op,
-            stablehlo::MulOp::create(rewriter, op.getLoc(),
-                                     lhsDivOp->getOperand(0),
-                                     rhsDivOp->getOperand(1)),
-            stablehlo::MulOp::create(rewriter, op.getLoc(),
-                                     lhsDivOp->getOperand(1),
-                                     rhsDivOp->getOperand(0)));
+        auto numerator = stablehlo::MulOp::create(rewriter, op.getLoc(),
+                                                  lhsDivOp->getOperand(0),
+                                                  rhsDivOp->getOperand(1));
+        auto denominator = stablehlo::MulOp::create(rewriter, op.getLoc(),
+                                                    lhsDivOp->getOperand(1),
+                                                    rhsDivOp->getOperand(0));
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(op, numerator,
+                                                      denominator);
         return success();
       } else {
         // Case II.
@@ -27813,12 +27813,11 @@ struct LogSimplify final
         // is NaN while log(a*a) is finite. Gating on the analysis avoids an abs
         // (possibly slower than the mul). See #2570.
         if (lhs == rhs && guaranteedNonNegativeResult(lhs, rewriter)) {
-          rewriter.replaceOpWithNewOp<stablehlo::MulOp>(
-              op,
-              stablehlo::ConstantOp::create(
-                  rewriter, op.getLoc(), lhs.getType(),
-                  cast<ElementsAttr>(makeAttr(lhs.getType(), 2))),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), lhs));
+          auto two = stablehlo::ConstantOp::create(
+              rewriter, op.getLoc(), lhs.getType(),
+              cast<ElementsAttr>(makeAttr(lhs.getType(), 2)));
+          auto logLhs = stablehlo::LogOp::create(rewriter, op.getLoc(), lhs);
+          rewriter.replaceOpWithNewOp<stablehlo::MulOp>(op, two, logLhs);
           return success();
         }
 
@@ -27830,9 +27829,9 @@ struct LogSimplify final
           // #2570.
           Value cst = matchPattern(lhs, m_Constant()) ? lhs : rhs;
           if (isPositiveFiniteConstant(cst, /*allowZero=*/false)) {
-            rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
-                op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
-                stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
+            auto logLhs = stablehlo::LogOp::create(rewriter, op.getLoc(), lhs);
+            auto logRhs = stablehlo::LogOp::create(rewriter, op.getLoc(), rhs);
+            rewriter.replaceOpWithNewOp<stablehlo::AddOp>(op, logLhs, logRhs);
             return success();
           }
         }
@@ -27845,14 +27844,13 @@ struct LogSimplify final
         auto lhs = defOp.getLhs();
         auto rhs = defOp.getRhs();
         if (lhs == rhs) { // log(add(a, a)) -> log(2) + log(a)
-          rewriter.replaceOpWithNewOp<stablehlo::AddOp>(
-              op,
-              stablehlo::LogOp::create(
-                  rewriter, op.getLoc(),
-                  stablehlo::ConstantOp::create(
-                      rewriter, op.getLoc(), lhs.getType(),
-                      cast<ElementsAttr>(makeAttr(lhs.getType(), 2)))),
-              stablehlo::LogOp::create(rewriter, op.getLoc(), lhs));
+          auto logTwo = stablehlo::LogOp::create(
+              rewriter, op.getLoc(),
+              stablehlo::ConstantOp::create(
+                  rewriter, op.getLoc(), lhs.getType(),
+                  cast<ElementsAttr>(makeAttr(lhs.getType(), 2))));
+          auto logLhs = stablehlo::LogOp::create(rewriter, op.getLoc(), lhs);
+          rewriter.replaceOpWithNewOp<stablehlo::AddOp>(op, logTwo, logLhs);
           return success();
         }
 
@@ -27890,9 +27888,10 @@ struct LogSimplify final
           bool constantIsLhs = matchPattern(lhs, m_Constant());
           Value cst = constantIsLhs ? lhs : rhs;
           if (isPositiveFiniteConstant(cst, /*allowZero=*/!constantIsLhs)) {
-            rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(
-                op, stablehlo::LogOp::create(rewriter, op.getLoc(), lhs),
-                stablehlo::LogOp::create(rewriter, op.getLoc(), rhs));
+            auto logLhs = stablehlo::LogOp::create(rewriter, op.getLoc(), lhs);
+            auto logRhs = stablehlo::LogOp::create(rewriter, op.getLoc(), rhs);
+            rewriter.replaceOpWithNewOp<stablehlo::SubtractOp>(op, logLhs,
+                                                               logRhs);
             return success();
           }
         }
@@ -27903,12 +27902,12 @@ struct LogSimplify final
       auto defOp = op.getOperand().getDefiningOp<stablehlo::SqrtOp>();
       if (defOp &&
           isOnlyUsedInOperation(defOp, op)) { // log(sqrt(x)) -> log(x) / 2
-        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
-            op,
-            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand()),
-            stablehlo::ConstantOp::create(
-                rewriter, op.getLoc(), defOp.getType(),
-                cast<ElementsAttr>(makeAttr(defOp.getType(), 2))));
+        auto logOperand =
+            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand());
+        auto two = stablehlo::ConstantOp::create(
+            rewriter, op.getLoc(), defOp.getType(),
+            cast<ElementsAttr>(makeAttr(defOp.getType(), 2)));
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(op, logOperand, two);
         return success();
       }
     }
@@ -27917,12 +27916,12 @@ struct LogSimplify final
       auto defOp = op.getOperand().getDefiningOp<stablehlo::CbrtOp>();
       if (defOp &&
           isOnlyUsedInOperation(defOp, op)) { // log(cbrt(x)) -> log(x) / 3
-        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
-            op,
-            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand()),
-            stablehlo::ConstantOp::create(
-                rewriter, op.getLoc(), defOp.getType(),
-                cast<ElementsAttr>(makeAttr(defOp.getType(), 3))));
+        auto logOperand =
+            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand());
+        auto three = stablehlo::ConstantOp::create(
+            rewriter, op.getLoc(), defOp.getType(),
+            cast<ElementsAttr>(makeAttr(defOp.getType(), 3)));
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(op, logOperand, three);
         return success();
       }
     }
@@ -27931,12 +27930,12 @@ struct LogSimplify final
       auto defOp = op.getOperand().getDefiningOp<stablehlo::RsqrtOp>();
       if (defOp &&
           isOnlyUsedInOperation(defOp, op)) { // log(rsqrt(x)) -> -log(x) / 2
-        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(
-            op,
-            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand()),
-            stablehlo::ConstantOp::create(
-                rewriter, op.getLoc(), defOp.getType(),
-                cast<ElementsAttr>(makeAttr(defOp.getType(), -2))));
+        auto logOperand =
+            stablehlo::LogOp::create(rewriter, op.getLoc(), defOp.getOperand());
+        auto negTwo = stablehlo::ConstantOp::create(
+            rewriter, op.getLoc(), defOp.getType(),
+            cast<ElementsAttr>(makeAttr(defOp.getType(), -2)));
+        rewriter.replaceOpWithNewOp<stablehlo::DivOp>(op, logOperand, negTwo);
         return success();
       }
     }
@@ -30500,15 +30499,14 @@ struct DUSToDynamicPad
     for (auto [i, index] : llvm::enumerate(indices)) {
       auto cType = RankedTensorType::get(
           {}, cast<RankedTensorType>(index.getType()).getElementType());
+      auto lowerBound = stablehlo::ConstantOp::create(
+          rewriter, op.getLoc(), cType, cast<ElementsAttr>(makeAttr(cType, 0)));
+      auto upperBound = stablehlo::ConstantOp::create(
+          rewriter, op.getLoc(), cType,
+          cast<ElementsAttr>(
+              makeAttr(cType, operandShape[i] - updateShape[i])));
       auto clampedIndex = stablehlo::ClampOp::create(
-          rewriter, op.getLoc(),
-          stablehlo::ConstantOp::create(rewriter, op.getLoc(), cType,
-                                        cast<ElementsAttr>(makeAttr(cType, 0))),
-          index,
-          stablehlo::ConstantOp::create(
-              rewriter, op.getLoc(), cType,
-              cast<ElementsAttr>(
-                  makeAttr(cType, operandShape[i] - updateShape[i]))));
+          rewriter, op.getLoc(), lowerBound, index, upperBound);
 
       auto reshapedIndex = stablehlo::ReshapeOpCreate(
           rewriter, op.getLoc(), clampedIndex, ArrayRef<int64_t>{1});
@@ -31218,8 +31216,9 @@ struct BinaryNegatedOperandsSimplify
     if (lhsInfo.kind == NegKind::SUB && rhsInfo.kind == NegKind::SUB)
       return failure();
 
-    rewriter.replaceOpWithNewOp<OpTy>(op, negateOperand(lhsInfo, rewriter),
-                                      negateOperand(rhsInfo, rewriter));
+    Value negatedLhs = negateOperand(lhsInfo, rewriter);
+    Value negatedRhs = negateOperand(rhsInfo, rewriter);
+    rewriter.replaceOpWithNewOp<OpTy>(op, negatedLhs, negatedRhs);
     return success();
   }
 
@@ -31533,17 +31532,18 @@ struct DotGeneralToSyrk
         cast<RankedTensorType>(syrkInput.getType()).getElementType();
     auto alphaType = RankedTensorType::get({}, elemType);
 
+    auto cMatrix = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), op.getType(),
+        cast<ElementsAttr>(makeAttr(op.getType(), 0)));
+    auto alpha = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), alphaType,
+        cast<ElementsAttr>(makeAttr(alphaType, 1)));
+    auto beta = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), alphaType,
+        cast<ElementsAttr>(makeAttr(alphaType, 0)));
     auto syrkOp = enzymexla::SyrkOp::create(
-        rewriter, op.getLoc(), op.getResult().getType(), syrkInput,
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), op.getType(),
-            cast<ElementsAttr>(makeAttr(op.getType(), 0))),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), alphaType,
-            cast<ElementsAttr>(makeAttr(alphaType, 1))),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), alphaType,
-            cast<ElementsAttr>(makeAttr(alphaType, 0))),
+        rewriter, op.getLoc(), op.getResult().getType(), syrkInput, cMatrix,
+        alpha, beta,
         enzymexla::LapackUploAttr::get(op.getContext(),
                                        enzymexla::LapackUplo::F),
         enzymexla::LapackUploAttr::get(op.getContext(),
@@ -31620,19 +31620,20 @@ struct DotGeneralToSymm
     auto elemType = cast<RankedTensorType>(lhs.getType()).getElementType();
     auto alphaType = RankedTensorType::get({}, elemType);
 
+    auto cMatrix = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), op.getType(),
+        cast<ElementsAttr>(makeAttr(op.getType(), 0)));
+    auto alpha = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), alphaType,
+        cast<ElementsAttr>(makeAttr(alphaType, 1)));
+    auto beta = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), alphaType,
+        cast<ElementsAttr>(makeAttr(alphaType, 0)));
     auto symmOp = enzymexla::SymmOp::create(
         rewriter, op.getLoc(), op.getResult().getType(),
         symmMatrix, // A (symmetric)
         genMatrix,  // B (general)
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), op.getType(),
-            cast<ElementsAttr>(makeAttr(op.getType(), 0))), // C
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), alphaType,
-            cast<ElementsAttr>(makeAttr(alphaType, 1))), // alpha
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), alphaType,
-            cast<ElementsAttr>(makeAttr(alphaType, 0))), // beta
+        cMatrix, alpha, beta,
         enzymexla::LapackSideAttr::get(op.getContext(), side),
         enzymexla::LapackUploAttr::get(op.getContext(),
                                        enzymexla::LapackUplo::F));

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLALapack.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLALapack.cpp
@@ -1294,12 +1294,12 @@ struct GemqrtOpLowering : public OpRewritePattern<enzymexla::GemqrtOp> {
 
 Value anyNonFiniteValue(PatternRewriter &rewriter, Location loc, Type outType,
                         Value input, int64_t inputRank) {
-  auto areFinite = stablehlo::AndOp::create(
-      rewriter, loc,
-      stablehlo::IsFiniteOp::create(
-          rewriter, loc, stablehlo::RealOp::create(rewriter, loc, input)),
-      stablehlo::IsFiniteOp::create(
-          rewriter, loc, stablehlo::ImagOp::create(rewriter, loc, input)));
+  auto realFinite = stablehlo::IsFiniteOp::create(
+      rewriter, loc, stablehlo::RealOp::create(rewriter, loc, input));
+  auto imagFinite = stablehlo::IsFiniteOp::create(
+      rewriter, loc, stablehlo::ImagOp::create(rewriter, loc, input));
+  auto areFinite =
+      stablehlo::AndOp::create(rewriter, loc, realFinite, imagFinite);
 
   SmallVector<int64_t> reductionDims;
   for (int i = inputRank - 2; i < inputRank; i++)
@@ -1901,21 +1901,21 @@ private:
 
     // LAPACK returns 1-indexed pivots, while XLA returns 0-indexed pivots.
     // We make it consistent with LAPACK by adding 1 to the pivots.
-    auto pivots1Indexed = stablehlo::AddOp::create(
-        rewriter, op.getLoc(),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), pivotType,
-            cast<ElementsAttr>(makeAttr(pivotType, 1))),
-        stablehlo::ConvertOp::create(rewriter, op.getLoc(), pivotType,
-                                     customCall.getResult(1)));
+    auto pivotOne = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), pivotType,
+        cast<ElementsAttr>(makeAttr(pivotType, 1)));
+    auto pivots = stablehlo::ConvertOp::create(rewriter, op.getLoc(), pivotType,
+                                               customCall.getResult(1));
+    auto pivots1Indexed =
+        stablehlo::AddOp::create(rewriter, op.getLoc(), pivotOne, pivots);
 
+    auto permutationOne = stablehlo::ConstantOp::create(
+        rewriter, op.getLoc(), permutationType,
+        cast<ElementsAttr>(makeAttr(permutationType, 1)));
+    auto permutation = stablehlo::ConvertOp::create(
+        rewriter, op.getLoc(), permutationType, customCall.getResult(2));
     auto permutation1Indexed = stablehlo::AddOp::create(
-        rewriter, op.getLoc(),
-        stablehlo::ConstantOp::create(
-            rewriter, op.getLoc(), permutationType,
-            cast<ElementsAttr>(makeAttr(permutationType, 1))),
-        stablehlo::ConvertOp::create(rewriter, op.getLoc(), permutationType,
-                                     customCall.getResult(2)));
+        rewriter, op.getLoc(), permutationOne, permutation);
 
     auto info = anyNonFiniteValue(rewriter, op.getLoc(), infoType,
                                   customCall.getResult(0), inputRank);
@@ -2216,12 +2216,12 @@ LogicalResult lowerSVDAlgorithmCPU(OpTy op, PatternRewriter &rewriter,
         auto NVal = LLVM::LoadOp::create(
             rewriter, op.getLoc(), type_llvm_lapack_int, funcOp.getArgument(1));
 
-        auto const5minMN = LLVM::MulOp::create(
-            rewriter, op.getLoc(),
-            LLVM::ConstantOp::create(
-                rewriter, op.getLoc(), type_llvm_lapack_int,
-                rewriter.getIntegerAttr(type_llvm_lapack_int, 5)),
-            arith::MinSIOp::create(rewriter, op.getLoc(), MVal, NVal));
+        auto const5 = LLVM::ConstantOp::create(
+            rewriter, op.getLoc(), type_llvm_lapack_int,
+            rewriter.getIntegerAttr(type_llvm_lapack_int, 5));
+        auto minMN = arith::MinSIOp::create(rewriter, op.getLoc(), MVal, NVal);
+        auto const5minMN =
+            LLVM::MulOp::create(rewriter, op.getLoc(), const5, minMN);
 
         auto rworkptr =
             LLVM::AllocaOp::create(rewriter, op.getLoc(), type_llvm_ptr,

--- a/src/enzyme_ad/jax/Passes/RaiseTritonCustomCallPass.cpp
+++ b/src/enzyme_ad/jax/Passes/RaiseTritonCustomCallPass.cpp
@@ -87,15 +87,21 @@ replaceWithTritonCall(stablehlo::CustomCallOp callOp, PatternRewriter &rewriter,
                                         outerMod.getSymNameAttr(), nestedRefs);
 
   rewriter.setInsertionPoint(callOp);
+
+  Value gridxVal = TI64(rewriter, callOp->getLoc(), gridx);
+  Value gridyVal = TI64(rewriter, callOp->getLoc(), gridy);
+  Value gridzVal = TI64(rewriter, callOp->getLoc(), gridz);
+
+  Value blockxVal = TI64(rewriter, callOp->getLoc(), 1);
+  Value blockyVal = TI64(rewriter, callOp->getLoc(), 1);
+  Value blockzVal = TI64(rewriter, callOp->getLoc(), 1);
+
   rewriter.replaceOpWithNewOp<enzymexla::triton_ext::TritonCallOp>(
       callOp, callOp->getResultTypes(), fn,
 
-      TI64(rewriter, callOp->getLoc(), gridx),
-      TI64(rewriter, callOp->getLoc(), gridy),
-      TI64(rewriter, callOp->getLoc(), gridz),
+      gridxVal, gridyVal, gridzVal,
 
-      TI64(rewriter, callOp->getLoc(), 1), TI64(rewriter, callOp->getLoc(), 1),
-      TI64(rewriter, callOp->getLoc(), 1),
+      blockxVal, blockyVal, blockzVal,
 
       callOp.getInputs(),
       /* backendConfig */ StringAttr::get(callOp.getContext(), ""),


### PR DESCRIPTION
Follow-up to #2726 (stacked on it — the base retargets to `main` once that merges), so this pattern cannot come back.

## The check

Building two or more ops directly in one argument list leaves their insertion order to the compiler, since C++ does not sequence argument evaluation:

```cpp
Value cond = stablehlo::OrOp::create(
    rewriter, loc,
    stablehlo::CompareOp::create(rewriter, loc, n, one, LE),   // which of these
    stablehlo::CompareOp::create(rewriter, loc, s, one, LE));  // is inserted first?
```

The emitted IR — and any CHECK line pinning it — then depends on the toolchain. That is what broke #2721 on Linux while passing on macOS.

`scripts/check_emission_order.py` brace-matches every call expression and reports argument lists with two or more sibling *emitters*: `X::create(...)`, `builder.create<X>(...)`, `rewriter.replaceOpWithNewOp<X>(...)`, and calls to any function or lambda in the tree whose own body does one of those (`makeI64Constant`, `TI64`, `negateOperand`, a local `constOfType` lambda, ...).

Deliberately *not* flagged: a lambda literal passed as an argument, since its body runs inside the callee, after argument evaluation — that keeps `llvm::map_to_vector(getIVs(rewriter, forOp), [&](Value v){ ... })` clean. Anything else that trips it can be suppressed with `// NOLINT(emission-order)`.

Output is a plain diagnostic plus `::error` annotations under `--github`, so findings land on the diff:

```
src/enzyme_ad/jax/Passes/LowerEnzymeXLAMath.cpp:93: stablehlo::OrOp::create(...) builds two or
more ops in one argument list; evaluation order is unspecified, so the emitted IR order is
compiler-dependent. Bind each to a local first.
```

## The job

A standalone `Lint` workflow — the scan is ~1.5s over `src/`, so it does not need to ride along with a build. `src/external` is skipped as vendored.

Validated by running it against the pre-fix tree (flags exactly the sites #2726 repairs, including the one that broke #2721) and against the fixed tree (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)