### PR TITLE
Skip the dependence solve for provably disjoint atomics

### DIFF
--- a/src/enzyme_ad/jax/Passes/RemoveAtomics.cpp
+++ b/src/enzyme_ad/jax/Passes/RemoveAtomics.cpp
@@ -327,6 +327,20 @@ bool isAccessRacy(ScopStmt &stmtA, MemoryAccess *accessA, ScopStmt &stmtB,
   LLVM_DEBUG(polly::dumpIslObj(stmtA.getSchedule()));
   LLVM_DEBUG(polly::dumpIslObj(stmtB.getSchedule()));
 
+  // Two accesses can only be dependent, and hence racy, if they can reach the
+  // same element. Ruling that out costs a set intersection, where getDeps below
+  // solves three dataflow problems over the whole schedule tree -- and it is
+  // asked for every pair of atomics in the scop.
+  isl::set rangeA =
+      accessA->getAccessRelation().intersect_domain(stmtA.getDomain()).range();
+  isl::set rangeB =
+      accessB->getAccessRelation().intersect_domain(stmtB.getDomain()).range();
+  if (rangeA.get_space().is_equal(rangeB.get_space()) &&
+      rangeA.intersect(rangeB).is_empty()) {
+    LDBG() << "Accesses touch disjoint elements";
+    return false;
+  }
+
   isl::union_map deps = getDeps(stmtA, accessA, stmtB, accessB);
 
   isl::schedule schedule = stmtA.getParent()->getScheduleTree();


### PR DESCRIPTION
`remove-atomics` decides whether an atomic can be made non-atomic by asking, for every pair of atomics in the scop, whether the two accesses race. Each query calls `getDeps`, which runs three dataflow analyses (RAW, WAW, WAR) and gives each of them the **entire scop's schedule tree** while populating only two access relations. The query count is quadratic in the atomic count.

LBM's reverse pass has 19 atomics per gpu wrapper across 2 wrappers — roughly 684 pairs, ~2000 `isl_union_access_info_compute_flow` calls at ~0.37s each. `perf` attributes 99.6% of the pass to that one path:

```
RemoveAtomicsPass::runOnOperation      99.60%
  handleGPUWrapper
    isSafeToRemoveAtomic               99.57%
      isSafeToRemoveAtomicImpl
        isAccessRacy                   99.56%
          getDeps                      99.56%
```

The flat profile shows no single hotspot, just isl churn (`isl_sioimath_*`, `isl_space_*`, malloc) — it is the same expensive setup repeated hundreds of times.

### Change

`isAccessRacy` now intersects the two access ranges before reaching `getDeps`. Two accesses can only be dependent if they can reach the same element, and the function already returns `false` the moment the dependences come back empty — so proving the ranges disjoint reaches the same answer for the cost of a set intersection.

This is a pure fast path: it only ever answers "definitely not racy", and anything it cannot prove falls through to the existing analysis unchanged. Nothing becomes less conservative.

For LBM this is close to ideal — the 19 scatter targets live in distinct lattice-direction planes megabytes apart, so every pair is provably disjoint and skips the solve entirely.

### Results

| | before | after |
|---|---|---|
| `affine-cfg,remove-atomics` on the LBM module | 253 s | **1 s** |
| full `RMATOMICS=yes` LBM compile | 275 s | **27 s** |

Output is unchanged: the pass still removes all 38 `enzyme.atomic_rmw`, and the resulting module is **byte-identical** (263,902 bytes, `diff` clean) to the pre-change output on the same input. End to end the binary is unchanged too — `sm_120` cubins, gradient kernel `REDG=0 / LDG=43 / STG=38`, runtime 22.33 ms vs 22.47 ms before.

### Not done here

A larger refactor would compute one dependence relation per scop and query it per pair, as Polly does. That is **not** equivalent as written: `getDeps` passes `MustWrite` as `must_source`, so a whole-scop solve would let a third access kill a dependence the pairwise problem reports, making the result less conservative. Worth doing deliberately rather than as a side effect of an optimization.

Also still available, for whatever survives the fast path: memoizing symmetric pairs (`(i,j)` is computed in both `i`'s and `j`'s loop, an immediate 2×), and hoisting the scop-invariant setup out of `getDeps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)