### PR TITLE
Extend remove-duplicate-func-def to gpu modules

### DIFF
--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -52,8 +52,8 @@ def DialectCanonicalize : Pass<"dialect-canonicalize"> {
 
 def RemoveDuplicateFuncDefPass
     : Pass<"remove-duplicate-func-def", "mlir::ModuleOp"> {
-  let summary = "Remove duplicate function definitions";
-  let dependentDialects = ["mlir::LLVM::LLVMDialect"];
+  let summary = "Remove duplicate function and gpu module definitions";
+  let dependentDialects = ["mlir::LLVM::LLVMDialect", "mlir::gpu::GPUDialect"];
 }
 
 def PropagateConstantBoundsPass

--- a/src/enzyme_ad/jax/Passes/RemoveDuplicateFuncDef.cpp
+++ b/src/enzyme_ad/jax/Passes/RemoveDuplicateFuncDef.cpp
@@ -12,6 +12,7 @@
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
 namespace mlir {
@@ -63,55 +64,75 @@ struct RemoveDuplicateFuncDefPass
         body1, body2, OperationEquivalence::IgnoreLocations);
   }
 
+  // Outlining emits one gpu.module per launch site, so a kernel launched from
+  // several places (e.g. a ping-pong loop, or the augmented forward and
+  // gradient of one kernel) yields byte-identical modules that each get their
+  // own binary, stub and registration ctor.
+  static bool areEquivalent(gpu::GPUModuleOp moduleOp1,
+                            gpu::GPUModuleOp moduleOp2) {
+    if (moduleOp1 == moduleOp2)
+      return true;
+
+    // Everything but the name -- targets, offloading handler, ... -- has to
+    // agree for the modules to compile to the same binary.
+    auto attrsWithoutName = [](gpu::GPUModuleOp moduleOp) {
+      NamedAttrList attrs(moduleOp->getAttrDictionary());
+      attrs.erase(SymbolTable::getSymbolAttrName());
+      return attrs.getDictionary(moduleOp.getContext());
+    };
+    if (attrsWithoutName(moduleOp1) != attrsWithoutName(moduleOp2))
+      return false;
+
+    return OperationEquivalence::isRegionEquivalentTo(
+        &moduleOp1.getBodyRegion(), &moduleOp2.getBodyRegion(),
+        OperationEquivalence::IgnoreLocations);
+  }
+
+  // Point every use of `duplicate` at `canonicalName` and mark it for removal.
+  // Bails out if the uses cannot all be rewritten, since erasing it would then
+  // leave a dangling symbol reference.
+  template <typename OpT>
+  static void mergeInto(OpT &duplicate, StringAttr canonicalName,
+                        ModuleOp moduleOp,
+                        SmallVectorImpl<Operation *> &toRemove) {
+    if (failed(SymbolTable::replaceAllSymbolUses(duplicate, canonicalName,
+                                                 moduleOp)))
+      return;
+    toRemove.push_back(duplicate);
+    duplicate = nullptr;
+  }
+
+  // Deduplicate `ops`, which must all live directly in `moduleOp`.
+  template <typename OpT>
+  static void deduplicate(SmallVectorImpl<OpT> &ops, ModuleOp moduleOp,
+                          SmallVectorImpl<Operation *> &toRemove) {
+    for (size_t i = 0, e = ops.size(); i < e; ++i) {
+      if (!ops[i])
+        continue;
+      for (size_t j = i + 1; j < e; ++j) {
+        if (!ops[j] || !areEquivalent(ops[i], ops[j]))
+          continue;
+        mergeInto(ops[j], ops[i].getSymNameAttr(), moduleOp, toRemove);
+      }
+    }
+  }
+
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
-    SymbolTable symbolTable(moduleOp);
+    SmallVector<Operation *> toRemove;
 
-    // TODO: Use CallableOpInterface.
-    SmallVector<LLVM::LLVMFuncOp> funcOps;
-    moduleOp->walk([&](LLVM::LLVMFuncOp funcOp) { funcOps.push_back(funcOp); });
+    // Only symbols owned by this module's symbol table are considered: names
+    // are unique within a symbol table, but a gpu.module is one of its own, so
+    // kernels outlined from the same source share a name across modules.
+    auto funcOps = llvm::to_vector(moduleOp.getOps<LLVM::LLVMFuncOp>());
+    deduplicate(funcOps, moduleOp, toRemove);
 
-    DenseMap<StringRef, StringRef> equivalenceMap;
-    SmallVector<CallableOpInterface> toRemove;
-    for (size_t i = 0, e = funcOps.size(); i < e; ++i) {
-      // Already found equivalent.
-      if (equivalenceMap.count(funcOps[i].getSymName()))
-        continue;
-      // Find *all* the possible equivalent functions to funcOps[i].
-      for (size_t j = i + 1; j < e; ++j) {
-        if (areEquivalent(funcOps[i], funcOps[j])) {
-          equivalenceMap[funcOps[j].getSymName()] = funcOps[i].getSymName();
-          toRemove.push_back(funcOps[j]);
-          // llvm::errs() << funcOps[j].getSymName() << " is equivalent to "
-          //              << funcOps[i].getSymName() << "\n";
-        }
-      }
-    }
+    auto gpuModuleOps = llvm::to_vector(moduleOp.getOps<gpu::GPUModuleOp>());
+    deduplicate(gpuModuleOps, moduleOp, toRemove);
 
-    SmallVector<SymbolUserOpInterface> callOps;
-    moduleOp->walk(
-        [&](SymbolUserOpInterface callOp) { callOps.push_back(callOp); });
-
-    for (SymbolUserOpInterface symbolUserOp : callOps) {
-      if (auto callOp =
-              dyn_cast<CallOpInterface>(symbolUserOp.getOperation())) {
-        SymbolRefAttr sym = llvm::dyn_cast_if_present<SymbolRefAttr>(
-            callOp.getCallableForCallee());
-        if (!sym)
-          continue;
-        Operation *op = SymbolTable::lookupNearestSymbolFrom(callOp, sym);
-        assert(op && "Kernel function not found");
-        auto funcOp = dyn_cast<FunctionOpInterface>(op);
-        assert(funcOp && "Kernel function is not a function");
-        if (equivalenceMap.count(funcOp.getNameAttr()))
-          callOp.setCalleeFromCallable(SymbolRefAttr::get(
-              op->getContext(), equivalenceMap[funcOp.getNameAttr()]));
-      }
-    }
-
-    // At this point it should be safe to remove the duplicate functions.
-    for (CallableOpInterface callableOp : toRemove)
-      callableOp.erase();
+    // At this point it should be safe to remove the duplicates.
+    for (Operation *op : toRemove)
+      op->erase();
   }
 };
 } // end anonymous namespace

--- a/test/lit_tests/remove_duplicate_gpu_modules.mlir
+++ b/test/lit_tests/remove_duplicate_gpu_modules.mlir
@@ -1,0 +1,50 @@
+// RUN: enzymexlamlir-opt %s -remove-duplicate-func-def | FileCheck %s
+
+// Outlining emits one gpu.module per launch site, so a kernel launched twice
+// (here with its arguments swapped, as in a ping-pong loop) yields identical
+// modules that would each get their own binary, stub and registration ctor.
+
+module attributes {gpu.container_module} {
+  // CHECK: gpu.module @kern_mod
+  gpu.module @kern_mod {
+    gpu.func @kern(%arg0: !llvm.ptr, %arg1: !llvm.ptr) kernel {
+      %0 = llvm.load %arg0 : !llvm.ptr -> f32
+      llvm.store %0, %arg1 : f32, !llvm.ptr
+      gpu.return
+    }
+  }
+
+  // CHECK-NOT: gpu.module @kern_mod_0
+  gpu.module @kern_mod_0 {
+    gpu.func @kern(%arg0: !llvm.ptr, %arg1: !llvm.ptr) kernel {
+      %0 = llvm.load %arg0 : !llvm.ptr -> f32
+      llvm.store %0, %arg1 : f32, !llvm.ptr
+      gpu.return
+    }
+  }
+
+  // A module whose body differs must survive.
+  // CHECK: gpu.module @other_mod
+  gpu.module @other_mod {
+    gpu.func @kern(%arg0: !llvm.ptr, %arg1: !llvm.ptr) kernel {
+      %0 = llvm.load %arg1 : !llvm.ptr -> f32
+      llvm.store %0, %arg0 : f32, !llvm.ptr
+      gpu.return
+    }
+  }
+
+  // CHECK-LABEL: @main
+  func.func @main(%src: !llvm.ptr, %dst: !llvm.ptr) {
+    %c1 = arith.constant 1 : index
+    // CHECK: gpu.launch_func @kern_mod::@kern
+    gpu.launch_func @kern_mod::@kern blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%src : !llvm.ptr, %dst : !llvm.ptr)
+    // The duplicate's launch site is repointed at the survivor, keeping its
+    // own (swapped) arguments.
+    // CHECK: gpu.launch_func @kern_mod::@kern
+    // CHECK-SAME: args(%arg1 : !llvm.ptr, %arg0 : !llvm.ptr)
+    gpu.launch_func @kern_mod_0::@kern blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%dst : !llvm.ptr, %src : !llvm.ptr)
+    // CHECK: gpu.launch_func @other_mod::@kern
+    gpu.launch_func @other_mod::@kern blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%src : !llvm.ptr, %dst : !llvm.ptr)
+    return
+  }
+}


### PR DESCRIPTION
Draft: not yet enabled in any pipeline.

`gpu-kernel-outlining` emits one `gpu.module` per launch site, so a kernel launched from several places yields identical modules that each get their own binary, device stub and registration ctor. In an LBM reverse-mode build that is 6 `gpu.module`s over 3 distinct kernels — the ping-pong loop body launches the same kernel twice with swapped grids, and reverse mode doubles that again into an augmented-forward and a gradient kernel:

```
.nv_fatbin       97,856 bytes   (6 fatbins, byte-identical in pairs)
.nvFatBinSegment      0x90      (6 wrappers, 6 __cudaRegisterFatBinary calls)
```

This extends `remove-duplicate-func-def` to collapse them.

### Changes

- **`gpu.module` equivalence** — attribute dictionary minus `sym_name` (so `targets`, offloading handler, etc. must agree) plus `isRegionEquivalentTo(..., IgnoreLocations)`, the same predicate the function path already used.
- **`SymbolTable::replaceAllSymbolUses` instead of hand-rolled callee rewriting.** `gpu.launch_func` implements `SymbolUserOpInterface` but *not* `CallOpInterface`, so the old rewrite loop skipped it — it would have erased a duplicate module and left a dangling `@module::@kernel`. This also picks up function references the old code missed, notably `llvm.mlir.addressof`. Failure-checked: if the uses cannot all be rewritten, the duplicate is left in place.
- **Dedup restricted to each symbol table's own children.** Names are unique within a symbol table, but a `gpu.module` is one of its own, so kernels outlined from the same source share a name across modules. The previous flat `DenseMap<StringRef, StringRef>` would have recorded `name -> name` and erased one of them. For a flat module the behavior is unchanged.

Device stubs are created once per `gpu.module` inside `ConvertGPUModuleOp` and only *referenced* by name at launch sites via `AddressOfOp`, so collapsing modules leaves one stub with both launches pointing at it — no collision.

### Testing

New `test/lit_tests/remove_duplicate_gpu_modules.mlir`: two identical modules collapse; the duplicate's launch site is repointed at the survivor **while keeping its own swapped arguments**; a module with a differing body survives. The pre-existing `remove_duplicate_funcs.mlir` still passes, covering the rewrite-mechanism change for `enzymexla.kernel_call` and `llvm.call`.

### Known limitation

Enabled after `gpu-kernel-outlining` on that LBM build, this currently collapses 6 modules to 5, not to 3. Inlining the same kernel at several call sites gives each copy fresh `#llvm.alias_scope` identities (`distinct` attributes, unique by construction), and the two non-merging pairs differ by *nothing else*:

```diff
-      llvm.intr.experimental.noalias.scope.decl #alias_scope
-      llvm.intr.experimental.noalias.scope.decl #alias_scope1
+      llvm.intr.experimental.noalias.scope.decl #alias_scope2
+      llvm.intr.experimental.noalias.scope.decl #alias_scope3
```

They still compile to byte-identical cubins, since NVPTX does not emit noalias scopes. Those scopes are private to each kernel, so renaming them is a sound alpha-conversion; making the comparison insensitive to it (canonicalizing each module's alias scopes to a shared pool by order of first appearance) would recover the remaining pairs. Left for a follow-up, which is why this is not yet wired into a pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)