### PR TITLE
Pull loop-invariant broadcasts out of sum reductions

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -4250,6 +4250,78 @@ struct ConvertConvertInt final
   }
 };
 
+// reduce_add(multiply(broadcast_in_dim(v), A), dims)
+//   -> multiply(broadcast_in_dim(v)', reduce_add(A, dims))
+//
+// Valid when the broadcast is constant along every reduced dimension, i.e. none
+// of the reduced dimensions is one of the broadcast's mapped dimensions. This
+// removes a multiply at the pre-reduction shape and leaves the scaling to be
+// applied at the (much smaller) reduced shape. Only fires when the multiply is
+// single-use, so it is erased rather than duplicated.
+struct ReduceMulBroadcast final
+    : CheckedOpRewritePattern<stablehlo::ReduceOp, ReduceMulBroadcast> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ReduceOp op,
+                                    PatternRewriter &rewriter) const {
+    if (op.getInputs().size() != 1 || op.getInitValues().size() != 1)
+      return failure();
+
+    if (mlir::stablehlo::CheckCommonReduceOp(op).kind !=
+        stablehlo::ReduceOpKind::Add)
+      return failure();
+
+    auto mul = op.getInputs()[0].getDefiningOp<stablehlo::MulOp>();
+    if (!mul || !mul->hasOneUse())
+      return failure();
+
+    auto dims = op.getDimensions();
+
+    // Pick a side whose broadcast does not vary along any reduced dimension.
+    stablehlo::BroadcastInDimOp bcast = nullptr;
+    Value other;
+    for (auto [cand, rest] : {std::make_pair(mul.getLhs(), mul.getRhs()),
+                              std::make_pair(mul.getRhs(), mul.getLhs())}) {
+      auto candidate = cand.getDefiningOp<stablehlo::BroadcastInDimOp>();
+      if (!candidate)
+        continue;
+      if (llvm::any_of(candidate.getBroadcastDimensions(), [&](int64_t bd) {
+            return llvm::is_contained(dims, bd);
+          }))
+        continue;
+      bcast = candidate;
+      other = rest;
+      break;
+    }
+    if (!bcast)
+      return failure();
+
+    // Reduced dimensions disappear from the result shape, so each surviving
+    // broadcast dimension shifts down by the number of reduced dimensions
+    // below it.
+    SmallVector<int64_t> newBroadcastDims;
+    for (int64_t bd : bcast.getBroadcastDimensions())
+      newBroadcastDims.push_back(
+          bd - llvm::count_if(dims, [&](int64_t d) { return d < bd; }));
+
+    auto resultType = op.getResultTypes()[0];
+
+    auto newReduce = stablehlo::ReduceOp::create(
+        rewriter, op.getLoc(), TypeRange(resultType), ValueRange(other),
+        op.getInitValues(), dims);
+    IRMapping map;
+    op.getRegion().cloneInto(&newReduce.getRegion(), map);
+
+    auto newBcast = stablehlo::BroadcastInDimOp::create(
+        rewriter, bcast.getLoc(), resultType, bcast.getOperand(),
+        newBroadcastDims);
+
+    rewriter.replaceOpWithNewOp<stablehlo::MulOp>(op, resultType, newBcast,
+                                                  newReduce.getResult(0));
+    return success();
+  }
+};
+
 struct ReduceConcat final
     : CheckedOpRewritePattern<stablehlo::ReduceOp, ReduceConcat> {
   using CheckedOpRewritePattern::CheckedOpRewritePattern;
@@ -36580,6 +36652,7 @@ struct EnzymeHLOOptPass
         ScatterUpdateComputationConstProp,
         ScatterIndicesAreUnique,
         ReduceTransposeSimplify,
+        ReduceMulBroadcast,
         BroadcastIotaSimplify,
         BroadcastIota,
         BroadcastCompare,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1798,6 +1798,11 @@ def ApplyReduceTransposeSimplifyPatterns : EnzymeHLOPatternOp<
   let patterns = ["ReduceTransposeSimplify"];
 }
 
+def ApplyReduceMulBroadcastPatterns : EnzymeHLOPatternOp<
+    "reduce_mul_broadcast"> {
+  let patterns = ["ReduceMulBroadcast"];
+}
+
 def CompareIotaConstSimplifyPatterns : EnzymeHLOPatternOp<
   "compare_iota_const_simplify"
 > {

--- a/test/lit_tests/reduce_mul_broadcast.mlir
+++ b/test/lit_tests/reduce_mul_broadcast.mlir
@@ -1,0 +1,86 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-generate-td{patterns=reduce_mul_broadcast},transform-interpreter,enzyme-hlo-remove-transform)" %s | FileCheck %s
+
+// The broadcast does not vary along the reduced dimension (1), so it can be
+// pulled out of the reduction and applied at the reduced shape.
+func.func @pull_out_rhs(%v: tensor<256xf32>, %a: tensor<256x1024xf32>) -> tensor<256xf32> {
+  %init = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+  %b = stablehlo.broadcast_in_dim %v, dims = [0] : (tensor<256xf32>) -> tensor<256x1024xf32>
+  %0 = stablehlo.multiply %b, %a : tensor<256x1024xf32>
+  %1 = stablehlo.reduce(%0 init: %init) applies stablehlo.add across dimensions = [1] : (tensor<256x1024xf32>, tensor<f32>) -> tensor<256xf32>
+  return %1 : tensor<256xf32>
+}
+
+// CHECK-LABEL: func.func @pull_out_rhs
+// CHECK-SAME: (%[[V:.+]]: tensor<256xf32>, %[[A:.+]]: tensor<256x1024xf32>)
+// CHECK-NOT: stablehlo.multiply %{{.+}}, %{{.+}} : tensor<256x1024xf32>
+// CHECK: %[[R:.+]] = stablehlo.reduce(%[[A]] init: %{{.+}}) applies stablehlo.add across dimensions = [1] : (tensor<256x1024xf32>, tensor<f32>) -> tensor<256xf32>
+// CHECK: stablehlo.multiply %{{.+}}, %[[R]] : tensor<256xf32>
+
+// The broadcast may sit on either side of the multiply.
+func.func @pull_out_lhs(%v: tensor<256xf32>, %a: tensor<256x1024xf32>) -> tensor<256xf32> {
+  %init = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+  %b = stablehlo.broadcast_in_dim %v, dims = [0] : (tensor<256xf32>) -> tensor<256x1024xf32>
+  %0 = stablehlo.multiply %a, %b : tensor<256x1024xf32>
+  %1 = stablehlo.reduce(%0 init: %init) applies stablehlo.add across dimensions = [1] : (tensor<256x1024xf32>, tensor<f32>) -> tensor<256xf32>
+  return %1 : tensor<256xf32>
+}
+
+// CHECK-LABEL: func.func @pull_out_lhs
+// CHECK-NOT: stablehlo.multiply %{{.+}}, %{{.+}} : tensor<256x1024xf32>
+// CHECK: stablehlo.multiply %{{.+}}, %{{.+}} : tensor<256xf32>
+
+// Reducing dimension 1 of a rank-3 value: the surviving broadcast dimension 2
+// shifts down to 1.
+func.func @shift_dims(%v: tensor<4x6xf32>, %a: tensor<4x8x6xf32>) -> tensor<4x6xf32> {
+  %init = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+  %b = stablehlo.broadcast_in_dim %v, dims = [0, 2] : (tensor<4x6xf32>) -> tensor<4x8x6xf32>
+  %0 = stablehlo.multiply %b, %a : tensor<4x8x6xf32>
+  %1 = stablehlo.reduce(%0 init: %init) applies stablehlo.add across dimensions = [1] : (tensor<4x8x6xf32>, tensor<f32>) -> tensor<4x6xf32>
+  return %1 : tensor<4x6xf32>
+}
+
+// CHECK-LABEL: func.func @shift_dims
+// CHECK-SAME: (%[[V:.+]]: tensor<4x6xf32>, %[[A:.+]]: tensor<4x8x6xf32>)
+// CHECK-NOT: stablehlo.multiply %{{.+}}, %{{.+}} : tensor<4x8x6xf32>
+// CHECK: %[[R:.+]] = stablehlo.reduce(%[[A]] init: %{{.+}}) applies stablehlo.add across dimensions = [1] : (tensor<4x8x6xf32>, tensor<f32>) -> tensor<4x6xf32>
+// CHECK: %[[B:.+]] = stablehlo.broadcast_in_dim %[[V]], dims = [0, 1] : (tensor<4x6xf32>) -> tensor<4x6xf32>
+// CHECK: stablehlo.multiply %[[B]], %[[R]] : tensor<4x6xf32>
+
+// The broadcast varies along the reduced dimension, so it cannot be pulled out.
+func.func @no_pull_varying(%v: tensor<1024xf32>, %a: tensor<256x1024xf32>) -> tensor<256xf32> {
+  %init = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+  %b = stablehlo.broadcast_in_dim %v, dims = [1] : (tensor<1024xf32>) -> tensor<256x1024xf32>
+  %0 = stablehlo.multiply %b, %a : tensor<256x1024xf32>
+  %1 = stablehlo.reduce(%0 init: %init) applies stablehlo.add across dimensions = [1] : (tensor<256x1024xf32>, tensor<f32>) -> tensor<256xf32>
+  return %1 : tensor<256xf32>
+}
+
+// CHECK-LABEL: func.func @no_pull_varying
+// CHECK: %[[M:.+]] = stablehlo.multiply %{{.+}}, %{{.+}} : tensor<256x1024xf32>
+// CHECK: stablehlo.reduce(%[[M]]
+
+// A multiply feeding more than the reduction must not be duplicated.
+func.func @no_pull_multi_use(%v: tensor<256xf32>, %a: tensor<256x1024xf32>) -> (tensor<256xf32>, tensor<256x1024xf32>) {
+  %init = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+  %b = stablehlo.broadcast_in_dim %v, dims = [0] : (tensor<256xf32>) -> tensor<256x1024xf32>
+  %0 = stablehlo.multiply %b, %a : tensor<256x1024xf32>
+  %1 = stablehlo.reduce(%0 init: %init) applies stablehlo.add across dimensions = [1] : (tensor<256x1024xf32>, tensor<f32>) -> tensor<256xf32>
+  return %1, %0 : tensor<256xf32>, tensor<256x1024xf32>
+}
+
+// CHECK-LABEL: func.func @no_pull_multi_use
+// CHECK: %[[M:.+]] = stablehlo.multiply %{{.+}}, %{{.+}} : tensor<256x1024xf32>
+// CHECK: stablehlo.reduce(%[[M]]
+
+// Only sum reductions commute with scaling; max does not.
+func.func @no_pull_max(%v: tensor<256xf32>, %a: tensor<256x1024xf32>) -> tensor<256xf32> {
+  %init = stablehlo.constant dense<0xFF800000> : tensor<f32>
+  %b = stablehlo.broadcast_in_dim %v, dims = [0] : (tensor<256xf32>) -> tensor<256x1024xf32>
+  %0 = stablehlo.multiply %b, %a : tensor<256x1024xf32>
+  %1 = stablehlo.reduce(%0 init: %init) applies stablehlo.maximum across dimensions = [1] : (tensor<256x1024xf32>, tensor<f32>) -> tensor<256xf32>
+  return %1 : tensor<256xf32>
+}
+
+// CHECK-LABEL: func.func @no_pull_max
+// CHECK: %[[M:.+]] = stablehlo.multiply %{{.+}}, %{{.+}} : tensor<256x1024xf32>
+// CHECK: stablehlo.reduce(%[[M]]


### PR DESCRIPTION
```
reduce_add(multiply(broadcast_in_dim(v), A), dims)
  -> multiply(broadcast_in_dim(v)', reduce_add(A, dims))
```

Valid when the broadcast is constant along every reduced dimension, i.e. none of the reduced dimensions is one of the broadcast's mapped dimensions. Under that condition the scaling factor is shared by every element summed into a given output element, so it can be applied once at the reduced shape instead of once per pre-reduction element.

This removes a multiply at the full pre-reduction shape — for the motivating case, a `tensor<256x1024xf32>` multiply replaced by a `tensor<256xf32>` one — and never duplicates work, since it only fires when the multiply is single-use. `BroadcastReduce` already handles the bare `reduce(broadcast(x))` case; this covers the broadcast-as-a-scaling-factor case and composes with it.

Enabled in the default pattern set: it is a strict reduction in both op count and traffic, and the full lit suite is unchanged.

### Context

Found while studying how reverse-mode AD interacts with optimization phase ordering. Differentiating a loop whose body was batched *before* AD leaves an adjoint epilogue that scales wide accumulators before reducing them, which is exactly this shape.

### Testing

- New `test/lit_tests/reduce_mul_broadcast.mlir`: broadcast on either side of the multiply, a rank-3 case exercising the broadcast-dimension shift, and three negative cases (broadcast varying along the reduced dimension, multi-use multiply, non-sum reduction).
- Full lit suite: 1094/1095 pass. The one failure, `mem2reg_transfers.mlir`, is pre-existing — it contains no `stablehlo.reduce` or `stablehlo.multiply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)