### PR TITLE
Drop the add from a while scatter accumulator

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -475,6 +475,7 @@ static void addBaseTransformPasses(std::vector<std::string> &list,
   list.push_back("while_dus");
   list.push_back("while_updatewithoutcorners");
   list.push_back("while_op_induction_replacement");
+  list.push_back("while_scatter_accumulator_no_add");
   list.push_back("dus_concat");
   list.push_back("dusdus_to_duspad");
   list.push_back("slice_dus_to_concat");

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -20584,6 +20584,116 @@ struct WhileWrap
   }
 };
 
+// A while-carried accumulator of the form
+//
+//   init      = <zero splat>
+//   yield[k]  = add(bodyArg[k], dynamic_update_slice(<zero>, row, i))
+//
+// only ever adds into rows that are still zero, provided the scatter index i is
+// distinct on every iteration and never clamped. The add is then a no-op
+// everywhere except the written row, where it adds to zero, so the whole thing
+// collapses to a read-modify-write of that row:
+//
+//   yield[k] = dynamic_update_slice(bodyArg[k], row, i)
+//
+// That turns a full-tensor materialise-and-add -- roughly 4 x S0 x M of traffic
+// per iteration -- into a single row write, which XLA can perform in place
+// since the accumulator is a loop carry with no other reader.
+//
+// This needs only injectivity, not full coverage of [0, S0): rows that are
+// never written keep the zero they started with under either form.
+struct WhileScatterAccumulatorNoAdd final
+    : CheckedOpRewritePattern<stablehlo::AddOp, WhileScatterAccumulatorNoAdd> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::AddOp addOp,
+                                    PatternRewriter &rewriter) const {
+    auto whileOp = dyn_cast<stablehlo::WhileOp>(addOp->getParentOp());
+    if (!whileOp || addOp->getBlock() != &whileOp.getBody().front())
+      return failure();
+
+    // The accumulator must be yielded straight back, and read by nothing else.
+    if (!addOp->hasOneUse())
+      return failure();
+    auto yieldOp = dyn_cast<stablehlo::ReturnOp>(*addOp->getUsers().begin());
+    if (!yieldOp)
+      return failure();
+
+    BlockArgument bodyArg;
+    Value dusSide;
+    for (auto [a, b] : {std::make_pair(addOp.getLhs(), addOp.getRhs()),
+                        std::make_pair(addOp.getRhs(), addOp.getLhs())}) {
+      if (auto arg = dyn_cast<BlockArgument>(a)) {
+        if (arg.getOwner() == &whileOp.getBody().front()) {
+          bodyArg = arg;
+          dusSide = b;
+          break;
+        }
+      }
+    }
+    if (!bodyArg || !bodyArg.hasOneUse())
+      return failure();
+
+    unsigned idx = bodyArg.getArgNumber();
+    if (yieldOp.getOperand(idx) != addOp.getResult())
+      return failure();
+    if (!enzyme::isZero(whileOp.getOperands()[idx]))
+      return failure();
+
+    auto dus = dusSide.getDefiningOp<stablehlo::DynamicUpdateSliceOp>();
+    if (!dus || !dus->hasOneUse() || !enzyme::isZero(dus.getOperand()))
+      return failure();
+
+    auto accTy = cast<RankedTensorType>(dus.getType());
+    auto updateTy = cast<RankedTensorType>(dus.getUpdate().getType());
+    if (updateTy.getRank() != accTy.getRank())
+      return failure();
+
+    // Exactly one dimension may be scattered; the rest must be written whole,
+    // at offset zero, so that "the written row" is well defined.
+    int64_t scatterDim = -1;
+    auto starts = dus.getStartIndices();
+    for (int64_t d = 0; d < accTy.getRank(); ++d) {
+      if (updateTy.getDimSize(d) == accTy.getDimSize(d)) {
+        if (!enzyme::isZero(starts[d]))
+          return failure();
+        continue;
+      }
+      if (updateTy.getDimSize(d) != 1 || scatterDim != -1)
+        return failure();
+      scatterDim = d;
+    }
+    if (scatterDim == -1)
+      return failure();
+
+    enzyme::WhileLoopInfo info(whileOp);
+    if (failed(info.computeInfo()) || !info.isValid() || !info.isConstant())
+      return failure();
+    info.propagateAffineIndexInfo();
+    info.propagateBounds();
+
+    Value index = starts[scatterDim];
+
+    // Distinct on every iteration: the index must actually vary with the
+    // induction variable.
+    auto affine = info.getAffineIndexInfo();
+    auto affineIt = affine.find(index);
+    if (affineIt == affine.end() || affineIt->second.scale.isZero())
+      return failure();
+
+    // Never clamped: dynamic_update_slice would otherwise fold out-of-range
+    // iterations onto the boundary row and genuinely accumulate there.
+    auto bounds = info.getBounds(index);
+    if (!bounds || bounds->min.isNegative() ||
+        bounds->max.getSExtValue() > accTy.getDimSize(scatterDim) - 1)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<stablehlo::DynamicUpdateSliceOp>(
+        addOp, bodyArg, dus.getUpdate(), starts);
+    return success();
+  }
+};
+
 // Replace while op iteration variables which are not updated with their
 // upcoming value
 struct WhileSimplify
@@ -36609,6 +36719,7 @@ struct EnzymeHLOOptPass
         ScatterUpdateComputationConstProp,
         ScatterIndicesAreUnique,
         ReduceTransposeSimplify,
+        WhileScatterAccumulatorNoAdd,
         BroadcastIotaSimplify,
         BroadcastIota,
         BroadcastCompare,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1798,6 +1798,11 @@ def ApplyReduceTransposeSimplifyPatterns : EnzymeHLOPatternOp<
   let patterns = ["ReduceTransposeSimplify"];
 }
 
+def ApplyWhileScatterAccumulatorNoAddPatterns : EnzymeHLOPatternOp<
+    "while_scatter_accumulator_no_add"> {
+  let patterns = ["WhileScatterAccumulatorNoAdd"];
+}
+
 def CompareIotaConstSimplifyPatterns : EnzymeHLOPatternOp<
   "compare_iota_const_simplify"
 > {

--- a/test/lit_tests/diffrules/stablehlo/while6.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while6.mlir
@@ -67,9 +67,8 @@ func.func @main(%arg0: tensor<12x16x4xf32>) -> (tensor<12x4xf32>) {
 // REVERSE-NEXT:       %5 = stablehlo.add %c_3, %4 {enzymexla.bounds = {{\[\[}}1, 15]]} : tensor<i32>
 // REVERSE-NEXT:       %6 = stablehlo.add %iterArg, %c_0 {enzymexla.bounds = {{\[\[}}1, 15]]} : tensor<i64>
 // REVERSE-NEXT:       %7 = stablehlo.reshape %2 : (tensor<12x4xf32>) -> tensor<12x1x4xf32>
-// REVERSE-NEXT:       %8 = stablehlo.dynamic_update_slice %cst, %7, %c_4, %5, %c_4 : (tensor<12x16x4xf32>, tensor<12x1x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x16x4xf32>
-// REVERSE-NEXT:       %9 = stablehlo.add %iterArg_6, %8 : tensor<12x16x4xf32>
-// REVERSE-NEXT:       stablehlo.return %6, %9 : tensor<i64>, tensor<12x16x4xf32>
+// REVERSE-NEXT:       %8 = stablehlo.dynamic_update_slice %iterArg_6, %7, %c_4, %5, %c_4 : (tensor<12x16x4xf32>, tensor<12x1x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x16x4xf32>
+// REVERSE-NEXT:       stablehlo.return %6, %8 : tensor<i64>, tensor<12x16x4xf32>
 // REVERSE-NEXT:     }
 // REVERSE-NEXT:     return %0#1 : tensor<12x16x4xf32>
 // REVERSE-NEXT:   }

--- a/test/lit_tests/while_scatter_accumulator_no_add.mlir
+++ b/test/lit_tests/while_scatter_accumulator_no_add.mlir
@@ -1,0 +1,177 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-generate-td{patterns=while_scatter_accumulator_no_add},transform-interpreter,enzyme-hlo-remove-transform)" %s | FileCheck %s
+
+// A gradient accumulator that scatters one row per iteration. The row index is
+// the induction variable, so it is distinct every iteration and the accumulator
+// starts at zero: the add is always an add to zero and collapses to a plain
+// read-modify-write of the row.
+func.func @forward_index(%row: tensor<1x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c8 = stablehlo.constant dense<8> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:2 = stablehlo.while(%iv = %c0, %a = %wide) : tensor<i64>, tensor<8x4xf32>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %iv, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %na = stablehlo.add %a, %sa : tensor<8x4xf32>
+    stablehlo.return %next, %na : tensor<i64>, tensor<8x4xf32>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @forward_index
+// CHECK: stablehlo.dynamic_update_slice %iterArg{{[_0-9]*}}, %arg0
+// CHECK-NOT: stablehlo.add %{{.+}}, %{{.+}} : tensor<8x4xf32>
+
+// The reverse index derived from the induction variable, which is the form
+// reverse-mode AD emits: numIters-1 down to 0, distinct and in bounds.
+func.func @reverse_index(%row: tensor<1x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c7 = stablehlo.constant dense<7> : tensor<i64>
+  %c8 = stablehlo.constant dense<8> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:2 = stablehlo.while(%iv = %c0, %a = %wide) : tensor<i64>, tensor<8x4xf32>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %ri = stablehlo.subtract %c7, %iv : tensor<i64>
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %ri, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %na = stablehlo.add %a, %sa : tensor<8x4xf32>
+    stablehlo.return %next, %na : tensor<i64>, tensor<8x4xf32>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @reverse_index
+// CHECK: stablehlo.dynamic_update_slice %iterArg{{[_0-9]*}}, %arg0
+// CHECK-NOT: stablehlo.add %{{.+}}, %{{.+}} : tensor<8x4xf32>
+
+// Partial coverage is fine here, unlike for the epilogue sink: rows 4..7 are
+// never written and keep their zero under either form.
+func.func @partial_coverage_still_ok(%row: tensor<1x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c4 = stablehlo.constant dense<4> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:2 = stablehlo.while(%iv = %c0, %a = %wide) : tensor<i64>, tensor<8x4xf32>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %iv, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %na = stablehlo.add %a, %sa : tensor<8x4xf32>
+    stablehlo.return %next, %na : tensor<i64>, tensor<8x4xf32>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @partial_coverage_still_ok
+// CHECK: stablehlo.dynamic_update_slice %iterArg{{[_0-9]*}}, %arg0
+// CHECK-NOT: stablehlo.add %{{.+}}, %{{.+}} : tensor<8x4xf32>
+
+// The index runs past the end of the accumulator. dynamic_update_slice clamps,
+// so iterations 8..15 all write row 7 and genuinely accumulate there.
+func.func @no_fold_out_of_bounds(%row: tensor<1x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c16 = stablehlo.constant dense<16> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:2 = stablehlo.while(%iv = %c0, %a = %wide) : tensor<i64>, tensor<8x4xf32>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c16 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %iv, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %na = stablehlo.add %a, %sa : tensor<8x4xf32>
+    stablehlo.return %next, %na : tensor<i64>, tensor<8x4xf32>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @no_fold_out_of_bounds
+// CHECK: stablehlo.add %{{.+}}, %{{.+}} : tensor<8x4xf32>
+
+// A loop-invariant index writes the same row every iteration, so the adds
+// genuinely accumulate.
+func.func @no_fold_constant_index(%row: tensor<1x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c3 = stablehlo.constant dense<3> : tensor<i64>
+  %c8 = stablehlo.constant dense<8> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:2 = stablehlo.while(%iv = %c0, %a = %wide) : tensor<i64>, tensor<8x4xf32>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %c3, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %na = stablehlo.add %a, %sa : tensor<8x4xf32>
+    stablehlo.return %next, %na : tensor<i64>, tensor<8x4xf32>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @no_fold_constant_index
+// CHECK: stablehlo.add %{{.+}}, %{{.+}} : tensor<8x4xf32>
+
+// A non-zero initialiser means the first write is not an add to zero.
+func.func @no_fold_nonzero_init(%row: tensor<1x4xf32>, %init: tensor<8x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c8 = stablehlo.constant dense<8> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:2 = stablehlo.while(%iv = %c0, %a = %init) : tensor<i64>, tensor<8x4xf32>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %iv, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %na = stablehlo.add %a, %sa : tensor<8x4xf32>
+    stablehlo.return %next, %na : tensor<i64>, tensor<8x4xf32>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @no_fold_nonzero_init
+// CHECK: stablehlo.add %{{.+}}, %{{.+}} : tensor<8x4xf32>
+
+// The accumulator is read inside the loop as well, so the rows it holds at that
+// point are observable and must not change.
+func.func @no_fold_extra_reader(%row: tensor<1x4xf32>) -> (tensor<8x4xf32>, tensor<8x4xf32>) {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c8 = stablehlo.constant dense<8> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:3 = stablehlo.while(%iv = %c0, %a = %wide, %b = %wide) : tensor<i64>, tensor<8x4xf32>, tensor<8x4xf32>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %iv, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %na = stablehlo.add %a, %sa : tensor<8x4xf32>
+    %obs = stablehlo.multiply %a, %a : tensor<8x4xf32>
+    stablehlo.return %next, %na, %obs : tensor<i64>, tensor<8x4xf32>, tensor<8x4xf32>
+  }
+  return %w#1, %w#2 : tensor<8x4xf32>, tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @no_fold_extra_reader
+// CHECK: stablehlo.add %{{.+}}, %{{.+}} : tensor<8x4xf32>


### PR DESCRIPTION
A while-carried accumulator of the form

```mlir
init      = <zero splat>
yield[k]  = add(bodyArg[k], dynamic_update_slice(<zero>, row, i))
```

only ever adds into rows that are still zero, provided the scatter index `i` is distinct on every iteration and never clamped. The add is then a no-op everywhere except the written row, where it adds to zero, so it collapses to a read-modify-write of that row:

```mlir
yield[k] = dynamic_update_slice(bodyArg[k], row, i)
```

One op instead of two, and a single row write which XLA can perform in place since the accumulator is a loop carry with no other reader. The `while6` reverse golden shows exactly this:

```diff
-  %8 = stablehlo.dynamic_update_slice %cst, %7, %c_4, %5, %c_4 : ...
-  %9 = stablehlo.add %iterArg_6, %8 : tensor<12x16x4xf32>
-  stablehlo.return %6, %9 : tensor<i64>, tensor<12x16x4xf32>
+  %8 = stablehlo.dynamic_update_slice %iterArg_6, %7, %c_4, %5, %c_4 : ...
+  stablehlo.return %6, %8 : tensor<i64>, tensor<12x16x4xf32>
```

### Preconditions

Both come from `WhileLoopInfo` rather than bespoke analysis:

- **Distinct each iteration**: `propagateAffineIndexInfo` gives a non-zero scale relative to the induction variable.
- **Never clamped**: `propagateBounds` answers whether `dynamic_update_slice` would clamp. This matters — an index running past the end folds several iterations onto the boundary row, where the adds genuinely do accumulate.

Note this needs only *injectivity*, not full coverage of `[0, S0)`: rows that are never written keep the zero they started with under either form. `while6` exercises that — its index ranges over `[1, 15]` of a 16-row accumulator.

### Enabled by default

Registered in `enzymexlaGetTransformPassesList` as well as in the `enzyme-hlo-opt` pass. These are two separate mechanisms: adding a pattern to `patterns.add<...>` makes it run under `enzymexlamlir-opt --enzyme-hlo-opt`, but Reactant builds its pipeline from the curated name list, so a pattern absent from that list never runs there.

Measured through Reactant on a Bloch-equation simulation differentiated in reverse (256 timesteps x 1024 spins), `optimize=:all`: the reverse loop's **nine** full-tensor `tensor<256x1024xf32>` accumulate-adds go to **zero**, total ops 282 -> 273.

Worth being straight about the runtime, though: on that benchmark removing the accumulates did **not** make it faster (3.765 -> 3.843 ms at 1024 spins, i.e. marginally worse, and within a few percent across sizes). XLA was evidently already handling `add(acc, dus(0,row,i))` about as well as the explicit in-place write. The justification here is that it is strictly fewer ops and strictly less work to hand the backend, not a measured speedup.

### Testing

`test/lit_tests/while_scatter_accumulator_no_add.mlir`: three cases that fold (index from the induction variable, index derived as `numIters-1 - iv` which is the form reverse-mode AD emits, and partial coverage) and four that must not — out-of-bounds so `dynamic_update_slice` clamps, a loop-invariant index, a non-zero initialiser, and an accumulator with a second reader inside the loop.

`diffrules/stablehlo/while6.mlir` regenerated; full lit suite otherwise unchanged.
