### PR TITLE
polygeist-mem2reg: understand transfers, offsets and views

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -12,6 +12,7 @@
 // dead memref store's and perform more complex forwarding when support for
 // SSA scalars live out of 'affine.for'/'affine.if' statements is available.
 //===----------------------------------------------------------------------===//
+#include "Enzyme/MLIR/Interfaces/AutoDiffOpInterface.h"
 #include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -1925,6 +1926,15 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   return changed;
 }
 
+// The pointer a memcpy/memmove reads from; memset has no source.
+static Value transferSource(Operation *op) {
+  if (auto cpy = dyn_cast<LLVM::MemcpyOp>(op))
+    return cpy.getSrc();
+  if (auto mv = dyn_cast<LLVM::MemmoveOp>(op))
+    return mv.getSrc();
+  return nullptr;
+}
+
 bool isPromotable(mlir::Value AI) {
   std::deque<mlir::Value> list = {AI};
 
@@ -1940,13 +1950,19 @@ bool isPromotable(mlir::Value AI) {
         continue;
       } else if (auto LO = dyn_cast<LLVM::LoadOp>(U)) {
         continue;
-      } else if (auto SO = dyn_cast<LLVM::StoreOp>(U)) {
-        continue;
       } else if (auto LO = dyn_cast<affine::AffineLoadOp>(U)) {
         continue;
-      } else if (auto SO = dyn_cast<memref::StoreOp>(U)) {
-        continue;
-      } else if (auto SO = dyn_cast<affine::AffineStoreOp>(U)) {
+      } else if (auto SO = dyn_cast<enzyme::StoreLikeInterface>(U)) {
+        // Only a store *into* val keeps it promotable; storing val itself puts
+        // the pointer into memory, from where anything may reach it.
+        if (SO.getStoredValue() != val)
+          continue;
+        LLVM_DEBUG(llvm::dbgs()
+                   << "non promotable " << AI << " due to " << *U << "\n");
+        return false;
+      } else if (isa<LLVM::MemcpyOp, LLVM::MemmoveOp, LLVM::MemsetOp>(U)) {
+        // The forwarding treats these as an opaque write of the destination and
+        // a read of the source, neither of which lets the pointer escape.
         continue;
       } else if (isa<memref::DeallocOp>(U)) {
         continue;
@@ -1962,6 +1978,10 @@ bool isPromotable(mlir::Value AI) {
       } else if (auto CO = dyn_cast<Memref2PointerOp>(U)) {
         list.push_back(CO);
       } else if (auto CO = dyn_cast<Pointer2MemrefOp>(U)) {
+        list.push_back(CO);
+      } else if (auto CO = dyn_cast<LLVM::GEPOp>(U)) {
+        // Accesses through an offset of the allocation are what the forwarding
+        // marks as indexed: they never match a slot and only block it.
         list.push_back(CO);
       } else {
         LLVM_DEBUG(llvm::dbgs()
@@ -2118,35 +2138,31 @@ void PolygeistMem2Reg::runOnOperation() {
         list.pop_front();
 
         for (auto *U : val.getUsers()) {
-          if (auto SO = dyn_cast<LLVM::StoreOp>(U)) {
-            if (SO.getValue() == val) {
+          if (auto SO = dyn_cast<enzyme::StoreLikeInterface>(U)) {
+            if (SO.getStoredValue() == val) {
               error = true;
               break;
             }
             toErase.push_back(U);
-          } else if (auto SO = dyn_cast<memref::StoreOp>(U)) {
-            if (SO.getValue() == val) {
+          } else if (isa<LLVM::MemsetOp, LLVM::MemcpyOp, LLVM::MemmoveOp>(U)) {
+            // Writing into the allocation goes away with it; reading out of it
+            // writes somewhere else and has to stay.
+            if (transferSource(U) == val) {
               error = true;
               break;
             }
             toErase.push_back(U);
-          } else if (auto SO = dyn_cast<affine::AffineStoreOp>(U)) {
-            if (SO.getValue() == val) {
-              error = true;
-              break;
-            }
+          } else if (isa<LLVM::LifetimeStartOp, LLVM::LifetimeEndOp>(U)) {
             toErase.push_back(U);
           } else if (isa<memref::DeallocOp>(U)) {
             toErase.push_back(U);
           } else if (isa<func::CallOp>(U) &&
                      cast<func::CallOp>(U).getCallee() == "free") {
             toErase.push_back(U);
-          } else if (auto CO = dyn_cast<memref::CastOp>(U)) {
+          } else if (isa<memref::CastOp, Pointer2MemrefOp, Memref2PointerOp,
+                         LLVM::GEPOp>(U)) {
             toErase.push_back(U);
-            list.push_back(CO);
-            //} else if (auto CO = dyn_cast<SubIndexOp>(U)) {
-            //  toErase.push_back(U);
-            //  list.push_back(CO);
+            list.push_back(U->getResult(0));
           } else {
             error = true;
             break;

--- a/test/lit_tests/mem2reg_transfers.mlir
+++ b/test/lit_tests/mem2reg_transfers.mlir
@@ -1,0 +1,140 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+// A memcpy reading the allocation does not stop the parts it does not name from
+// being forwarded, and does not let the pointer escape.
+llvm.func @memcpy_src(%dst: !llvm.ptr) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memcpy"(%dst, %mem, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @memcpy_src(
+// CHECK: %[[C42:.+]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK: "llvm.intr.memcpy"
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[C42]] : i32
+
+// -----
+
+// A memcpy writing the allocation overwrites it, so the store before it must
+// not reach the load after it.
+llvm.func @memcpy_dst(%src: !llvm.ptr) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memcpy"(%mem, %src, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @memcpy_dst(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : i32
+
+// -----
+
+// Likewise for a memset, and for a memmove reading it.
+llvm.func @memset_dst(%other: !llvm.ptr) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %byte = llvm.mlir.constant(0 : i8) : i8
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memset"(%mem, %byte, %len) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @memset_dst(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : i32
+
+// -----
+
+llvm.func @memmove_src(%dst: !llvm.ptr) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memmove"(%dst, %mem, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @memmove_src(
+// CHECK: %[[C42:.+]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK: "llvm.intr.memmove"
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[C42]] : i32
+
+// -----
+
+// An allocation only ever written -- through a view, an offset of it, and a
+// transfer into it -- is dead and goes away with all of them.
+llvm.func @dead_alloca(%src: !llvm.ptr) {
+  %c0 = arith.constant 0 : index
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %c2 = llvm.mlir.constant(2 : i64) : i64
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %byte = llvm.mlir.constant(0 : i8) : i8
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<4 x i32> : (i32) -> !llvm.ptr
+  llvm.intr.lifetime.start %mem : !llvm.ptr
+  %gep = llvm.getelementptr %mem[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<4 x i32>
+  llvm.store %val, %gep : i32, !llvm.ptr
+  %view = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<?xi32>
+  memref.store %val, %view[%c0] : memref<?xi32>
+  "llvm.intr.memcpy"(%mem, %src, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  "llvm.intr.memset"(%mem, %byte, %len) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  llvm.intr.lifetime.end %mem : !llvm.ptr
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @dead_alloca(
+// CHECK-NOT: llvm.alloca
+// CHECK-NOT: llvm.intr.mem
+// CHECK: llvm.return
+
+// -----
+
+// The same allocation stays when something reads out of it.
+llvm.func @live_alloca(%dst: !llvm.ptr) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memcpy"(%dst, %mem, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @live_alloca(
+// CHECK: llvm.alloca
+// CHECK: "llvm.intr.memcpy"
+
+// -----
+
+// Storing the pointer itself hands it to whoever reads that memory, so nothing
+// may be forwarded through it.
+llvm.func @escaped_through_store(%out: !llvm.ptr) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  llvm.store %mem, %out : !llvm.ptr, !llvm.ptr
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @escaped_through_store(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : i32


### PR DESCRIPTION
`isPromotable` rejected an allocation outright when it was used by a `memcpy`/`memmove`/`memset`, reached through a GEP, or reached through a `pointer2memref`/`memref2pointer` view — even though `forwardStoreToLoad` already handles all of them conservatively: a transfer into the allocation is an opaque write, a transfer out of it is a read, and an access through an offset is marked indexed, so it never matches a slot and only blocks one. Accepting them means a single such user no longer makes the whole allocation unpromotable.

The same ops now participate in the dead-allocation cleanup at the end of the pass: an allocation only ever written — through views, offsets, transfers into it, and lifetime markers — is erased along with all of them, while a transfer *reading* out of it keeps it alive, since that copy writes somewhere else.

Store users go through `enzyme::StoreLikeInterface` instead of one branch per dialect. That also adds a check the three branches were missing: a store *of* the pointer puts it into memory, from where anything may reach it, and must not be treated like a store *into* it.

This is deliberately only the understanding half — no forwarding through the transfers themselves. That follows in a second PR, where a transfer covering exactly the whole allocation becomes a load/store of the allocated value.

Tested with `test/lit_tests/mem2reg_transfers.mlir`: forwarding across a transfer that reads the allocation, no forwarding across one that writes it (memcpy and memset), erasure of an allocation written through a view/GEP/transfer/lifetime pair, retention of one that is read, and the escape case. Full lit suite: 1092 pass, the same 4 unrelated failures as on main.