### PR TITLE
polygeist-mem2reg: forward through transfers

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -821,6 +821,69 @@ public:
 
 static OffsetTree accessOffsets(Type accessed) { return OffsetTree(accessed); }
 
+// The pointer a memcpy/memmove reads from; a memset reads from nothing.
+static Value transferSource(Operation *op) {
+  if (auto cpy = dyn_cast<LLVM::MemcpyOp>(op))
+    return cpy.getSrc();
+  if (auto mv = dyn_cast<LLVM::MemmoveOp>(op))
+    return mv.getSrc();
+  return nullptr;
+}
+
+static Value transferDest(Operation *op) {
+  if (auto cpy = dyn_cast<LLVM::MemcpyOp>(op))
+    return cpy.getDst();
+  if (auto mv = dyn_cast<LLVM::MemmoveOp>(op))
+    return mv.getDst();
+  if (auto ms = dyn_cast<LLVM::MemsetOp>(op))
+    return ms.getDst();
+  return nullptr;
+}
+
+// How many bytes a transfer moves, when that is a known constant.
+static std::optional<uint64_t> transferLength(Operation *op) {
+  Value len;
+  if (auto cpy = dyn_cast<LLVM::MemcpyOp>(op))
+    len = cpy.getLen();
+  else if (auto mv = dyn_cast<LLVM::MemmoveOp>(op))
+    len = mv.getLen();
+  else if (auto ms = dyn_cast<LLVM::MemsetOp>(op))
+    len = ms.getLen();
+  else
+    return std::nullopt;
+
+  APInt val;
+  if (!matchPattern(len, m_ConstantInt(&val)))
+    return std::nullopt;
+  return val.getZExtValue();
+}
+
+// What a transfer states about the alignment of the end it is asked about,
+// which is all an access put in its place may assume; absent, it promises
+// nothing beyond a byte. The destination is its first argument, the source its
+// second.
+static unsigned transferAlignment(Operation *op, unsigned arg) {
+  auto argAttrs = op->getAttrOfType<ArrayAttr>("arg_attrs");
+  if (!argAttrs || argAttrs.size() <= arg)
+    return 1;
+  auto dict = dyn_cast<DictionaryAttr>(argAttrs[arg]);
+  if (!dict)
+    return 1;
+  if (auto align =
+          dict.getAs<IntegerAttr>(LLVM::LLVMDialect::getAlignAttrName()))
+    return align.getInt();
+  return 1;
+}
+
+// What a transfer touches is a number of bytes rather than a value of some
+// type, which is the same thing as an access of an integer that wide. Anything
+// larger than a slot could hold is not worth naming.
+static OffsetTree transferAccess(uint64_t bytes, MLIRContext *ctx) {
+  if (!bytes || bytes > 4096)
+    return OffsetTree::unknown();
+  return OffsetTree(IntegerType::get(ctx, bytes * 8));
+}
+
 static OffsetTree accessOffsets(Type accessed, Value memory,
                                 mlir::OperandRange indices,
                                 const DataLayout &dl) {
@@ -1629,7 +1692,8 @@ void removeRedundantBlockArgs(
       if (auto op = dyn_cast<cf::BranchOp>(pred->getTerminator())) {
         pval = op.getOperands()[blockArg.getArgNumber()];
         if (pval.getType() != elType) {
-          pval.getDefiningOp()->getParentRegion()->getParentOp()->dump();
+          if (auto *def = pval.getDefiningOp())
+            def->getParentRegion()->getParentOp()->dump();
           llvm::errs() << pval << " - " << AI << "\n";
         }
         assert(pval.getType() == elType);
@@ -1952,6 +2016,8 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing) {
   bool changed = false;
   std::set<mlir::Operation *> loadOps;
+  // Transfers that read exactly one slot, which act as a load of it.
+  std::set<mlir::Operation *> transferLoads;
   mlir::Type subType = nullptr;
   mlir::Location loc = AI.getLoc();
   std::set<mlir::Operation *> allStoreOps;
@@ -2103,24 +2169,49 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
         }
         continue;
       }
-      if (auto op = dyn_cast<mlir::LLVM::MemsetOp>(user)) {
-        if (op.getDst() == val) {
-          LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << op << "\n");
-          AliasingStoreOperations.insert(op);
+      if (isa<LLVM::MemsetOp, LLVM::MemmoveOp, LLVM::MemcpyOp>(user)) {
+        auto bytes = transferLength(user);
+        // Without a length there is no telling what it touches, so anything it
+        // writes may be this slot.
+        OffsetTree touched =
+            bytes ? tree.add(transferAccess(*bytes, user->getContext()), dl)
+                  : OffsetTree::unknown();
+
+        if (transferDest(user) == val) {
+          switch (idx.matches(touched, dl)) {
+          case Match::Exact:
+            // Writing exactly this slot writes a value that is known when what
+            // it was written from is: the bytes of a fill, when they are zero,
+            // or whatever the copy read.
+            if (auto ms = dyn_cast<LLVM::MemsetOp>(user)) {
+              APInt byte;
+              if (matchPattern(ms.getVal(), m_ConstantInt(&byte)) &&
+                  byte.isZero()) {
+                LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << *user << "\n");
+                allStoreOps.insert(user);
+                break;
+              }
+            } else {
+              LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << *user << "\n");
+              allStoreOps.insert(user);
+              break;
+            }
+            LLVM_FALLTHROUGH;
+          case Match::Maybe:
+            LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << *user << "\n");
+            AliasingStoreOperations.insert(user);
+            break;
+          case Match::None:
+            break;
+          }
         }
-        continue;
-      }
-      if (auto op = dyn_cast<mlir::LLVM::MemmoveOp>(user)) {
-        if (op.getDst() == val) {
-          LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << op << "\n");
-          AliasingStoreOperations.insert(op);
-        }
-        continue;
-      }
-      if (auto op = dyn_cast<mlir::LLVM::MemcpyOp>(user)) {
-        if (op.getDst() == val) {
-          LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << op << "\n");
-          AliasingStoreOperations.insert(op);
+
+        // Reading exactly this slot is reading the value in it, whatever the
+        // copy then does with it.
+        if (transferSource(user) == val &&
+            idx.matches(touched, dl) == Match::Exact) {
+          LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << *user << "\n");
+          transferLoads.insert(user);
         }
         continue;
       }
@@ -2181,7 +2272,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     }
   }
 
-  if (loadOps.size() == 0) {
+  if (loadOps.size() == 0 && transferLoads.size() == 0) {
     return changed;
   }
 
@@ -2196,6 +2287,9 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   {
     SmallVector<Region *> todo;
     for (auto *load : loadOps) {
+      todo.push_back(load->getParentRegion());
+    }
+    for (auto *load : transferLoads) {
       todo.push_back(load->getParentRegion());
     }
     while (todo.size()) {
@@ -2290,6 +2384,25 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     }
   };
 
+  // A transfer reading the whole of a slot consumes the value in it, so once
+  // that value is known the copy is a store of it into the destination. Padding
+  // bytes become undef rather than being copied, the same trade LLVM's SROA
+  // makes when it forwards through a copy.
+  auto replaceTransfer = [&](Operation *op, ValueOrPlaceholder *incoming) {
+    incoming->materialize(/*full*/ false);
+    // Whatever reaches the slot covers exactly the bytes the copy moves, since
+    // that is what naming the same slot means.
+    if (incoming->overwritten || !incoming->val)
+      return;
+    OpBuilder builder(op);
+    LLVM::StoreOp::create(builder, op->getLoc(), incoming->val,
+                          transferDest(op), transferAlignment(op, 0));
+    LLVM_DEBUG(llvm::dbgs() << " replaced " << *op << " with a store of "
+                            << incoming->val << "\n");
+    loadOpsToErase.push_back(op);
+    changed = true;
+  };
+
   // Start by setting valueAtEndOfBlock to the last store directly in that block
   // Note that this may miss a store within a region of an operation in that
   // block
@@ -2345,17 +2458,36 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           } else if (loadOps.count(a)) {
             Value loadOp = a->getResult(0);
             lastVal = replaceValue(loadOp, lastVal);
-          } else if (auto storeOp = dyn_cast<memref::StoreOp>(a)) {
-            if (allStoreOps.count(storeOp)) {
-              lastVal = metaMap.get(storeOp.getValueToStore());
+          } else if (transferLoads.count(a)) {
+            replaceTransfer(a, lastVal);
+          } else if (isa<LLVM::MemcpyOp, LLVM::MemmoveOp, LLVM::MemsetOp>(a)) {
+            // A transfer writing the slot leaves what it wrote there: a copy
+            // leaves what it read, which a load of that says, and a fill of
+            // zero bytes leaves a zero of whatever the slot holds. Anything
+            // else it wrote is something this cannot name, and stands as an
+            // overwrite.
+            if (allStoreOps.count(a)) {
+              OpBuilder builder(a);
+              // Of what the slot holds, since that is what everything threaded
+              // through it is of; of as many bytes as were moved when nothing
+              // has said yet what those bytes are.
+              Type moved = elType ? elType
+                                  : IntegerType::get(a->getContext(),
+                                                     *transferLength(a) * 8);
+              Value written;
+              if (!LLVM::isCompatibleType(moved)) {
+                // Nothing to name it with.
+              } else if (Value src = transferSource(a)) {
+                written = LLVM::LoadOp::create(builder, a->getLoc(), moved, src,
+                                               transferAlignment(a, 1));
+              } else {
+                written = LLVM::ZeroOp::create(builder, a->getLoc(), moved);
+              }
+              lastVal = written ? metaMap.get(written) : emptyValue;
             }
-          } else if (auto storeOp = dyn_cast<LLVM::StoreOp>(a)) {
+          } else if (auto storeOp = dyn_cast<enzyme::StoreLikeInterface>(a)) {
             if (allStoreOps.count(storeOp)) {
-              lastVal = metaMap.get(storeOp.getValue());
-            }
-          } else if (auto storeOp = dyn_cast<affine::AffineStoreOp>(a)) {
-            if (allStoreOps.count(storeOp)) {
-              lastVal = metaMap.get(storeOp.getValueToStore());
+              lastVal = metaMap.get(storeOp.getStoredValue());
             }
           } else {
             // since not storing operation the value at the start of every block
@@ -2573,8 +2705,14 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       assert(valueAtEndOfBlock.find(pred)->second);
       mlir::Value pval =
           valueAtEndOfBlock.find(pred)->second->materialize(true);
+      // What reaches the end of a predecessor is of the slot's extent but need
+      // not be spelled as the slot is, and what a block argument takes must be.
+      if (pval && pval.getType() != elType)
+        pval = castToType(elType, pval, pred->getTerminator());
       if (!pval || pval.getType() != elType) {
-        AI.getDefiningOp()->getParentOfType<func::FuncOp>().dump();
+        if (auto fn =
+                AI.getDefiningOp()->getParentOfType<FunctionOpInterface>())
+          fn.dump();
         pred->dump();
         llvm::errs() << "pval: " << *valueAtEndOfBlock.find(pred)->second
                      << " AI: " << AI << "\n";
@@ -2651,15 +2789,6 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     }
   }
   return changed;
-}
-
-// The pointer a memcpy/memmove reads from; memset has no source.
-static Value transferSource(Operation *op) {
-  if (auto cpy = dyn_cast<LLVM::MemcpyOp>(op))
-    return cpy.getSrc();
-  if (auto mv = dyn_cast<LLVM::MemmoveOp>(op))
-    return mv.getSrc();
-  return nullptr;
 }
 
 bool isPromotable(mlir::Value AI) {
@@ -2752,6 +2881,11 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
         lastStored[tree.add(accessOffsets(SO.getValue().getType()), dl)]++;
       } else if (auto LO = dyn_cast<LLVM::LoadOp>(U)) {
         lastStored[tree.add(accessOffsets(LO.getType()), dl)]++;
+      } else if (isa<LLVM::MemcpyOp, LLVM::MemmoveOp, LLVM::MemsetOp>(U)) {
+        // What a transfer reads or fills is a slot like any other, and the
+        // forwarding can only be asked about slots it is told of.
+        if (auto bytes = transferLength(U))
+          lastStored[tree.add(transferAccess(*bytes, U->getContext()), dl)]++;
       } else if (auto GO = dyn_cast<LLVM::GEPOp>(U)) {
         list.emplace_back(GO, tree.add(gepOffsets(GO, dl), dl));
       } else if (isa<memref::CastOp, Memref2PointerOp, Pointer2MemrefOp,

--- a/test/lit_tests/mem2reg_transfers.mlir
+++ b/test/lit_tests/mem2reg_transfers.mlir
@@ -1,7 +1,7 @@
 // RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
 
-// A memcpy reading the allocation does not stop the parts it does not name from
-// being forwarded, and does not let the pointer escape.
+// A copy reading exactly what an allocation holds reads the value in it, so it
+// is a store of that value into wherever it was copying to.
 llvm.func @memcpy_src(%dst: !llvm.ptr) -> i32 {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %len = llvm.mlir.constant(4 : i64) : i64
@@ -14,51 +14,17 @@ llvm.func @memcpy_src(%dst: !llvm.ptr) -> i32 {
 }
 
 // CHECK-LABEL: llvm.func @memcpy_src(
+// CHECK-SAME: %[[DST:[a-z0-9]+]]: !llvm.ptr
 // CHECK: %[[C42:.+]] = llvm.mlir.constant(42 : i32) : i32
-// CHECK: "llvm.intr.memcpy"
-// CHECK-NOT: llvm.load
+// CHECK-NOT: llvm.alloca
+// CHECK-NOT: "llvm.intr.memcpy"
+// CHECK: llvm.store %[[C42]], %[[DST]]
 // CHECK: llvm.return %[[C42]] : i32
 
 // -----
 
-// A memcpy writing the allocation overwrites it, so the store before it must
-// not reach the load after it.
-llvm.func @memcpy_dst(%src: !llvm.ptr) -> i32 {
-  %c1 = llvm.mlir.constant(1 : i32) : i32
-  %len = llvm.mlir.constant(4 : i64) : i64
-  %val = llvm.mlir.constant(42 : i32) : i32
-  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
-  llvm.store %val, %mem : i32, !llvm.ptr
-  "llvm.intr.memcpy"(%mem, %src, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
-  %loaded = llvm.load %mem : !llvm.ptr -> i32
-  llvm.return %loaded : i32
-}
-
-// CHECK-LABEL: llvm.func @memcpy_dst(
-// CHECK: %[[LD:.+]] = llvm.load
-// CHECK: llvm.return %[[LD]] : i32
-
-// -----
-
-// Likewise for a memset, and for a memmove reading it.
-llvm.func @memset_dst(%other: !llvm.ptr) -> i32 {
-  %c1 = llvm.mlir.constant(1 : i32) : i32
-  %len = llvm.mlir.constant(4 : i64) : i64
-  %byte = llvm.mlir.constant(0 : i8) : i8
-  %val = llvm.mlir.constant(42 : i32) : i32
-  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
-  llvm.store %val, %mem : i32, !llvm.ptr
-  "llvm.intr.memset"(%mem, %byte, %len) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
-  %loaded = llvm.load %mem : !llvm.ptr -> i32
-  llvm.return %loaded : i32
-}
-
-// CHECK-LABEL: llvm.func @memset_dst(
-// CHECK: %[[LD:.+]] = llvm.load
-// CHECK: llvm.return %[[LD]] : i32
-
-// -----
-
+// The same for a memmove, which moves what it reads before anything else sees
+// it either way.
 llvm.func @memmove_src(%dst: !llvm.ptr) -> i32 {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %len = llvm.mlir.constant(4 : i64) : i64
@@ -71,10 +37,114 @@ llvm.func @memmove_src(%dst: !llvm.ptr) -> i32 {
 }
 
 // CHECK-LABEL: llvm.func @memmove_src(
+// CHECK-SAME: %[[DST:[a-z0-9]+]]: !llvm.ptr
 // CHECK: %[[C42:.+]] = llvm.mlir.constant(42 : i32) : i32
-// CHECK: "llvm.intr.memmove"
-// CHECK-NOT: llvm.load
+// CHECK-NOT: "llvm.intr.memmove"
+// CHECK: llvm.store %[[C42]], %[[DST]]
 // CHECK: llvm.return %[[C42]] : i32
+
+// -----
+
+// A copy writing the allocation puts what it read there, which is not what the
+// store before it put there: that store does not reach the load after it, and
+// what the copy read does.
+llvm.func @memcpy_dst(%src: !llvm.ptr) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memcpy"(%mem, %src, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @memcpy_dst(
+// CHECK-SAME: %[[SRC:[a-z0-9]+]]: !llvm.ptr
+// CHECK-NOT: "llvm.intr.memcpy"
+// CHECK: %[[LD:.+]] = llvm.load %[[SRC]]
+// CHECK: llvm.return %[[LD]] : i32
+
+// -----
+
+// Filling the allocation with zero bytes leaves a zero of what it holds, which
+// is what a read of it finds.
+llvm.func @memset_dst() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %byte = llvm.mlir.constant(0 : i8) : i8
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memset"(%mem, %byte, %len) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @memset_dst(
+// CHECK-NOT: "llvm.intr.memset"
+// CHECK: %[[Z:.+]] = llvm.mlir.zero : i32
+// CHECK: llvm.return %[[Z]] : i32
+
+// -----
+
+// Filled with something else, what is there is only known once it is said what
+// those bytes make of the value.
+llvm.func @memset_nonzero() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %byte = llvm.mlir.constant(7 : i8) : i8
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memset"(%mem, %byte, %len) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @memset_nonzero(
+// CHECK: "llvm.intr.memset"
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : i32
+
+// -----
+
+// Reading part of what an allocation holds is not reading the value in it, so
+// the copy stays and so does what it copies from.
+llvm.func @partial_copy(%dst: !llvm.ptr) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(2 : i64) : i64
+  %val = llvm.mlir.constant(42 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memcpy"(%dst, %mem, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @partial_copy(
+// CHECK: llvm.alloca
+// CHECK: "llvm.intr.memcpy"
+
+// -----
+
+// A copy into one field says nothing about another, so what was written there
+// is still what is read there.
+llvm.func @copy_into_other_field(%src: !llvm.ptr, %val: f32) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %mem = llvm.alloca %c1 x !llvm.struct<(f32, f32)> : (i32) -> !llvm.ptr
+  %f0 = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32, f32)>
+  llvm.store %val, %f0 : f32, !llvm.ptr
+  %f1 = llvm.getelementptr %mem[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32, f32)>
+  "llvm.intr.memcpy"(%f1, %src, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  %loaded = llvm.load %f0 : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @copy_into_other_field(
+// CHECK-SAME: %{{[a-z0-9]+}}: !llvm.ptr, %[[VAL:[a-z0-9]+]]: f32
+// CHECK-NOT: llvm.load
+// CHECK: llvm.return %[[VAL]] : f32
 
 // -----
 
@@ -106,23 +176,6 @@ llvm.func @dead_alloca(%src: !llvm.ptr) {
 
 // -----
 
-// The same allocation stays when something reads out of it.
-llvm.func @live_alloca(%dst: !llvm.ptr) {
-  %c1 = llvm.mlir.constant(1 : i32) : i32
-  %len = llvm.mlir.constant(4 : i64) : i64
-  %val = llvm.mlir.constant(42 : i32) : i32
-  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
-  llvm.store %val, %mem : i32, !llvm.ptr
-  "llvm.intr.memcpy"(%dst, %mem, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
-  llvm.return
-}
-
-// CHECK-LABEL: llvm.func @live_alloca(
-// CHECK: llvm.alloca
-// CHECK: "llvm.intr.memcpy"
-
-// -----
-
 // Storing the pointer itself hands it to whoever reads that memory, so nothing
 // may be forwarded through it.
 llvm.func @escaped_through_store(%out: !llvm.ptr) -> i32 {
@@ -138,3 +191,139 @@ llvm.func @escaped_through_store(%out: !llvm.ptr) -> i32 {
 // CHECK-LABEL: llvm.func @escaped_through_store(
 // CHECK: %[[LD:.+]] = llvm.load
 // CHECK: llvm.return %[[LD]] : i32
+
+// -----
+
+// A store put where a copy was may assume of the destination only what the copy
+// said of it, which is what the copy carries rather than what the source it
+// read from happened to be.
+llvm.func @copy_states_alignment(%dst: !llvm.ptr, %val: i32) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memcpy"(%dst, %mem, %len) <{arg_attrs = [{llvm.align = 4 : i64}, {}, {}], isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @copy_states_alignment(
+// CHECK-SAME: %[[DST:[a-z0-9]+]]: !llvm.ptr, %[[VAL:[a-z0-9]+]]: i32
+// CHECK: llvm.store %[[VAL]], %[[DST]] {alignment = 4 : i64}
+
+// -----
+
+// Saying nothing of it, a byte is all that may be assumed -- whatever the
+// allocation it copied out of was aligned to.
+llvm.func @copy_states_nothing(%dst: !llvm.ptr, %val: i32) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %mem = llvm.alloca %c1 x i32 {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : i32, !llvm.ptr
+  "llvm.intr.memcpy"(%dst, %mem, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @copy_states_nothing(
+// CHECK-SAME: %[[DST:[a-z0-9]+]]: !llvm.ptr, %[[VAL:[a-z0-9]+]]: i32
+// CHECK: llvm.store %[[VAL]], %[[DST]] {alignment = 1 : i64}
+
+// -----
+
+// A copy into exactly what an allocation holds leaves what it read there, so a
+// read of it afterwards is a read of where the copy came from.
+llvm.func @copy_in(%src: !llvm.ptr) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  "llvm.intr.memcpy"(%mem, %src, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @copy_in(
+// CHECK-SAME: %[[SRC:[a-z0-9]+]]: !llvm.ptr
+// CHECK-NOT: llvm.alloca
+// CHECK-NOT: "llvm.intr.memcpy"
+// CHECK: %[[LD:.+]] = llvm.load %[[SRC]]
+// CHECK: llvm.return %[[LD]] : i32
+
+// -----
+
+// Copied from one allocation to another and read back, the value goes straight
+// across and neither allocation is left.
+llvm.func @copy_between(%val: i32) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %a = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %b = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  llvm.store %val, %a : i32, !llvm.ptr
+  "llvm.intr.memcpy"(%b, %a, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  %loaded = llvm.load %b : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @copy_between(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: i32
+// CHECK-NOT: llvm.alloca
+// CHECK-NOT: "llvm.intr.memcpy"
+// CHECK: llvm.return %[[VAL]] : i32
+
+// -----
+
+// What a transfer leaves in a slot is threaded to the reads of it like anything
+// else, which for a read past a join means through a block argument -- so it
+// has to be of what the slot holds, not of the bytes that were moved.
+func.func @transfer_through_branch(%cond: i1, %src: !llvm.ptr) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(4 : i64) : i64
+  %byte = llvm.mlir.constant(0 : i8) : i8
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  cf.cond_br %cond, ^bb1, ^bb2
+^bb1:
+  "llvm.intr.memcpy"(%mem, %src, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  cf.br ^bb3
+^bb2:
+  "llvm.intr.memset"(%mem, %byte, %len) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  cf.br ^bb3
+^bb3:
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  return %loaded : i32
+}
+
+// CHECK-LABEL: func.func @transfer_through_branch(
+// CHECK-SAME: %{{[a-z0-9]+}}: i1, %[[SRC:[a-z0-9]+]]: !llvm.ptr
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[LD:.+]] = llvm.load %[[SRC]]
+// CHECK: cf.br ^[[JOIN:.+]](%[[LD]] : i32)
+// CHECK: %[[Z:.+]] = llvm.mlir.zero : i32
+// CHECK: cf.br ^[[JOIN]](%[[Z]] : i32)
+// CHECK: ^[[JOIN]](%[[ARG:.+]]: i32):
+// CHECK: return %[[ARG]] : i32
+
+// -----
+
+// One value of an allocation may be spelled two ways -- here a pointer and the
+// struct that holds one -- and what reaches a read of it through a block
+// argument has to be spelled as that argument is.
+func.func @transfer_of_wrapped_pointer(%cond: i1, %src: !llvm.ptr, %p: !llvm.ptr) -> !llvm.ptr {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %len = llvm.mlir.constant(8 : i64) : i64
+  %undef = llvm.mlir.undef : !llvm.struct<(ptr)>
+  %wrapped = llvm.insertvalue %p, %undef[0] : !llvm.struct<(ptr)>
+  %mem = llvm.alloca %c1 x !llvm.struct<(ptr)> : (i32) -> !llvm.ptr
+  cf.cond_br %cond, ^bb1, ^bb2
+^bb1:
+  llvm.store %wrapped, %mem : !llvm.struct<(ptr)>, !llvm.ptr
+  cf.br ^bb3
+^bb2:
+  "llvm.intr.memcpy"(%mem, %src, %len) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  cf.br ^bb3
+^bb3:
+  %loaded = llvm.load %mem : !llvm.ptr -> !llvm.ptr
+  return %loaded : !llvm.ptr
+}
+
+// CHECK-LABEL: func.func @transfer_of_wrapped_pointer(
+// CHECK-NOT: llvm.alloca
+// CHECK: ^{{.+}}(%[[ARG:.+]]: !llvm.ptr):
+// CHECK: return %[[ARG]] : !llvm.ptr


### PR DESCRIPTION
Stacked on #2745 (based on that branch).

A `memcpy`, `memmove` or `memset` was opaque to the forwarding: whatever it wrote overwrote the allocation entirely, and whatever it read was simply ignored. But what each of them touches is a number of bytes at an offset — exactly what an `OffsetTree` describes — so they can be asked the same question every other access is asked: *which slot is this, if any*. A transfer of `N` bytes is an access of an `N`-byte value, which is all the tree needs to line it up against the loads and stores around it.

What that buys:

- **Reading exactly one slot is reading the value in it.** Once that value is known, the copy becomes a store of it into wherever it was copying to, and the allocation it read from is often then dead. That is the shape a by-value argument takes after inlining — a slot written once, copied into a second slot, and read from there — which is what motivated this.
- **Filling exactly one slot with zero bytes** leaves a zero of whatever the slot holds, so the reads after it find that. Filled with any other byte, what is there is only known once it is said what those bytes make of the value, so it stays an overwrite.
- **Writing a slot overwrites only the slots it covers.** A copy into one field of a struct no longer stops what was written to another field from being read there.

Partial transfers, transfers whose length is not known, and anything reached through a pointer that escapes behave as before.

`test/lit_tests/mem2reg_transfers.mlir` covers each: a copy and a move reading a slot (now a store into the destination, allocation gone), a copy writing one (still blocks), a zero fill (forwards a zero) against a non-zero fill (does not), a partial copy (neither), a copy into a different field (does not block), the dead-allocation case, and the escape. Full lit suite: 1094 pass, the same 4 unrelated failures as main.