### PR TITLE
polygeist-mem2reg: track where an access lands with an OffsetTree

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -474,14 +474,65 @@ public:
     return unknown();
   }
 
+  // The number of elements (if dim) or bytes moved
+  // by changing the i-th index by 1
+  int64_t stepOf(int64_t i) const {
+    assert(i < units.size());
+    if (units[i].kind == OffsetType::Kind::Bytes) {
+       return units[i].stride;
+    } else {
+       int64_t cur = 1;
+       for (int64_t j=i+1; j<units.size(); j++) {
+          if (units[i].dimSize == ShapedType::kDynamic) {
+	    return ShapedType::kDynamic;
+	  }
+	  cur *= units[i].dimSize;
+       }
+       return cur;
+    }
+  }
+
+  // The maximum value allowed as an arg for the i-th index
+  int64_t maxValue(int64_t i) const {
+    if (units[i].kind == OffsetType::Kind::Bytes) {
+      if (i == 0) return ShapedType::kDynamic;
+      auto prevStep = stepOf(i-1);
+      auto curStep = stepOf(i);
+      assert(prevStep % curStep == 0);
+      assert(prevStep != curStep);
+      return prevStep / curStep;
+    } else {
+      return units[i].dimSize;
+    }
+  }
+
   // Whether this index or one outside it is known to move, which is what puts
   // an access past everything the indices within it can reach. The outer ones
   // are the ones before it.
-  bool movesUpTo(size_t at) const {
-    for (size_t i = 0; i <= at && i < offsets.size(); i++)
-      if (offsets[i].type == Offset::Type::Index && !offsets[i].isZero())
-        return true;
-    return false;
+  int64_t smallestStrideUpTo(size_t at) const {
+    assert(at < offsets.size());
+
+    if (!hasDim()) {
+      int64_t best = INT64_MAX;
+      for (size_t i = 0; i < at; i++) {
+        if (offsets[i].isZero()) continue;
+        assert(units[i].kind == OffsetType::Kind::Bytes);
+	if (units[i].stride < best) {
+	  best = units[i].stride;
+	}
+      }
+      return best;
+    } else {
+      if (at == 0) return INT64_MAX;
+      size_t cur = 1;
+      for (size_t i = at; i < offsets.size(); i++) {
+        if (units[i].dimSize == ShapedType::kDynamic) {
+	   continue;
+	}
+	cur *= units[i].dimSize;
+      }
+      return (int64_t)cur;
+    }
   }
 
   // One index against another, given what a step of each covers, how far all of
@@ -489,45 +540,71 @@ public:
   // to have moved at this index or an outer one. What the shapes leave open is
   // kDynamic, which compares to nothing.
   static Match compareIndex(const Offset &lhs, int64_t lhsStep,
-                            int64_t lhsWhole, int64_t lhsSize, bool lhsMoves,
+                            std::optional<uint64_t> lhsSize, bool lhsSmallestStride,
                             const Offset &rhs, int64_t rhsStep,
-                            int64_t rhsWhole, int64_t rhsSize, bool rhsMoves) {
-    // Stepping over the same amount, the indices can be compared directly.
-    if (lhsStep != ShapedType::kDynamic && lhsStep == rhsStep) {
-      if (lhs.type != rhs.type)
-        return Match::Maybe;
-      switch (lhs.type) {
-      case Offset::Type::Affine:
-        return (lhs.aff == rhs.aff && lhs.dim == rhs.dim && lhs.sym == rhs.sym)
-                   ? Match::Exact
-                   : Match::Maybe;
-      case Offset::Type::Value:
-        return lhs.val == rhs.val ? Match::Exact : Match::Maybe;
-      case Offset::Type::Index:
-        break;
+                            std::optional<uint64_t> rhsSize, bool rhsSmallestStride, bool isDim, bool sameExtent) {
+    
+    // The lhs step is smaller than the rhs step, and it can be proven that the lhs stride cannot possibly equal a single
+    // rhs stride.
+    if (lhsStep != ShapedType::kDynamic && rhsStep != ShapedType::kDynamic && lhsStep < rhsStep && rhsStep % lhsStep == 0) {
+      if (lhs.type == Offset::Type::Index && lhs.idx != 0 && lhs.idx < rhsStep % lhsStep) {
+	return Match::None;
       }
-      if (lhs.idx == rhs.idx)
-        return Match::Exact;
-      // Whichever starts first has to end before the other begins, so the
-      // extent that decides is the one belonging to it.
-      bool first = lhs.idx < rhs.idx;
-      uint64_t between =
-          (first ? rhs.idx - lhs.idx : lhs.idx - rhs.idx) * (uint64_t)lhsStep;
-      int64_t reach = first ? lhsSize : rhsSize;
-      return reach != ShapedType::kDynamic && between >= (uint64_t)reach
-                 ? Match::None
-                 : Match::Maybe;
+    }
+    
+    // Same the other way
+    if (rhsStep != ShapedType::kDynamic && lhsStep != ShapedType::kDynamic && rhsStep < lhsStep && lhsStep % rhsStep == 0) {
+      if (rhs.type == Offset::Type::Index && rhs.idx != 0 && rhs.idx < lhsStep % rhsStep) {
+        return Match::None;
+      }
     }
 
-    // Stepping over different amounts, one is clear of the other when all its
-    // index can reach fits within a single step of the other's, and the other
-    // is known to have taken at least one of those steps.
-    if (lhsWhole != ShapedType::kDynamic && rhsStep != ShapedType::kDynamic &&
-        lhsWhole <= rhsStep && rhsMoves)
-      return Match::None;
-    if (rhsWhole != ShapedType::kDynamic && lhsStep != ShapedType::kDynamic &&
-        rhsWhole <= lhsStep && lhsMoves)
-      return Match::None;
+    if (lhsStep != ShapedType::kDynamic && lhsStep == rhsStep && (sameExtent || !isDim)) {
+      switch (lhs.type) {
+      bool first;
+      int64_t difference = INT64_MAX;
+      case Offset::Type::Affine:
+	if (lhs.dim == rhs.dim && lhs.sym == rhs.sym) {
+	   if (lhs.aff == rhs.aff) {
+	      return Match::Exact;
+	   }
+	   if (auto cst = dyn_cast<AffineConstantExpr>(rhs.aff - lhs.aff)) {
+      	      first = lhs.idx < rhs.idx;
+	      difference = std::abs(cst.getValue());
+	      break;
+	   }
+	}
+      case Offset::Type::Value:
+        if (lhs.val == rhs.val)
+	  return Match::Exact;
+	break;
+      case Offset::Type::Index:
+        if (lhs.idx == rhs.idx) {
+          return Match::Exact;
+	}
+	first = lhs.aff < rhs.aff;
+	difference = (first ? rhs.idx - lhs.idx : lhs.idx - rhs.idx);
+        break;
+      }
+
+      if (difference == INT64_MAX) return Match::Maybe;
+
+      if (isDim) {
+        if (difference < lhsSmallestStride && difference < rhsSmallestStride) {
+	  return Match::None;
+	}
+      } else {
+        if (sameExtent || (lhsSize && rhsSize)) {
+          if (!sameExtent) {
+	    difference += std::abs(*lhsSize - *rhsSize);
+	  }
+          if (difference < lhsSmallestStride && difference < rhsSmallestStride) {
+	    return Match::None;
+	  }
+	}
+      }
+    }
+    
     return Match::Maybe;
   }
 
@@ -547,77 +624,58 @@ public:
     if (!sameExtent && (!size || !osize))
       return Match::Maybe;
 
-    // Counting in dimensions of a memref and counting in bytes of a pointer
-    // cannot be lined up against each other.
-    if ((hasDim() && o.hasByte()) || (o.hasDim() && hasByte()))
+    bool isDim = true;
+
+    if (hasDim() && o.hasDim()) {
+      isDim = true;
+    } else if (!o.hasDim() && !o.hasDim()) {
+      isDim = false;
+    } else {
       return Match::Maybe;
-
-    // A path counts in what its access reads: in those, when both read the
-    // same amount -- the only unit there is when the layout cannot measure
-    // them -- and in bytes when they do not, which is also all a path through
-    // bytes can count in.
-    int64_t reach = 1, oreach = 1;
-    if (!sameExtent || (!hasDim() && !o.hasDim())) {
-      reach = size ? (int64_t)*size : ShapedType::kDynamic;
-      oreach = osize ? (int64_t)*osize : ShapedType::kDynamic;
     }
-
-    // What an index steps over is everything the indices inside it cover, which
-    // is why they are held innermost first: the running product is that.
-    auto stepOf = [](const OffsetType &unit, int64_t inner) -> int64_t {
-      return unit.kind == OffsetType::Kind::Bytes ? (int64_t)unit.stride
-                                                  : inner;
-    };
-    // How far all of an index reaches. A pointer index is given no bound, and
-    // neither is a dimension whose extent the shape leaves open.
-    auto wholeOf = [](const OffsetType &unit, int64_t inner) -> int64_t {
-      if (unit.kind == OffsetType::Kind::Bytes ||
-          inner == ShapedType::kDynamic ||
-          unit.dimSize == ShapedType::kDynamic || unit.dimSize < 0)
-        return ShapedType::kDynamic;
-      return inner * unit.dimSize;
-    };
-
-    // One of whatever is being counted in, to start with.
-    int64_t inner = reach, oinner = oreach;
-    unsigned apart = 0;
-    bool unsure = false;
-
-    auto record = [&](Match m) {
-      if (m == Match::None)
-        apart++;
-      else if (m == Match::Maybe)
-        unsure = true;
-    };
 
     // The indices run most significant first, so the walk runs the other way:
     // what an index steps over is everything the ones after it cover, which is
     // what the running product holds by the time it is reached.
     ssize_t i = offsets.size() - 1, j = o.offsets.size() - 1;
 
+    bool exact = true;
+
     while (i >= 0 && j >= 0) {
       // An index that does not move lines up with anything, though whatever it
       // would have stepped over still lies inside the ones outside it.
       if (offsets[i].isZero()) {
-        inner = wholeOf(units[i], inner);
         i--;
         continue;
       }
       if (o.offsets[j].isZero()) {
-        oinner = wholeOf(o.units[j], oinner);
         j--;
         continue;
       }
 
-      auto lhsStep = stepOf(units[i], inner);
-      auto lhsWhole = wholeOf(units[i], inner);
-      auto rhsStep = stepOf(o.units[j], oinner);
-      auto rhsWhole = wholeOf(o.units[j], oinner);
-      record(compareIndex(offsets[i], lhsStep, lhsWhole, reach, movesUpTo(i),
-                          o.offsets[j], rhsStep, rhsWhole, oreach,
-                          o.movesUpTo(j)));
-      inner = lhsWhole;
-      oinner = rhsWhole;
+      auto lhsStep = stepOf(i);
+      auto rhsStep = o.stepOf(j);
+      
+      auto lhsStride = smallestStrideUpTo(i);
+      auto rhsStride = o.smallestStrideUpTo(j);
+      auto res = compareIndex(offsets[i], lhsStep, size, smallestStrideUpTo(i),
+                          o.offsets[j], rhsStep, osize,
+                          o.smallestStrideUpTo(j), isDim, sameExtent);
+      if (res == Match::None) return Match::None;
+      
+      if (res == Match::Exact) {
+        i--;
+	j--;
+	continue;
+      }
+
+      if (lhsStep == rhsStep) {
+        exact = false;
+	i--;
+	j--;
+	continue;
+      }
+
       i--;
       j--;
     }
@@ -626,38 +684,30 @@ public:
     // which is wherever the indices it did have put it.
     for (; i >= 0; i--) {
       if (offsets[i].isZero()) {
-        inner = wholeOf(units[i], inner);
         continue;
       }
-      auto step = stepOf(units[i], inner);
-      auto whole = wholeOf(units[i], inner);
-      record(compareIndex(offsets[i], step, whole, reach, movesUpTo(i),
-                          Offset((size_t)0), step, step, oreach,
-                          /*moves=*/false));
-      inner = whole;
+      if (offsets[i].type == Offset::Type::Value) {
+        if (offsets[i].val != 0) {
+	  return Match::None;
+	}
+      }
     }
     for (; j >= 0; j--) {
       if (o.offsets[j].isZero()) {
-        oinner = wholeOf(o.units[j], oinner);
         continue;
       }
-      auto step = stepOf(o.units[j], oinner);
-      auto whole = wholeOf(o.units[j], oinner);
-      record(compareIndex(Offset((size_t)0), step, step, reach,
-                          /*moves=*/false, o.offsets[j], step, whole, oreach,
-                          o.movesUpTo(j)));
-      oinner = whole;
+      if (offsets[j].type == Offset::Type::Value) {
+        if (offsets[j].val != 0) {
+	  return Match::None;
+	}
+      }
     }
 
-    // One index landing clear of the other says the two are different places,
-    // but only once every other index is known to land together: what an index
-    // that may land elsewhere adds is what could put them back on the same
-    // byte, and so is a second index that lands clear the other way -- being
-    // four elements behind at one level and a step ahead at the next is the
-    // same byte reached two ways.
-    if (apart)
-      return unsure || apart > 1 ? Match::Maybe : Match::None;
-    return unsure || !sameExtent ? Match::Maybe : Match::Exact;
+    if (exact) {
+      return Match::Exact;
+    } else {
+      return Match::Maybe;
+    }
   }
 
   bool operator<(const OffsetTree &o) const {

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -479,24 +479,25 @@ public:
   int64_t stepOf(int64_t i) const {
     assert(i < units.size());
     if (units[i].kind == OffsetType::Kind::Bytes) {
-       return units[i].stride;
+      return units[i].stride;
     } else {
-       int64_t cur = 1;
-       for (int64_t j=i+1; j<units.size(); j++) {
-          if (units[i].dimSize == ShapedType::kDynamic) {
-	    return ShapedType::kDynamic;
-	  }
-	  cur *= units[i].dimSize;
-       }
-       return cur;
+      int64_t cur = 1;
+      for (int64_t j = i + 1; j < units.size(); j++) {
+        if (units[i].dimSize == ShapedType::kDynamic) {
+          return ShapedType::kDynamic;
+        }
+        cur *= units[i].dimSize;
+      }
+      return cur;
     }
   }
 
   // The maximum value allowed as an arg for the i-th index
   int64_t maxValue(int64_t i) const {
     if (units[i].kind == OffsetType::Kind::Bytes) {
-      if (i == 0) return ShapedType::kDynamic;
-      auto prevStep = stepOf(i-1);
+      if (i == 0)
+        return ShapedType::kDynamic;
+      auto prevStep = stepOf(i - 1);
       auto curStep = stepOf(i);
       assert(prevStep % curStep == 0);
       assert(prevStep != curStep);
@@ -515,21 +516,23 @@ public:
     if (!hasDim()) {
       int64_t best = INT64_MAX;
       for (size_t i = 0; i < at; i++) {
-        if (offsets[i].isZero()) continue;
+        if (offsets[i].isZero())
+          continue;
         assert(units[i].kind == OffsetType::Kind::Bytes);
-	if (units[i].stride < best) {
-	  best = units[i].stride;
-	}
+        if (units[i].stride < best) {
+          best = units[i].stride;
+        }
       }
       return best;
     } else {
-      if (at == 0) return INT64_MAX;
+      if (at == 0)
+        return INT64_MAX;
       size_t cur = 1;
       for (size_t i = at; i < offsets.size(); i++) {
         if (units[i].dimSize == ShapedType::kDynamic) {
-	   continue;
-	}
-	cur *= units[i].dimSize;
+          continue;
+        }
+        cur *= units[i].dimSize;
       }
       return (int64_t)cur;
     }
@@ -540,71 +543,79 @@ public:
   // to have moved at this index or an outer one. What the shapes leave open is
   // kDynamic, which compares to nothing.
   static Match compareIndex(const Offset &lhs, int64_t lhsStep,
-                            std::optional<uint64_t> lhsSize, bool lhsSmallestStride,
-                            const Offset &rhs, int64_t rhsStep,
-                            std::optional<uint64_t> rhsSize, bool rhsSmallestStride, bool isDim, bool sameExtent) {
-    
-    // The lhs step is smaller than the rhs step, and it can be proven that the lhs stride cannot possibly equal a single
-    // rhs stride.
-    if (lhsStep != ShapedType::kDynamic && rhsStep != ShapedType::kDynamic && lhsStep < rhsStep && rhsStep % lhsStep == 0) {
-      if (lhs.type == Offset::Type::Index && lhs.idx != 0 && lhs.idx < rhsStep % lhsStep) {
-	return Match::None;
-      }
-    }
-    
-    // Same the other way
-    if (rhsStep != ShapedType::kDynamic && lhsStep != ShapedType::kDynamic && rhsStep < lhsStep && lhsStep % rhsStep == 0) {
-      if (rhs.type == Offset::Type::Index && rhs.idx != 0 && rhs.idx < lhsStep % rhsStep) {
+                            std::optional<uint64_t> lhsSize,
+                            int64_t lhsSmallestStride, const Offset &rhs,
+                            int64_t rhsStep, std::optional<uint64_t> rhsSize,
+                            int64_t rhsSmallestStride, bool isDim,
+                            bool sameExtent) {
+
+    // The lhs step is smaller than the rhs step, and it can be proven that the
+    // lhs stride cannot possibly equal a single rhs stride.
+    if (lhsStep != ShapedType::kDynamic && rhsStep != ShapedType::kDynamic &&
+        lhsStep < rhsStep && rhsStep % lhsStep == 0) {
+      if (lhs.type == Offset::Type::Index && lhs.idx != 0 &&
+          (int64_t)lhs.idx < rhsStep / lhsStep) {
         return Match::None;
       }
     }
 
-    if (lhsStep != ShapedType::kDynamic && lhsStep == rhsStep && (sameExtent || !isDim)) {
-      switch (lhs.type) {
-      bool first;
+    // Same the other way
+    if (rhsStep != ShapedType::kDynamic && lhsStep != ShapedType::kDynamic &&
+        rhsStep < lhsStep && lhsStep % rhsStep == 0) {
+      if (rhs.type == Offset::Type::Index && rhs.idx != 0 &&
+          (int64_t)rhs.idx < lhsStep / rhsStep) {
+        return Match::None;
+      }
+    }
+
+    if (lhsStep != ShapedType::kDynamic && lhsStep == rhsStep &&
+        (sameExtent || !isDim)) {
       int64_t difference = INT64_MAX;
+      switch (lhs.type) {
       case Offset::Type::Affine:
-	if (lhs.dim == rhs.dim && lhs.sym == rhs.sym) {
-	   if (lhs.aff == rhs.aff) {
-	      return Match::Exact;
-	   }
-	   if (auto cst = dyn_cast<AffineConstantExpr>(rhs.aff - lhs.aff)) {
-      	      first = lhs.idx < rhs.idx;
-	      difference = std::abs(cst.getValue());
-	      break;
-	   }
-	}
+        if (lhs.dim == rhs.dim && lhs.sym == rhs.sym) {
+          if (lhs.aff == rhs.aff) {
+            return Match::Exact;
+          }
+          if (auto cst = dyn_cast<AffineConstantExpr>(rhs.aff - lhs.aff)) {
+            difference = std::abs(cst.getValue());
+          }
+        }
+        break;
       case Offset::Type::Value:
         if (lhs.val == rhs.val)
-	  return Match::Exact;
-	break;
+          return Match::Exact;
+        break;
       case Offset::Type::Index:
         if (lhs.idx == rhs.idx) {
           return Match::Exact;
-	}
-	first = lhs.aff < rhs.aff;
-	difference = (first ? rhs.idx - lhs.idx : lhs.idx - rhs.idx);
+        }
+        difference =
+            (lhs.idx < rhs.idx ? rhs.idx - lhs.idx : lhs.idx - rhs.idx);
         break;
       }
 
-      if (difference == INT64_MAX) return Match::Maybe;
+      if (difference == INT64_MAX)
+        return Match::Maybe;
 
       if (isDim) {
         if (difference < lhsSmallestStride && difference < rhsSmallestStride) {
-	  return Match::None;
-	}
+          return Match::None;
+        }
       } else {
         if (sameExtent || (lhsSize && rhsSize)) {
           if (!sameExtent) {
-	    difference += std::abs(*lhsSize - *rhsSize);
-	  }
-          if (difference < lhsSmallestStride && difference < rhsSmallestStride) {
-	    return Match::None;
-	  }
-	}
+            difference +=
+                *lhsSize > *rhsSize ? *lhsSize - *rhsSize : *rhsSize - *lhsSize;
+          }
+          if (difference < lhsSmallestStride &&
+              difference < rhsSmallestStride) {
+            return Match::None;
+          }
+        }
       }
     }
-    
+
     return Match::Maybe;
   }
 
@@ -655,25 +666,30 @@ public:
 
       auto lhsStep = stepOf(i);
       auto rhsStep = o.stepOf(j);
-      
+
       auto lhsStride = smallestStrideUpTo(i);
       auto rhsStride = o.smallestStrideUpTo(j);
-      auto res = compareIndex(offsets[i], lhsStep, size, smallestStrideUpTo(i),
-                          o.offsets[j], rhsStep, osize,
-                          o.smallestStrideUpTo(j), isDim, sameExtent);
-      if (res == Match::None) return Match::None;
-      
+      auto res =
+          compareIndex(offsets[i], lhsStep, size, lhsStride, o.offsets[j],
+                       rhsStep, osize, rhsStride, isDim, sameExtent);
+      if (res == Match::None)
+        return Match::None;
+
       if (res == Match::Exact) {
         i--;
-	j--;
-	continue;
+        j--;
+        continue;
       }
 
-      if (lhsStep == rhsStep) {
-        exact = false;
-	i--;
-	j--;
-	continue;
+      exact = false;
+      
+      if (lhsStep != rhsStep && lhsStep != ShapedType::kDynamic && rhsStep != ShapedType::kDynamic) {
+	if (lhsStep < rhsStep) {
+          i--;
+	} else {
+          j--;
+	}
+        continue;
       }
 
       i--;
@@ -688,18 +704,18 @@ public:
       }
       if (offsets[i].type == Offset::Type::Value) {
         if (offsets[i].val != 0) {
-	  return Match::None;
-	}
+          return Match::None;
+        }
       }
     }
     for (; j >= 0; j--) {
       if (o.offsets[j].isZero()) {
         continue;
       }
-      if (offsets[j].type == Offset::Type::Value) {
-        if (offsets[j].val != 0) {
-	  return Match::None;
-	}
+      if (o.offsets[j].type == Offset::Type::Value) {
+        if (o.offsets[j].val != 0) {
+          return Match::None;
+        }
       }
     }
 

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -85,6 +85,17 @@ public:
     idx = constant;
     type = Type::Index;
   }
+  // An index counts from the start of what it is an offset into, so anything
+  // below that is the expression it is instead, which takes a context to name.
+  Offset(int64_t constant, MLIRContext *ctx) {
+    if (constant >= 0) {
+      idx = constant;
+      type = Type::Index;
+      return;
+    }
+    aff = getAffineConstantExpr(constant, ctx);
+    type = Type::Affine;
+  }
   Offset(AffineExpr expr, SmallVector<Value> dims, SmallVector<Value> syms) {
     if (auto cst = dyn_cast<AffineConstantExpr>(expr)) {
       if (cst.getValue() >= 0) {
@@ -433,11 +444,10 @@ public:
     if (unknownOffset || o.unknownOffset)
       return unknown();
 
+    // This path does not move, so it lands wherever the access does.
     if (isZero())
-      return OffsetTree(o.base);
-    if (o.isZero())
       return o;
-    
+
     // Dimensions count what the access reads, so two paths through them only
     // compose when what they count is the same size.
     if ((hasDim() || o.hasDim()) && base != o.base) {
@@ -445,6 +455,11 @@ public:
       if (!lhsSize || !rhsSize || *lhsSize != *rhsSize)
         return unknown();
     }
+
+    // The access is at the start of what this path reached, so it lands here,
+    // reading what the access reads.
+    if (o.isZero())
+      return OffsetTree(o.base, offsets, units);
 
     // Moving the same way twice is moving once by the two together.
     if (units == o.units) {
@@ -491,11 +506,11 @@ public:
       return units[i].stride;
     } else {
       int64_t cur = 1;
-      for (int64_t j = i + 1; j < units.size(); j++) {
-        if (units[i].dimSize == ShapedType::kDynamic) {
+      for (int64_t j = i + 1; j < (int64_t)units.size(); j++) {
+        if (units[j].dimSize == ShapedType::kDynamic) {
           return ShapedType::kDynamic;
         }
-        cur *= units[i].dimSize;
+        cur *= units[j].dimSize;
       }
       return cur;
     }
@@ -695,7 +710,7 @@ public:
     // what the running product holds by the time it is reached.
     ssize_t i = offsets.size() - 1, j = o.offsets.size() - 1;
 
-    bool exact = true;
+    bool exact = sameExtent;
 
     while (i >= 0 && j >= 0) {
       // An index that does not move lines up with anything, though whatever it
@@ -828,16 +843,16 @@ static OffsetTree gepOffsets(LLVM::GEPOp gep, const DataLayout &dl) {
   std::vector<Offset> offsets;
   std::vector<OffsetType> units;
   Type cur = gep.getElemType();
+  assert(cur && "a getelementptr walks into a type");
 
   auto step = [&](std::optional<int64_t> constant, Value dynamic,
                   uint64_t stride) {
     if (constant) {
-      offsets.emplace_back((size_t)(*constant * stride));
-      units.push_back(OffsetType::bytes(1));
+      offsets.emplace_back(*constant, gep.getContext());
     } else {
       offsets.emplace_back(dynamic);
-      units.push_back(OffsetType::bytes(stride));
     }
+    units.push_back(OffsetType::bytes(stride));
   };
 
   for (auto &&[i, arg] : llvm::enumerate(gep.getIndices())) {
@@ -870,6 +885,7 @@ static OffsetTree gepOffsets(LLVM::GEPOp gep, const DataLayout &dl) {
       offsets.emplace_back((size_t)byte);
       units.push_back(OffsetType::bytes(1));
       cur = ST.getBody()[*constant];
+      assert(cur && "a field of a struct is of some type");
       continue;
     }
 
@@ -881,11 +897,14 @@ static OffsetTree gepOffsets(LLVM::GEPOp gep, const DataLayout &dl) {
     else
       return OffsetTree::unknown();
 
+    assert(element && "an aggregate is made of something");
     step(constant, dynamic, dl.getTypeSize(element));
     cur = element;
   }
 
-  return OffsetTree({}, std::move(offsets), std::move(units));
+  // Where the walk ended is what an access through this reads.
+  assert(cur && "a getelementptr lands on a type");
+  return OffsetTree(cur, std::move(offsets), std::move(units));
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const OffsetType unit) {

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -433,17 +433,18 @@ public:
     if (unknownOffset || o.unknownOffset)
       return unknown();
 
+    if (isZero())
+      return OffsetTree(o.base);
+    if (o.isZero())
+      return o;
+    
     // Dimensions count what the access reads, so two paths through them only
     // compose when what they count is the same size.
-    if ((hasDim() || o.hasDim()) && base && o.base && base != o.base) {
+    if ((hasDim() || o.hasDim()) && base != o.base) {
       auto lhsSize = typeSize(base, dl), rhsSize = typeSize(o.base, dl);
       if (!lhsSize || !rhsSize || *lhsSize != *rhsSize)
         return unknown();
     }
-    if (isZero())
-      return o;
-    if (o.isZero())
-      return OffsetTree(o.base, offsets, units);
 
     // Moving the same way twice is moving once by the two together.
     if (units == o.units) {
@@ -533,18 +534,20 @@ public:
   // Whether a constant index at `at` puts this past everything `o` can name.
   bool beyond(size_t at, std::optional<uint64_t> mySize, const OffsetTree &o,
               std::optional<uint64_t> oSize, bool sameExtent) const {
-    int64_t step = stepOf(at), bound = o.reachBound(oSize);
-    assert(step != 0)
+    int64_t step = stepOf(at), bound = o.reachBound();
+    assert(step != 0);
     if (step == ShapedType::kDynamic || bound == ShapedType::kDynamic)
       return false;
     if (sameExtent) {
-	    if (offsets[at].idx * step >= bound) return true;
+      if ((int64_t)offsets[at].idx * step >= bound)
+        return true;
     } else if (mySize && oSize) {
-	  if (hasDim()) {
-	    step *= *mySize;
-	    bound *= *osize;
-	  }
-	    if (offsets[at].idx * step >= bound) return true;
+      if (hasDim()) {
+        step *= (int64_t)*mySize;
+        bound *= (int64_t)*oSize;
+      }
+      if ((int64_t)offsets[at].idx * step >= bound)
+        return true;
     }
     return false;
   }
@@ -746,7 +749,8 @@ public:
         continue;
       }
       exact = false;
-      if (offsets[i].type == Offset::Type::Index && beyond(i, size, o, osize, sameExtent)) {
+      if (offsets[i].type == Offset::Type::Index &&
+          beyond(i, size, o, osize, sameExtent)) {
         return Match::None;
       }
     }

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -553,18 +553,31 @@ public:
     assert(step != 0);
     if (step == ShapedType::kDynamic || bound == ShapedType::kDynamic)
       return false;
-    if (sameExtent) {
-      if ((int64_t)offsets[at].idx * step >= bound)
-        return true;
-    } else if (mySize && oSize) {
-      if (hasDim()) {
+
+    // Reading different amounts, the two only line up once both are counted in
+    // bytes rather than in the elements each reads.
+    if (!sameExtent) {
+      if (!mySize || !oSize)
+        return false;
+      if (hasDim())
         step *= (int64_t)*mySize;
+      if (o.hasDim())
         bound *= (int64_t)*oSize;
-      }
-      if ((int64_t)offsets[at].idx * step >= bound)
-        return true;
     }
-    return false;
+
+    // A dimension counts the elements the other reads, so its bound already
+    // spans what is read at the last of them. A byte offset is only where the
+    // other starts, and what it reads there comes after that.
+    if (!o.hasDim()) {
+      if (!oSize)
+        return false;
+      bound += (int64_t)*oSize;
+    }
+
+    uint64_t idx = offsets[at].idx;
+    if (idx > (uint64_t)(INT64_MAX / step))
+      return false;
+    return (int64_t)idx * step >= bound;
   }
 
   // Whether this index or one outside it is known to move, which is what puts

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -427,11 +427,19 @@ public:
                   syms);
   }
 
-  // Composing this path with a further one, which names the accessed value and
-  // so says what type and size the result is of.
-  OffsetTree add(const OffsetTree &o) const {
+  // Composing this path with a further one. The further one names the value
+  // that is read or written, so the result is of its type.
+  OffsetTree add(const OffsetTree &o, const DataLayout &dl) const {
     if (unknownOffset || o.unknownOffset)
       return unknown();
+
+    // Dimensions count what the access reads, so two paths through them only
+    // compose when what they count is the same size.
+    if ((hasDim() || o.hasDim()) && base && o.base && base != o.base) {
+      auto lhsSize = typeSize(base, dl), rhsSize = typeSize(o.base, dl);
+      if (!lhsSize || !rhsSize || *lhsSize != *rhsSize)
+        return unknown();
+    }
     if (isZero())
       return o;
     if (o.isZero())
@@ -499,12 +507,46 @@ public:
         return ShapedType::kDynamic;
       auto prevStep = stepOf(i - 1);
       auto curStep = stepOf(i);
+      if (prevStep == ShapedType::kDynamic || curStep == ShapedType::kDynamic ||
+          curStep == 0)
+        return ShapedType::kDynamic;
       assert(prevStep % curStep == 0);
       assert(prevStep != curStep);
       return prevStep / curStep;
     } else {
       return units[i].dimSize;
     }
+  }
+
+  // The first index guaranteed not to be touched by this access, if any
+  int64_t reachBound() const {
+    if (units.empty())
+      return 0;
+
+    int64_t step = stepOf(0), extent = maxValue(0);
+    assert(step != 0);
+    if (step == ShapedType::kDynamic || extent == ShapedType::kDynamic)
+      return ShapedType::kDynamic;
+    return step * extent;
+  }
+
+  // Whether a constant index at `at` puts this past everything `o` can name.
+  bool beyond(size_t at, std::optional<uint64_t> mySize, const OffsetTree &o,
+              std::optional<uint64_t> oSize, bool sameExtent) const {
+    int64_t step = stepOf(at), bound = o.reachBound(oSize);
+    assert(step != 0)
+    if (step == ShapedType::kDynamic || bound == ShapedType::kDynamic)
+      return false;
+    if (sameExtent) {
+	    if (offsets[at].idx * step >= bound) return true;
+    } else if (mySize && oSize) {
+	  if (hasDim()) {
+	    step *= *mySize;
+	    bound *= *osize;
+	  }
+	    if (offsets[at].idx * step >= bound) return true;
+    }
+    return false;
   }
 
   // Whether this index or one outside it is known to move, which is what puts
@@ -639,7 +681,7 @@ public:
 
     if (hasDim() && o.hasDim()) {
       isDim = true;
-    } else if (!o.hasDim() && !o.hasDim()) {
+    } else if (!hasDim() && !o.hasDim()) {
       isDim = false;
     } else {
       return Match::Maybe;
@@ -682,13 +724,14 @@ public:
       }
 
       exact = false;
-      
-      if (lhsStep != rhsStep && lhsStep != ShapedType::kDynamic && rhsStep != ShapedType::kDynamic) {
-	if (lhsStep < rhsStep) {
+
+      if (sameExtent && lhsStep != rhsStep && lhsStep != ShapedType::kDynamic &&
+          rhsStep != ShapedType::kDynamic) {
+        if (lhsStep < rhsStep) {
           i--;
-	} else {
+        } else {
           j--;
-	}
+        }
         continue;
       }
 
@@ -702,20 +745,19 @@ public:
       if (offsets[i].isZero()) {
         continue;
       }
-      if (offsets[i].type == Offset::Type::Value) {
-        if (offsets[i].val != 0) {
-          return Match::None;
-        }
+      exact = false;
+      if (offsets[i].type == Offset::Type::Index && beyond(i, size, o, osize, sameExtent)) {
+        return Match::None;
       }
     }
     for (; j >= 0; j--) {
       if (o.offsets[j].isZero()) {
         continue;
       }
-      if (o.offsets[j].type == Offset::Type::Value) {
-        if (o.offsets[j].val != 0) {
-          return Match::None;
-        }
+      exact = false;
+      if (o.offsets[j].type == Offset::Type::Index &&
+          o.beyond(j, osize, *this, size, sameExtent)) {
+        return Match::None;
       }
     }
 
@@ -745,34 +787,18 @@ public:
   }
 };
 
-// The offset an access lands at within the value it indexes, in the units that
-// value counts in: dimensions of a memref, bytes of an llvm pointer. An access
-// with no indices reads the start of what it is given.
 static OffsetTree accessOffsets(Type accessed) { return OffsetTree(accessed); }
-
-// Dimensions count what the access reads, so an access reading something other
-// than what the memref holds says nothing about where it lands.
-static bool countsWhatItReads(Type accessed, MemRefType MT,
-                              const DataLayout &dl) {
-  if (accessed == MT.getElementType())
-    return true;
-  auto size = typeSize(accessed, dl),
-       elSize = typeSize(MT.getElementType(), dl);
-  return size && elSize && *size == *elSize;
-}
 
 static OffsetTree accessOffsets(Type accessed, Value memory,
                                 mlir::OperandRange indices,
                                 const DataLayout &dl) {
   std::vector<Offset> offsets;
   std::vector<OffsetType> units;
-  if (auto MT = dyn_cast<MemRefType>(memory.getType())) {
-    if (!indices.empty() && !countsWhatItReads(accessed, MT, dl))
-      return OffsetTree::unknown();
-    for (auto &&[i, idx] : llvm::enumerate(indices)) {
-      offsets.emplace_back(idx);
-      units.push_back(OffsetType::dim(MT.getShape()[i]));
-    }
+  auto MT = cast<MemRefType>(memory.getType());
+  assert(MT.getElementType() == accessed);
+  for (auto &&[i, idx] : llvm::enumerate(indices)) {
+    offsets.emplace_back(idx);
+    units.push_back(OffsetType::dim(MT.getShape()[i]));
   }
   return OffsetTree(accessed, std::move(offsets), std::move(units));
 }
@@ -783,8 +809,7 @@ static OffsetTree accessOffsets(Type accessed, Value memory, AffineMap map,
   std::vector<Offset> offsets;
   std::vector<OffsetType> units;
   auto MT = cast<MemRefType>(memory.getType());
-  if (map.getNumResults() && !countsWhatItReads(accessed, MT, dl))
-    return OffsetTree::unknown();
+  assert(MT.getElementType() == accessed);
   for (auto &&[i, expr] : llvm::enumerate(map.getResults())) {
     offsets.emplace_back(expr, map.getNumDims(), map.getNumSymbols(), operands);
     units.push_back(OffsetType::dim(MT.getShape()[i]));
@@ -1941,7 +1966,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
         continue;
       }
       if (auto co = dyn_cast<mlir::LLVM::GEPOp>(user)) {
-        list.emplace_back((Value)co, tree.add(gepOffsets(co, dl)));
+        list.emplace_back((Value)co, tree.add(gepOffsets(co, dl), dl));
         continue;
       }
       if (auto co = dyn_cast<mlir::LLVM::BitcastOp>(user)) {
@@ -1958,7 +1983,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       // A load naming the slot reads it; one that may only overlap it reads
       // something this knows nothing about, which is no reason to stop.
       auto matchLoad = [&](Operation *loadOp, OffsetTree accessed) {
-        if (idx.matches(tree.add(accessed), dl) != Match::Exact)
+        if (idx.matches(tree.add(accessed, dl), dl) != Match::Exact)
           return;
         subType = loadOp->getResult(0).getType();
         // Whichever spelling of the slot is read first is the one the value
@@ -1970,7 +1995,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
         LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << *loadOp << "\n");
       };
       auto matchStore = [&](Operation *storeOp, OffsetTree accessed) {
-        switch (idx.matches(tree.add(accessed), dl)) {
+        switch (idx.matches(tree.add(accessed, dl), dl)) {
         case Match::Exact:
           LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << *storeOp << "\n");
           allStoreOps.insert(storeOp);
@@ -2669,25 +2694,30 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
     list.pop_front();
     for (auto *U : val.getUsers()) {
       if (auto SO = dyn_cast<memref::StoreOp>(U)) {
-        lastStored[tree.add(accessOffsets(
-            SO.getValue().getType(), SO.getMemRef(), SO.getIndices(), dl))]++;
+        lastStored[tree.add(accessOffsets(SO.getValue().getType(),
+                                          SO.getMemRef(), SO.getIndices(), dl),
+                            dl)]++;
       } else if (auto LO = dyn_cast<memref::LoadOp>(U)) {
-        lastStored[tree.add(accessOffsets(LO.getType(), LO.getMemRef(),
-                                          LO.getIndices(), dl))]++;
+        lastStored[tree.add(
+            accessOffsets(LO.getType(), LO.getMemRef(), LO.getIndices(), dl),
+            dl)]++;
       } else if (auto SO = dyn_cast<affine::AffineStoreOp>(U)) {
-        lastStored[tree.add(accessOffsets(
-            SO.getValue().getType(), SO.getMemRef(),
-            SO.getAffineMapAttr().getValue(), SO.getMapOperands(), dl))]++;
+        lastStored[tree.add(accessOffsets(SO.getValue().getType(),
+                                          SO.getMemRef(),
+                                          SO.getAffineMapAttr().getValue(),
+                                          SO.getMapOperands(), dl),
+                            dl)]++;
       } else if (auto LO = dyn_cast<affine::AffineLoadOp>(U)) {
         lastStored[tree.add(accessOffsets(LO.getType(), LO.getMemRef(),
                                           LO.getAffineMapAttr().getValue(),
-                                          LO.getMapOperands(), dl))]++;
+                                          LO.getMapOperands(), dl),
+                            dl)]++;
       } else if (auto SO = dyn_cast<LLVM::StoreOp>(U)) {
-        lastStored[tree.add(accessOffsets(SO.getValue().getType()))]++;
+        lastStored[tree.add(accessOffsets(SO.getValue().getType()), dl)]++;
       } else if (auto LO = dyn_cast<LLVM::LoadOp>(U)) {
-        lastStored[tree.add(accessOffsets(LO.getType()))]++;
+        lastStored[tree.add(accessOffsets(LO.getType()), dl)]++;
       } else if (auto GO = dyn_cast<LLVM::GEPOp>(U)) {
-        list.emplace_back(GO, tree.add(gepOffsets(GO, dl)));
+        list.emplace_back(GO, tree.add(gepOffsets(GO, dl), dl));
       } else if (isa<memref::CastOp, Memref2PointerOp, Pointer2MemrefOp,
                      LLVM::BitcastOp, LLVM::AddrSpaceCastOp>(U)) {
         list.emplace_back(U->getResult(0), tree);

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -81,15 +81,53 @@ public:
   AffineExpr aff;
   SmallVector<Value> dim;
   SmallVector<Value> sym;
-  Offset(mlir::Value v) {
-    if (auto op = v.getDefiningOp<ConstantIntOp>()) {
-      idx = op.value();
-      type = Type::Index;
+  Offset(size_t constant) {
+    idx = constant;
+    type = Type::Index;
+  }
+  Offset(AffineExpr expr, SmallVector<Value> dims, SmallVector<Value> syms) {
+    if (auto cst = dyn_cast<AffineConstantExpr>(expr)) {
+      if (cst.getValue() >= 0) {
+        idx = cst.getValue();
+        type = Type::Index;
+      } else {
+        aff = expr;
+        type = Type::Affine;
+      }
       return;
     }
-    if (auto op = v.getDefiningOp<ConstantIndexOp>()) {
-      idx = op.value();
-      type = Type::Index;
+    if (auto d = dyn_cast<AffineDimExpr>(expr)) {
+      val = dims[d.getPosition()];
+      type = Type::Value;
+      return;
+    }
+    if (auto sy = dyn_cast<AffineSymbolExpr>(expr)) {
+      val = syms[sy.getPosition()];
+      type = Type::Value;
+      return;
+    }
+    type = Type::Affine;
+    aff = expr;
+    dim = std::move(dims);
+    sym = std::move(syms);
+  }
+  Offset(mlir::Value v) {
+    std::optional<int64_t> constant;
+    if (auto op = v.getDefiningOp<ConstantIntOp>())
+      constant = op.value();
+    else if (auto op = v.getDefiningOp<ConstantIndexOp>())
+      constant = op.value();
+
+    if (constant) {
+      // An index counts from the start of what it is an offset into, so
+      // anything below that is the expression it is instead.
+      if (*constant >= 0) {
+        idx = *constant;
+        type = Type::Index;
+      } else {
+        aff = getAffineConstantExpr(*constant, v.getContext());
+        type = Type::Affine;
+      }
       return;
     }
     val = v;
@@ -97,9 +135,16 @@ public:
   }
   Offset(AffineExpr op, unsigned numDims, unsigned numSymbols,
          mlir::OperandRange vals) {
+    // An index counts from the start of what it is an offset into, so anything
+    // below that is the expression it is instead, of nothing.
     if (auto opc = dyn_cast<AffineConstantExpr>(op)) {
-      idx = opc.getValue();
-      type = Type::Index;
+      if (opc.getValue() >= 0) {
+        idx = opc.getValue();
+        type = Type::Index;
+      } else {
+        aff = op;
+        type = Type::Affine;
+      }
       return;
     }
     if (auto opd = dyn_cast<AffineDimExpr>(op)) {
@@ -122,21 +167,8 @@ public:
 
     type = Type::Affine;
   }
-  Match matches(const Offset o) const {
-    if (type != o.type)
-      return Match::Maybe;
-    switch (type) {
-    case Type::Affine:
-      return (aff == o.aff && dim == o.dim && sym == o.sym) ? Match::Exact
-                                                            : Match::Maybe;
-    case Type::Value:
-      return (val == o.val) ? Match::Exact : Match::Maybe;
-    case Type::Index:
-      return (idx == o.idx) ? Match::Exact : Match::None;
-    default:
-      llvm_unreachable("Unknown offset type");
-    }
-  }
+  bool isZero() const { return type == Type::Index && idx == 0; }
+
   bool operator<(const Offset o) const {
     if (type != o.type) {
       return type < o.type;
@@ -167,6 +199,630 @@ public:
     }
   }
 };
+
+// The extent of a value, when the layout can say what it is.
+static std::optional<uint64_t> typeSize(mlir::Type ty, const DataLayout &dl) {
+  // Asking for the size of anything the layout cannot measure is fatal rather
+  // than an error to handle, so this asks only about what it can: what
+  // getDefaultTypeSizeInBits answers for, plus whatever brings its own answer.
+  if (!ty ||
+      !(ty.isIntOrFloat() ||
+        isa<IndexType, VectorType, ComplexType, DataLayoutTypeInterface>(ty)))
+    return std::nullopt;
+  return dl.getTypeSize(ty);
+}
+
+// What a single index of an access counts in: bytes of the type a
+// getelementptr steps through, or a dimension of a memref.
+class OffsetType {
+public:
+  enum class Kind { Bytes, Dim } kind = Kind::Bytes;
+  // Bytes: the size an index of this component multiplies.
+  uint64_t stride = 0;
+  // Dim: how many elements the dimension holds.
+  int64_t dimSize = ShapedType::kDynamic;
+
+  static OffsetType bytes(uint64_t stride) {
+    OffsetType res;
+    res.kind = Kind::Bytes;
+    res.stride = stride;
+    return res;
+  }
+  static OffsetType dim(int64_t dimSize) {
+    OffsetType res;
+    res.kind = Kind::Dim;
+    res.dimSize = dimSize;
+    return res;
+  }
+
+  bool operator<(const OffsetType &o) const {
+    if (kind != o.kind)
+      return kind < o.kind;
+    switch (kind) {
+    case Kind::Bytes:
+      return stride < o.stride;
+    case Kind::Dim:
+      return dimSize < o.dimSize;
+    }
+    llvm_unreachable("Unknown offset unit");
+  }
+  bool operator==(const OffsetType &o) const {
+    return !(*this < o) && !(o < *this);
+  }
+};
+
+// Where an access lands within an allocation: one Offset per index, each with
+// the unit it counts in, and the type of the value the access reads or writes.
+// `unknown` is an offset which could be anywhere, the same as an Offset holding
+// a value except that no value has to exist to name it -- which is what adding
+// two offsets counted in units that cannot be mixed produces.
+class OffsetTree {
+  bool unknownOffset = false;
+  std::vector<Offset> offsets;
+  std::vector<OffsetType> units;
+  mlir::Type base;
+
+  void normalize() {
+    if (unknownOffset) {
+      offsets.clear();
+      units.clear();
+      return;
+    }
+
+    // Counting in dimensions of a memref and in bytes of a pointer are two
+    // ways of saying where something is, and one path takes one of them.
+    assert((!hasDim() || !hasByte()) &&
+           "an offset counts in dimensions or in bytes, not both");
+
+    // Naming the start of an allocation is naming no offset into it at all,
+    // whatever the rank of the access that got there. Holding one form of it is
+    // what lets an access at [0, 0] of a view meet the index-free access an
+    // llvm.load performs.
+    if (isZero()) {
+      offsets.clear();
+      units.clear();
+      return;
+    }
+    // A constant lands at one byte however many indices reached it, which is
+    // what lets paths of different shapes that reach it meet.
+    if (auto bytes = constantBytes()) {
+      offsets.assign(1, Offset((size_t)*bytes));
+      units.assign(1, OffsetType::bytes(1));
+      return;
+    }
+
+    // The indices run most significant first, which is what lets the product of
+    // what the ones after an index cover be what that index steps over. A
+    // constant displacement -- a field of a struct -- is no stride at all and
+    // sits wherever the walk into the type put it.
+#ifndef NDEBUG
+    std::optional<uint64_t> last;
+    for (auto &&[off, unit] : llvm::zip(offsets, units)) {
+      if (unit.kind != OffsetType::Kind::Bytes ||
+          off.type == Offset::Type::Index)
+        continue;
+      assert((!last || *last >= unit.stride) &&
+             "byte offsets are held most significant first");
+      last = unit.stride;
+    }
+#endif
+  }
+
+public:
+  OffsetTree(mlir::Type base = {}, std::vector<Offset> offsets = {},
+             std::vector<OffsetType> units = {})
+      : offsets(std::move(offsets)), units(std::move(units)), base(base) {
+    assert(this->offsets.size() == this->units.size());
+    normalize();
+  }
+
+  // An offset which could be anywhere: it may be any other, and is none.
+  static OffsetTree unknown() {
+    OffsetTree res;
+    res.unknownOffset = true;
+    return res;
+  }
+
+  bool isUnknown() const { return unknownOffset; }
+  mlir::Type getBase() const { return base; }
+
+  bool hasDim() const {
+    return llvm::any_of(units, [](const OffsetType &unit) {
+      return unit.kind == OffsetType::Kind::Dim;
+    });
+  }
+  // A byte offset of no bytes is the placeholder for not moving at all, which
+  // is not a way of counting anything.
+  bool hasByte() const {
+    return llvm::any_of(units, [](const OffsetType &unit) {
+      return unit.kind == OffsetType::Kind::Bytes && unit.stride != 0;
+    });
+  }
+
+  void print(llvm::raw_ostream &o) const;
+
+  // Whether this names the start of what it is an offset into.
+  bool isZero() const {
+    if (unknownOffset)
+      return false;
+    return llvm::all_of(offsets,
+                        [](const Offset &off) { return off.isZero(); });
+  }
+
+  // A single constant offset in bytes, when that is all this is.
+  std::optional<uint64_t> constantBytes() const {
+    if (unknownOffset)
+      return std::nullopt;
+    uint64_t total = 0;
+    for (auto [off, unit] : llvm::zip(offsets, units)) {
+      if (off.type != Offset::Type::Index ||
+          unit.kind != OffsetType::Kind::Bytes)
+        return std::nullopt;
+      total += off.idx * unit.stride;
+    }
+    return total;
+  }
+
+  // The expression an offset is, over shared lists of the values everything is
+  // built from: whatever it needs that is already named is reused, and what is
+  // not is added, so several offsets can be put into one numbering.
+  static AffineExpr asAffine(const Offset &off, SmallVector<Value> &dims,
+                             SmallVector<Value> &syms, MLIRContext *ctx) {
+    auto exprFor = [&](Value val, bool asSymbol) -> AffineExpr {
+      auto dim = llvm::find(dims, val);
+      if (dim != dims.end())
+        return getAffineDimExpr(std::distance(dims.begin(), dim), ctx);
+      auto sym = llvm::find(syms, val);
+      if (sym != syms.end())
+        return getAffineSymbolExpr(std::distance(syms.begin(), sym), ctx);
+      if (asSymbol) {
+        syms.push_back(val);
+        return getAffineSymbolExpr(syms.size() - 1, ctx);
+      }
+      dims.push_back(val);
+      return getAffineDimExpr(dims.size() - 1, ctx);
+    };
+
+    switch (off.type) {
+    case Offset::Type::Index:
+      return getAffineConstantExpr(off.idx, ctx);
+    case Offset::Type::Value:
+      // Nothing is known about a value an index just is, which is what a
+      // symbol is for; a dimension is something an affine map may index by.
+      return exprFor(off.val, /*asSymbol=*/true);
+    case Offset::Type::Affine: {
+      SmallVector<AffineExpr> dimMap, symMap;
+      for (Value val : off.dim)
+        dimMap.push_back(exprFor(val, /*asSymbol=*/false));
+      for (Value val : off.sym)
+        symMap.push_back(exprFor(val, /*asSymbol=*/true));
+      return off.aff.replaceDimsAndSymbols(dimMap, symMap);
+    }
+    }
+    llvm_unreachable("Unknown offset type");
+  }
+
+  // Two offsets of the same thing, counted the same way, add up: as
+  // expressions of everything either of them is built from.
+  static Offset addOffsets(const Offset &lhs, const Offset &rhs) {
+    if (lhs.isZero())
+      return rhs;
+    if (rhs.isZero())
+      return lhs;
+    if (lhs.type == Offset::Type::Index && rhs.type == Offset::Type::Index)
+      return Offset(lhs.idx + rhs.idx);
+
+    MLIRContext *ctx = nullptr;
+    for (const Offset *off : {&lhs, &rhs}) {
+      if (off->type == Offset::Type::Value)
+        ctx = off->val.getContext();
+      else if (off->type == Offset::Type::Affine)
+        ctx = off->aff.getContext();
+    }
+
+    SmallVector<Value> dims, syms;
+    AffineExpr expr = asAffine(lhs, dims, syms, ctx);
+    expr = expr + asAffine(rhs, dims, syms, ctx);
+    return Offset(simplifyAffineExpr(expr, dims.size(), syms.size()), dims,
+                  syms);
+  }
+
+  // Composing this path with a further one, which names the accessed value and
+  // so says what type and size the result is of.
+  OffsetTree add(const OffsetTree &o) const {
+    if (unknownOffset || o.unknownOffset)
+      return unknown();
+    if (isZero())
+      return o;
+    if (o.isZero())
+      return OffsetTree(o.base, offsets, units);
+
+    // Moving the same way twice is moving once by the two together.
+    if (units == o.units) {
+      std::vector<Offset> sum;
+      for (auto &&[lhs, rhs] : llvm::zip(offsets, o.offsets))
+        sum.push_back(addOffsets(lhs, rhs));
+      return OffsetTree(o.base, std::move(sum), units);
+    }
+
+    // Two constant amounts, however many indices reached either, are one.
+    auto lhsBytes = constantBytes(), rhsBytes = o.constantBytes();
+    if (lhsBytes && rhsBytes)
+      return OffsetTree(o.base, {Offset((size_t)(*lhsBytes + *rhsBytes))},
+                        {OffsetType::bytes(1)});
+
+    // Otherwise a constant amount of bytes joins a path that steps by a size it
+    // is a multiple of: it is that many of those steps, taken innermost, which
+    // is where the smallest of them is.
+    auto join = [](const OffsetTree &path, uint64_t bytes,
+                   mlir::Type base) -> OffsetTree {
+      if (path.units.empty() ||
+          path.units.back().kind != OffsetType::Kind::Bytes)
+        return unknown();
+      uint64_t stride = path.units.back().stride;
+      if (!stride || bytes % stride)
+        return unknown();
+      std::vector<Offset> offsets = path.offsets;
+      offsets.back() =
+          addOffsets(path.offsets.back(), Offset((size_t)(bytes / stride)));
+      return OffsetTree(base, std::move(offsets), path.units);
+    };
+    if (rhsBytes)
+      return join(*this, *rhsBytes, o.base);
+    if (lhsBytes)
+      return join(o, *lhsBytes, o.base);
+    return unknown();
+  }
+
+  // Whether this index or one outside it is known to move, which is what puts
+  // an access past everything the indices within it can reach. The outer ones
+  // are the ones before it.
+  bool movesUpTo(size_t at) const {
+    for (size_t i = 0; i <= at && i < offsets.size(); i++)
+      if (offsets[i].type == Offset::Type::Index && !offsets[i].isZero())
+        return true;
+    return false;
+  }
+
+  // One index against another, given what a step of each covers, how far all of
+  // each index reaches, how much each access reads, and whether either is known
+  // to have moved at this index or an outer one. What the shapes leave open is
+  // kDynamic, which compares to nothing.
+  static Match compareIndex(const Offset &lhs, int64_t lhsStep,
+                            int64_t lhsWhole, int64_t lhsSize, bool lhsMoves,
+                            const Offset &rhs, int64_t rhsStep,
+                            int64_t rhsWhole, int64_t rhsSize, bool rhsMoves) {
+    // Stepping over the same amount, the indices can be compared directly.
+    if (lhsStep != ShapedType::kDynamic && lhsStep == rhsStep) {
+      if (lhs.type != rhs.type)
+        return Match::Maybe;
+      switch (lhs.type) {
+      case Offset::Type::Affine:
+        return (lhs.aff == rhs.aff && lhs.dim == rhs.dim && lhs.sym == rhs.sym)
+                   ? Match::Exact
+                   : Match::Maybe;
+      case Offset::Type::Value:
+        return lhs.val == rhs.val ? Match::Exact : Match::Maybe;
+      case Offset::Type::Index:
+        break;
+      }
+      if (lhs.idx == rhs.idx)
+        return Match::Exact;
+      // Whichever starts first has to end before the other begins, so the
+      // extent that decides is the one belonging to it.
+      bool first = lhs.idx < rhs.idx;
+      uint64_t between =
+          (first ? rhs.idx - lhs.idx : lhs.idx - rhs.idx) * (uint64_t)lhsStep;
+      int64_t reach = first ? lhsSize : rhsSize;
+      return reach != ShapedType::kDynamic && between >= (uint64_t)reach
+                 ? Match::None
+                 : Match::Maybe;
+    }
+
+    // Stepping over different amounts, one is clear of the other when all its
+    // index can reach fits within a single step of the other's, and the other
+    // is known to have taken at least one of those steps.
+    if (lhsWhole != ShapedType::kDynamic && rhsStep != ShapedType::kDynamic &&
+        lhsWhole <= rhsStep && rhsMoves)
+      return Match::None;
+    if (rhsWhole != ShapedType::kDynamic && lhsStep != ShapedType::kDynamic &&
+        rhsWhole <= lhsStep && lhsMoves)
+      return Match::None;
+    return Match::Maybe;
+  }
+
+  Match matches(const OffsetTree &o, const DataLayout &dl) const {
+    if (unknownOffset || o.unknownOffset)
+      return Match::Maybe;
+
+    // A different type at the same place may still be the same value, since
+    // castToType converts between spellings of one extent. One type covers the
+    // same bytes as itself whether or not the layout can say how many; two of
+    // them do only if it can say so, and two extents of different length
+    // starting together share no more than a part.
+    std::optional<uint64_t> size = typeSize(base, dl);
+    std::optional<uint64_t> osize =
+        base == o.base ? size : typeSize(o.base, dl);
+    bool sameExtent = base == o.base || (size && osize && *size == *osize);
+    if (!sameExtent && (!size || !osize))
+      return Match::Maybe;
+
+    // Counting in dimensions of a memref and counting in bytes of a pointer
+    // cannot be lined up against each other.
+    if ((hasDim() && o.hasByte()) || (o.hasDim() && hasByte()))
+      return Match::Maybe;
+
+    // A path counts in what its access reads: in those, when both read the
+    // same amount -- the only unit there is when the layout cannot measure
+    // them -- and in bytes when they do not, which is also all a path through
+    // bytes can count in.
+    int64_t reach = 1, oreach = 1;
+    if (!sameExtent || (!hasDim() && !o.hasDim())) {
+      reach = size ? (int64_t)*size : ShapedType::kDynamic;
+      oreach = osize ? (int64_t)*osize : ShapedType::kDynamic;
+    }
+
+    // What an index steps over is everything the indices inside it cover, which
+    // is why they are held innermost first: the running product is that.
+    auto stepOf = [](const OffsetType &unit, int64_t inner) -> int64_t {
+      return unit.kind == OffsetType::Kind::Bytes ? (int64_t)unit.stride
+                                                  : inner;
+    };
+    // How far all of an index reaches. A pointer index is given no bound, and
+    // neither is a dimension whose extent the shape leaves open.
+    auto wholeOf = [](const OffsetType &unit, int64_t inner) -> int64_t {
+      if (unit.kind == OffsetType::Kind::Bytes ||
+          inner == ShapedType::kDynamic ||
+          unit.dimSize == ShapedType::kDynamic || unit.dimSize < 0)
+        return ShapedType::kDynamic;
+      return inner * unit.dimSize;
+    };
+
+    // One of whatever is being counted in, to start with.
+    int64_t inner = reach, oinner = oreach;
+    unsigned apart = 0;
+    bool unsure = false;
+
+    auto record = [&](Match m) {
+      if (m == Match::None)
+        apart++;
+      else if (m == Match::Maybe)
+        unsure = true;
+    };
+
+    // The indices run most significant first, so the walk runs the other way:
+    // what an index steps over is everything the ones after it cover, which is
+    // what the running product holds by the time it is reached.
+    ssize_t i = offsets.size() - 1, j = o.offsets.size() - 1;
+
+    while (i >= 0 && j >= 0) {
+      // An index that does not move lines up with anything, though whatever it
+      // would have stepped over still lies inside the ones outside it.
+      if (offsets[i].isZero()) {
+        inner = wholeOf(units[i], inner);
+        i--;
+        continue;
+      }
+      if (o.offsets[j].isZero()) {
+        oinner = wholeOf(o.units[j], oinner);
+        j--;
+        continue;
+      }
+
+      auto lhsStep = stepOf(units[i], inner);
+      auto lhsWhole = wholeOf(units[i], inner);
+      auto rhsStep = stepOf(o.units[j], oinner);
+      auto rhsWhole = wholeOf(o.units[j], oinner);
+      record(compareIndex(offsets[i], lhsStep, lhsWhole, reach, movesUpTo(i),
+                          o.offsets[j], rhsStep, rhsWhole, oreach,
+                          o.movesUpTo(j)));
+      inner = lhsWhole;
+      oinner = rhsWhole;
+      i--;
+      j--;
+    }
+
+    // Whatever is left over of one path moves on from where the other stopped,
+    // which is wherever the indices it did have put it.
+    for (; i >= 0; i--) {
+      if (offsets[i].isZero()) {
+        inner = wholeOf(units[i], inner);
+        continue;
+      }
+      auto step = stepOf(units[i], inner);
+      auto whole = wholeOf(units[i], inner);
+      record(compareIndex(offsets[i], step, whole, reach, movesUpTo(i),
+                          Offset((size_t)0), step, step, oreach,
+                          /*moves=*/false));
+      inner = whole;
+    }
+    for (; j >= 0; j--) {
+      if (o.offsets[j].isZero()) {
+        oinner = wholeOf(o.units[j], oinner);
+        continue;
+      }
+      auto step = stepOf(o.units[j], oinner);
+      auto whole = wholeOf(o.units[j], oinner);
+      record(compareIndex(Offset((size_t)0), step, step, reach,
+                          /*moves=*/false, o.offsets[j], step, whole, oreach,
+                          o.movesUpTo(j)));
+      oinner = whole;
+    }
+
+    // One index landing clear of the other says the two are different places,
+    // but only once every other index is known to land together: what an index
+    // that may land elsewhere adds is what could put them back on the same
+    // byte, and so is a second index that lands clear the other way -- being
+    // four elements behind at one level and a step ahead at the next is the
+    // same byte reached two ways.
+    if (apart)
+      return unsure || apart > 1 ? Match::Maybe : Match::None;
+    return unsure || !sameExtent ? Match::Maybe : Match::Exact;
+  }
+
+  bool operator<(const OffsetTree &o) const {
+    if (unknownOffset != o.unknownOffset)
+      return unknownOffset < o.unknownOffset;
+    if (offsets.size() != o.offsets.size())
+      return offsets.size() < o.offsets.size();
+    for (auto &&[i, off] : llvm::enumerate(offsets)) {
+      if (off < o.offsets[i])
+        return true;
+      if (o.offsets[i] < off)
+        return false;
+      if (units[i] < o.units[i])
+        return true;
+      if (o.units[i] < units[i])
+        return false;
+    }
+    return false;
+  }
+};
+
+// The offset an access lands at within the value it indexes, in the units that
+// value counts in: dimensions of a memref, bytes of an llvm pointer. An access
+// with no indices reads the start of what it is given.
+static OffsetTree accessOffsets(Type accessed) { return OffsetTree(accessed); }
+
+// Dimensions count what the access reads, so an access reading something other
+// than what the memref holds says nothing about where it lands.
+static bool countsWhatItReads(Type accessed, MemRefType MT,
+                              const DataLayout &dl) {
+  if (accessed == MT.getElementType())
+    return true;
+  auto size = typeSize(accessed, dl),
+       elSize = typeSize(MT.getElementType(), dl);
+  return size && elSize && *size == *elSize;
+}
+
+static OffsetTree accessOffsets(Type accessed, Value memory,
+                                mlir::OperandRange indices,
+                                const DataLayout &dl) {
+  std::vector<Offset> offsets;
+  std::vector<OffsetType> units;
+  if (auto MT = dyn_cast<MemRefType>(memory.getType())) {
+    if (!indices.empty() && !countsWhatItReads(accessed, MT, dl))
+      return OffsetTree::unknown();
+    for (auto &&[i, idx] : llvm::enumerate(indices)) {
+      offsets.emplace_back(idx);
+      units.push_back(OffsetType::dim(MT.getShape()[i]));
+    }
+  }
+  return OffsetTree(accessed, std::move(offsets), std::move(units));
+}
+
+static OffsetTree accessOffsets(Type accessed, Value memory, AffineMap map,
+                                mlir::OperandRange operands,
+                                const DataLayout &dl) {
+  std::vector<Offset> offsets;
+  std::vector<OffsetType> units;
+  auto MT = cast<MemRefType>(memory.getType());
+  if (map.getNumResults() && !countsWhatItReads(accessed, MT, dl))
+    return OffsetTree::unknown();
+  for (auto &&[i, expr] : llvm::enumerate(map.getResults())) {
+    offsets.emplace_back(expr, map.getNumDims(), map.getNumSymbols(), operands);
+    units.push_back(OffsetType::dim(MT.getShape()[i]));
+  }
+  return OffsetTree(accessed, std::move(offsets), std::move(units));
+}
+
+// A getelementptr walks into its element type: the first index steps over the
+// whole of it, and each one after that into what the previous one selected.
+// What it lands on is only known when every index into an aggregate is.
+static OffsetTree gepOffsets(LLVM::GEPOp gep, const DataLayout &dl) {
+  std::vector<Offset> offsets;
+  std::vector<OffsetType> units;
+  Type cur = gep.getElemType();
+
+  auto step = [&](std::optional<int64_t> constant, Value dynamic,
+                  uint64_t stride) {
+    if (constant) {
+      offsets.emplace_back((size_t)(*constant * stride));
+      units.push_back(OffsetType::bytes(1));
+    } else {
+      offsets.emplace_back(dynamic);
+      units.push_back(OffsetType::bytes(stride));
+    }
+  };
+
+  for (auto &&[i, arg] : llvm::enumerate(gep.getIndices())) {
+    Value dynamic = dyn_cast<Value>(arg);
+    std::optional<int64_t> constant;
+    if (auto attr = dyn_cast<IntegerAttr>(arg))
+      constant = attr.getInt();
+    else if (APInt val; matchPattern(dynamic, m_ConstantInt(&val)))
+      constant = val.getSExtValue();
+
+    if (i == 0) {
+      step(constant, dynamic, dl.getTypeSize(cur));
+      continue;
+    }
+
+    if (auto ST = dyn_cast<LLVM::LLVMStructType>(cur)) {
+      // Only a constant can select a field, and it lands at a fixed byte.
+      if (!constant || *constant < 0 ||
+          (size_t)*constant >= ST.getBody().size())
+        return OffsetTree::unknown();
+      uint64_t byte = 0;
+      for (auto member : ST.getBody().take_front(*constant)) {
+        if (!ST.isPacked())
+          byte = llvm::alignTo(byte, dl.getTypeABIAlignment(member));
+        byte += dl.getTypeSize(member);
+      }
+      if (!ST.isPacked())
+        byte = llvm::alignTo(byte,
+                             dl.getTypeABIAlignment(ST.getBody()[*constant]));
+      offsets.emplace_back((size_t)byte);
+      units.push_back(OffsetType::bytes(1));
+      cur = ST.getBody()[*constant];
+      continue;
+    }
+
+    Type element;
+    if (auto AT = dyn_cast<LLVM::LLVMArrayType>(cur))
+      element = AT.getElementType();
+    else if (auto VT = dyn_cast<VectorType>(cur))
+      element = VT.getElementType();
+    else
+      return OffsetTree::unknown();
+
+    step(constant, dynamic, dl.getTypeSize(element));
+    cur = element;
+  }
+
+  return OffsetTree({}, std::move(offsets), std::move(units));
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const OffsetType unit) {
+  switch (unit.kind) {
+  case OffsetType::Kind::Bytes:
+    return o << unit.stride << "B";
+  case OffsetType::Kind::Dim:
+    return o << "dim<" << unit.dimSize << ">";
+  }
+  llvm_unreachable("Unknown offset unit");
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const Offset off);
+
+void OffsetTree::print(llvm::raw_ostream &o) const {
+  if (unknownOffset) {
+    o << "unknown";
+    return;
+  }
+  o << "[";
+  for (auto &&[i, off] : llvm::enumerate(offsets)) {
+    if (i)
+      o << ", ";
+    o << off << " x " << units[i];
+  }
+  o << "] of " << base;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const OffsetTree &tree) {
+  tree.print(o);
+  return o;
+}
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const Offset off) {
   switch (off.type) {
@@ -222,47 +878,12 @@ struct PolygeistMem2Reg
 
   // return if changed
   bool forwardStoreToLoad(
-      mlir::Value AI, std::vector<Offset> idx,
+      mlir::Value AI, OffsetTree idx,
       SmallVectorImpl<Operation *> &loadOpsToErase,
       DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing);
 };
 
 } // end anonymous namespace
-
-Match matchesIndices(mlir::OperandRange ops, const std::vector<Offset> &idx) {
-  if (ops.size() != idx.size())
-    return Match::None;
-  for (size_t i = 0; i < idx.size(); i++) {
-    switch (idx[i].matches(Offset(ops[i]))) {
-    case Match::None:
-      return Match::None;
-    case Match::Maybe:
-      return Match::Maybe;
-    case Match::Exact:
-      break;
-    }
-  }
-  return Match::Exact;
-}
-
-Match matchesIndices(AffineMap map, mlir::OperandRange ops,
-                     const std::vector<Offset> &idx) {
-  auto idxs = map.getResults();
-  if (idxs.size() != idx.size())
-    return Match::None;
-  for (size_t i = 0; i < idx.size(); i++) {
-    switch (idx[i].matches(
-        Offset(idxs[i], map.getNumDims(), map.getNumSymbols(), ops))) {
-    case Match::None:
-      return Match::None;
-    case Match::Maybe:
-      return Match::Maybe;
-    case Match::Exact:
-      break;
-    }
-  }
-  return Match::Exact;
-}
 
 class ValueOrPlaceholder;
 
@@ -1199,7 +1820,7 @@ std::set<std::string> NoWriteFunctions = {"exit", "__errno_location"};
 // This is a straightforward implementation not optimized for speed. Optimize
 // if needed.
 bool PolygeistMem2Reg::forwardStoreToLoad(
-    mlir::Value AI, std::vector<Offset> idx,
+    mlir::Value AI, OffsetTree idx,
     SmallVectorImpl<Operation *> &loadOpsToErase,
     DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing) {
   bool changed = false;
@@ -1208,11 +1829,12 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   mlir::Location loc = AI.getLoc();
   std::set<mlir::Operation *> allStoreOps;
 
+  DataLayout dl = DataLayout::closest(AI.getDefiningOp());
   Type elType = nullptr;
   if (auto MT = dyn_cast<MemRefType>(AI.getType()))
     elType = MT.getElementType();
 
-  std::deque<std::pair<mlir::Value, /*indexed*/ bool>> list = {{AI, false}};
+  std::deque<std::pair<mlir::Value, OffsetTree>> list = {{AI, OffsetTree()}};
 
   SmallPtrSet<Operation *, 4> AliasingStoreOperations;
 
@@ -1232,135 +1854,113 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       auto PT = dyn_cast<LLVM::LLVMPointerType>(val.getType());
       SharedMemAddr = PT.getAddressSpace() == 5;
     }
-    auto modified = pair.second;
+    auto tree = pair.second;
     list.pop_front();
     for (auto *user : val.getUsers()) {
       if (auto co = dyn_cast<mlir::memref::CastOp>(user)) {
-        list.emplace_back((Value)co, modified);
+        list.emplace_back((Value)co, tree);
         continue;
       }
       if (auto co = dyn_cast<Memref2PointerOp>(user)) {
-        list.emplace_back((Value)co, modified);
+        list.emplace_back((Value)co, tree);
         continue;
       }
       if (auto co = dyn_cast<Pointer2MemrefOp>(user)) {
-        list.emplace_back((Value)co, modified);
+        list.emplace_back((Value)co, tree);
         continue;
       }
-      /*if (auto co = dyn_cast<SubIndexOp>(user)) {
-        list.emplace_back((Value)co, true);
-        continue;
-      }
-      */
       // If at the same index, the "hole" property applies
       // and we can go through.
       if (isa<BarrierOp>(user)) {
         continue;
       }
       if (auto co = dyn_cast<mlir::LLVM::GEPOp>(user)) {
-        list.emplace_back((Value)co, true);
+        list.emplace_back((Value)co, tree.add(gepOffsets(co, dl)));
         continue;
       }
       if (auto co = dyn_cast<mlir::LLVM::BitcastOp>(user)) {
-        list.emplace_back((Value)co, modified);
+        list.emplace_back((Value)co, tree);
         continue;
       }
       if (auto co = dyn_cast<mlir::LLVM::AddrSpaceCastOp>(user)) {
-        list.emplace_back((Value)co, modified);
+        list.emplace_back((Value)co, tree);
         continue;
       }
       if (isa<LLVM::LifetimeStartOp, LLVM::LifetimeEndOp>(user)) {
         continue;
       }
-      if (auto loadOp = dyn_cast<mlir::memref::LoadOp>(user)) {
-        if (!modified &&
-            matchesIndices(loadOp.getIndices(), idx) == Match::Exact) {
-          subType = loadOp.getType();
-          if (subType == elType || elType == nullptr) {
-            elType = subType;
-            loadOps.insert(loadOp);
-            LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << loadOp << "\n");
-          }
+      // A load naming the slot reads it; one that may only overlap it reads
+      // something this knows nothing about, which is no reason to stop.
+      auto matchLoad = [&](Operation *loadOp, OffsetTree accessed) {
+        if (idx.matches(tree.add(accessed), dl) != Match::Exact)
+          return;
+        subType = loadOp->getResult(0).getType();
+        // Whichever spelling of the slot is read first is the one the value
+        // forwarded out of it takes.
+        if (elType && subType != elType)
+          return;
+        elType = subType;
+        loadOps.insert(loadOp);
+        LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << *loadOp << "\n");
+      };
+      auto matchStore = [&](Operation *storeOp, OffsetTree accessed) {
+        switch (idx.matches(tree.add(accessed), dl)) {
+        case Match::Exact:
+          LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << *storeOp << "\n");
+          allStoreOps.insert(storeOp);
+          break;
+        case Match::Maybe:
+          LLVM_DEBUG(llvm::dbgs()
+                     << "Mabye Aliasing Store: " << *storeOp << "\n");
+          AliasingStoreOperations.insert(storeOp);
+          break;
+        case Match::None:
+          break;
         }
+      };
+
+      if (auto loadOp = dyn_cast<mlir::memref::LoadOp>(user)) {
+        matchLoad(loadOp, accessOffsets(loadOp.getType(), loadOp.getMemRef(),
+                                        loadOp.getIndices(), dl));
         continue;
       }
       if (auto loadOp = dyn_cast<mlir::LLVM::LoadOp>(user)) {
-        if (!modified) {
-          subType = loadOp.getType();
-          if (subType == elType || elType == nullptr) {
-            elType = subType;
-            loadOps.insert(loadOp);
-            LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << loadOp << "\n");
-          }
-        }
+        matchLoad(loadOp, accessOffsets(loadOp.getType()));
         continue;
       }
       if (auto loadOp = dyn_cast<affine::AffineLoadOp>(user)) {
-        if (!modified &&
-            matchesIndices(loadOp.getAffineMapAttr().getValue(),
-                           loadOp.getMapOperands(), idx) == Match::Exact) {
-          subType = loadOp.getType();
-          if (subType == elType || elType == nullptr) {
-            elType = subType;
-            loadOps.insert(loadOp);
-            LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << loadOp << "\n");
-          }
-        }
+        matchLoad(loadOp, accessOffsets(loadOp.getType(), loadOp.getMemRef(),
+                                        loadOp.getAffineMapAttr().getValue(),
+                                        loadOp.getMapOperands(), dl));
         continue;
       }
       if (auto storeOp = dyn_cast<mlir::memref::StoreOp>(user)) {
         if (storeOp.getValue() == val)
           captured = true;
-        else if (!modified) {
-          switch (matchesIndices(storeOp.getIndices(), idx)) {
-          case Match::Exact:
-            LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << storeOp << "\n");
-            allStoreOps.insert(storeOp);
-            break;
-          case Match::Maybe:
-            LLVM_DEBUG(llvm::dbgs()
-                       << "Mabye Aliasing Store: " << storeOp << "\n");
-            AliasingStoreOperations.insert(storeOp);
-            break;
-          case Match::None:
-            break;
-          }
-        } else
-          AliasingStoreOperations.insert(storeOp);
+        else
+          matchStore(storeOp, accessOffsets(storeOp.getValue().getType(),
+                                            storeOp.getMemRef(),
+                                            storeOp.getIndices(), dl));
         continue;
       }
       if (auto storeOp = dyn_cast<LLVM::StoreOp>(user)) {
 
         if (storeOp.getValue() == val) {
           captured = true;
-        } else if (!modified) {
-          LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << storeOp << "\n");
-          allStoreOps.insert(storeOp);
         } else
-          AliasingStoreOperations.insert(storeOp);
+          matchStore(storeOp, accessOffsets(storeOp.getValue().getType()));
         continue;
       }
 
       if (auto storeOp = dyn_cast<affine::AffineStoreOp>(user)) {
         if (storeOp.getValue() == val) {
           captured = true;
-        } else if (!modified) {
-          switch (matchesIndices(storeOp.getAffineMapAttr().getValue(),
-                                 storeOp.getMapOperands(), idx)) {
-          case Match::Exact:
-            LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << storeOp << "\n");
-            allStoreOps.insert(storeOp);
-            break;
-          case Match::Maybe:
-            LLVM_DEBUG(llvm::dbgs()
-                       << "Mabye Aliasing Store: " << storeOp << "\n");
-            AliasingStoreOperations.insert(storeOp);
-            break;
-          case Match::None:
-            break;
-          }
         } else
-          AliasingStoreOperations.insert(storeOp);
+          matchStore(storeOp,
+                     accessOffsets(storeOp.getValue().getType(),
+                                   storeOp.getMemRef(),
+                                   storeOp.getAffineMapAttr().getValue(),
+                                   storeOp.getMapOperands(), dl));
         continue;
       }
       if (auto callOp = dyn_cast<CallOpInterface>(user)) {
@@ -1993,56 +2593,43 @@ bool isPromotable(mlir::Value AI) {
   return true;
 }
 
-std::vector<std::vector<Offset>> getLastStored(mlir::Value AI) {
-  std::map<std::vector<Offset>, unsigned> lastStored;
+std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
+  std::map<OffsetTree, unsigned> lastStored;
 
-  std::deque<mlir::Value> list = {AI};
+  std::deque<std::pair<mlir::Value, OffsetTree>> list = {{AI, OffsetTree()}};
 
   while (list.size()) {
-    auto val = list.front();
+    auto [val, tree] = list.front();
     list.pop_front();
     for (auto *U : val.getUsers()) {
       if (auto SO = dyn_cast<memref::StoreOp>(U)) {
-        std::vector<Offset> vec;
-        for (auto idx : SO.getIndices()) {
-          vec.emplace_back(idx);
-        }
-        lastStored[vec]++;
-      } else if (auto SO = dyn_cast<affine::AffineLoadOp>(U)) {
-        std::vector<Offset> vec;
-        auto map = SO.getAffineMapAttr().getValue();
-        for (auto idx : map.getResults()) {
-          vec.emplace_back(idx, map.getNumDims(), map.getNumSymbols(),
-                           SO.getMapOperands());
-        }
-        lastStored[vec]++;
-      } else if (isa<LLVM::LoadOp>(U)) {
-        std::vector<Offset> vec;
-        lastStored[vec]++;
-      } else if (isa<LLVM::StoreOp>(U)) {
-        std::vector<Offset> vec;
-        lastStored[vec]++;
-      } else if (auto SO = dyn_cast<memref::LoadOp>(U)) {
-        std::vector<Offset> vec;
-        for (auto idx : SO.getIndices()) {
-          vec.emplace_back(idx);
-        }
-        lastStored[vec]++;
+        lastStored[tree.add(accessOffsets(
+            SO.getValue().getType(), SO.getMemRef(), SO.getIndices(), dl))]++;
+      } else if (auto LO = dyn_cast<memref::LoadOp>(U)) {
+        lastStored[tree.add(accessOffsets(LO.getType(), LO.getMemRef(),
+                                          LO.getIndices(), dl))]++;
       } else if (auto SO = dyn_cast<affine::AffineStoreOp>(U)) {
-        std::vector<Offset> vec;
-        auto map = SO.getAffineMapAttr().getValue();
-        for (auto idx : map.getResults()) {
-          vec.emplace_back(idx, map.getNumDims(), map.getNumSymbols(),
-                           SO.getMapOperands());
-        }
-        lastStored[vec]++;
-      } else if (auto CO = dyn_cast<memref::CastOp>(U)) {
-        list.push_back(CO);
+        lastStored[tree.add(accessOffsets(
+            SO.getValue().getType(), SO.getMemRef(),
+            SO.getAffineMapAttr().getValue(), SO.getMapOperands(), dl))]++;
+      } else if (auto LO = dyn_cast<affine::AffineLoadOp>(U)) {
+        lastStored[tree.add(accessOffsets(LO.getType(), LO.getMemRef(),
+                                          LO.getAffineMapAttr().getValue(),
+                                          LO.getMapOperands(), dl))]++;
+      } else if (auto SO = dyn_cast<LLVM::StoreOp>(U)) {
+        lastStored[tree.add(accessOffsets(SO.getValue().getType()))]++;
+      } else if (auto LO = dyn_cast<LLVM::LoadOp>(U)) {
+        lastStored[tree.add(accessOffsets(LO.getType()))]++;
+      } else if (auto GO = dyn_cast<LLVM::GEPOp>(U)) {
+        list.emplace_back(GO, tree.add(gepOffsets(GO, dl)));
+      } else if (isa<memref::CastOp, Memref2PointerOp, Pointer2MemrefOp,
+                     LLVM::BitcastOp, LLVM::AddrSpaceCastOp>(U)) {
+        list.emplace_back(U->getResult(0), tree);
       }
     }
   }
 
-  std::vector<std::vector<Offset>> todo;
+  std::vector<OffsetTree> todo;
   for (auto &pair : lastStored) {
     if (pair.second > 1)
       todo.push_back(pair.first);
@@ -2092,13 +2679,13 @@ void PolygeistMem2Reg::runOnOperation() {
     DenseMap<Operation *, SmallVector<Operation *>> capturedAliasing;
     for (auto AI : toPromote) {
       LLVM_DEBUG(llvm::dbgs() << " attempting to promote " << AI << "\n");
-      auto lastStored = getLastStored(AI);
+      // A nested region may carry a layout of its own, so the sizes an offset
+      // is counted in are the ones in force where the allocation is.
+      auto lastStored =
+          getLastStored(AI, DataLayout::closest(AI.getDefiningOp()));
       for (const auto &vec : lastStored) {
-        LLVM_DEBUG(llvm::dbgs() << " + forwarding vec to promote {";
-                   for (auto m
-                        : vec) llvm::dbgs()
-                   << m << ",";
-                   llvm::dbgs() << "} of " << AI << "\n");
+        LLVM_DEBUG(llvm::dbgs() << " + forwarding vec to promote {" << vec
+                                << "} of " << AI << "\n");
         // llvm::errs() << " PRE " << AI << "\n";
         // f.dump();
         changed |=

--- a/test/lit_tests/mem2reg_offsets.mlir
+++ b/test/lit_tests/mem2reg_offsets.mlir
@@ -281,3 +281,80 @@ llvm.func @wide_overlap(%val: i128, %other: i128) -> i128 {
 // CHECK-LABEL: llvm.func @wide_overlap(
 // CHECK: %[[LD:.+]] = llvm.load
 // CHECK: llvm.return %[[LD]] : i128
+
+// -----
+
+// The step of an index is what the indices after it cover, not what its own
+// dimension holds: [1, 0] of a 2x4 is element 4, which is past all four
+// elements the other view names, so nothing it writes reaches them.
+func.func @cross_shape_beyond(%val: f32, %other: f32, %j: index) -> f32 {
+  %c0 = arith.constant 0 : index
+  %c1i = arith.constant 1 : index
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<8 x f32> : (i32) -> !llvm.ptr
+  %small = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<4xf32>
+  %rect = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<2x4xf32>
+  memref.store %val, %small[%j] : memref<4xf32>
+  memref.store %other, %rect[%c1i, %c0] : memref<2x4xf32>
+  %loaded = memref.load %small[%j] : memref<4xf32>
+  return %loaded : f32
+}
+
+// CHECK-LABEL: func.func @cross_shape_beyond(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: memref.load
+// CHECK: return %[[VAL]] : f32
+
+// -----
+
+// An offset below the start of what it offsets into is that, and not a very
+// large one: element 3 is not element 4, and does not reach past the view.
+llvm.func @negative_offset(%val: f32, %other: f32) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<8 x f32> : (i32) -> !llvm.ptr
+  %mid = llvm.getelementptr %mem[0, 4] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<8 x f32>
+  llvm.store %val, %mid : f32, !llvm.ptr
+  %back = llvm.getelementptr %mid[-1] : (!llvm.ptr) -> !llvm.ptr, f32
+  llvm.store %other, %back : f32, !llvm.ptr
+  %loaded = llvm.load %mid : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @negative_offset(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// Four bytes of what was written as eight is not what was written, however the
+// two spellings line up at the byte they start from.
+llvm.func @narrower_read(%val: f64) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x f64 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : f64, !llvm.ptr
+  %loaded = llvm.load %mem : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @narrower_read(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : f32
+
+// -----
+
+// Reading as many bytes as were written is reading what was written, whatever
+// the two call it.
+llvm.func @same_extent(%val: i32) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  %loaded = llvm.load %mem : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @same_extent(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: i32
+// CHECK-NOT: llvm.load
+// CHECK: %[[BC:.+]] = arith.bitcast %[[VAL]] : i32 to f32
+// CHECK: llvm.return %[[BC]] : f32

--- a/test/lit_tests/mem2reg_offsets.mlir
+++ b/test/lit_tests/mem2reg_offsets.mlir
@@ -183,3 +183,101 @@ llvm.func @gep_two_values(%val: f32, %i: i64, %j: i64) -> f32 {
 // CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
 // CHECK-NOT: llvm.load
 // CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// An index that is not known could be the one being read, so what is written
+// through it may be what a later read finds. Storing a different value than the
+// first store is what makes that visible.
+llvm.func @unknown_index_other_value(%val: f32, %other: f32, %i: i64) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<4 x f32> : (i32) -> !llvm.ptr
+  %f0 = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<4 x f32>
+  llvm.store %val, %f0 : f32, !llvm.ptr
+  %fi = llvm.getelementptr %mem[0, %i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<4 x f32>
+  llvm.store %other, %fi : f32, !llvm.ptr
+  %loaded = llvm.load %f0 : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @unknown_index_other_value(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : f32
+
+// -----
+
+// Element 1 of a view of f32 is byte 4. A byte offset of 1 is not that, and
+// counting the two the same way would say it is.
+llvm.func @dim_meets_byte(%val: f32, %other: f32) -> f32 {
+  %c1i = arith.constant 1 : index
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<4 x f32> : (i32) -> !llvm.ptr
+  %view = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<4xf32>
+  memref.store %val, %view[%c1i] : memref<4xf32>
+  %byte1 = llvm.getelementptr %mem[1] : (!llvm.ptr) -> !llvm.ptr, i8
+  llvm.store %other, %byte1 : f32, !llvm.ptr
+  %loaded = memref.load %view[%c1i] : memref<4xf32>
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @dim_meets_byte(
+// CHECK: %[[LD:.+]] = memref.load
+// CHECK: llvm.return %[[LD]] : f32
+
+// -----
+
+// Two f32 one byte apart share three of their four bytes, so the second store
+// is what a read of the first may find.
+llvm.func @overlapping_bytes(%val: f32, %other: f32) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<8 x i8> : (i32) -> !llvm.ptr
+  %b0 = llvm.getelementptr %mem[0] : (!llvm.ptr) -> !llvm.ptr, i8
+  llvm.store %val, %b0 : f32, !llvm.ptr
+  %b1 = llvm.getelementptr %mem[1] : (!llvm.ptr) -> !llvm.ptr, i8
+  llvm.store %other, %b1 : f32, !llvm.ptr
+  %loaded = llvm.load %b0 : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @overlapping_bytes(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : f32
+
+// -----
+
+// Far enough apart, the same two are different places and the first store is
+// what the read finds.
+llvm.func @disjoint_bytes(%val: f32, %other: f32) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<16 x i8> : (i32) -> !llvm.ptr
+  %b0 = llvm.getelementptr %mem[0] : (!llvm.ptr) -> !llvm.ptr, i8
+  llvm.store %val, %b0 : f32, !llvm.ptr
+  %b8 = llvm.getelementptr %mem[8] : (!llvm.ptr) -> !llvm.ptr, i8
+  llvm.store %other, %b8 : f32, !llvm.ptr
+  %loaded = llvm.load %b0 : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @disjoint_bytes(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// How far apart is not enough on its own: two values of sixteen bytes, eight
+// apart, still share half of themselves.
+llvm.func @wide_overlap(%val: i128, %other: i128) -> i128 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<32 x i8> : (i32) -> !llvm.ptr
+  %b0 = llvm.getelementptr %mem[0] : (!llvm.ptr) -> !llvm.ptr, i8
+  llvm.store %val, %b0 : i128, !llvm.ptr
+  %b8 = llvm.getelementptr %mem[8] : (!llvm.ptr) -> !llvm.ptr, i8
+  llvm.store %other, %b8 : i128, !llvm.ptr
+  %loaded = llvm.load %b0 : !llvm.ptr -> i128
+  llvm.return %loaded : i128
+}
+
+// CHECK-LABEL: llvm.func @wide_overlap(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : i128

--- a/test/lit_tests/mem2reg_offsets.mlir
+++ b/test/lit_tests/mem2reg_offsets.mlir
@@ -1,0 +1,185 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+// An access at index zero of a view names the start of the allocation, which is
+// where an index-free access lands, whatever the rank the view was given.
+llvm.func @zero_index_meets_llvm_load(%val: f32) -> f32 {
+  %c0 = arith.constant 0 : index
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<4 x array<4 x f32>> : (i32) -> !llvm.ptr
+  %view = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<?x?xf32>
+  affine.store %val, %view[0, 0] : memref<?x?xf32>
+  %loaded = llvm.load %mem : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @zero_index_meets_llvm_load(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// The same, the other way around: the value written without indices is read
+// back through a zero index of a view.
+llvm.func @llvm_store_meets_zero_index(%val: f32) -> f32 {
+  %c0 = arith.constant 0 : index
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<4 x array<4 x f32>> : (i32) -> !llvm.ptr
+  %view = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<?x?xf32>
+  llvm.store %val, %mem : f32, !llvm.ptr
+  %loaded = memref.load %view[%c0, %c0] : memref<?x?xf32>
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @llvm_store_meets_zero_index(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: memref.load
+// CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// A field written and read through the same offset of the allocation is one
+// slot, which the offsets say without either access being index-free.
+llvm.func @gep_same_field(%val: f32) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i64, f32, f32)> : (i32) -> !llvm.ptr
+  %f1 = llvm.getelementptr %mem[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, f32, f32)>
+  llvm.store %val, %f1 : f32, !llvm.ptr
+  %f1again = llvm.getelementptr %mem[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, f32, f32)>
+  %loaded = llvm.load %f1again : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @gep_same_field(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// A store to a different field of the same allocation is a different slot, so
+// it neither forwards to the load nor stops the store that does.
+llvm.func @gep_other_field(%val: f32, %other: f32) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i64, f32, f32)> : (i32) -> !llvm.ptr
+  %f1 = llvm.getelementptr %mem[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, f32, f32)>
+  llvm.store %val, %f1 : f32, !llvm.ptr
+  %f2 = llvm.getelementptr %mem[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, f32, f32)>
+  llvm.store %other, %f2 : f32, !llvm.ptr
+  %loaded = llvm.load %f1 : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @gep_other_field(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// An offset that is not known could be the one being read, so the store through
+// it stops the forwarding.
+llvm.func @gep_unknown_index(%val: f32, %i: i64) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<4 x f32> : (i32) -> !llvm.ptr
+  %f0 = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<4 x f32>
+  llvm.store %val, %f0 : f32, !llvm.ptr
+  %fi = llvm.getelementptr %mem[0, %i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<4 x f32>
+  llvm.store %val, %fi : f32, !llvm.ptr
+  %loaded = llvm.load %f0 : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @gep_unknown_index(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : f32
+
+// -----
+
+// Two views of one allocation with different shapes reach the same byte by
+// different routes: [1, 0] of a 4x4 is element 4, which is [4] of a 16. The
+// store through one must not be taken for a different place than the load
+// through the other.
+llvm.func @cross_shape_same_byte(%val: f32, %other: f32) -> f32 {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %c1_index = arith.constant 1 : index
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<16 x f32> : (i32) -> !llvm.ptr
+  %flat = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<16xf32>
+  %square = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<4x4xf32>
+  memref.store %val, %flat[%c4] : memref<16xf32>
+  memref.store %other, %square[%c1_index, %c0] : memref<4x4xf32>
+  %loaded = memref.load %flat[%c4] : memref<16xf32>
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @cross_shape_same_byte(
+// CHECK: %[[LD:.+]] = memref.load
+// CHECK: llvm.return %[[LD]] : f32
+
+// -----
+
+// Two offsets of the same allocation, counted the same way, add up: the field
+// reached by stepping to element 1 and then 2 more is the one reached by
+// stepping 3, whether the steps are constant or not.
+llvm.func @gep_of_gep(%val: f32, %i: i64) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %c2 = llvm.mlir.constant(2 : i64) : i64
+  %c3 = llvm.mlir.constant(3 : i64) : i64
+  %mem = llvm.alloca %c1 x !llvm.array<8 x f32> : (i32) -> !llvm.ptr
+  %flat = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<8 x f32>
+  %one = llvm.getelementptr %flat[1] : (!llvm.ptr) -> !llvm.ptr, f32
+  %three = llvm.getelementptr %one[2] : (!llvm.ptr) -> !llvm.ptr, f32
+  llvm.store %val, %three : f32, !llvm.ptr
+  %again = llvm.getelementptr %flat[3] : (!llvm.ptr) -> !llvm.ptr, f32
+  %loaded = llvm.load %again : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @gep_of_gep(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// The same when one of the two steps is not known: %i then 2 is %i + 2, which
+// is what the load steps by.
+llvm.func @gep_of_gep_symbolic(%val: f32, %i: i64) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %c2 = llvm.mlir.constant(2 : i64) : i64
+  %mem = llvm.alloca %c1 x !llvm.array<8 x f32> : (i32) -> !llvm.ptr
+  %flat = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<8 x f32>
+  %at = llvm.getelementptr %flat[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+  %past = llvm.getelementptr %at[2] : (!llvm.ptr) -> !llvm.ptr, f32
+  llvm.store %val, %past : f32, !llvm.ptr
+  %loaded = llvm.load %past : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @gep_of_gep_symbolic(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32
+
+// -----
+
+// Stepping by one value and then another lands where stepping by their sum
+// does, which is an expression of both and needs nothing built to name it.
+llvm.func @gep_two_values(%val: f32, %i: i64, %j: i64) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<8 x f32> : (i32) -> !llvm.ptr
+  %flat = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<8 x f32>
+  %at = llvm.getelementptr %flat[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+  %past = llvm.getelementptr %at[%j] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+  llvm.store %val, %past : f32, !llvm.ptr
+  %other = llvm.getelementptr %at[%j] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+  %loaded = llvm.load %other : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @gep_two_values(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32


### PR DESCRIPTION
Follow-up to #2743, rebased onto main now that it is merged.

A slot was a bare `std::vector<Offset>`, which only means something for accesses of the same shape through the same view. So anything reached through a `getelementptr` was marked `modified` and matched no slot, an access through a `pointer2memref` of an allocation was never walked when collecting slots, and an access at `[0, 0]` of a 2-D view could not be recognised as the same place as the index-free access an `llvm.load` performs.

`OffsetTree` carries, per index, the unit that index counts in — bytes of the type a `getelementptr` steps through, or a dimension of a memref — plus the type of the value read or written. It is normalised on construction and immutable afterwards. `add` composes two paths: a zero offset takes the other, two constant byte offsets add, and a byte offset added to a dimension offset with neither provably zero yields the unknown offset, which could be anywhere — `Maybe` against everything, naming nothing.

What that buys:

- every way of naming the start of an allocation normalises to the same zero-sized byte offset, whatever the rank of the access that got there, so a memref or affine access at all-zero indices meets an `llvm.load`;
- a `getelementptr` contributes real offsets, so two accesses of the same field are one slot, and accesses of different fields are different slots when neither extent reaches the other;
- a slot is *where* an access lands rather than *what* is read there, so the differing spellings of one value that `castToType` exists to convert between still meet (`mem2reg_type_casting.mlir`), with the extents deciding whether they can.

`matches` takes the `DataLayout` rather than a remembered size: equal types cover equal bytes; differing ones are compared by extent when the layout can give it, and are a `Maybe` when it cannot. Sizes come from the layout in force where the allocation is, since a nested region may carry its own.

The sweep walks with the same trees, so the `modified` flag and both `matchesIndices` overloads are gone: a path the tree cannot model is an unknown offset, which behaves exactly as `modified` did.

No memcpy/memmove forwarding here — that is the next step on top of this.

`test/lit_tests/mem2reg_offsets.mlir` covers: an `affine.store` at `[0, 0]` of a 2-D view forwarding to an `llvm.load` and the reverse, a gep-keyed field forwarding to itself, a store to a disjoint field not blocking it, and an unknown gep index blocking it. Full lit suite: 1094 pass, the same 4 unrelated failures as main.