### PR TITLE
Move stack allocations to where they are freed

### DIFF
--- a/src/enzyme_ad/jax/Passes/HoistAllocas.cpp
+++ b/src/enzyme_ad/jax/Passes/HoistAllocas.cpp
@@ -1,0 +1,121 @@
+//===- HoistAllocas.cpp - Move allocations to where they are freed -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// This file implements a pass that moves stack allocations to the start of the
+// region whose exit frees them -- the nearest enclosing
+// AutomaticAllocationScope
+// -- which is where everything downstream expects to find them.
+//
+// An allocation is freed when the scope holding it is left, so where it sits
+// within that scope says nothing about how long it lives. Emitted in place it
+// commonly ends up in a block that is only conditionally reached: lowering a
+// parallel loop to a kernel, for instance, wraps the whole body in a bounds
+// check, and everything the body allocated is then inside that check.
+//
+// Nothing downstream expects that. LLVM's SROA only ever considers allocations
+// in the entry block of a function, so one left in a guarded block is never
+// promoted however simple its uses are, and the stack it takes is spent for the
+// whole call. Clang emits every fixed-size allocation in the entry block for
+// this reason.
+//
+// The scope this hoists to is the nearest one, so an allocation inside a loop
+// stays inside it: scf.for, scf.forall and scf.parallel free what their bodies
+// allocate on every iteration, and only what sits in something like an scf.if,
+// which frees nothing, travels any distance.
+//
+//===---------------------------------------------------------------------===//
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/Matchers.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_HOISTALLOCASPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+// Whether the allocation takes the same amount of stack however it is reached,
+// which is what makes taking it unconditionally the same as taking it here.
+static bool isFixedSize(Operation *op) {
+  if (auto alloca = dyn_cast<LLVM::AllocaOp>(op)) {
+    APInt count;
+    return matchPattern(alloca.getArraySize(), m_ConstantInt(&count));
+  }
+  if (auto alloca = dyn_cast<memref::AllocaOp>(op))
+    return alloca.getType().hasStaticShape() &&
+           alloca.getDynamicSizes().empty();
+  return false;
+}
+
+// The block whose exit frees what is allocated in it, and where an allocation
+// therefore belongs.
+static Block *allocationBlockOf(Operation *op) {
+  Operation *scope =
+      op->getParentWithTrait<OpTrait::AutomaticAllocationScope>();
+  if (!scope || scope->getNumRegions() == 0)
+    return nullptr;
+  Region &region = scope->getRegion(0);
+  if (region.empty())
+    return nullptr;
+  return &region.front();
+}
+
+static void hoistAllocas(Operation *root, DominanceInfo &domInfo) {
+  SmallVector<Operation *> allocas;
+  root->walk([&](Operation *op) {
+    if (isa<LLVM::AllocaOp, memref::AllocaOp>(op))
+      allocas.push_back(op);
+  });
+
+  for (Operation *alloca : allocas) {
+    if (!isFixedSize(alloca))
+      continue;
+    Block *block = allocationBlockOf(alloca);
+    if (!block || alloca->getBlock() == block)
+      continue;
+
+    // As early in the block as everything the allocation is built from allows,
+    // since what uses it lies after where it was.
+    Operation *after = nullptr;
+    for (Value operand : alloca->getOperands()) {
+      Operation *def = operand.getDefiningOp();
+      if (!def || def->getBlock() != block)
+        continue;
+      if (!after || after->isBeforeInBlock(def))
+        after = def;
+    }
+    Operation *before = after ? after->getNextNode() : &block->front();
+    if (!before)
+      continue;
+    if (!llvm::all_of(alloca->getOperands(), [&](Value operand) {
+          return domInfo.properlyDominates(operand, before);
+        }))
+      continue;
+
+    alloca->moveBefore(before);
+  }
+}
+
+struct HoistAllocasPass
+    : public enzyme::impl::HoistAllocasPassBase<HoistAllocasPass> {
+  using HoistAllocasPassBase::HoistAllocasPassBase;
+
+  void runOnOperation() override {
+    hoistAllocas(getOperation(), getAnalysis<DominanceInfo>());
+  }
+};
+
+} // end anonymous namespace

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -337,6 +337,15 @@ def SortMemory : Pass<"sort-memory"> {
   let summary = "Sort memory accesses";
 }
 
+def HoistAllocasPass : Pass<"hoist-allocas"> {
+  let summary = "Move stack allocations to the start of the region that frees "
+                "them";
+  let dependentDialects = [
+    "LLVM::LLVMDialect",
+    "memref::MemRefDialect",
+  ];
+}
+
 def SortBlockMemoryPass : Pass<"sort-block-memory"> {
   let summary = "Hoist non-overlapping loads to the start of their block and "
                 "sink stores to the end";

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -126,7 +126,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       } else {
         pass_pipeline += ",parallel-serialization,";
       }
-      pass_pipeline += "canonicalize,convert-polygeist-to-llvm{backend=";
+      pass_pipeline += "canonicalize,hoist-allocas,convert-polygeist-to-llvm{backend=";
       pass_pipeline += backend;
       pass_pipeline += "}";
   } else {
@@ -176,7 +176,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       } else {
 	      pass_pipeline += ",parallel-serialization,";
       }
-      pass_pipeline += "canonicalize,convert-polygeist-to-llvm{backend=";
+      pass_pipeline += "canonicalize,hoist-allocas,convert-polygeist-to-llvm{backend=";
       pass_pipeline += backend;
       pass_pipeline += "},strip-"
       "gpu-info,gpu-"

--- a/test/lit_tests/hoist_allocas.mlir
+++ b/test/lit_tests/hoist_allocas.mlir
@@ -1,0 +1,85 @@
+// RUN: enzymexlamlir-opt %s -hoist-allocas -split-input-file | FileCheck %s
+
+// An scf.if frees nothing, so what is allocated inside it lives as long as the
+// function does and belongs where the function frees it.
+func.func @out_of_a_conditional(%c: i1, %v: f32) -> f32 {
+  %z = arith.constant 0.0 : f32
+  %r = scf.if %c -> f32 {
+    %i = arith.constant 0 : index
+    %m = memref.alloca() : memref<4xf32>
+    memref.store %v, %m[%i] : memref<4xf32>
+    %l = memref.load %m[%i] : memref<4xf32>
+    scf.yield %l : f32
+  } else {
+    scf.yield %z : f32
+  }
+  return %r : f32
+}
+
+// CHECK-LABEL: func.func @out_of_a_conditional(
+// CHECK: memref.alloca
+// CHECK: scf.if
+
+// -----
+
+// The same for an allocation named in the LLVM dialect.
+func.func @llvm_out_of_a_conditional(%c: i1, %v: f32) -> f32 {
+  %z = arith.constant 0.0 : f32
+  %one = llvm.mlir.constant(1 : i32) : i32
+  %r = scf.if %c -> f32 {
+    %p = llvm.alloca %one x !llvm.array<4 x f32> : (i32) -> !llvm.ptr
+    llvm.store %v, %p : f32, !llvm.ptr
+    %l = llvm.load %p : !llvm.ptr -> f32
+    scf.yield %l : f32
+  } else {
+    scf.yield %z : f32
+  }
+  return %r : f32
+}
+
+// CHECK-LABEL: func.func @llvm_out_of_a_conditional(
+// CHECK: llvm.alloca
+// CHECK: scf.if
+
+// -----
+
+// An scf.for frees what its body allocated on every iteration, so an allocation
+// in it stays in it -- at the start of the body, which is where that freeing
+// begins again.
+func.func @stays_within_a_loop(%n: index, %v: f32, %c: i1) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  scf.for %i = %c0 to %n step %c1 {
+    scf.if %c {
+      %m = memref.alloca() : memref<4xf32>
+      memref.store %v, %m[%c0] : memref<4xf32>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @stays_within_a_loop(
+// CHECK: scf.for
+// CHECK: memref.alloca
+// CHECK: scf.if
+
+// -----
+
+// An allocation whose size is not fixed would take that much stack even where
+// it was not reached, so it stays where it is.
+func.func @keeps_a_dynamic_size(%c: i1, %v: f32, %n: i32) -> f32 {
+  %z = arith.constant 0.0 : f32
+  %r = scf.if %c -> f32 {
+    %p = llvm.alloca %n x f32 : (i32) -> !llvm.ptr
+    llvm.store %v, %p : f32, !llvm.ptr
+    %l = llvm.load %p : !llvm.ptr -> f32
+    scf.yield %l : f32
+  } else {
+    scf.yield %z : f32
+  }
+  return %r : f32
+}
+
+// CHECK-LABEL: func.func @keeps_a_dynamic_size(
+// CHECK: scf.if
+// CHECK: llvm.alloca


### PR DESCRIPTION
An allocation is freed when the region holding it is left, so where it sits within that region says nothing about how long it lives. Emitted in place it commonly ends up somewhere only conditionally reached — lowering a parallel loop to a kernel wraps the whole body in a bounds check, so everything the body allocated lands inside that check:

```mlir
gpu.func @..._kernel(%arg0: index, ...) {
  %4 = arith.cmpi ult, %3, %arg0 : index
  scf.if %4 {
    %7 = llvm.alloca ... x !llvm.struct<"struct.SimulationData.1", ...>
    %8 = llvm.alloca ... x !llvm.struct<"struct.Inputs.1", ...>
```

Nothing downstream expects that. LLVM's SROA builds its worklist from the entry block of a function alone:

```cpp
  BasicBlock &EntryBB = F.getEntryBlock();
  for (BasicBlock::iterator I = EntryBB.begin(), ...)
    if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) { ... Worklist.insert(AI); }
```

so an allocation left in a guarded block is never promoted however simple its uses are, and the stack it takes is spent for the whole call. Nothing moves it either: MLIR hoists allocations only when inlining, and LLVM's InstCombine relocates only *zero-sized* ones. Clang emits every fixed-size allocation in the entry block precisely so this can work; this pass restores that for what the lowering produces, and runs just before `convert-polygeist-to-llvm`.

The block hoisted to is the one whose exit frees the allocation — the nearest enclosing `AutomaticAllocationScope` — which makes the transform self-limiting. `scf.for`, `scf.forall` and `scf.parallel` free what their bodies allocate on every iteration, so an allocation within one stays within it; only what sits in something like an `scf.if`, which frees nothing, travels any distance. It lands as early in that block as what it is built from allows, since what uses it lies after where it was. Only fixed-size allocations move: one whose size is computed would take that much stack even where it was not reached.

Measured on XSBench's reverse kernel, extracting the device IR and running `opt -O3` by hand: as emitted, all four allocations survive; with those same four moved to the entry block and nothing else changed, `SimulationData` is promoted entirely and `Inputs` is reduced to an eight-byte remnant.

`test/lit_tests/hoist_allocas.mlir` covers a memref and an LLVM allocation leaving an `scf.if`, one staying inside an `scf.for` body, and one with a computed size staying where it is. Full lit suite: 1098 pass, the same 4 unrelated failures as main.