### PR TITLE
polygeist-mem2reg: read a piece of what a slot holds

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2993,7 +2993,13 @@ bool isPromotable(mlir::Value AI) {
 }
 
 std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
-  std::map<OffsetTree, unsigned> lastStored;
+  // Where an access lands and how much of it it reads: two spellings of one
+  // extent are one slot, but the whole of something and the first field of it
+  // start in the same place and are not.
+  auto slotOf = [&](const OffsetTree &tree) {
+    return std::make_pair(typeSize(tree.getBase(), dl).value_or(0), tree);
+  };
+  std::map<std::pair<uint64_t, OffsetTree>, unsigned> lastStored;
 
   std::deque<std::pair<mlir::Value, OffsetTree>> list = {{AI, OffsetTree()}};
 
@@ -3002,33 +3008,37 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
     list.pop_front();
     for (auto *U : val.getUsers()) {
       if (auto SO = dyn_cast<memref::StoreOp>(U)) {
-        lastStored[tree.add(accessOffsets(SO.getValue().getType(),
-                                          SO.getMemRef(), SO.getIndices(), dl),
-                            dl)]++;
+        lastStored[slotOf(
+            tree.add(accessOffsets(SO.getValue().getType(), SO.getMemRef(),
+                                   SO.getIndices(), dl),
+                     dl))]++;
       } else if (auto LO = dyn_cast<memref::LoadOp>(U)) {
-        lastStored[tree.add(
+        lastStored[slotOf(tree.add(
             accessOffsets(LO.getType(), LO.getMemRef(), LO.getIndices(), dl),
-            dl)]++;
+            dl))]++;
       } else if (auto SO = dyn_cast<affine::AffineStoreOp>(U)) {
-        lastStored[tree.add(accessOffsets(SO.getValue().getType(),
-                                          SO.getMemRef(),
-                                          SO.getAffineMapAttr().getValue(),
-                                          SO.getMapOperands(), dl),
-                            dl)]++;
+        lastStored[slotOf(
+            tree.add(accessOffsets(SO.getValue().getType(), SO.getMemRef(),
+                                   SO.getAffineMapAttr().getValue(),
+                                   SO.getMapOperands(), dl),
+                     dl))]++;
       } else if (auto LO = dyn_cast<affine::AffineLoadOp>(U)) {
-        lastStored[tree.add(accessOffsets(LO.getType(), LO.getMemRef(),
-                                          LO.getAffineMapAttr().getValue(),
-                                          LO.getMapOperands(), dl),
-                            dl)]++;
+        lastStored[slotOf(
+            tree.add(accessOffsets(LO.getType(), LO.getMemRef(),
+                                   LO.getAffineMapAttr().getValue(),
+                                   LO.getMapOperands(), dl),
+                     dl))]++;
       } else if (auto SO = dyn_cast<LLVM::StoreOp>(U)) {
-        lastStored[tree.add(accessOffsets(SO.getValue().getType()), dl)]++;
+        lastStored[slotOf(
+            tree.add(accessOffsets(SO.getValue().getType()), dl))]++;
       } else if (auto LO = dyn_cast<LLVM::LoadOp>(U)) {
-        lastStored[tree.add(accessOffsets(LO.getType()), dl)]++;
+        lastStored[slotOf(tree.add(accessOffsets(LO.getType()), dl))]++;
       } else if (isa<LLVM::MemcpyOp, LLVM::MemmoveOp, LLVM::MemsetOp>(U)) {
         // What a transfer reads or fills is a slot like any other, and the
         // forwarding can only be asked about slots it is told of.
         if (auto bytes = transferLength(U))
-          lastStored[tree.add(transferAccess(*bytes, U->getContext()), dl)]++;
+          lastStored[slotOf(
+              tree.add(transferAccess(*bytes, U->getContext()), dl))]++;
       } else if (auto GO = dyn_cast<LLVM::GEPOp>(U)) {
         list.emplace_back(GO, tree.add(gepOffsets(GO, dl), dl));
       } else if (isa<memref::CastOp, Memref2PointerOp, Pointer2MemrefOp,
@@ -3045,10 +3055,11 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
   for (auto &pair : lastStored) {
     unsigned count = pair.second;
     for (auto &other : lastStored)
-      if (&other != &pair && pair.first.containsAt(other.first, dl))
+      if (&other != &pair &&
+          pair.first.second.containsAt(other.first.second, dl))
         count += other.second;
     if (count > 1)
-      todo.push_back(pair.first);
+      todo.push_back(pair.first.second);
   }
   return todo;
 }
@@ -3114,7 +3125,13 @@ void PolygeistMem2Reg::runOnOperation() {
     }
 
     // Erase all load op's whose results were replaced with store fwd'ed ones.
+    // One read may be forwarded out of more than one slot -- the whole of
+    // something and a piece of it are both slots it reads -- and is only there
+    // to be erased once.
+    SmallPtrSet<Operation *, 8> erased;
     for (auto *loadOp : loadOpsToErase) {
+      if (!erased.insert(loadOp).second)
+        continue;
       changed = true;
       loadOp->erase();
     }

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -49,7 +49,9 @@ namespace enzyme {
 } // namespace enzyme
 } // namespace mlir
 
-enum class Match { Exact, Maybe, None };
+// Whether two accesses name the same place, one lies wholly within the other,
+// they may share bytes, or they share none.
+enum class Match { Exact, Contains, Maybe, None };
 
 bool operator<(Value lhs, Value rhs) {
   if (auto lhsBA = dyn_cast<BlockArgument>(lhs)) {
@@ -438,6 +440,44 @@ public:
                   syms);
   }
 
+  // How far from the start of what it is an offset into this lands, in bytes,
+  // when every index says where it goes.
+  std::optional<uint64_t> constantOffset(const DataLayout &dl) const {
+    if (unknownOffset)
+      return std::nullopt;
+    auto element = typeSize(base, dl);
+    uint64_t total = 0;
+    for (auto &&[i, off] : llvm::enumerate(offsets)) {
+      if (off.type != Offset::Type::Index)
+        return std::nullopt;
+      int64_t step = stepOf(i);
+      if (step == ShapedType::kDynamic)
+        return std::nullopt;
+      // A dimension steps by that many of what the access reads.
+      uint64_t bytes = step;
+      if (units[i].kind == OffsetType::Kind::Dim) {
+        if (!element)
+          return std::nullopt;
+        bytes = step * *element;
+      }
+      total += off.idx * bytes;
+    }
+    return total;
+  }
+
+  // Where `o` starts within what this names, when everything it names lies
+  // inside and both say where they land.
+  std::optional<uint64_t> containsAt(const OffsetTree &o,
+                                     const DataLayout &dl) const {
+    auto mine = constantOffset(dl), theirs = o.constantOffset(dl);
+    auto mySize = typeSize(base, dl), oSize = typeSize(o.base, dl);
+    if (!mine || !theirs || !mySize || !oSize)
+      return std::nullopt;
+    if (*theirs < *mine || *theirs + *oSize > *mine + *mySize)
+      return std::nullopt;
+    return *theirs - *mine;
+  }
+
   // Composing this path with a further one. The further one names the value
   // that is read or written, so the result is of its type.
   OffsetTree add(const OffsetTree &o, const DataLayout &dl) const {
@@ -692,7 +732,8 @@ public:
     return Match::Maybe;
   }
 
-  Match matches(const OffsetTree &o, const DataLayout &dl) const {
+  Match matches(const OffsetTree &o, const DataLayout &dl,
+                uint64_t *containedAt = nullptr) const {
     if (unknownOffset || o.unknownOffset)
       return Match::Maybe;
 
@@ -707,6 +748,14 @@ public:
     bool sameExtent = base == o.base || (size && osize && *size == *osize);
     if (!sameExtent && (!size || !osize))
       return Match::Maybe;
+
+    // Lying wholly within is a question of where each lands and how far it
+    // reaches, which needs nothing of how either counts its way there.
+    if (!sameExtent && containedAt)
+      if (auto at = containsAt(o, dl)) {
+        *containedAt = *at;
+        return Match::Contains;
+      }
 
     bool isDim = true;
 
@@ -795,9 +844,9 @@ public:
 
     if (exact) {
       return Match::Exact;
-    } else {
-      return Match::Maybe;
     }
+
+    return Match::Maybe;
   }
 
   bool operator<(const OffsetTree &o) const {
@@ -2010,6 +2059,48 @@ bool isCallNonCapturing(CallOpInterface callOp, Value val) {
 std::set<std::string> NoWriteFunctions = {"exit", "__errno_location"};
 // This is a straightforward implementation not optimized for speed. Optimize
 // if needed.
+// The way into `from` that reaches what lies at `at` bytes into it and is of
+// the size of `want`, as the indices an extractvalue takes. Aggregates are
+// walked into; anything else is only reachable when it is the whole of it.
+static bool extractPath(Type from, uint64_t at, Type want, const DataLayout &dl,
+                        SmallVectorImpl<int64_t> &path) {
+  auto wantSize = typeSize(want, dl), fromSize = typeSize(from, dl);
+  if (!wantSize || !fromSize || at + *wantSize > *fromSize)
+    return false;
+  if (at == 0 && *wantSize == *fromSize)
+    return true;
+
+  if (auto ST = dyn_cast<LLVM::LLVMStructType>(from)) {
+    uint64_t byte = 0;
+    for (auto &&[i, member] : llvm::enumerate(ST.getBody())) {
+      auto size = typeSize(member, dl);
+      if (!size)
+        return false;
+      if (!ST.isPacked())
+        byte = llvm::alignTo(byte, dl.getTypeABIAlignment(member));
+      if (at >= byte && at + *wantSize <= byte + *size) {
+        path.push_back(i);
+        return extractPath(member, at - byte, want, dl, path);
+      }
+      byte += *size;
+    }
+    return false;
+  }
+
+  if (auto AT = dyn_cast<LLVM::LLVMArrayType>(from)) {
+    auto size = typeSize(AT.getElementType(), dl);
+    if (!size || !*size)
+      return false;
+    uint64_t index = at / *size;
+    if (index >= AT.getNumElements() || at % *size + *wantSize > *size)
+      return false;
+    path.push_back(index);
+    return extractPath(AT.getElementType(), at % *size, want, dl, path);
+  }
+
+  return false;
+}
+
 bool PolygeistMem2Reg::forwardStoreToLoad(
     mlir::Value AI, OffsetTree idx,
     SmallVectorImpl<Operation *> &loadOpsToErase,
@@ -2018,6 +2109,8 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   std::set<mlir::Operation *> loadOps;
   // Transfers that read exactly one slot, which act as a load of it.
   std::set<mlir::Operation *> transferLoads;
+  // Loads of a piece of the slot, and how far into it that piece lies.
+  DenseMap<mlir::Operation *, uint64_t> containedLoads;
   mlir::Type subType = nullptr;
   mlir::Location loc = AI.getLoc();
   std::set<mlir::Operation *> allStoreOps;
@@ -2085,14 +2178,30 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       // A load naming the slot reads it; one that may only overlap it reads
       // something this knows nothing about, which is no reason to stop.
       auto matchLoad = [&](Operation *loadOp, OffsetTree accessed) {
-        if (idx.matches(tree.add(accessed, dl), dl) != Match::Exact)
+        uint64_t at = 0;
+        Type read = loadOp->getResult(0).getType();
+        switch (idx.matches(tree.add(accessed, dl), dl, &at)) {
+        case Match::Exact:
+          // Whichever spelling of the slot is read first is the one the value
+          // forwarded out of it takes.
+          if (elType && read != elType)
+            return;
+          subType = read;
+          elType = read;
+          break;
+        case Match::Contains: {
+          // Reading a piece of the slot is reading a piece of its value, as
+          // long as there is a way into it that reaches that piece.
+          Type held = elType ? elType : idx.getBase();
+          SmallVector<int64_t> path;
+          if (!held || !extractPath(held, at, read, dl, path))
+            return;
+          containedLoads[loadOp] = at;
+          break;
+        }
+        default:
           return;
-        subType = loadOp->getResult(0).getType();
-        // Whichever spelling of the slot is read first is the one the value
-        // forwarded out of it takes.
-        if (elType && subType != elType)
-          return;
-        elType = subType;
+        }
         loadOps.insert(loadOp);
         LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << *loadOp << "\n");
       };
@@ -2102,6 +2211,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << *storeOp << "\n");
           allStoreOps.insert(storeOp);
           break;
+        case Match::Contains:
         case Match::Maybe:
           LLVM_DEBUG(llvm::dbgs()
                      << "Mabye Aliasing Store: " << *storeOp << "\n");
@@ -2197,6 +2307,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
               break;
             }
             LLVM_FALLTHROUGH;
+          case Match::Contains:
           case Match::Maybe:
             LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << *user << "\n");
             AliasingStoreOperations.insert(user);
@@ -2271,6 +2382,11 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       AliasingStoreOperations.insert(op);
     }
   }
+
+  // Only a load that names the whole slot says how it is spelled; when every
+  // load names a piece of it, what it holds is what it was keyed on.
+  if (!elType)
+    elType = subType = idx.getBase();
 
   if (loadOps.size() == 0 && transferLoads.size() == 0) {
     return changed;
@@ -2354,18 +2470,40 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
 
   auto *emptyValue = metaMap.get(nullptr);
 
+  // What a load takes out of the value in the slot: the whole of it, or the
+  // piece of it the load names.
+  auto valueFor = [&](Value orig, Value slotValue) -> Value {
+    auto contained = containedLoads.find(orig.getDefiningOp());
+    if (contained == containedLoads.end())
+      return castToType(elType, slotValue, orig.getDefiningOp());
+    SmallVector<int64_t> path;
+    bool found =
+        extractPath(elType, contained->second, orig.getType(), dl, path);
+    (void)found;
+    assert(found && "a piece that was named cannot be reached");
+    OpBuilder builder(orig.getDefiningOp());
+    Value piece = slotValue.getType() == elType
+                      ? slotValue
+                      : castToType(elType, slotValue, orig.getDefiningOp());
+    if (!path.empty())
+      piece =
+          LLVM::ExtractValueOp::create(builder, orig.getLoc(), slotValue, path);
+    return castToType(orig.getType(), piece, orig.getDefiningOp());
+  };
+
   auto replaceValue =
       [&](Value orig, ValueOrPlaceholder *replacement) -> ValueOrPlaceholder * {
     assert(replacement);
     replacement->materialize(/*full*/ false);
-    assert(orig.getType() == elType);
+    assert(orig.getType() == elType ||
+           containedLoads.count(orig.getDefiningOp()));
     if (replacement->overwritten) {
       loadOps.erase(orig.getDefiningOp());
       return metaMap.get(orig);
     } else if (replacement->val) {
       changed = true;
       assert(orig != replacement->val);
-      auto castVal = castToType(elType, replacement->val, orig.getDefiningOp());
+      auto castVal = valueFor(orig, replacement->val);
       LLVM_DEBUG(llvm::dbgs()
                  << " replaced " << orig << " with " << castVal << "\n");
       metaMap.replaceValue(orig, castVal);
@@ -2457,7 +2595,11 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
             lastVal = emptyValue;
           } else if (loadOps.count(a)) {
             Value loadOp = a->getResult(0);
-            lastVal = replaceValue(loadOp, lastVal);
+            auto *read = replaceValue(loadOp, lastVal);
+            // What a load of the whole slot read is what is in it from here
+            // on; what a load of a piece read says nothing of the rest.
+            if (!containedLoads.count(a))
+              lastVal = read;
           } else if (transferLoads.count(a)) {
             replaceTransfer(a, lastVal);
           } else if (isa<LLVM::MemcpyOp, LLVM::MemmoveOp, LLVM::MemsetOp>(a)) {
@@ -2676,6 +2818,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     changed = true;
     assert(pair.first != val);
     assert(val.getType() == elType);
+    val = valueFor(pair.first, val);
     assert(pair.first.getType() == val.getType() && "mismatched load type");
     LLVM_DEBUG(llvm::dbgs()
                << " replaced " << pair.first << " with " << val << "\n");
@@ -2895,9 +3038,16 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
     }
   }
 
+  // A slot is worth trying when more than one access names it -- and an access
+  // of a piece of a slot is an access of that slot too, since the piece can be
+  // taken out of what is in it.
   std::vector<OffsetTree> todo;
   for (auto &pair : lastStored) {
-    if (pair.second > 1)
+    unsigned count = pair.second;
+    for (auto &other : lastStored)
+      if (&other != &pair && pair.first.containsAt(other.first, dl))
+        count += other.second;
+    if (count > 1)
       todo.push_back(pair.first);
   }
   return todo;

--- a/test/lit_tests/mem2reg_contained.mlir
+++ b/test/lit_tests/mem2reg_contained.mlir
@@ -1,0 +1,96 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+// A read of part of what an allocation holds is a read of part of the value in
+// it: the field is taken out of what was stored, wherever the read spells its
+// way there.
+func.func @field_of_stored_struct(%val: !llvm.struct<(i64, i32, i32)>) -> i32 {
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i64, i32, i32)> : (i32) -> !llvm.ptr
+  %view = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<?x!llvm.struct<(i64, i32, i32)>>
+  memref.store %val, %view[%c0] : memref<?x!llvm.struct<(i64, i32, i32)>>
+  %punned = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<?xi32>
+  %loaded = memref.load %punned[%c2] : memref<?xi32>
+  return %loaded : i32
+}
+
+// CHECK-LABEL: func.func @field_of_stored_struct(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: !llvm.struct<(i64, i32, i32)>
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[F:.+]] = llvm.extractvalue %[[VAL]][1]
+// CHECK: return %[[F]] : i32
+
+// -----
+
+// The same through a getelementptr, and for a field that is not the first byte
+// of the value it sits in.
+llvm.func @field_by_gep(%val: !llvm.struct<(i64, f32, f32)>) -> f32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i64, f32, f32)> : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : !llvm.struct<(i64, f32, f32)>, !llvm.ptr
+  %f2 = llvm.getelementptr %mem[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, f32, f32)>
+  %loaded = llvm.load %f2 : !llvm.ptr -> f32
+  llvm.return %loaded : f32
+}
+
+// CHECK-LABEL: llvm.func @field_by_gep(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: !llvm.struct<(i64, f32, f32)>
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[F:.+]] = llvm.extractvalue %[[VAL]][2]
+// CHECK: llvm.return %[[F]] : f32
+
+// -----
+
+// An element of an array is reached the same way, and what is nested inside it
+// through the way in to that.
+llvm.func @element_of_nested_array(%val: !llvm.array<2 x array<2 x i32>>) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<2 x array<2 x i32>> : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : !llvm.array<2 x array<2 x i32>>, !llvm.ptr
+  %at = llvm.getelementptr %mem[0, 1, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<2 x array<2 x i32>>
+  %loaded = llvm.load %at : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @element_of_nested_array(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: !llvm.array<2 x array<2 x i32>>
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[F:.+]] = llvm.extractvalue %[[VAL]][1, 1]
+// CHECK: llvm.return %[[F]] : i32
+
+// -----
+
+// A read that straddles two fields is not any one of them, so there is no way
+// into the value that reaches it and the allocation stays.
+llvm.func @straddling_read(%val: !llvm.struct<(i32, i32, i32, i32)>) -> i64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i32, i32, i32, i32)> : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : !llvm.struct<(i32, i32, i32, i32)>, !llvm.ptr
+  %mid = llvm.getelementptr %mem[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32, i32, i32)>
+  %loaded = llvm.load %mid : !llvm.ptr -> i64
+  llvm.return %loaded : i64
+}
+
+// CHECK-LABEL: llvm.func @straddling_read(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : i64
+
+// -----
+
+// A write of a part says nothing of the rest, so what was there before it does
+// not reach a read after it.
+llvm.func @write_of_a_part(%val: !llvm.struct<(i32, i32)>, %other: i32) -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i32, i32)> : (i32) -> !llvm.ptr
+  llvm.store %val, %mem : !llvm.struct<(i32, i32)>, !llvm.ptr
+  %f1 = llvm.getelementptr %mem[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+  llvm.store %other, %f1 : i32, !llvm.ptr
+  %f0 = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+  %loaded = llvm.load %f0 : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK-LABEL: llvm.func @write_of_a_part(
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]] : i32

--- a/test/lit_tests/mem2reg_contained.mlir
+++ b/test/lit_tests/mem2reg_contained.mlir
@@ -94,3 +94,25 @@ llvm.func @write_of_a_part(%val: !llvm.struct<(i32, i32)>, %other: i32) -> i32 {
 // CHECK-LABEL: llvm.func @write_of_a_part(
 // CHECK: %[[LD:.+]] = llvm.load
 // CHECK: llvm.return %[[LD]] : i32
+
+// -----
+
+// The whole of something and the first field of it start at the same byte and
+// read different amounts, so they are not one slot: what is stored whole is
+// what the field read takes its piece out of.
+func.func @whole_and_first_field(%val: !llvm.struct<(ptr, i32, i32)>) -> !llvm.ptr {
+  %c0 = arith.constant 0 : index
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(ptr, i32, i32)> : (i32) -> !llvm.ptr
+  %view = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<?x!llvm.struct<(ptr, i32, i32)>>
+  memref.store %val, %view[%c0] : memref<?x!llvm.struct<(ptr, i32, i32)>>
+  %punned = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+  %loaded = memref.load %punned[%c0] : memref<?x!llvm.ptr>
+  return %loaded : !llvm.ptr
+}
+
+// CHECK-LABEL: func.func @whole_and_first_field(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: !llvm.struct<(ptr, i32, i32)>
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[F:.+]] = llvm.extractvalue %[[VAL]][0]
+// CHECK: return %[[F]] : !llvm.ptr


### PR DESCRIPTION
Follows #2746, rebased onto main now that it is merged.

An access lying wholly within another was only ever a may-share: the two overlap, so nothing could be forwarded between them and the allocation stayed. But a read of part of a slot is a read of part of the value in it, and where that part sits is something the offsets already say.

`Match` gains that answer. Landing in the same place and reading the same amount is `Exact` as before; lying wholly within is now `Contains`, along with how far in the piece starts. That is purely a question of where each access lands and how far each reaches, so it is asked as soon as the extents are known — before anything about how either counted its way there, which matters because the containing slot is usually the index-free whole while the piece is reached through a view of another type.

A load of a piece is forwarded by taking that piece out of the value the slot holds, as the indices of an `extractvalue`: into a field of a struct, an element of an array, and through what is nested in either. There has to be a way in that reaches exactly it — a read straddling two fields is not any one of them and stays where it is.

Only a load may do this. A write of a part says nothing about the rest, so it stays what it was: something that overwrites the slot.

Three consequences of a slot whose reads are all of pieces, each of which needed handling:

- nothing names how the whole is spelled, so it is spelled as the slot was keyed;
- a piece that was read is not what the slot holds from there on, so it must not become the value the rest of the block reads (this one showed up as a `castToType` failure on real IR, not in the tests);
- the slot has to be proposed at all, so an access of a piece counts towards the slot containing it.

This is the shape a by-value struct argument leaves after inlining: stored once as a whole, then read field by field through views of other types. On XSBench it removes one of the two remaining allocations — local depot 200 → 136 bytes, runtime 5.050 → 4.963 s (min of 5, idle GPU; the LLVM AD is at 4.712 s with no depot).

`test/lit_tests/mem2reg_contained.mlir` covers a field read through a punned view, the same through a getelementptr, an element of a nested array, a read straddling two fields (not forwarded), and a write of a part (still an overwrite). Full lit suite: 1095 pass, the same 4 unrelated failures as main.