### PR TITLE
Do not tape the induction variable of a differentiated stablehlo.while

### DIFF
--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -3841,8 +3841,29 @@ public:
 
     Value itersV = nullptr;
 
+    // Caches whose pushed value is the loop induction variable. The reverse
+    // loop is given its own counter below (step 4) which holds exactly the
+    // forward index being reversed, so taping the induction variable would
+    // materialize an identity map `tape[i] = i`. Worse, reading it back makes
+    // every reverse index data-dependent, which blinds bounds analysis and
+    // stops `while_induction_reduction` (and friends) from shrinking the
+    // loop-carried buffers. Skip materializing these and substitute the
+    // reverse counter in step 5 instead.
+    //
+    // Enzyme's shared loop handling (RemovalUtils.h) achieves this for
+    // scf/affine loops by seeding `fwdrevmap` with the forward IV before
+    // running the min cut, so the IV is never a cut root. stablehlo.while
+    // builds its reverse counter after the min cut has already run, so it is
+    // handled here instead.
+    SmallPtrSet<Operation *, 2> inductionVariableCaches;
+
     for (auto &cinfo : caches) {
       Value cache = cinfo.initOp.getResult();
+
+      if (inductionVariable && cinfo.pushedValue() == inductionVariable) {
+        inductionVariableCaches.insert(cinfo.pushOp);
+        continue;
+      }
 
       // push does not depend on a value inside the loop, we can hoist the
       // push/pop before the for loops.
@@ -4060,6 +4081,24 @@ public:
     for (auto &info : caches) {
       if (info.pushedValue().getParentRegion() != &newWhile.getBody())
         continue;
+
+      // The induction variable is not taped; the reverse loop's own counter
+      // already holds the forward index for the step being reversed.
+      if (inductionVariableCaches.contains(info.pushOp)) {
+        Block *popBody = &otherWhileOp.getBody().front();
+        Value revIV = popBody->getArgument(popBody->getNumArguments() - 1);
+        Value popValue = info.popOp.getResult();
+        if (revIV.getType() != popValue.getType()) {
+          OpBuilder::InsertionGuard guard(rewriter);
+          rewriter.setInsertionPoint(info.popOp);
+          revIV = stablehlo::ConvertOp::create(rewriter, info.popOp->getLoc(),
+                                               popValue.getType(), revIV);
+        }
+        rewriter.replaceAllUsesWith(popValue, revIV);
+        rewriter.eraseOp(info.popOp);
+        rewriter.eraseOp(info.pushOp);
+        continue;
+      }
 
       Value cache = info.initOp.getResult();
 

--- a/test/lit_tests/while_no_induction_variable_cache.mlir
+++ b/test/lit_tests/while_no_induction_variable_cache.mlir
@@ -1,0 +1,50 @@
+// RUN: enzymexlamlir-opt %s --enzyme --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s
+
+// The reverse of a stablehlo.while is given its own counter, initialised to
+// numIters-1 and decremented each step, so it already holds the forward index of
+// the iteration being reversed. Taping the forward induction variable therefore
+// materialises an identity map `tape[i] = i`.
+//
+// Beyond the wasted buffer, reading it back makes every reverse index
+// data-dependent, which blinds bounds analysis and stops while_induction_reduction
+// (and while_dus / while_dus_ds_simplify) from shrinking the loop-carried buffers.
+//
+// Enzyme's shared loop handling seeds `fwdrevmap` with the forward IV before running
+// the min cut so it is never a cut root (RemovalUtils.h, used by scf/affine).
+// stablehlo.while builds its reverse counter after the min cut has run, so it must
+// drop the induction-variable cache explicitly.
+
+module {
+  func.func private @loop(%x: tensor<8x4xf32>) -> tensor<4xf32> {
+    %c0 = stablehlo.constant dense<0> : tensor<i64>
+    %c8 = stablehlo.constant dense<8> : tensor<i64>
+    %c1 = stablehlo.constant dense<1> : tensor<i64>
+    %init = stablehlo.constant dense<1.000000e+00> : tensor<4xf32>
+    %r:2 = stablehlo.while(%i = %c0, %acc = %init) : tensor<i64>, tensor<4xf32>
+    cond {
+      %c = stablehlo.compare LT, %i, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+      stablehlo.return %c : tensor<i1>
+    } do {
+      %row = stablehlo.dynamic_slice %x, %i, %c0, sizes = [1, 4] : (tensor<8x4xf32>, tensor<i64>, tensor<i64>) -> tensor<1x4xf32>
+      %rowr = stablehlo.reshape %row : (tensor<1x4xf32>) -> tensor<4xf32>
+      %prod = stablehlo.multiply %acc, %rowr : tensor<4xf32>
+      %inext = stablehlo.add %i, %c1 : tensor<i64>
+      stablehlo.return %inext, %prod : tensor<i64>, tensor<4xf32>
+    }
+    return %r#1 : tensor<4xf32>
+  }
+  func.func @main(%x: tensor<8x4xf32>) -> tensor<8x4xf32> {
+    %seed = stablehlo.constant dense<1.000000e+00> : tensor<4xf32>
+    %0 = enzyme.autodiff @loop(%x, %seed) {activity = [#enzyme<activity enzyme_active>], ret_activity = [#enzyme<activity enzyme_activenoneed>]} : (tensor<8x4xf32>, tensor<4xf32>) -> tensor<8x4xf32>
+    return %0 : tensor<8x4xf32>
+  }
+}
+
+// The induction variable must not be taped: no i64 buffer is carried, and the
+// augmented forward loop carries only the counter, the primal accumulator and the
+// one genuine cache.
+// CHECK-LABEL:   func.func private @diffeloop(
+// CHECK-NOT:       tensor<8xi64>
+// CHECK:           stablehlo.while(%iterArg = %{{.*}}, %iterArg_{{.*}} = %{{.*}}, %iterArg_{{.*}} = %{{.*}}) : tensor<i64>, tensor<4xf32>, tensor<8x4xf32>
+// CHECK-NOT:       tensor<8xi64>
+// CHECK:           return


### PR DESCRIPTION
## Problem

The reverse of a `stablehlo.while` is given its own counter, initialised to `numIters - 1` and decremented each step — so it already holds the forward index of the iteration being reversed. Caching the forward induction variable therefore materialises an identity map, `tape[i] = i`.

The wasted buffer is the smaller problem. Reading the index back makes every reverse index **data-dependent**, which blinds bounds analysis and stops `while_induction_reduction`, `while_dus` and `while_dus_ds_simplify` from shrinking the loop-carried buffers the index feeds.

## Why it happens

Enzyme's shared loop handling already avoids this. `RemovalUtils.h` seeds `fwdrevmap` with the forward IV before running the min cut, so `minCutValues` never sees it as a root:

```cpp
if (isDefinedOutside || fwdrevmap.contains(todo))
  continue;                 // not a root -> never cached
Operation *owner = todo.getDefiningOp();
if (!owner || !isMovable(owner))
  roots.insert(todo);       // block argument -> root -> must be cached
```

scf and affine loops get this through `getCanonicalLoopIVs` / `createArgumentMap`. **`stablehlo.while` does not** — it builds its reverse counter in step 4, *after* `minCutCache` has already run in step 3, and passes a default-constructed (empty) `fwdrevmap`. The induction variable is `body->getArgument(0)`, a block argument with no defining op, so it falls straight through to `roots.insert`.

The min cut is cardinality-based with unit capacities, so a 2 KB index tape and a 1 MB buffer both "cost one" — it has no reason to prefer recomputing the trivially recomputable one.

## What this PR does

Drops the induction-variable cache where it would be materialised and substitutes the reverse loop's counter when replacing the pop.

## Known limitation — this does not fix the min cut itself

**The min cut still runs with the induction variable as a flow source.** This PR removes the resulting tape after the fact; it does not tell the solver that the IV is free. Because an extra source changes which cut is minimal, the cut chosen for the *rest* of the graph may still be suboptimal — values recomputable from the counter (indexed reads, affine index arithmetic) look cuttable rather than free.

The principled fix is to seed `fwdrevmap` before `minCutCache`, as scf/affine do. I attempted two forms and landed neither:

1. **Build the reverse counter before the min cut.** `minCutCache` can *clear* `caches` (it does so when every push was hoisted out of the loop), so step 4's `caches.size() != 0` guard goes false after the block argument has already been added, leaving operands and block arguments mismatched. Fixing that exposed a dominance violation (the shared `itersV` is materialised at `otherWhileOp` but the cache buffers are placed earlier) and an i32/i64 type mismatch (`while6` runs its IV at `tensor<i32>` while the counter is built at i64). With those fixed, the checkpointing paths regressed — `while_checkpointing2` grew 31 -> 45 ops, since it carries `enzyme.disable_mincut` and gains a counter it never needed.

2. **Seed the map with an `enzyme.placeholder`** and RAUW it to the real counter in step 4, leaving step 4 untouched. Builds and passes 1088/1090, but when `minCutCache` clears `caches` step 4 never runs, so the placeholder is never replaced and leaks into the output IR (`while5` ends up with 10 surviving `enzyme.placeholder` ops). Not correct, so not proposed.

Both need restructuring of the step 3/4 boundary that I would rather leave to someone who knows this code. Happy to take a steer.

## Effect

On the reduced test the augmented forward loop goes from

```
(tensor<i64>, tensor<4xf32>, tensor<8xi64>, tensor<8x4xf32>)
```
to
```
(tensor<i64>, tensor<4xf32>, tensor<8x4xf32>)
```

On `grad(bloch_rf_optimization)` from Reactant.jl's `benchmark/misc` this removes the `tensor<256xi64>` index tape whose data-dependent reads were preventing the nine `tensor<256x1024xf32>` adjoint accumulators from being narrowed.

## Testing

- New lit test `while_no_induction_variable_cache.mlir`. **Confirmed it fails without the fix** and passes with it.
- All 1090 lit tests pass, unchanged — no goldens needed regenerating.
- Numerically verified: for `prod_i x[i,:]` over 8 rows of 2s the gradient is 128 = 2^7 everywhere, under `stablehlo-translate --interpret`.

## Not verified

End-to-end wall clock. The GPUs on my machine are currently unusable — GPU 0 (the display GPU) returns `CUDA_ERROR_NOT_INITIALIZED` from `cuInit` and poisons initialisation for the whole process; `nvidia-smi -r` refuses to reset the primary GPU and reloading `nvidia_uvm` did not help. Everything above is IR-level; no speedup is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)