### PR TITLE
Derive the reverse cache index from the reverse loop's induction variable

### DIFF
--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -4023,6 +4023,10 @@ public:
     // placeholder behind. `minCutCache` clears `caches` when every push was
     // hoisted out of the loop, so the second condition is not implied by the
     // first.
+    // Index into the caches from the reverse loop, counting numIters-1 down
+    // to 0. Set by the block below, and read back when pops become slices.
+    Value reverseIndexValue = nullptr;
+
     if (inductionVariable &&
         (caches.size() != 0 ||
          (reverseIVPlaceholder && !reverseIVPlaceholder->use_empty()))) {
@@ -4030,73 +4034,111 @@ public:
           cast<BlockArgument>(inductionVariable).getArgNumber() != 0)
         resultIdx++;
 
-      OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPoint(otherWhileOp);
-      SmallVector<Value> operands(otherWhileOp->getOperands().begin(),
-                                  otherWhileOp->getOperands().end());
-      if (info.isConstant()) {
-        operands.push_back(
-            makeI64Constant(otherWhileOp->getLoc(), rewriter, numIters - 1));
-      } else {
-        if (!itersV)
-          itersV = info.getNumIters(rewriter);
-        auto one = stablehlo::ConstantOp::create(
-            rewriter, otherWhileOp->getLoc(), itersV.getType(),
-            cast<ElementsAttr>(makeAttr(itersV.getType(), 1)));
-        auto sub = stablehlo::SubtractOp::create(
-            rewriter, otherWhileOp->getLoc(), itersV, one);
-        operands.push_back(sub);
-      }
-
-      Block *otherBody = &otherWhileOp.getBody().front();
-      Block *otherCond = &otherWhileOp.getCond().front();
-      Value otherInductionVariable = otherBody->addArgument(
-          operands.back().getType(), otherWhileOp->getLoc());
-      otherCond->addArgument(otherInductionVariable.getType(),
-                             otherWhileOp->getLoc());
-      auto otherTerm = otherBody->getTerminator();
-
-      // Now that the real counter exists, retire the placeholder the min cut
-      // was seeded with.
-      if (reverseIVPlaceholder) {
-        OpBuilder::InsertionGuard g(rewriter);
+      // The reverse loop already counts 0, 1, ... numIters-1 to drive its own
+      // condition, so the index into the caches can simply be derived from it.
+      // Carrying a second counter that walks the other way costs an extra
+      // loop-carried dependence, and hides the index from the loop analyses,
+      // which only see values reachable from the induction variable.
+      enzyme::WhileLoopInfo otherInfo(otherWhileOp);
+      if (info.isConstant() && succeeded(otherInfo.computeInfo()) &&
+          otherInfo.isValid() && otherInfo.isConstantStart() &&
+          *otherInfo.getConstantStart() == 0 && otherInfo.isStepOne()) {
+        Block *otherBody = &otherWhileOp.getBody().front();
+        OpBuilder::InsertionGuard guard(rewriter);
         rewriter.setInsertionPointToStart(otherBody);
-        Value real = otherInductionVariable;
-        if (real.getType() != reverseIVPlaceholder.getType())
-          real = stablehlo::ConvertOp::create(rewriter, otherWhileOp->getLoc(),
-                                              reverseIVPlaceholder.getType(),
-                                              real);
-        rewriter.replaceOp(reverseIVPlaceholder, real);
-        reverseIVPlaceholder = nullptr;
+
+        Value iv = otherInfo.getInductionVariable();
+        Value last = stablehlo::ConstantOp::create(
+            rewriter, otherWhileOp->getLoc(), iv.getType(),
+            cast<ElementsAttr>(makeAttr(iv.getType(), numIters - 1)));
+        Value reverseIndex = stablehlo::SubtractOp::create(
+            rewriter, otherWhileOp->getLoc(), last, iv);
+
+        if (reverseIVPlaceholder) {
+          Value real = reverseIndex;
+          if (real.getType() != reverseIVPlaceholder.getType())
+            real = stablehlo::ConvertOp::create(
+                rewriter, otherWhileOp->getLoc(),
+                reverseIVPlaceholder.getType(), real);
+          rewriter.replaceOp(reverseIVPlaceholder, real);
+          reverseIVPlaceholder = nullptr;
+        }
+
+        reverseIndexValue = reverseIndex;
+      } else {
+
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(otherWhileOp);
+        SmallVector<Value> operands(otherWhileOp->getOperands().begin(),
+                                    otherWhileOp->getOperands().end());
+        if (info.isConstant()) {
+          operands.push_back(
+              makeI64Constant(otherWhileOp->getLoc(), rewriter, numIters - 1));
+        } else {
+          if (!itersV)
+            itersV = info.getNumIters(rewriter);
+          auto one = stablehlo::ConstantOp::create(
+              rewriter, otherWhileOp->getLoc(), itersV.getType(),
+              cast<ElementsAttr>(makeAttr(itersV.getType(), 1)));
+          auto sub = stablehlo::SubtractOp::create(
+              rewriter, otherWhileOp->getLoc(), itersV, one);
+          operands.push_back(sub);
+        }
+
+        Block *otherBody = &otherWhileOp.getBody().front();
+        Block *otherCond = &otherWhileOp.getCond().front();
+        Value otherInductionVariable = otherBody->addArgument(
+            operands.back().getType(), otherWhileOp->getLoc());
+        otherCond->addArgument(otherInductionVariable.getType(),
+                               otherWhileOp->getLoc());
+        auto otherTerm = otherBody->getTerminator();
+
+        // Now that the real counter exists, retire the placeholder the min cut
+        // was seeded with.
+        if (reverseIVPlaceholder) {
+          OpBuilder::InsertionGuard g(rewriter);
+          rewriter.setInsertionPointToStart(otherBody);
+          Value real = otherInductionVariable;
+          if (real.getType() != reverseIVPlaceholder.getType())
+            real = stablehlo::ConvertOp::create(
+                rewriter, otherWhileOp->getLoc(),
+                reverseIVPlaceholder.getType(), real);
+          rewriter.replaceOp(reverseIVPlaceholder, real);
+          reverseIVPlaceholder = nullptr;
+        }
+
+        rewriter.setInsertionPoint(otherTerm);
+
+        otherInductionVariable =
+            stablehlo::SubtractOp::create(
+                rewriter, otherWhileOp->getLoc(), otherInductionVariable,
+                stablehlo::ConstantOp::create(
+                    rewriter, otherWhileOp->getLoc(),
+                    otherInductionVariable.getType(),
+                    cast<ElementsAttr>(
+                        makeAttr(otherInductionVariable.getType(), 1))))
+                .getResult();
+        otherTerm->insertOperands(otherTerm->getNumOperands(),
+                                  ValueRange(otherInductionVariable));
+
+        rewriter.setInsertionPoint(otherWhileOp);
+        auto newOtherWhileOp = stablehlo::WhileOp::create(
+            rewriter, otherWhileOp->getLoc(), operands);
+
+        for (auto &&[res, newRes] : llvm::zip(otherWhileOp->getResults(),
+                                              newOtherWhileOp->getResults())) {
+          rewriter.replaceAllUsesWith(res, newRes);
+        }
+        newOtherWhileOp.getCond().takeBody(otherWhileOp.getCond());
+        newOtherWhileOp.getBody().takeBody(otherWhileOp.getBody());
+
+        rewriter.eraseOp(otherWhileOp);
+        otherWhileOp = newOtherWhileOp;
+
+        Block *popBody = &otherWhileOp.getBody().front();
+        reverseIndexValue =
+            popBody->getArgument(popBody->getNumArguments() - 1);
       }
-
-      rewriter.setInsertionPoint(otherTerm);
-
-      otherInductionVariable =
-          stablehlo::SubtractOp::create(
-              rewriter, otherWhileOp->getLoc(), otherInductionVariable,
-              stablehlo::ConstantOp::create(
-                  rewriter, otherWhileOp->getLoc(),
-                  otherInductionVariable.getType(),
-                  cast<ElementsAttr>(
-                      makeAttr(otherInductionVariable.getType(), 1))))
-              .getResult();
-      otherTerm->insertOperands(otherTerm->getNumOperands(),
-                                ValueRange(otherInductionVariable));
-
-      rewriter.setInsertionPoint(otherWhileOp);
-      auto newOtherWhileOp = stablehlo::WhileOp::create(
-          rewriter, otherWhileOp->getLoc(), operands);
-
-      for (auto &&[res, newRes] : llvm::zip(otherWhileOp->getResults(),
-                                            newOtherWhileOp->getResults())) {
-        rewriter.replaceAllUsesWith(res, newRes);
-      }
-      newOtherWhileOp.getCond().takeBody(otherWhileOp.getCond());
-      newOtherWhileOp.getBody().takeBody(otherWhileOp.getBody());
-
-      rewriter.eraseOp(otherWhileOp);
-      otherWhileOp = newOtherWhileOp;
     } else if (reverseIVPlaceholder) {
       // No counter was built, so nothing may still refer to the stand-in.
       assert(reverseIVPlaceholder->use_empty() &&
@@ -4149,11 +4191,9 @@ public:
         auto popNewValue = enzyme::PopOp::create(rewriter, info.popOp->getLoc(),
                                                  newType, newInit.getResult());
 
-        Block *popBody = &otherWhileOp.getBody().front();
         rewriter.setInsertionPoint(info.popOp);
 
-        Value newInductionVariable =
-            popBody->getArgument(popBody->getNumArguments() - 1);
+        Value newInductionVariable = reverseIndexValue;
 
         Value popValue;
         if (auto TT = dyn_cast<TensorType>(info.cachedType())) {

--- a/test/lit_tests/diffrules/stablehlo/while3.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while3.mlir
@@ -37,60 +37,95 @@ module {
   }
 }
 
-// FORWARD:  func.func @f(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
-// FORWARD-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
-// FORWARD-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i64>
-// FORWARD-NEXT:    %c_1 = stablehlo.constant dense<3> : tensor<i64>
-// FORWARD-NEXT:    %0:3 = stablehlo.while(%iterArg = %c, %iterArg_2 = %arg0, %iterArg_3 = %arg1) : tensor<i64>, tensor<f64>, tensor<f64>
+// FORWARD: module {
+// FORWARD-NEXT:   func.func @main() {
+// FORWARD-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// FORWARD-NEXT:     %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// FORWARD-NEXT:     %0:2 = enzyme.autodiff @f(%cst, %cst_0) {activity = [#enzyme<activity enzyme_active>], ret_activity = [#enzyme<activity enzyme_active>]} : (tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+// FORWARD-NEXT:     check.expect_eq_const %0#0, dense<2.560000e+02> : tensor<f64>
+// FORWARD-NEXT:     check.expect_eq_const %0#1, dense<1.024000e+03> : tensor<f64>
+// FORWARD-NEXT:     return
+// FORWARD-NEXT:   }
+// FORWARD-NEXT:   func.func @f(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+// FORWARD-NEXT:     %c = stablehlo.constant dense<0> : tensor<i64>
+// FORWARD-NEXT:     %c_0 = stablehlo.constant dense<1> : tensor<i64>
+// FORWARD-NEXT:     %c_1 = stablehlo.constant dense<3> : tensor<i64>
+// FORWARD-NEXT:     %0:3 = stablehlo.while(%iterArg = %c, %iterArg_2 = %arg0, %iterArg_3 = %arg1) : tensor<i64>, tensor<f64>, tensor<f64>
 // FORWARD-NEXT:     cond {
-// FORWARD-NEXT:      %1 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// FORWARD-NEXT:      stablehlo.return %1 : tensor<i1>
-// FORWARD-NEXT:    } do {
-// FORWARD-NEXT:      %1 = stablehlo.multiply %iterArg_3, %iterArg_2 : tensor<f64>
-// FORWARD-NEXT:      %2 = stablehlo.multiply %iterArg_3, %iterArg_2 : tensor<f64>
-// FORWARD-NEXT:      %3 = arith.addf %1, %2 : tensor<f64>
-// FORWARD-NEXT:      %4 = stablehlo.multiply %iterArg_2, %iterArg_2 : tensor<f64>
-// FORWARD-NEXT:      %5 = stablehlo.add %iterArg, %c_0 : tensor<i64>
-// FORWARD-NEXT:      stablehlo.return %5, %4, %3 : tensor<i64>, tensor<f64>, tensor<f64>
-// FORWARD-NEXT:    }
-// FORWARD-NEXT:    return %0#1, %0#2 : tensor<f64>, tensor<f64>
-// FORWARD-NEXT:  }
+// FORWARD-NEXT:       %1 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// FORWARD-NEXT:       stablehlo.return %1 : tensor<i1>
+// FORWARD-NEXT:     } do {
+// FORWARD-NEXT:       %1 = stablehlo.multiply %iterArg_3, %iterArg_2 : tensor<f64>
+// FORWARD-NEXT:       %2 = stablehlo.multiply %iterArg_3, %iterArg_2 : tensor<f64>
+// FORWARD-NEXT:       %3 = arith.addf %1, %2 : tensor<f64>
+// FORWARD-NEXT:       %4 = stablehlo.multiply %iterArg_2, %iterArg_2 : tensor<f64>
+// FORWARD-NEXT:       %5 = stablehlo.add %iterArg, %c_0 : tensor<i64>
+// FORWARD-NEXT:       stablehlo.return %5, %4, %3 : tensor<i64>, tensor<f64>, tensor<f64>
+// FORWARD-NEXT:     }
+// FORWARD-NEXT:     return %0#1, %0#2 : tensor<f64>, tensor<f64>
+// FORWARD-NEXT:   }
+// FORWARD-NEXT: }
 
-// REVERSE:  func.func private @diffef(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
-// REVERSE-NEXT:    %c = stablehlo.constant dense<2> : tensor<i64>
-// REVERSE-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
-// REVERSE-NEXT:    %c_0 = stablehlo.constant dense<3> : tensor<i64>
-// REVERSE-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<i64>
-// REVERSE-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<i64>
-// REVERSE-NEXT:    %cst_3 = arith.constant dense<0.000000e+00> : tensor<f64>
-// REVERSE-NEXT:    %[[a2:.+]]:3 = stablehlo.while(%iterArg = %c_2, %iterArg_4 = %arg0, %iterArg_5 = %cst) : tensor<i64>, tensor<f64>, tensor<3xf64>
+// REVERSE: module {
+// REVERSE-NEXT:   func.func @main() {
+// REVERSE-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// REVERSE-NEXT:     %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// REVERSE-NEXT:     %0:2 = call @diffef(%cst, %cst_0) : (tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+// REVERSE-NEXT:     check.expect_eq_const %0#0, dense<2.560000e+02> : tensor<f64>
+// REVERSE-NEXT:     check.expect_eq_const %0#1, dense<1.024000e+03> : tensor<f64>
+// REVERSE-NEXT:     return
+// REVERSE-NEXT:   }
+// REVERSE-NEXT:   func.func @f(%arg0: tensor<f64>) -> tensor<f64> {
+// REVERSE-NEXT:     %c = stablehlo.constant dense<0> : tensor<i64>
+// REVERSE-NEXT:     %c_0 = stablehlo.constant dense<1> : tensor<i64>
+// REVERSE-NEXT:     %c_1 = stablehlo.constant dense<3> : tensor<i64>
+// REVERSE-NEXT:     %0:2 = stablehlo.while(%iterArg = %c, %iterArg_2 = %arg0) : tensor<i64>, tensor<f64>
 // REVERSE-NEXT:     cond {
-// REVERSE-NEXT:      %[[a6:.+]] = stablehlo.compare  LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// REVERSE-NEXT:      stablehlo.return %[[a6]] : tensor<i1>
-// REVERSE-NEXT:    } do {
-// REVERSE-NEXT:      %[[a6:.+]] = stablehlo.reshape %iterArg_4 : (tensor<f64>) -> tensor<1xf64>
-// REVERSE-NEXT:      %[[a7:.+]] = stablehlo.dynamic_update_slice %iterArg_5, %[[a6]], %iterArg : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
-// REVERSE-NEXT:      %[[a8:.+]] = stablehlo.multiply %iterArg_4, %iterArg_4 : tensor<f64>
-// REVERSE-NEXT:      %[[a9:.+]] = stablehlo.add %iterArg, %c_1 : tensor<i64>
-// REVERSE-NEXT:      stablehlo.return %[[a9]], %[[a8]], %[[a7]] : tensor<i64>, tensor<f64>, tensor<3xf64>
-// REVERSE-NEXT:    }
-// REVERSE-NEXT:    %[[a3:.+]] = arith.addf %arg1, %cst_3 : tensor<f64>
-// REVERSE-NEXT:    %[[a4:.+]]:3 = stablehlo.while(%iterArg = %c_2, %iterArg_4 = %[[a3]], %iterArg_5 = %c) : tensor<i64>, tensor<f64>, tensor<i64>
+// REVERSE-NEXT:       %1 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       stablehlo.return %1 : tensor<i1>
+// REVERSE-NEXT:     } do {
+// REVERSE-NEXT:       %1 = stablehlo.multiply %iterArg_2, %iterArg_2 : tensor<f64>
+// REVERSE-NEXT:       %2 = stablehlo.add %iterArg, %c_0 : tensor<i64>
+// REVERSE-NEXT:       stablehlo.return %2, %1 : tensor<i64>, tensor<f64>
+// REVERSE-NEXT:     }
+// REVERSE-NEXT:     return %0#1 : tensor<f64>
+// REVERSE-NEXT:   }
+// REVERSE-NEXT:   func.func private @diffef(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+// REVERSE-NEXT:     %c = stablehlo.constant dense<2> : tensor<i64>
+// REVERSE-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
+// REVERSE-NEXT:     %c_0 = stablehlo.constant dense<3> : tensor<i64>
+// REVERSE-NEXT:     %c_1 = stablehlo.constant dense<1> : tensor<i64>
+// REVERSE-NEXT:     %c_2 = stablehlo.constant dense<0> : tensor<i64>
+// REVERSE-NEXT:     %cst_3 = arith.constant dense<0.000000e+00> : tensor<f64>
+// REVERSE-NEXT:     %0:3 = stablehlo.while(%iterArg = %c_2, %iterArg_4 = %arg0, %iterArg_5 = %cst) : tensor<i64>, tensor<f64>, tensor<3xf64>
 // REVERSE-NEXT:     cond {
-// REVERSE-NEXT:      %[[a6:.+]] = stablehlo.compare  LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// REVERSE-NEXT:      stablehlo.return %[[a6]] : tensor<i1>
-// REVERSE-NEXT:    } do {
-// REVERSE-NEXT:      %[[a7:.+]] = stablehlo.dynamic_slice %[[a2]]#2, %iterArg_5, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
-// REVERSE-NEXT:      %[[a8:.+]] = stablehlo.reshape %[[a7]] : (tensor<1xf64>) -> tensor<f64>
-// REVERSE-NEXT:      %[[a6:.+]] = stablehlo.add %iterArg, %c_1 : tensor<i64>
-// REVERSE-NEXT:      %[[i4:.+]] = arith.addf %iterArg_4, %cst_3 : tensor<f64>
-// REVERSE-NEXT:      %[[a9:.+]] = stablehlo.multiply %[[i4]], %[[a8]] : tensor<f64>
-// REVERSE-NEXT:      %[[a10:.+]] = arith.addf %[[a9]], %cst_3 : tensor<f64>
-// REVERSE-NEXT:      %[[a11:.+]] = stablehlo.multiply %[[i4]], %[[a8]] : tensor<f64>
-// REVERSE-NEXT:      %[[a12:.+]] = arith.addf %[[a10]], %[[a11]] : tensor<f64>
-// REVERSE-NEXT:      %[[a13:.+]] = stablehlo.subtract %iterArg_5, %c_1 : tensor<i64>
-// REVERSE-NEXT:      stablehlo.return %[[a6]], %[[a12]], %[[a13]] : tensor<i64>, tensor<f64>, tensor<i64>
-// REVERSE-NEXT:    }
-// REVERSE-NEXT:    %[[a5:.+]] = arith.addf %[[a4]]#1, %cst_3 : tensor<f64>
-// REVERSE-NEXT:    return %[[a2]]#1, %[[a5]] : tensor<f64>, tensor<f64>
-// REVERSE-NEXT:  }
+// REVERSE-NEXT:       %4 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       stablehlo.return %4 : tensor<i1>
+// REVERSE-NEXT:     } do {
+// REVERSE-NEXT:       %4 = stablehlo.reshape %iterArg_4 : (tensor<f64>) -> tensor<1xf64>
+// REVERSE-NEXT:       %5 = stablehlo.dynamic_update_slice %iterArg_5, %4, %iterArg : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
+// REVERSE-NEXT:       %6 = stablehlo.multiply %iterArg_4, %iterArg_4 : tensor<f64>
+// REVERSE-NEXT:       %7 = stablehlo.add %iterArg, %c_1 : tensor<i64>
+// REVERSE-NEXT:       stablehlo.return %7, %6, %5 : tensor<i64>, tensor<f64>, tensor<3xf64>
+// REVERSE-NEXT:     }
+// REVERSE-NEXT:     %1 = arith.addf %arg1, %cst_3 : tensor<f64>
+// REVERSE-NEXT:     %2:2 = stablehlo.while(%iterArg = %c_2, %iterArg_4 = %1) : tensor<i64>, tensor<f64>
+// REVERSE-NEXT:     cond {
+// REVERSE-NEXT:       %4 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       stablehlo.return %4 : tensor<i1>
+// REVERSE-NEXT:     } do {
+// REVERSE-NEXT:       %4 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// REVERSE-NEXT:       %5 = stablehlo.dynamic_slice %0#2, %4, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
+// REVERSE-NEXT:       %6 = stablehlo.reshape %5 : (tensor<1xf64>) -> tensor<f64>
+// REVERSE-NEXT:       %7 = stablehlo.add %iterArg, %c_1 : tensor<i64>
+// REVERSE-NEXT:       %8 = arith.addf %iterArg_4, %cst_3 : tensor<f64>
+// REVERSE-NEXT:       %9 = stablehlo.multiply %8, %6 : tensor<f64>
+// REVERSE-NEXT:       %10 = arith.addf %9, %cst_3 : tensor<f64>
+// REVERSE-NEXT:       %11 = stablehlo.multiply %8, %6 : tensor<f64>
+// REVERSE-NEXT:       %12 = arith.addf %10, %11 : tensor<f64>
+// REVERSE-NEXT:       stablehlo.return %7, %12 : tensor<i64>, tensor<f64>
+// REVERSE-NEXT:     }
+// REVERSE-NEXT:     %3 = arith.addf %2#1, %cst_3 : tensor<f64>
+// REVERSE-NEXT:     return %0#1, %3 : tensor<f64>, tensor<f64>
+// REVERSE-NEXT:   }
+// REVERSE-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/while4.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while4.mlir
@@ -113,109 +113,119 @@ module {
   }
 }
 
-// CHECK:    func.func private @"diffeConst{typeof(sumabs2)}(Main.sumabs2)_autodiff"(%arg0: tensor<6x2x3xf32>, %arg1: tensor<3x3xf32>, %arg2: tensor<3x3xf32>, %arg3: tensor<3xf32>, %arg4: tensor<3xf32>, %arg5: tensor<2xui64>, %arg6: tensor<f32>, %arg7: tensor<2xui64>, %arg8: tensor<3x3xf32>, %arg9: tensor<3x3xf32>, %arg10: tensor<3xf32>, %arg11: tensor<3xf32>) -> (tensor<6x2x3xf32>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<2xui64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>) {
-// CHECK-NEXT:    %c = stablehlo.constant dense<4> : tensor<i64>
-// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<5x2x3xf32>
-// CHECK-NEXT:    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<5x3x2xf32>
-// CHECK-NEXT:    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<5x3x3xf32>
-// CHECK-NEXT:    %c_2 = stablehlo.constant dense<5> : tensor<i64>
-// CHECK-NEXT:    %cst_3 = stablehlo.constant dense<1.000000e+00> : tensor<3x2xf32>
-// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %c_5 = stablehlo.constant dense<2> : tensor<i64>
-// CHECK-NEXT:    %c_6 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %cst_7 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK-NEXT:    %cst_8 = stablehlo.constant dense<0.000000e+00> : tensor<3x2xf32>
-// CHECK-NEXT:    %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<6x2x3xf32>) -> tensor<3x2x6xf32>
-// CHECK-NEXT:    %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    %2 = stablehlo.transpose %arg2, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    %3 = stablehlo.slice %arg0 [0:1, 0:2, 0:3] : (tensor<6x2x3xf32>) -> tensor<1x2x3xf32>
-// CHECK-NEXT:    %4 = stablehlo.reshape %3 : (tensor<1x2x3xf32>) -> tensor<2x3xf32>
-// CHECK-NEXT:    %5 = stablehlo.broadcast_in_dim %arg4, dims = [0] : (tensor<3xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:    %6 = stablehlo.dot_general %arg1, %4, contracting_dims = [0] x [1] : (tensor<3x3xf32>, tensor<2x3xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %arg3, dims = [0] : (tensor<3xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:    %8 = stablehlo.add %6, %7 : tensor<3x2xf32>
-// CHECK-NEXT:    %9 = stablehlo.add %5, %8 : tensor<3x2xf32>
-// CHECK-NEXT:    %10 = stablehlo.tanh %9 : tensor<3x2xf32>
-// CHECK-NEXT:    %11:9 = stablehlo.while(%iterArg = %c_4, %iterArg_9 = %1, %iterArg_10 = %2, %iterArg_11 = %10, %iterArg_12 = %0, %iterArg_13 = %cst_1, %iterArg_14 = %cst_0, %iterArg_15 = %cst_0, %iterArg_16 = %cst) : tensor<i64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3x2xf32>, tensor<3x2x6xf32>, tensor<5x3x3xf32>, tensor<5x3x2xf32>, tensor<5x3x2xf32>, tensor<5x2x3xf32>
-// CHECK-NEXT:    cond {
-// CHECK-NEXT:      %36 = stablehlo.compare LT, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %36 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %36 = stablehlo.reshape %iterArg_11 : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
-// CHECK-NEXT:      %37 = stablehlo.dynamic_update_slice %iterArg_14, %36, %iterArg, %c_4, %c_4 : (tensor<5x3x2xf32>, tensor<1x3x2xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<5x3x2xf32>
-// CHECK-NEXT:      %38 = stablehlo.reshape %iterArg_10 : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
-// CHECK-NEXT:      %39 = stablehlo.dynamic_update_slice %iterArg_13, %38, %iterArg, %c_4, %c_4 : (tensor<5x3x3xf32>, tensor<1x3x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<5x3x3xf32>
-// CHECK-NEXT:      %40 = stablehlo.add %iterArg, %c_6 {enzymexla.bounds = {{.*}}} : tensor<i64>
-// CHECK-NEXT:      %41 = stablehlo.add %c_5, %iterArg {enzymexla.bounds = {{.*}}} : tensor<i64>
-// CHECK-NEXT:      %42 = stablehlo.subtract %41, %c_6 {enzymexla.bounds = {{.*}}} : tensor<i64>
-// CHECK-NEXT:      %43 = stablehlo.dynamic_slice %iterArg_12, %c_4, %c_4, %42, sizes = [3, 2, 1] : (tensor<3x2x6xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<3x2x1xf32>
-// CHECK-NEXT:      %44 = stablehlo.transpose %43, dims = [2, 1, 0] : (tensor<3x2x1xf32>) -> tensor<1x2x3xf32>
-// CHECK-NEXT:      %45 = stablehlo.reshape %44 : (tensor<1x2x3xf32>) -> tensor<2x3xf32>
-// CHECK-NEXT:      %46 = stablehlo.reshape %45 : (tensor<2x3xf32>) -> tensor<1x2x3xf32>
-// CHECK-NEXT:      %47 = stablehlo.dynamic_update_slice %iterArg_16, %46, %iterArg, %c_4, %c_4 : (tensor<5x2x3xf32>, tensor<1x2x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<5x2x3xf32>
-// CHECK-NEXT:      %48 = stablehlo.dot_general %iterArg_10, %iterArg_11, contracting_dims = [1] x [0] : (tensor<3x3xf32>, tensor<3x2xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:      %49 = stablehlo.broadcast_in_dim %arg4, dims = [0] : (tensor<3xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:      %50 = stablehlo.add %48, %49 : tensor<3x2xf32>
-// CHECK-NEXT:      %51 = stablehlo.dot_general %iterArg_9, %45, contracting_dims = [1] x [1] : (tensor<3x3xf32>, tensor<2x3xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:      %52 = stablehlo.broadcast_in_dim %arg3, dims = [0] : (tensor<3xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:      %53 = stablehlo.add %51, %52 : tensor<3x2xf32>
-// CHECK-NEXT:      %54 = stablehlo.add %50, %53 : tensor<3x2xf32>
-// CHECK-NEXT:      %55 = stablehlo.reshape %54 : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
-// CHECK-NEXT:      %56 = stablehlo.dynamic_update_slice %iterArg_15, %55, %iterArg, %c_4, %c_4 : (tensor<5x3x2xf32>, tensor<1x3x2xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<5x3x2xf32>
-// CHECK-NEXT:      %57 = stablehlo.tanh %54 : tensor<3x2xf32>
-// CHECK-NEXT:      stablehlo.return %40, %iterArg_9, %iterArg_10, %57, %iterArg_12, %39, %37, %56, %47 : tensor<i64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3x2xf32>, tensor<3x2x6xf32>, tensor<5x3x3xf32>, tensor<5x3x2xf32>, tensor<5x3x2xf32>, tensor<5x2x3xf32>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %12 = stablehlo.abs %11#3 : tensor<3x2xf32>
-// CHECK-NEXT:    %13 = stablehlo.transpose %11#4, dims = [2, 1, 0] : (tensor<3x2x6xf32>) -> tensor<6x2x3xf32>
-// CHECK-NEXT:    %14 = stablehlo.transpose %11#1, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    %15 = stablehlo.transpose %11#2, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    %16 = stablehlo.transpose %arg9, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    %17 = stablehlo.transpose %arg8, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    %18 = stablehlo.broadcast_in_dim %arg6, dims = [] : (tensor<f32>) -> tensor<3x2xf32>
-// CHECK-NEXT:    %19 = stablehlo.multiply %18, %12 : tensor<3x2xf32>
-// CHECK-NEXT:    %20 = stablehlo.add %19, %19 : tensor<3x2xf32>
-// CHECK-NEXT:    %21 = stablehlo.compare GE, %11#3, %cst_8 : (tensor<3x2xf32>, tensor<3x2xf32>) -> tensor<3x2xi1>
-// CHECK-NEXT:    %22 = stablehlo.negate %20 : tensor<3x2xf32>
-// CHECK-NEXT:    %23 = stablehlo.select %21, %20, %22 : tensor<3x2xi1>, tensor<3x2xf32>
-// CHECK-NEXT:    %24:7 = stablehlo.while(%iterArg = %c_4, %iterArg_9 = %17, %iterArg_10 = %16, %iterArg_11 = %arg10, %iterArg_12 = %arg11, %iterArg_13 = %23, %iterArg_14 = %c) : tensor<i64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3x2xf32>, tensor<i64>
-// CHECK-NEXT:    cond {
-// CHECK-NEXT:      %36 = stablehlo.compare LT, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %36 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %36 = stablehlo.dynamic_slice %11#5, %iterArg_14, %c_4, %c_4, sizes = [1, 3, 3] : (tensor<5x3x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x3x3xf32>
-// CHECK-NEXT:      %37 = stablehlo.reshape %36 : (tensor<1x3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:      %38 = stablehlo.dynamic_slice %11#6, %iterArg_14, %c_4, %c_4, sizes = [1, 3, 2] : (tensor<5x3x2xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x3x2xf32>
-// CHECK-NEXT:      %39 = stablehlo.reshape %38 : (tensor<1x3x2xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:      %40 = stablehlo.dynamic_slice %11#7, %iterArg_14, %c_4, %c_4, sizes = [1, 3, 2] : (tensor<5x3x2xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x3x2xf32>
-// CHECK-NEXT:      %41 = stablehlo.reshape %40 : (tensor<1x3x2xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:      %42 = stablehlo.dynamic_slice %11#8, %iterArg_14, %c_4, %c_4, sizes = [1, 2, 3] : (tensor<5x2x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x2x3xf32>
-// CHECK-NEXT:      %43 = stablehlo.reshape %42 : (tensor<1x2x3xf32>) -> tensor<2x3xf32>
-// CHECK-NEXT:      %44 = stablehlo.add %iterArg, %c_6 {enzymexla.bounds = {{.*}}} : tensor<i64>
-// CHECK-NEXT:      %45 = stablehlo.tanh %41 : tensor<3x2xf32>
-// CHECK-NEXT:      %46 = stablehlo.multiply %45, %45 : tensor<3x2xf32>
-// CHECK-NEXT:      %47 = stablehlo.subtract %cst_3, %46 : tensor<3x2xf32>
-// CHECK-NEXT:      %48 = stablehlo.multiply %iterArg_13, %47 : tensor<3x2xf32>
-// CHECK-NEXT:      %49 = stablehlo.reduce(%48 init: %cst_7) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
-// CHECK-NEXT:      %50 = stablehlo.add %iterArg_11, %49 : tensor<3xf32>
-// CHECK-NEXT:      %51 = stablehlo.dot_general %48, %43, contracting_dims = [1] x [0] : (tensor<3x2xf32>, tensor<2x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:      %52 = stablehlo.add %iterArg_9, %51 : tensor<3x3xf32>
-// CHECK-NEXT:      %53 = stablehlo.add %iterArg_12, %49 : tensor<3xf32>
-// CHECK-NEXT:      %54 = stablehlo.dot_general %48, %39, contracting_dims = [1] x [1] : (tensor<3x2xf32>, tensor<3x2xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:      %55 = stablehlo.add %iterArg_10, %54 : tensor<3x3xf32>
-// CHECK-NEXT:      %56 = stablehlo.dot_general %37, %48, contracting_dims = [0] x [0] : (tensor<3x3xf32>, tensor<3x2xf32>) -> tensor<3x2xf32>
-// CHECK-NEXT:      %57 = stablehlo.subtract %iterArg_14, %c_6 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %44, %52, %55, %50, %53, %56, %57 : tensor<i64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3x2xf32>, tensor<i64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %25 = stablehlo.multiply %10, %10 : tensor<3x2xf32>
-// CHECK-NEXT:    %26 = stablehlo.subtract %cst_3, %25 : tensor<3x2xf32>
-// CHECK-NEXT:    %27 = stablehlo.multiply %24#5, %26 : tensor<3x2xf32>
-// CHECK-NEXT:    %28 = stablehlo.reduce(%27 init: %cst_7) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
-// CHECK-NEXT:    %29 = stablehlo.add %24#3, %28 : tensor<3xf32>
-// CHECK-NEXT:    %30 = stablehlo.dot_general %27, %4, contracting_dims = [1] x [0] {enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<3x2xf32>, tensor<2x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    %31 = stablehlo.reduce(%27 init: %cst_7) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
-// CHECK-NEXT:    %32 = stablehlo.add %24#4, %31 : tensor<3xf32>
-// CHECK-NEXT:    %33 = stablehlo.transpose %24#2, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    %34 = stablehlo.add %30, %24#1 {enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<3x3xf32>
-// CHECK-NEXT:    %35 = stablehlo.transpose %34, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
-// CHECK-NEXT:    return %13, %14, %15, %arg3, %arg4, %arg5, %35, %33, %29, %32 : tensor<6x2x3xf32>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<2xui64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>
-// CHECK-NEXT:  }
+// CHECK: module {
+// CHECK-NEXT:   func.func private @"diffeConst{typeof(sumabs2)}(Main.sumabs2)_autodiff"(%arg0: tensor<6x2x3xf32>, %arg1: tensor<3x3xf32>, %arg2: tensor<3x3xf32>, %arg3: tensor<3xf32>, %arg4: tensor<3xf32>, %arg5: tensor<2xui64>, %arg6: tensor<f32>, %arg7: tensor<2xui64>, %arg8: tensor<3x3xf32>, %arg9: tensor<3x3xf32>, %arg10: tensor<3xf32>, %arg11: tensor<3xf32>) -> (tensor<6x2x3xf32>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<2xui64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>) {
+// CHECK-NEXT:     %c = stablehlo.constant dense<4> : tensor<i64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<5x2x3xf32>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<5x3x2xf32>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<5x3x3xf32>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<5> : tensor<i64>
+// CHECK-NEXT:     %cst_3 = stablehlo.constant dense<1.000000e+00> : tensor<3x2xf32>
+// CHECK-NEXT:     %c_4 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_5 = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:     %c_6 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %cst_7 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:     %cst_8 = stablehlo.constant dense<0.000000e+00> : tensor<3x2xf32>
+// CHECK-NEXT:     %0 = stablehlo.transpose %arg0, dims = [2, 1, 0] : (tensor<6x2x3xf32>) -> tensor<3x2x6xf32>
+// CHECK-NEXT:     %1 = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     %2 = stablehlo.transpose %arg2, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     %3 = stablehlo.slice %arg0 [0:1, 0:2, 0:3] : (tensor<6x2x3xf32>) -> tensor<1x2x3xf32>
+// CHECK-NEXT:     %4 = stablehlo.reshape %3 : (tensor<1x2x3xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:     %5 = stablehlo.broadcast_in_dim %arg4, dims = [0] : (tensor<3xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:     %6 = stablehlo.dot_general %arg1, %4, contracting_dims = [0] x [1] : (tensor<3x3xf32>, tensor<2x3xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:     %7 = stablehlo.broadcast_in_dim %arg3, dims = [0] : (tensor<3xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:     %8 = stablehlo.add %6, %7 : tensor<3x2xf32>
+// CHECK-NEXT:     %9 = stablehlo.add %5, %8 : tensor<3x2xf32>
+// CHECK-NEXT:     %10 = stablehlo.tanh %9 : tensor<3x2xf32>
+// CHECK-NEXT:     %11:9 = stablehlo.while(%iterArg = %c_4, %iterArg_9 = %1, %iterArg_10 = %2, %iterArg_11 = %10, %iterArg_12 = %0, %iterArg_13 = %cst_1, %iterArg_14 = %cst_0, %iterArg_15 = %cst_0, %iterArg_16 = %cst) : tensor<i64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3x2xf32>, tensor<3x2x6xf32>, tensor<5x3x3xf32>, tensor<5x3x2xf32>, tensor<5x3x2xf32>, tensor<5x2x3xf32>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %36 = stablehlo.compare LT, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %36 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %36 = stablehlo.reshape %iterArg_11 : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
+// CHECK-NEXT:       %37 = stablehlo.dynamic_update_slice %iterArg_14, %36, %iterArg, %c_4, %c_4 : (tensor<5x3x2xf32>, tensor<1x3x2xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<5x3x2xf32>
+// CHECK-NEXT:       %38 = stablehlo.reshape %iterArg_10 : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
+// CHECK-NEXT:       %39 = stablehlo.dynamic_update_slice %iterArg_13, %38, %iterArg, %c_4, %c_4 : (tensor<5x3x3xf32>, tensor<1x3x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<5x3x3xf32>
+// CHECK-NEXT:       %40 = stablehlo.add %iterArg, %c_6 {enzymexla.bounds = {{\[\[}}1, 5]]} : tensor<i64>
+// CHECK-NEXT:       %41 = stablehlo.add %c_5, %iterArg {enzymexla.bounds = {{\[\[}}2, 6]]} : tensor<i64>
+// CHECK-NEXT:       %42 = stablehlo.subtract %41, %c_6 {enzymexla.bounds = {{\[\[}}1, 5]]} : tensor<i64>
+// CHECK-NEXT:       %43 = stablehlo.dynamic_slice %iterArg_12, %c_4, %c_4, %42, sizes = [3, 2, 1] : (tensor<3x2x6xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<3x2x1xf32>
+// CHECK-NEXT:       %44 = stablehlo.transpose %43, dims = [2, 1, 0] : (tensor<3x2x1xf32>) -> tensor<1x2x3xf32>
+// CHECK-NEXT:       %45 = stablehlo.reshape %44 : (tensor<1x2x3xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:       %46 = stablehlo.reshape %45 : (tensor<2x3xf32>) -> tensor<1x2x3xf32>
+// CHECK-NEXT:       %47 = stablehlo.dynamic_update_slice %iterArg_16, %46, %iterArg, %c_4, %c_4 : (tensor<5x2x3xf32>, tensor<1x2x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<5x2x3xf32>
+// CHECK-NEXT:       %48 = stablehlo.dot_general %iterArg_10, %iterArg_11, contracting_dims = [1] x [0] : (tensor<3x3xf32>, tensor<3x2xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:       %49 = stablehlo.broadcast_in_dim %arg4, dims = [0] : (tensor<3xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:       %50 = stablehlo.add %48, %49 : tensor<3x2xf32>
+// CHECK-NEXT:       %51 = stablehlo.dot_general %iterArg_9, %45, contracting_dims = [1] x [1] : (tensor<3x3xf32>, tensor<2x3xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:       %52 = stablehlo.broadcast_in_dim %arg3, dims = [0] : (tensor<3xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:       %53 = stablehlo.add %51, %52 : tensor<3x2xf32>
+// CHECK-NEXT:       %54 = stablehlo.add %50, %53 : tensor<3x2xf32>
+// CHECK-NEXT:       %55 = stablehlo.reshape %54 : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
+// CHECK-NEXT:       %56 = stablehlo.dynamic_update_slice %iterArg_15, %55, %iterArg, %c_4, %c_4 : (tensor<5x3x2xf32>, tensor<1x3x2xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<5x3x2xf32>
+// CHECK-NEXT:       %57 = stablehlo.tanh %54 : tensor<3x2xf32>
+// CHECK-NEXT:       stablehlo.return %40, %iterArg_9, %iterArg_10, %57, %iterArg_12, %39, %37, %56, %47 : tensor<i64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3x2xf32>, tensor<3x2x6xf32>, tensor<5x3x3xf32>, tensor<5x3x2xf32>, tensor<5x3x2xf32>, tensor<5x2x3xf32>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %12 = stablehlo.abs %11#3 : tensor<3x2xf32>
+// CHECK-NEXT:     %13 = stablehlo.transpose %11#4, dims = [2, 1, 0] : (tensor<3x2x6xf32>) -> tensor<6x2x3xf32>
+// CHECK-NEXT:     %14 = stablehlo.transpose %11#1, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     %15 = stablehlo.transpose %11#2, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     %16 = stablehlo.transpose %arg9, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     %17 = stablehlo.transpose %arg8, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     %18 = stablehlo.broadcast_in_dim %arg6, dims = [] : (tensor<f32>) -> tensor<3x2xf32>
+// CHECK-NEXT:     %19 = stablehlo.multiply %18, %12 : tensor<3x2xf32>
+// CHECK-NEXT:     %20 = stablehlo.add %19, %19 : tensor<3x2xf32>
+// CHECK-NEXT:     %21 = stablehlo.compare GE, %11#3, %cst_8 : (tensor<3x2xf32>, tensor<3x2xf32>) -> tensor<3x2xi1>
+// CHECK-NEXT:     %22 = stablehlo.negate %20 : tensor<3x2xf32>
+// CHECK-NEXT:     %23 = stablehlo.select %21, %20, %22 : tensor<3x2xi1>, tensor<3x2xf32>
+// CHECK-NEXT:     %24:6 = stablehlo.while(%iterArg = %c_4, %iterArg_9 = %17, %iterArg_10 = %16, %iterArg_11 = %arg10, %iterArg_12 = %arg11, %iterArg_13 = %23) : tensor<i64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3x2xf32> attributes {enzymexla.symmetric_matrix = [#enzymexla<guaranteed UNKNOWN>, #enzymexla<guaranteed UNKNOWN>, #enzymexla<guaranteed NOTGUARANTEED>, #enzymexla<guaranteed UNKNOWN>, #enzymexla<guaranteed UNKNOWN>, #enzymexla<guaranteed UNKNOWN>]}
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %36 = stablehlo.compare LT, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %36 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %36 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %37 = stablehlo.dynamic_slice %11#5, %36, %c_4, %c_4, sizes = [1, 3, 3] : (tensor<5x3x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x3x3xf32>
+// CHECK-NEXT:       %38 = stablehlo.reshape %37 : (tensor<1x3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:       %39 = stablehlo.dynamic_slice %11#6, %36, %c_4, %c_4, sizes = [1, 3, 2] : (tensor<5x3x2xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x3x2xf32>
+// CHECK-NEXT:       %40 = stablehlo.reshape %39 : (tensor<1x3x2xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:       %41 = stablehlo.dynamic_slice %11#7, %36, %c_4, %c_4, sizes = [1, 3, 2] : (tensor<5x3x2xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x3x2xf32>
+// CHECK-NEXT:       %42 = stablehlo.reshape %41 : (tensor<1x3x2xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:       %43 = stablehlo.dynamic_slice %11#8, %36, %c_4, %c_4, sizes = [1, 2, 3] : (tensor<5x2x3xf32>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x2x3xf32>
+// CHECK-NEXT:       %44 = stablehlo.reshape %43 : (tensor<1x2x3xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:       %45 = stablehlo.add %iterArg, %c_6 {enzymexla.bounds = {{\[\[}}1, 5]]} : tensor<i64>
+// CHECK-NEXT:       %46 = stablehlo.tanh %42 : tensor<3x2xf32>
+// CHECK-NEXT:       %47 = stablehlo.multiply %46, %46 : tensor<3x2xf32>
+// CHECK-NEXT:       %48 = stablehlo.subtract %cst_3, %47 : tensor<3x2xf32>
+// CHECK-NEXT:       %49 = stablehlo.multiply %iterArg_13, %48 : tensor<3x2xf32>
+// CHECK-NEXT:       %50 = stablehlo.reduce(%49 init: %cst_7) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
+// CHECK-NEXT:       %51 = stablehlo.add %iterArg_11, %50 : tensor<3xf32>
+// CHECK-NEXT:       %52 = stablehlo.dot_general %49, %44, contracting_dims = [1] x [0] : (tensor<3x2xf32>, tensor<2x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:       %53 = stablehlo.add %iterArg_9, %52 : tensor<3x3xf32>
+// CHECK-NEXT:       %54 = stablehlo.add %iterArg_12, %50 : tensor<3xf32>
+// CHECK-NEXT:       %55 = stablehlo.dot_general %49, %40, contracting_dims = [1] x [1] : (tensor<3x2xf32>, tensor<3x2xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:       %56 = stablehlo.add %iterArg_10, %55 : tensor<3x3xf32>
+// CHECK-NEXT:       %57 = stablehlo.dot_general %38, %49, contracting_dims = [0] x [0] : (tensor<3x3xf32>, tensor<3x2xf32>) -> tensor<3x2xf32>
+// CHECK-NEXT:       stablehlo.return %45, %53, %56, %51, %54, %57 : tensor<i64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<3x2xf32>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %25 = stablehlo.multiply %10, %10 : tensor<3x2xf32>
+// CHECK-NEXT:     %26 = stablehlo.subtract %cst_3, %25 : tensor<3x2xf32>
+// CHECK-NEXT:     %27 = stablehlo.multiply %24#5, %26 : tensor<3x2xf32>
+// CHECK-NEXT:     %28 = stablehlo.reduce(%27 init: %cst_7) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
+// CHECK-NEXT:     %29 = stablehlo.add %24#3, %28 : tensor<3xf32>
+// CHECK-NEXT:     %30 = stablehlo.dot_general %27, %4, contracting_dims = [1] x [0] {enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<3x2xf32>, tensor<2x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     %31 = stablehlo.reduce(%27 init: %cst_7) applies stablehlo.add across dimensions = [1] : (tensor<3x2xf32>, tensor<f32>) -> tensor<3xf32>
+// CHECK-NEXT:     %32 = stablehlo.add %24#4, %31 : tensor<3xf32>
+// CHECK-NEXT:     %33 = stablehlo.transpose %24#2, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     %34 = stablehlo.add %30, %24#1 {enzymexla.symmetric_matrix = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<3x3xf32>
+// CHECK-NEXT:     %35 = stablehlo.transpose %34, dims = [1, 0] : (tensor<3x3xf32>) -> tensor<3x3xf32>
+// CHECK-NEXT:     return %13, %14, %15, %arg3, %arg4, %arg5, %35, %33, %29, %32 : tensor<6x2x3xf32>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<2xui64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func @main(%arg0: tensor<6x2x3xf32>, %arg1: tensor<3x3xf32>, %arg2: tensor<3x3xf32>, %arg3: tensor<3xf32>, %arg4: tensor<3xf32>, %arg5: tensor<2xui64>) -> (tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<6x2x3xf32>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<2xui64>) {
+// CHECK-NEXT:     %c = stablehlo.constant dense<1> : tensor<2xui64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<3xf32>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<3x3xf32>
+// CHECK-NEXT:     %0:10 = call @"diffeConst{typeof(sumabs2)}(Main.sumabs2)_autodiff"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %cst, %c, %cst_1, %cst_1, %cst_0, %cst_0) : (tensor<6x2x3xf32>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<2xui64>, tensor<f32>, tensor<2xui64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>) -> (tensor<6x2x3xf32>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<2xui64>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>)
+// CHECK-NEXT:     return %0#6, %0#7, %0#8, %0#9, %0#0, %0#1, %0#2, %0#3, %0#4, %0#5 : tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<6x2x3xf32>, tensor<3x3xf32>, tensor<3x3xf32>, tensor<3xf32>, tensor<3xf32>, tensor<2xui64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/while6.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while6.mlir
@@ -20,53 +20,57 @@ func.func @main(%arg0: tensor<12x16x4xf32>) -> (tensor<12x4xf32>) {
   return %8#1 : tensor<12x4xf32>
 }
 
-// FORWARD: func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x16x4xf32>) -> (tensor<12x4xf32>, tensor<12x4xf32>) {
-// FORWARD-NEXT:   %c = stablehlo.constant dense<0> : tensor<i32>
-// FORWARD-NEXT:   %c_0 = stablehlo.constant dense<15> : tensor<i32>
-// FORWARD-NEXT:   %c_1 = stablehlo.constant dense<1> : tensor<i32>
-// FORWARD-NEXT:   %0 = stablehlo.slice %arg1 [0:12, 0:1, 0:4] : (tensor<12x16x4xf32>) -> tensor<12x1x4xf32>
-// FORWARD-NEXT:   %1 = stablehlo.slice %arg0 [0:12, 0:1, 0:4] : (tensor<12x16x4xf32>) -> tensor<12x1x4xf32>
-// FORWARD-NEXT:   %2 = stablehlo.reshape %0 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
-// FORWARD-NEXT:   %3 = stablehlo.reshape %1 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
-// FORWARD-NEXT:   %4:3 = stablehlo.while(%iterArg = %c, %iterArg_2 = %3, %iterArg_3 = %2) : tensor<i32>, tensor<12x4xf32>, tensor<12x4xf32>
-// FORWARD-NEXT:   cond {
-// FORWARD-NEXT:     %5 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i32>, tensor<i32>) -> tensor<i1>
-// FORWARD-NEXT:     stablehlo.return %5 : tensor<i1>
-// FORWARD-NEXT:   } do {
-// FORWARD-NEXT:     %5 = stablehlo.add %c_1, %iterArg {enzymexla.bounds = {{.*}}} : tensor<i32>
-// FORWARD-NEXT:     %6 = stablehlo.dynamic_slice %arg1, %c, %5, %c, sizes = [12, 1, 4] : (tensor<12x16x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x1x4xf32>
-// FORWARD-NEXT:     %7 = stablehlo.dynamic_slice %arg0, %c, %5, %c, sizes = [12, 1, 4] : (tensor<12x16x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x1x4xf32>
-// FORWARD-NEXT:     %8 = stablehlo.reshape %6 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
-// FORWARD-NEXT:     %9 = stablehlo.reshape %7 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
-// FORWARD-NEXT:     stablehlo.return %5, %9, %8 : tensor<i32>, tensor<12x4xf32>, tensor<12x4xf32>
+// FORWARD: module {
+// FORWARD-NEXT:   func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x16x4xf32>) -> (tensor<12x4xf32>, tensor<12x4xf32>) {
+// FORWARD-NEXT:     %c = stablehlo.constant dense<0> : tensor<i32>
+// FORWARD-NEXT:     %c_0 = stablehlo.constant dense<15> : tensor<i32>
+// FORWARD-NEXT:     %c_1 = stablehlo.constant dense<1> : tensor<i32>
+// FORWARD-NEXT:     %0 = stablehlo.slice %arg1 [0:12, 0:1, 0:4] : (tensor<12x16x4xf32>) -> tensor<12x1x4xf32>
+// FORWARD-NEXT:     %1 = stablehlo.slice %arg0 [0:12, 0:1, 0:4] : (tensor<12x16x4xf32>) -> tensor<12x1x4xf32>
+// FORWARD-NEXT:     %2 = stablehlo.reshape %0 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
+// FORWARD-NEXT:     %3 = stablehlo.reshape %1 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
+// FORWARD-NEXT:     %4:3 = stablehlo.while(%iterArg = %c, %iterArg_2 = %3, %iterArg_3 = %2) : tensor<i32>, tensor<12x4xf32>, tensor<12x4xf32>
+// FORWARD-NEXT:     cond {
+// FORWARD-NEXT:       %5 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i32>, tensor<i32>) -> tensor<i1>
+// FORWARD-NEXT:       stablehlo.return %5 : tensor<i1>
+// FORWARD-NEXT:     } do {
+// FORWARD-NEXT:       %5 = stablehlo.add %c_1, %iterArg {enzymexla.bounds = {{\[\[}}1 : i32, 15 : i32]]} : tensor<i32>
+// FORWARD-NEXT:       %6 = stablehlo.dynamic_slice %arg1, %c, %5, %c, sizes = [12, 1, 4] : (tensor<12x16x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x1x4xf32>
+// FORWARD-NEXT:       %7 = stablehlo.dynamic_slice %arg0, %c, %5, %c, sizes = [12, 1, 4] : (tensor<12x16x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x1x4xf32>
+// FORWARD-NEXT:       %8 = stablehlo.reshape %6 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
+// FORWARD-NEXT:       %9 = stablehlo.reshape %7 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
+// FORWARD-NEXT:       stablehlo.return %5, %9, %8 : tensor<i32>, tensor<12x4xf32>, tensor<12x4xf32>
+// FORWARD-NEXT:     }
+// FORWARD-NEXT:     return %4#1, %4#2 : tensor<12x4xf32>, tensor<12x4xf32>
 // FORWARD-NEXT:   }
-// FORWARD-NEXT:   return %4#1, %4#2 : tensor<12x4xf32>, tensor<12x4xf32>
 // FORWARD-NEXT: }
 
-// REVERSE: func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x4xf32>) -> tensor<12x16x4xf32> {
-// REVERSE-NEXT:   %c = stablehlo.constant dense<14> : tensor<i64>
-// REVERSE-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<12x16x4xf32>
-// REVERSE-NEXT:   %c_0 = stablehlo.constant dense<1> : tensor<i64>
-// REVERSE-NEXT:   %c_1 = stablehlo.constant dense<15> : tensor<i64>
-// REVERSE-NEXT:   %c_2 = stablehlo.constant dense<0> : tensor<i64>
-// REVERSE-NEXT:   %c_3 = stablehlo.constant dense<1> : tensor<i32>
-// REVERSE-NEXT:   %c_4 = stablehlo.constant dense<0> : tensor<i32>
-// REVERSE-NEXT:   %cst_5 = stablehlo.constant dense<0.000000e+00> : tensor<12x4xf32>
-// REVERSE-NEXT:   %0:3 = stablehlo.while(%iterArg = %c_2, %iterArg_6 = %cst, %iterArg_7 = %c) : tensor<i64>, tensor<12x16x4xf32>, tensor<i64>
-// REVERSE-NEXT:   cond {
-// REVERSE-NEXT:     %1 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// REVERSE-NEXT:     stablehlo.return %1 : tensor<i1>
-// REVERSE-NEXT:   } do {
-// REVERSE-NEXT:     %1 = stablehlo.compare EQ, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// REVERSE-NEXT:     %2 = stablehlo.select %1, %arg1, %cst_5 : tensor<i1>, tensor<12x4xf32>
-// REVERSE-NEXT:     %3 = stablehlo.convert %iterArg_7 : (tensor<i64>) -> tensor<i32>
-// REVERSE-NEXT:     %4 = stablehlo.add %c_3, %3 {enzymexla.bounds = {{.*}}} : tensor<i32>
-// REVERSE-NEXT:     %5 = stablehlo.add %iterArg, %c_0 {enzymexla.bounds = {{.*}}} : tensor<i64>
-// REVERSE-NEXT:     %6 = stablehlo.reshape %2 : (tensor<12x4xf32>) -> tensor<12x1x4xf32>
-// REVERSE-NEXT:     %7 = stablehlo.dynamic_update_slice %cst, %6, %c_4, %4, %c_4 : (tensor<12x16x4xf32>, tensor<12x1x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x16x4xf32>
-// REVERSE-NEXT:     %8 = stablehlo.add %iterArg_6, %7 : tensor<12x16x4xf32>
-// REVERSE-NEXT:     %9 = stablehlo.subtract %iterArg_7, %c_0 : tensor<i64>
-// REVERSE-NEXT:     stablehlo.return %5, %8, %9 : tensor<i64>, tensor<12x16x4xf32>, tensor<i64>
+// REVERSE: module {
+// REVERSE-NEXT:   func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x4xf32>) -> tensor<12x16x4xf32> {
+// REVERSE-NEXT:     %c = stablehlo.constant dense<14> : tensor<i64>
+// REVERSE-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<12x16x4xf32>
+// REVERSE-NEXT:     %c_0 = stablehlo.constant dense<1> : tensor<i64>
+// REVERSE-NEXT:     %c_1 = stablehlo.constant dense<15> : tensor<i64>
+// REVERSE-NEXT:     %c_2 = stablehlo.constant dense<0> : tensor<i64>
+// REVERSE-NEXT:     %c_3 = stablehlo.constant dense<1> : tensor<i32>
+// REVERSE-NEXT:     %c_4 = stablehlo.constant dense<0> : tensor<i32>
+// REVERSE-NEXT:     %cst_5 = stablehlo.constant dense<0.000000e+00> : tensor<12x4xf32>
+// REVERSE-NEXT:     %0:2 = stablehlo.while(%iterArg = %c_2, %iterArg_6 = %cst) : tensor<i64>, tensor<12x16x4xf32>
+// REVERSE-NEXT:     cond {
+// REVERSE-NEXT:       %1 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       stablehlo.return %1 : tensor<i1>
+// REVERSE-NEXT:     } do {
+// REVERSE-NEXT:       %1 = stablehlo.compare EQ, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       %2 = stablehlo.select %1, %arg1, %cst_5 : tensor<i1>, tensor<12x4xf32>
+// REVERSE-NEXT:       %3 = stablehlo.subtract %c, %iterArg {enzymexla.bounds = {{\[\[}}0, 14]]} : tensor<i64>
+// REVERSE-NEXT:       %4 = stablehlo.convert %3 {enzymexla.bounds = {{\[\[}}0, 14]]} : (tensor<i64>) -> tensor<i32>
+// REVERSE-NEXT:       %5 = stablehlo.add %c_3, %4 {enzymexla.bounds = {{\[\[}}1, 15]]} : tensor<i32>
+// REVERSE-NEXT:       %6 = stablehlo.add %iterArg, %c_0 {enzymexla.bounds = {{\[\[}}1, 15]]} : tensor<i64>
+// REVERSE-NEXT:       %7 = stablehlo.reshape %2 : (tensor<12x4xf32>) -> tensor<12x1x4xf32>
+// REVERSE-NEXT:       %8 = stablehlo.dynamic_update_slice %cst, %7, %c_4, %5, %c_4 : (tensor<12x16x4xf32>, tensor<12x1x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x16x4xf32>
+// REVERSE-NEXT:       %9 = stablehlo.add %iterArg_6, %8 : tensor<12x16x4xf32>
+// REVERSE-NEXT:       stablehlo.return %6, %9 : tensor<i64>, tensor<12x16x4xf32>
+// REVERSE-NEXT:     }
+// REVERSE-NEXT:     return %0#1 : tensor<12x16x4xf32>
 // REVERSE-NEXT:   }
-// REVERSE-NEXT:   return %0#1 : tensor<12x16x4xf32>
 // REVERSE-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing.mlir
@@ -73,77 +73,160 @@ module {
   }
 }
 
-// CHECK:  func.func private @diffewith_checkpointing(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
-// CHECK-NEXT:    %[[zero3:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
-// CHECK-NEXT:    %[[c2:.+]] = stablehlo.constant dense<2> : tensor<i64>
-// CHECK-NEXT:    %[[c3:.+]] = stablehlo.constant dense<3> : tensor<i64>
-// CHECK-NEXT:    %[[c0:.+]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %[[c1:.+]] = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %[[zero:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK-NEXT:    %[[fwdOuter:.+]]:3 = stablehlo.while(%iterArg = %[[c0]], %iterArg_4 = %arg0, %iterArg_5 = %[[zero3]]) : tensor<i64>, tensor<f64>, tensor<3xf64>
+// CHECK: module {
+// CHECK-NEXT:   func.func @without_checkpointing(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<9> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %0:2 = stablehlo.while(%iterArg = %c_1, %iterArg_2 = %arg0) : tensor<i64>, tensor<f64> attributes {enzyme.disable_mincut}
 // CHECK-NEXT:     cond {
-// CHECK-NEXT:      %2 = stablehlo.compare  LT, %iterArg, %[[c3]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %2 = stablehlo.reshape %iterArg_4 : (tensor<f64>) -> tensor<1xf64>
-// CHECK-NEXT:      %3 = stablehlo.dynamic_update_slice %iterArg_5, %2, %iterArg : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
-// CHECK-NEXT:      %4 = stablehlo.multiply %iterArg, %c_0 : tensor<i64>
-// CHECK-NEXT:      %[[fwdInner:.+]]:2 = stablehlo.while(%iterArg_6 = %c_1, %iterArg_7 = %iterArg_4) : tensor<i64>, tensor<f64>
-// CHECK-NEXT:       cond {
-// CHECK-NEXT:        %7 = stablehlo.compare  LT, %iterArg_6, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %7 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %7 = stablehlo.add %iterArg_6, %4 : tensor<i64>
-// CHECK-NEXT:        %8 = stablehlo.add %7, %c_2 : tensor<i64>
-// CHECK-NEXT:        %9 = stablehlo.convert %8 : (tensor<i64>) -> tensor<f64>
-// CHECK-NEXT:        %10 = stablehlo.multiply %iterArg_7, %9 : tensor<f64>
-// CHECK-NEXT:        %11 = stablehlo.add %iterArg_6, %c_2 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %11, %10 : tensor<i64>, tensor<f64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %6 = stablehlo.add %iterArg, %c_2 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %6, %[[fwdInner]]#1, %3 : tensor<i64>, tensor<f64>, tensor<3xf64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %[[bwdOuter:.+]]:5 = stablehlo.while(%iterArg = %[[c0]], %iterArg_4 = %arg1, %iterArg_5 = %[[zero]], %iterArg_6 = %[[zero]], %iterArg_7 = %c) : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:       %1 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %1 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %1 = stablehlo.add %iterArg, %c : tensor<i64>
+// CHECK-NEXT:       %2 = stablehlo.convert %1 : (tensor<i64>) -> tensor<f64>
+// CHECK-NEXT:       %3 = stablehlo.multiply %iterArg_2, %2 : tensor<f64>
+// CHECK-NEXT:       stablehlo.return %1, %3 : tensor<i64>, tensor<f64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#1 : tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func @with_checkpointing(%arg0: tensor<f64>) -> tensor<f64> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<9> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %0:2 = stablehlo.while(%iterArg = %c_1, %iterArg_2 = %arg0) : tensor<i64>, tensor<f64> attributes {enzyme.disable_mincut, enzymexla.enable_checkpointing = true}
 // CHECK-NEXT:     cond {
-// CHECK-NEXT:      %[[cmp:.+]] = stablehlo.compare  LT, %iterArg, %[[c3]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %[[cmp]] : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %2 = stablehlo.dynamic_slice %0#2, %iterArg_7, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
-// CHECK-NEXT:      %3 = stablehlo.reshape %2 : (tensor<1xf64>) -> tensor<f64>
-// CHECK-NEXT:      %4 = stablehlo.subtract %c, %iterArg : tensor<i64>
-// CHECK-NEXT:      %5 = stablehlo.multiply %c_0, %4 : tensor<i64>
-// CHECK-NEXT:      %6:3 = stablehlo.while(%iterArg_8 = %c_1, %iterArg_9 = %3, %iterArg_10 = %cst) : tensor<i64>, tensor<f64>, tensor<3xf64>
+// CHECK-NEXT:       %1 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %1 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %1 = stablehlo.add %iterArg, %c : tensor<i64>
+// CHECK-NEXT:       %2 = stablehlo.convert %1 : (tensor<i64>) -> tensor<f64>
+// CHECK-NEXT:       %3 = stablehlo.multiply %iterArg_2, %2 : tensor<f64>
+// CHECK-NEXT:       stablehlo.return %1, %3 : tensor<i64>, tensor<f64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#1 : tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func @with_checkpointing_diff(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+// CHECK-NEXT:     %0:2 = call @diffewith_checkpointing(%arg0, %arg1) : (tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+// CHECK-NEXT:     return %0#0, %0#1 : tensor<f64>, tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func @without_checkpointing_diff(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+// CHECK-NEXT:     %0:2 = call @diffewithout_checkpointing(%arg0, %arg1) : (tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+// CHECK-NEXT:     return %0#0, %0#1 : tensor<f64>, tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func @main() {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.0000001000000001> : tensor<f64>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0:2 = call @diffewith_checkpointing(%cst, %cst_0) : (tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+// CHECK-NEXT:     %1:2 = call @diffewithout_checkpointing(%cst, %cst_0) : (tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+// CHECK-NEXT:     check.expect_almost_eq %0#0, %1#0 : tensor<f64>
+// CHECK-NEXT:     check.expect_almost_eq %0#1, %1#1 : tensor<f64>
+// CHECK-NEXT:     return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @diffewith_checkpointing(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
+// CHECK-NEXT:     %c = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<3> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %cst_3 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0:3 = stablehlo.while(%iterArg = %c_1, %iterArg_4 = %arg0, %iterArg_5 = %cst) : tensor<i64>, tensor<f64>, tensor<3xf64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.reshape %iterArg_4 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:       %3 = stablehlo.dynamic_update_slice %iterArg_5, %2, %iterArg : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
+// CHECK-NEXT:       %4 = stablehlo.multiply %iterArg, %c_0 : tensor<i64>
+// CHECK-NEXT:       %5:2 = stablehlo.while(%iterArg_6 = %c_1, %iterArg_7 = %iterArg_4) : tensor<i64>, tensor<f64>
 // CHECK-NEXT:       cond {
-// CHECK-NEXT:        %10 = stablehlo.compare  LT, %iterArg_8, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %10 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %[[add:.+]] = stablehlo.add %5, %iterArg_8 : tensor<i64>
-// CHECK-NEXT:        %[[mul:.+]] = stablehlo.multiply %c_2, %[[add]] : tensor<i64>
-// CHECK-NEXT:        %[[add2:.+]] = stablehlo.add %[[mul]], %c_2 : tensor<i64>
-// CHECK-NEXT:        %[[conv:.+]] = stablehlo.convert %[[add2]] : (tensor<i64>) -> tensor<f64>
-// CHECK-NEXT:        %[[reshape:.+]] = stablehlo.reshape %[[conv]] : (tensor<f64>) -> tensor<1xf64>
-// CHECK-NEXT:        %[[dus:.+]] = stablehlo.dynamic_update_slice %iterArg_10, %[[reshape]], %iterArg_8 : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
-// CHECK-NEXT:        %[[mul2:.+]] = stablehlo.multiply %iterArg_9, %[[conv]] : tensor<f64>
-// CHECK-NEXT:        %[[ivnext:.+]] = stablehlo.add %iterArg_8, %c_2 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %[[ivnext]], %[[mul2]], %[[dus]] : tensor<i64>, tensor<f64>, tensor<3xf64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %7:5 = stablehlo.while(%iterArg_8 = %c_1, %iterArg_9 = %iterArg_4, %iterArg_10 = %iterArg_5, %iterArg_11 = %iterArg_6, %iterArg_12 = %c) : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>
+// CHECK-NEXT:         %7 = stablehlo.compare LT, %iterArg_6, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %7 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %7 = stablehlo.add %iterArg_6, %4 : tensor<i64>
+// CHECK-NEXT:         %8 = stablehlo.add %7, %c_2 : tensor<i64>
+// CHECK-NEXT:         %9 = stablehlo.convert %8 : (tensor<i64>) -> tensor<f64>
+// CHECK-NEXT:         %10 = stablehlo.multiply %iterArg_7, %9 : tensor<f64>
+// CHECK-NEXT:         %11 = stablehlo.add %iterArg_6, %c_2 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %11, %10 : tensor<i64>, tensor<f64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %6 = stablehlo.add %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %6, %5#1, %3 : tensor<i64>, tensor<f64>, tensor<3xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1:4 = stablehlo.while(%iterArg = %c_1, %iterArg_4 = %arg1, %iterArg_5 = %cst_3, %iterArg_6 = %cst_3) : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.dynamic_slice %0#2, %2, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:       %4 = stablehlo.reshape %3 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %5 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %6 = stablehlo.multiply %c_0, %5 : tensor<i64>
+// CHECK-NEXT:       %7:3 = stablehlo.while(%iterArg_7 = %c_1, %iterArg_8 = %4, %iterArg_9 = %cst) : tensor<i64>, tensor<f64>, tensor<3xf64>
 // CHECK-NEXT:       cond {
-// CHECK-NEXT:        %10 = stablehlo.compare  LT, %iterArg_8, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %10 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %10 = stablehlo.add %iterArg_10, %iterArg_9 : tensor<f64>
-// CHECK-NEXT:        %11 = stablehlo.dynamic_slice %6#2, %iterArg_12, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
-// CHECK-NEXT:        %12 = stablehlo.reshape %11 : (tensor<1xf64>) -> tensor<f64>
-// CHECK-NEXT:        %13 = stablehlo.multiply %10, %12 : tensor<f64>
-// CHECK-NEXT:        %14 = stablehlo.add %iterArg_11, %13 : tensor<f64>
-// CHECK-NEXT:        %15 = stablehlo.add %iterArg_8, %c_2 : tensor<i64>
-// CHECK-NEXT:        %16 = stablehlo.subtract %iterArg_12, %c_2 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %15, %14, %cst_3, %cst_3, %16 : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %8 = stablehlo.add %iterArg, %c_2 : tensor<i64>
-// CHECK-NEXT:      %9 = stablehlo.subtract %iterArg_7, %c_2 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %8, %7#1, %7#2, %7#3, %9 : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<i64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    return %[[fwdOuter]]#1, %[[bwdOuter]]#1 : tensor<f64>, tensor<f64>
-// CHECK-NEXT:  }
+// CHECK-NEXT:         %10 = stablehlo.compare LT, %iterArg_7, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %10 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %10 = stablehlo.add %6, %iterArg_7 : tensor<i64>
+// CHECK-NEXT:         %11 = stablehlo.multiply %c_2, %10 : tensor<i64>
+// CHECK-NEXT:         %12 = stablehlo.add %11, %c_2 : tensor<i64>
+// CHECK-NEXT:         %13 = stablehlo.convert %12 : (tensor<i64>) -> tensor<f64>
+// CHECK-NEXT:         %14 = stablehlo.reshape %13 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:         %15 = stablehlo.dynamic_update_slice %iterArg_9, %14, %iterArg_7 : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
+// CHECK-NEXT:         %16 = stablehlo.multiply %iterArg_8, %13 : tensor<f64>
+// CHECK-NEXT:         %17 = stablehlo.add %iterArg_7, %c_2 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %17, %16, %15 : tensor<i64>, tensor<f64>, tensor<3xf64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %8:4 = stablehlo.while(%iterArg_7 = %c_1, %iterArg_8 = %iterArg_4, %iterArg_9 = %iterArg_5, %iterArg_10 = %iterArg_6) : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %10 = stablehlo.compare LT, %iterArg_7, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %10 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %10 = stablehlo.subtract %c, %iterArg_7 : tensor<i64>
+// CHECK-NEXT:         %11 = stablehlo.add %iterArg_9, %iterArg_8 : tensor<f64>
+// CHECK-NEXT:         %12 = stablehlo.dynamic_slice %7#2, %10, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:         %13 = stablehlo.reshape %12 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:         %14 = stablehlo.multiply %11, %13 : tensor<f64>
+// CHECK-NEXT:         %15 = stablehlo.add %iterArg_10, %14 : tensor<f64>
+// CHECK-NEXT:         %16 = stablehlo.add %iterArg_7, %c_2 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %16, %15, %cst_3, %cst_3 : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %9 = stablehlo.add %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %9, %8#1, %8#2, %8#3 : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#1, %1#1 : tensor<f64>, tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @diffewithout_checkpointing(%arg0: tensor<f64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+// CHECK-NEXT:     %c = stablehlo.constant dense<8> : tensor<i64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<9xf64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<9> : tensor<i64>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %0:3 = stablehlo.while(%iterArg = %c_0, %iterArg_3 = %arg0, %iterArg_4 = %cst) : tensor<i64>, tensor<f64>, tensor<9xf64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.add %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.convert %2 : (tensor<i64>) -> tensor<f64>
+// CHECK-NEXT:       %4 = stablehlo.reshape %3 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:       %5 = stablehlo.dynamic_update_slice %iterArg_4, %4, %iterArg : (tensor<9xf64>, tensor<1xf64>, tensor<i64>) -> tensor<9xf64>
+// CHECK-NEXT:       %6 = stablehlo.multiply %iterArg_3, %3 : tensor<f64>
+// CHECK-NEXT:       stablehlo.return %2, %6, %5 : tensor<i64>, tensor<f64>, tensor<9xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1:2 = stablehlo.while(%iterArg = %c_0, %iterArg_3 = %arg1) : tensor<i64>, tensor<f64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.add %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:       %4 = stablehlo.dynamic_slice %0#2, %2, sizes = [1] : (tensor<9xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:       %5 = stablehlo.reshape %4 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %6 = stablehlo.multiply %iterArg_3, %5 : tensor<f64>
+// CHECK-NEXT:       stablehlo.return %3, %6 : tensor<i64>, tensor<f64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#1, %1#1 : tensor<f64>, tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing3.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing3.mlir
@@ -32,80 +32,107 @@ module {
   }
 }
 
-// CHECK:  func.func private @diffef(%arg0: tensor<31xf64>, %arg1: tensor<f64>) -> tensor<31xf64> {
-// CHECK-NEXT:    %c = stablehlo.constant dense<3> : tensor<i64>
-// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<4x31xf64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<4x31xi64>
-// CHECK-NEXT:    %c_1 = stablehlo.constant dense<4> : tensor<i64>
-// CHECK-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %c_4 = stablehlo.constant dense<2> : tensor<31xi64>
-// CHECK-NEXT:    %cst_5 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK-NEXT:    %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<31xf64>
-// CHECK-NEXT:    %0:5 = stablehlo.while(%iterArg = %c_3, %iterArg_7 = %c_4, %iterArg_8 = %arg0, %iterArg_9 = %c_0, %iterArg_10 = %cst) : tensor<i64>, tensor<31xi64>, tensor<31xf64>, tensor<4x31xi64>, tensor<4x31xf64>
+// CHECK: module {
+// CHECK-NEXT:   func.func private @f(%arg0: tensor<31xf64>) -> tensor<f64> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<2> : tensor<31xi64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<16> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %0:3 = stablehlo.while(%iterArg = %c_1, %iterArg_3 = %c, %iterArg_4 = %arg0) : tensor<i64>, tensor<31xi64>, tensor<31xf64> attributes {enzyme.disable_mincut, enzymexla.enable_checkpointing = true}
 // CHECK-NEXT:     cond {
-// CHECK-NEXT:      %4 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %4 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %4 = stablehlo.reshape %iterArg_8 : (tensor<31xf64>) -> tensor<1x31xf64>
-// CHECK-NEXT:      %5 = stablehlo.dynamic_update_slice %iterArg_10, %4, %iterArg, %c_3 : (tensor<4x31xf64>, tensor<1x31xf64>, tensor<i64>, tensor<i64>) -> tensor<4x31xf64>
-// CHECK-NEXT:      %6 = stablehlo.reshape %iterArg_7 : (tensor<31xi64>) -> tensor<1x31xi64>
-// CHECK-NEXT:      %7 = stablehlo.dynamic_update_slice %iterArg_9, %6, %iterArg, %c_3 : (tensor<4x31xi64>, tensor<1x31xi64>, tensor<i64>, tensor<i64>) -> tensor<4x31xi64>
-// CHECK-NEXT:      %8:3 = stablehlo.while(%iterArg_11 = %c_3, %iterArg_12 = %iterArg_7, %iterArg_13 = %iterArg_8) : tensor<i64>, tensor<31xi64>, tensor<31xf64>
-// CHECK-NEXT:       cond {
-// CHECK-NEXT:        %10 = stablehlo.compare  LT, %iterArg_11, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %10 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %10 = stablehlo.multiply %iterArg_12, %iterArg_12 : tensor<31xi64>
-// CHECK-NEXT:        %11 = stablehlo.convert %10 : (tensor<31xi64>) -> tensor<31xf64>
-// CHECK-NEXT:        %12 = stablehlo.multiply %iterArg_13, %11 : tensor<31xf64>
-// CHECK-NEXT:        %13 = stablehlo.add %iterArg_11, %c_2 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %13, %10, %12 : tensor<i64>, tensor<31xi64>, tensor<31xf64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %9 = stablehlo.add %iterArg, %c_2 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %9, %8#1, %8#2, %7, %5 : tensor<i64>, tensor<31xi64>, tensor<31xf64>, tensor<4x31xi64>, tensor<4x31xf64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %1 = stablehlo.reshape %arg1 : (tensor<f64>) -> tensor<1xf64>
-// CHECK-NEXT:    %2 = stablehlo.pad %1, %cst_5, low = [8], high = [22], interior = [0] : (tensor<1xf64>, tensor<f64>) -> tensor<31xf64>
-// CHECK-NEXT:    %3:5 = stablehlo.while(%iterArg = %c_3, %iterArg_7 = %2, %iterArg_8 = %cst_6, %iterArg_9 = %cst_6, %iterArg_10 = %c) : tensor<i64>, tensor<31xf64>, tensor<31xf64>, tensor<31xf64>, tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %3 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %3 = stablehlo.add %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:       %4 = stablehlo.multiply %iterArg_3, %iterArg_3 : tensor<31xi64>
+// CHECK-NEXT:       %5 = stablehlo.convert %4 : (tensor<31xi64>) -> tensor<31xf64>
+// CHECK-NEXT:       %6 = stablehlo.multiply %iterArg_4, %5 : tensor<31xf64>
+// CHECK-NEXT:       stablehlo.return %3, %4, %6 : tensor<i64>, tensor<31xi64>, tensor<31xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1 = stablehlo.slice %0#2 [8:9] : (tensor<31xf64>) -> tensor<1xf64>
+// CHECK-NEXT:     %2 = stablehlo.reshape %1 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:     return %2 : tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func @df(%arg0: tensor<31xf64>) -> tensor<31xf64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0 = call @diffef(%arg0, %cst) : (tensor<31xf64>, tensor<f64>) -> tensor<31xf64>
+// CHECK-NEXT:     return %0 : tensor<31xf64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @diffef(%arg0: tensor<31xf64>, %arg1: tensor<f64>) -> tensor<31xf64> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<3> : tensor<i64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<4x31xf64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<0> : tensor<4x31xi64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<4> : tensor<i64>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %c_3 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_4 = stablehlo.constant dense<2> : tensor<31xi64>
+// CHECK-NEXT:     %cst_5 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<31xf64>
+// CHECK-NEXT:     %0:5 = stablehlo.while(%iterArg = %c_3, %iterArg_7 = %c_4, %iterArg_8 = %arg0, %iterArg_9 = %c_0, %iterArg_10 = %cst) : tensor<i64>, tensor<31xi64>, tensor<31xf64>, tensor<4x31xi64>, tensor<4x31xf64>
 // CHECK-NEXT:     cond {
-// CHECK-NEXT:      %4 = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %4 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %[[a6:.+]] = stablehlo.dynamic_slice %0#3, %iterArg_10, %c_3, sizes = [1, 31] : (tensor<4x31xi64>, tensor<i64>, tensor<i64>) -> tensor<1x31xi64>
-// CHECK-NEXT:      %[[a7:.+]] = stablehlo.reshape %[[a6]] : (tensor<1x31xi64>) -> tensor<31xi64>
-// CHECK-NEXT:      %[[a4:.+]] = stablehlo.dynamic_slice %0#4, %iterArg_10, %c_3, sizes = [1, 31] : (tensor<4x31xf64>, tensor<i64>, tensor<i64>) -> tensor<1x31xf64>
-// CHECK-NEXT:      %[[a5:.+]] = stablehlo.reshape %[[a4]] : (tensor<1x31xf64>) -> tensor<31xf64>
-// CHECK-NEXT:      %8:4 = stablehlo.while(%iterArg_11 = %c_3, %iterArg_12 = %[[a7]], %iterArg_13 = %[[a5]], %iterArg_14 = %cst) : tensor<i64>, tensor<31xi64>, tensor<31xf64>, tensor<4x31xf64>
+// CHECK-NEXT:       %4 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %4 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %4 = stablehlo.reshape %iterArg_8 : (tensor<31xf64>) -> tensor<1x31xf64>
+// CHECK-NEXT:       %5 = stablehlo.dynamic_update_slice %iterArg_10, %4, %iterArg, %c_3 : (tensor<4x31xf64>, tensor<1x31xf64>, tensor<i64>, tensor<i64>) -> tensor<4x31xf64>
+// CHECK-NEXT:       %6 = stablehlo.reshape %iterArg_7 : (tensor<31xi64>) -> tensor<1x31xi64>
+// CHECK-NEXT:       %7 = stablehlo.dynamic_update_slice %iterArg_9, %6, %iterArg, %c_3 : (tensor<4x31xi64>, tensor<1x31xi64>, tensor<i64>, tensor<i64>) -> tensor<4x31xi64>
+// CHECK-NEXT:       %8:3 = stablehlo.while(%iterArg_11 = %c_3, %iterArg_12 = %iterArg_7, %iterArg_13 = %iterArg_8) : tensor<i64>, tensor<31xi64>, tensor<31xf64>
 // CHECK-NEXT:       cond {
-// CHECK-NEXT:        %12 = stablehlo.compare  LT, %iterArg_11, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %12 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %12 = stablehlo.multiply %iterArg_12, %iterArg_12 : tensor<31xi64>
-// CHECK-NEXT:        %13 = stablehlo.convert %12 : (tensor<31xi64>) -> tensor<31xf64>
-// CHECK-NEXT:        %14 = stablehlo.reshape %13 : (tensor<31xf64>) -> tensor<1x31xf64>
-// CHECK-NEXT:        %15 = stablehlo.dynamic_update_slice %iterArg_14, %14, %iterArg_11, %c_3 : (tensor<4x31xf64>, tensor<1x31xf64>, tensor<i64>, tensor<i64>) -> tensor<4x31xf64>
-// CHECK-NEXT:        %16 = stablehlo.multiply %iterArg_13, %13 : tensor<31xf64>
-// CHECK-NEXT:        %17 = stablehlo.add %iterArg_11, %c_2 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %17, %12, %16, %15 : tensor<i64>, tensor<31xi64>, tensor<31xf64>, tensor<4x31xf64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %9:5 = stablehlo.while(%iterArg_11 = %c_3, %iterArg_12 = %iterArg_7, %iterArg_13 = %iterArg_8, %iterArg_14 = %iterArg_9, %iterArg_15 = %c) : tensor<i64>, tensor<31xf64>, tensor<31xf64>, tensor<31xf64>, tensor<i64>
+// CHECK-NEXT:         %10 = stablehlo.compare LT, %iterArg_11, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %10 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %10 = stablehlo.multiply %iterArg_12, %iterArg_12 : tensor<31xi64>
+// CHECK-NEXT:         %11 = stablehlo.convert %10 : (tensor<31xi64>) -> tensor<31xf64>
+// CHECK-NEXT:         %12 = stablehlo.multiply %iterArg_13, %11 : tensor<31xf64>
+// CHECK-NEXT:         %13 = stablehlo.add %iterArg_11, %c_2 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %13, %10, %12 : tensor<i64>, tensor<31xi64>, tensor<31xf64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %9 = stablehlo.add %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %9, %8#1, %8#2, %7, %5 : tensor<i64>, tensor<31xi64>, tensor<31xf64>, tensor<4x31xi64>, tensor<4x31xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1 = stablehlo.reshape %arg1 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:     %2 = stablehlo.pad %1, %cst_5, low = [8], high = [22], interior = [0] : (tensor<1xf64>, tensor<f64>) -> tensor<31xf64>
+// CHECK-NEXT:     %3:4 = stablehlo.while(%iterArg = %c_3, %iterArg_7 = %2, %iterArg_8 = %cst_6, %iterArg_9 = %cst_6) : tensor<i64>, tensor<31xf64>, tensor<31xf64>, tensor<31xf64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %4 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %4 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %4 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %5 = stablehlo.dynamic_slice %0#3, %4, %c_3, sizes = [1, 31] : (tensor<4x31xi64>, tensor<i64>, tensor<i64>) -> tensor<1x31xi64>
+// CHECK-NEXT:       %6 = stablehlo.reshape %5 : (tensor<1x31xi64>) -> tensor<31xi64>
+// CHECK-NEXT:       %7 = stablehlo.dynamic_slice %0#4, %4, %c_3, sizes = [1, 31] : (tensor<4x31xf64>, tensor<i64>, tensor<i64>) -> tensor<1x31xf64>
+// CHECK-NEXT:       %8 = stablehlo.reshape %7 : (tensor<1x31xf64>) -> tensor<31xf64>
+// CHECK-NEXT:       %9:4 = stablehlo.while(%iterArg_10 = %c_3, %iterArg_11 = %6, %iterArg_12 = %8, %iterArg_13 = %cst) : tensor<i64>, tensor<31xi64>, tensor<31xf64>, tensor<4x31xf64>
 // CHECK-NEXT:       cond {
-// CHECK-NEXT:        %12 = stablehlo.compare  LT, %iterArg_11, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %12 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %12 = stablehlo.add %iterArg_13, %iterArg_12 : tensor<31xf64>
-// CHECK-NEXT:        %13 = stablehlo.dynamic_slice %8#3, %iterArg_15, %c_3, sizes = [1, 31] : (tensor<4x31xf64>, tensor<i64>, tensor<i64>) -> tensor<1x31xf64>
-// CHECK-NEXT:        %14 = stablehlo.reshape %13 : (tensor<1x31xf64>) -> tensor<31xf64>
-// CHECK-NEXT:        %15 = stablehlo.multiply %12, %14 : tensor<31xf64>
-// CHECK-NEXT:        %16 = stablehlo.add %iterArg_14, %15 : tensor<31xf64>
-// CHECK-NEXT:        %17 = stablehlo.add %iterArg_11, %c_2 : tensor<i64>
-// CHECK-NEXT:        %18 = stablehlo.subtract %iterArg_15, %c_2 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %17, %16, %cst_6, %cst_6, %18 : tensor<i64>, tensor<31xf64>, tensor<31xf64>, tensor<31xf64>, tensor<i64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %10 = stablehlo.add %iterArg, %c_2 : tensor<i64>
-// CHECK-NEXT:      %11 = stablehlo.subtract %iterArg_10, %c_2 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %10, %9#1, %9#2, %9#3, %11 : tensor<i64>, tensor<31xf64>, tensor<31xf64>, tensor<31xf64>, tensor<i64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    return %3#1 : tensor<31xf64>
-// CHECK-NEXT:  }
+// CHECK-NEXT:         %12 = stablehlo.compare LT, %iterArg_10, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %12 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %12 = stablehlo.multiply %iterArg_11, %iterArg_11 : tensor<31xi64>
+// CHECK-NEXT:         %13 = stablehlo.convert %12 : (tensor<31xi64>) -> tensor<31xf64>
+// CHECK-NEXT:         %14 = stablehlo.reshape %13 : (tensor<31xf64>) -> tensor<1x31xf64>
+// CHECK-NEXT:         %15 = stablehlo.dynamic_update_slice %iterArg_13, %14, %iterArg_10, %c_3 : (tensor<4x31xf64>, tensor<1x31xf64>, tensor<i64>, tensor<i64>) -> tensor<4x31xf64>
+// CHECK-NEXT:         %16 = stablehlo.multiply %iterArg_12, %13 : tensor<31xf64>
+// CHECK-NEXT:         %17 = stablehlo.add %iterArg_10, %c_2 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %17, %12, %16, %15 : tensor<i64>, tensor<31xi64>, tensor<31xf64>, tensor<4x31xf64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %10:4 = stablehlo.while(%iterArg_10 = %c_3, %iterArg_11 = %iterArg_7, %iterArg_12 = %iterArg_8, %iterArg_13 = %iterArg_9) : tensor<i64>, tensor<31xf64>, tensor<31xf64>, tensor<31xf64>
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %12 = stablehlo.compare LT, %iterArg_10, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %12 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %12 = stablehlo.subtract %c, %iterArg_10 : tensor<i64>
+// CHECK-NEXT:         %13 = stablehlo.add %iterArg_12, %iterArg_11 : tensor<31xf64>
+// CHECK-NEXT:         %14 = stablehlo.dynamic_slice %9#3, %12, %c_3, sizes = [1, 31] : (tensor<4x31xf64>, tensor<i64>, tensor<i64>) -> tensor<1x31xf64>
+// CHECK-NEXT:         %15 = stablehlo.reshape %14 : (tensor<1x31xf64>) -> tensor<31xf64>
+// CHECK-NEXT:         %16 = stablehlo.multiply %13, %15 : tensor<31xf64>
+// CHECK-NEXT:         %17 = stablehlo.add %iterArg_13, %16 : tensor<31xf64>
+// CHECK-NEXT:         %18 = stablehlo.add %iterArg_10, %c_2 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %18, %17, %cst_6, %cst_6 : tensor<i64>, tensor<31xf64>, tensor<31xf64>, tensor<31xf64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %11 = stablehlo.add %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %11, %10#1, %10#2, %10#3 : tensor<i64>, tensor<31xf64>, tensor<31xf64>, tensor<31xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %3#1 : tensor<31xf64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing_iv_dependent.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing_iv_dependent.mlir
@@ -81,12 +81,225 @@ module {
   }
 }
 
-// CHECK-LABEL: func.func private @diffewith_checkpointing
 // The reverse sweep visits checkpoint blocks back to front, so the block's
 // first iteration is outerStart = nInner * (nOuter - 1 - iterArg).
-// CHECK:        %[[outerStep:.+]] = stablehlo.subtract %c, %iterArg : tensor<i64>
-// CHECK-NEXT:   %[[outerStart:.+]] = stablehlo.multiply %c_2, %[[outerStep]] : tensor<i64>
 // Within the block, the recompute sweep must count forward from outerStart.
-// CHECK:        } do {
-// CHECK-NEXT:     %[[iv:.+]] = stablehlo.add %[[outerStart]], %iterArg_18 : tensor<i64>
-// CHECK-NEXT:     %{{.+}} = stablehlo.multiply %c_7, %[[iv]] : tensor<i64>
+
+// CHECK: module {
+// CHECK-NEXT:   func.func private @without_checkpointing(%arg0: tensor<f64>, %arg1: tensor<12xf64>) -> tensor<f64> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<12> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst_2 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0:5 = stablehlo.while(%iterArg = %c_1, %iterArg_3 = %arg0, %iterArg_4 = %arg1, %iterArg_5 = %cst, %iterArg_6 = %cst_2) : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %1 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %1 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %1 = stablehlo.add %iterArg, %c : tensor<i64>
+// CHECK-NEXT:       %2 = stablehlo.multiply %iterArg_3, %iterArg_5 : tensor<f64>
+// CHECK-NEXT:       %3 = stablehlo.convert %iterArg : (tensor<i64>) -> tensor<i32>
+// CHECK-NEXT:       %4 = stablehlo.dynamic_slice %iterArg_4, %3, sizes = [1] : (tensor<12xf64>, tensor<i32>) -> tensor<1xf64>
+// CHECK-NEXT:       %5 = stablehlo.reshape %4 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %6 = stablehlo.multiply %5, %2 : tensor<f64>
+// CHECK-NEXT:       %7 = stablehlo.add %iterArg_6, %6 : tensor<f64>
+// CHECK-NEXT:       stablehlo.return %1, %iterArg_3, %iterArg_4, %2, %7 : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#4 : tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @with_checkpointing(%arg0: tensor<f64>, %arg1: tensor<12xf64>) -> tensor<f64> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<12> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst_2 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0:5 = stablehlo.while(%iterArg = %c_1, %iterArg_3 = %arg0, %iterArg_4 = %arg1, %iterArg_5 = %cst, %iterArg_6 = %cst_2) : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_period = 4 : i64, enzymexla.enable_checkpointing = true}
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %1 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %1 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %1 = stablehlo.add %iterArg, %c : tensor<i64>
+// CHECK-NEXT:       %2 = stablehlo.multiply %iterArg_3, %iterArg_5 : tensor<f64>
+// CHECK-NEXT:       %3 = stablehlo.convert %iterArg : (tensor<i64>) -> tensor<i32>
+// CHECK-NEXT:       %4 = stablehlo.dynamic_slice %iterArg_4, %3, sizes = [1] : (tensor<12xf64>, tensor<i32>) -> tensor<1xf64>
+// CHECK-NEXT:       %5 = stablehlo.reshape %4 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %6 = stablehlo.multiply %5, %2 : tensor<f64>
+// CHECK-NEXT:       %7 = stablehlo.add %iterArg_6, %6 : tensor<f64>
+// CHECK-NEXT:       stablehlo.return %1, %iterArg_3, %iterArg_4, %2, %7 : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#4 : tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func @main() {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<1.100000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<[1.000000e+00, -2.000000e+00, 3.000000e+00, 5.000000e-01, -1.500000e+00, 0.69999999999999996, 2.500000e+00, -3.000000e-01, 1.200000e+00, -8.000000e-01, 4.000000e-01, 2.000000e+00]> : tensor<12xf64>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %0:2 = call @diffewith_checkpointing(%cst, %cst_0, %cst_1) : (tensor<f64>, tensor<12xf64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+// CHECK-NEXT:     %1:2 = call @diffewithout_checkpointing(%cst, %cst_0, %cst_1) : (tensor<f64>, tensor<12xf64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+// CHECK-NEXT:     check.expect_almost_eq %0#0, %1#0 : tensor<f64>
+// CHECK-NEXT:     check.expect_almost_eq %0#1, %1#1 : tensor<f64>
+// CHECK-NEXT:     return
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @diffewith_checkpointing(%arg0: tensor<f64>, %arg1: tensor<12xf64>, %arg2: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<4xf64>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<3x12xf64>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
+// CHECK-NEXT:     %c = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<4> : tensor<i64>
+// CHECK-NEXT:     %c_3 = stablehlo.constant dense<3> : tensor<i64>
+// CHECK-NEXT:     %cst_4 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst_5 = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %c_6 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_7 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %0:9 = stablehlo.while(%iterArg = %c_6, %iterArg_8 = %arg0, %iterArg_9 = %arg1, %iterArg_10 = %cst_5, %iterArg_11 = %cst_4, %iterArg_12 = %cst_1, %iterArg_13 = %cst_0, %iterArg_14 = %cst_1, %iterArg_15 = %cst_1) : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>, tensor<3xf64>, tensor<3x12xf64>, tensor<3xf64>, tensor<3xf64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_3 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.reshape %iterArg_8 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:       %3 = stablehlo.dynamic_update_slice %iterArg_15, %2, %iterArg : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
+// CHECK-NEXT:       %4 = stablehlo.reshape %iterArg_10 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:       %5 = stablehlo.dynamic_update_slice %iterArg_14, %4, %iterArg : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
+// CHECK-NEXT:       %6 = stablehlo.reshape %iterArg_9 : (tensor<12xf64>) -> tensor<1x12xf64>
+// CHECK-NEXT:       %7 = stablehlo.dynamic_update_slice %iterArg_13, %6, %iterArg, %c_6 : (tensor<3x12xf64>, tensor<1x12xf64>, tensor<i64>, tensor<i64>) -> tensor<3x12xf64>
+// CHECK-NEXT:       %8 = stablehlo.reshape %iterArg_11 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:       %9 = stablehlo.dynamic_update_slice %iterArg_12, %8, %iterArg : (tensor<3xf64>, tensor<1xf64>, tensor<i64>) -> tensor<3xf64>
+// CHECK-NEXT:       %10 = stablehlo.multiply %iterArg, %c_2 : tensor<i64>
+// CHECK-NEXT:       %11:5 = stablehlo.while(%iterArg_16 = %c_6, %iterArg_17 = %iterArg_8, %iterArg_18 = %iterArg_9, %iterArg_19 = %iterArg_10, %iterArg_20 = %iterArg_11) : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %13 = stablehlo.compare LT, %iterArg_16, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %13 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %13 = stablehlo.add %iterArg_16, %10 : tensor<i64>
+// CHECK-NEXT:         %14 = stablehlo.multiply %iterArg_17, %iterArg_19 : tensor<f64>
+// CHECK-NEXT:         %15 = stablehlo.convert %13 : (tensor<i64>) -> tensor<i32>
+// CHECK-NEXT:         %16 = stablehlo.dynamic_slice %iterArg_18, %15, sizes = [1] : (tensor<12xf64>, tensor<i32>) -> tensor<1xf64>
+// CHECK-NEXT:         %17 = stablehlo.reshape %16 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:         %18 = stablehlo.multiply %17, %14 : tensor<f64>
+// CHECK-NEXT:         %19 = stablehlo.add %iterArg_20, %18 : tensor<f64>
+// CHECK-NEXT:         %20 = stablehlo.add %iterArg_16, %c_7 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %20, %iterArg_17, %iterArg_18, %14, %19 : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %12 = stablehlo.add %iterArg, %c_7 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %12, %11#1, %11#2, %11#3, %11#4, %9, %7, %5, %3 : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>, tensor<3xf64>, tensor<3x12xf64>, tensor<3xf64>, tensor<3xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1:10 = stablehlo.while(%iterArg = %c_6, %iterArg_8 = %cst_4, %iterArg_9 = %cst_4, %iterArg_10 = %arg2, %iterArg_11 = %cst_4, %iterArg_12 = %cst_4, %iterArg_13 = %cst_4, %iterArg_14 = %cst_4, %iterArg_15 = %cst_4, %iterArg_16 = %cst_4) : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_3 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.dynamic_slice %0#5, %2, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:       %4 = stablehlo.reshape %3 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %5 = stablehlo.dynamic_slice %0#6, %2, %c_6, sizes = [1, 12] : (tensor<3x12xf64>, tensor<i64>, tensor<i64>) -> tensor<1x12xf64>
+// CHECK-NEXT:       %6 = stablehlo.reshape %5 : (tensor<1x12xf64>) -> tensor<12xf64>
+// CHECK-NEXT:       %7 = stablehlo.dynamic_slice %0#7, %2, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:       %8 = stablehlo.reshape %7 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %9 = stablehlo.dynamic_slice %0#8, %2, sizes = [1] : (tensor<3xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:       %10 = stablehlo.reshape %9 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %11 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %12 = stablehlo.multiply %c_2, %11 : tensor<i64>
+// CHECK-NEXT:       %13:8 = stablehlo.while(%iterArg_17 = %c_6, %iterArg_18 = %10, %iterArg_19 = %6, %iterArg_20 = %8, %iterArg_21 = %4, %iterArg_22 = %cst, %iterArg_23 = %cst, %iterArg_24 = %cst) : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>, tensor<4xf64>, tensor<4xf64>, tensor<4xf64>
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %16 = stablehlo.compare LT, %iterArg_17, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %16 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %16 = stablehlo.add %12, %iterArg_17 : tensor<i64>
+// CHECK-NEXT:         %17 = stablehlo.multiply %c_7, %16 : tensor<i64>
+// CHECK-NEXT:         %18 = stablehlo.reshape %iterArg_18 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:         %19 = stablehlo.dynamic_update_slice %iterArg_22, %18, %iterArg_17 : (tensor<4xf64>, tensor<1xf64>, tensor<i64>) -> tensor<4xf64>
+// CHECK-NEXT:         %20 = stablehlo.reshape %iterArg_20 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:         %21 = stablehlo.dynamic_update_slice %iterArg_23, %20, %iterArg_17 : (tensor<4xf64>, tensor<1xf64>, tensor<i64>) -> tensor<4xf64>
+// CHECK-NEXT:         %22 = stablehlo.multiply %iterArg_18, %iterArg_20 : tensor<f64>
+// CHECK-NEXT:         %23 = stablehlo.convert %17 : (tensor<i64>) -> tensor<i32>
+// CHECK-NEXT:         %24 = stablehlo.dynamic_slice %iterArg_19, %23, sizes = [1] : (tensor<12xf64>, tensor<i32>) -> tensor<1xf64>
+// CHECK-NEXT:         %25 = stablehlo.reshape %24 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:         %26 = stablehlo.reshape %25 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:         %27 = stablehlo.dynamic_update_slice %iterArg_24, %26, %iterArg_17 : (tensor<4xf64>, tensor<1xf64>, tensor<i64>) -> tensor<4xf64>
+// CHECK-NEXT:         %28 = stablehlo.multiply %25, %22 : tensor<f64>
+// CHECK-NEXT:         %29 = stablehlo.add %iterArg_21, %28 : tensor<f64>
+// CHECK-NEXT:         %30 = stablehlo.add %iterArg_17, %c_7 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %30, %iterArg_18, %iterArg_19, %22, %29, %19, %21, %27 : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>, tensor<4xf64>, tensor<4xf64>, tensor<4xf64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %14:10 = stablehlo.while(%iterArg_17 = %c_6, %iterArg_18 = %iterArg_8, %iterArg_19 = %iterArg_9, %iterArg_20 = %iterArg_10, %iterArg_21 = %iterArg_11, %iterArg_22 = %iterArg_12, %iterArg_23 = %iterArg_13, %iterArg_24 = %iterArg_14, %iterArg_25 = %iterArg_15, %iterArg_26 = %iterArg_16) : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %16 = stablehlo.compare LT, %iterArg_17, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %16 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %16 = stablehlo.subtract %c_3, %iterArg_17 : tensor<i64>
+// CHECK-NEXT:         %17 = stablehlo.add %iterArg_21, %iterArg_18 : tensor<f64>
+// CHECK-NEXT:         %18 = stablehlo.add %iterArg_22, %iterArg_19 : tensor<f64>
+// CHECK-NEXT:         %19 = stablehlo.add %iterArg_23, %iterArg_20 : tensor<f64>
+// CHECK-NEXT:         %20 = stablehlo.add %iterArg_24, %19 : tensor<f64>
+// CHECK-NEXT:         %21 = stablehlo.add %iterArg_25, %19 : tensor<f64>
+// CHECK-NEXT:         %22 = stablehlo.dynamic_slice %13#7, %16, sizes = [1] : (tensor<4xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:         %23 = stablehlo.reshape %22 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:         %24 = stablehlo.multiply %21, %23 : tensor<f64>
+// CHECK-NEXT:         %25 = stablehlo.add %18, %24 : tensor<f64>
+// CHECK-NEXT:         %26 = stablehlo.dynamic_slice %13#5, %16, sizes = [1] : (tensor<4xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:         %27 = stablehlo.reshape %26 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:         %28 = stablehlo.dynamic_slice %13#6, %16, sizes = [1] : (tensor<4xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:         %29 = stablehlo.reshape %28 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:         %30 = stablehlo.multiply %25, %29 : tensor<f64>
+// CHECK-NEXT:         %31 = stablehlo.add %17, %30 : tensor<f64>
+// CHECK-NEXT:         %32 = stablehlo.multiply %25, %27 : tensor<f64>
+// CHECK-NEXT:         %33 = stablehlo.add %iterArg_26, %32 : tensor<f64>
+// CHECK-NEXT:         %34 = stablehlo.add %iterArg_17, %c_7 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %34, %31, %33, %20, %cst_4, %cst_4, %cst_4, %cst_4, %cst_4, %cst_4 : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %15 = stablehlo.add %iterArg, %c_7 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %15, %14#1, %14#2, %14#3, %14#4, %14#5, %14#6, %14#7, %14#8, %14#9 : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#4, %1#1 : tensor<f64>, tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @diffewithout_checkpointing(%arg0: tensor<f64>, %arg1: tensor<12xf64>, %arg2: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+// CHECK-NEXT:     %c = stablehlo.constant dense<11> : tensor<i64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<12xf64>
+// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_3 = stablehlo.constant dense<12> : tensor<i64>
+// CHECK-NEXT:     %c_4 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %0:8 = stablehlo.while(%iterArg = %c_2, %iterArg_5 = %arg0, %iterArg_6 = %arg1, %iterArg_7 = %cst_1, %iterArg_8 = %cst_0, %iterArg_9 = %cst, %iterArg_10 = %cst, %iterArg_11 = %cst) : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>, tensor<12xf64>, tensor<12xf64>, tensor<12xf64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_3 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.add %iterArg, %c_4 : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.reshape %iterArg_5 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:       %4 = stablehlo.dynamic_update_slice %iterArg_9, %3, %iterArg : (tensor<12xf64>, tensor<1xf64>, tensor<i64>) -> tensor<12xf64>
+// CHECK-NEXT:       %5 = stablehlo.reshape %iterArg_7 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:       %6 = stablehlo.dynamic_update_slice %iterArg_10, %5, %iterArg : (tensor<12xf64>, tensor<1xf64>, tensor<i64>) -> tensor<12xf64>
+// CHECK-NEXT:       %7 = stablehlo.multiply %iterArg_5, %iterArg_7 : tensor<f64>
+// CHECK-NEXT:       %8 = stablehlo.convert %iterArg : (tensor<i64>) -> tensor<i32>
+// CHECK-NEXT:       %9 = stablehlo.dynamic_slice %iterArg_6, %8, sizes = [1] : (tensor<12xf64>, tensor<i32>) -> tensor<1xf64>
+// CHECK-NEXT:       %10 = stablehlo.reshape %9 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %11 = stablehlo.reshape %10 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:       %12 = stablehlo.dynamic_update_slice %iterArg_11, %11, %iterArg : (tensor<12xf64>, tensor<1xf64>, tensor<i64>) -> tensor<12xf64>
+// CHECK-NEXT:       %13 = stablehlo.multiply %10, %7 : tensor<f64>
+// CHECK-NEXT:       %14 = stablehlo.add %iterArg_8, %13 : tensor<f64>
+// CHECK-NEXT:       stablehlo.return %2, %iterArg_5, %iterArg_6, %7, %14, %4, %6, %12 : tensor<i64>, tensor<f64>, tensor<12xf64>, tensor<f64>, tensor<f64>, tensor<12xf64>, tensor<12xf64>, tensor<12xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1:4 = stablehlo.while(%iterArg = %c_2, %iterArg_5 = %cst_0, %iterArg_6 = %cst_0, %iterArg_7 = %arg2) : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_3 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.add %iterArg, %c_4 : tensor<i64>
+// CHECK-NEXT:       %4 = stablehlo.dynamic_slice %0#7, %2, sizes = [1] : (tensor<12xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:       %5 = stablehlo.reshape %4 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %6 = stablehlo.multiply %iterArg_7, %5 : tensor<f64>
+// CHECK-NEXT:       %7 = stablehlo.add %iterArg_6, %6 : tensor<f64>
+// CHECK-NEXT:       %8 = stablehlo.dynamic_slice %0#5, %2, sizes = [1] : (tensor<12xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:       %9 = stablehlo.reshape %8 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %10 = stablehlo.dynamic_slice %0#6, %2, sizes = [1] : (tensor<12xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:       %11 = stablehlo.reshape %10 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:       %12 = stablehlo.multiply %7, %11 : tensor<f64>
+// CHECK-NEXT:       %13 = stablehlo.add %iterArg_5, %12 : tensor<f64>
+// CHECK-NEXT:       %14 = stablehlo.multiply %7, %9 : tensor<f64>
+// CHECK-NEXT:       stablehlo.return %3, %13, %14, %iterArg_7 : tensor<i64>, tensor<f64>, tensor<f64>, tensor<f64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#4, %1#1 : tensor<f64>, tensor<f64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/while_mincut.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_mincut.mlir
@@ -19,47 +19,49 @@ module {
   }
 }
 
-// CHECK:  func.func @main(%[[ARG0:.+]]: tensor<3xf64>, %[[ARG1:.+]]: tensor<3xf64>) -> tensor<3xf64> {
-// CHECK-NEXT:    %c = stablehlo.constant dense<9> : tensor<i64>
-// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x3xf64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %c_1 = stablehlo.constant dense<10> : tensor<i64>
-// CHECK-NEXT:    %[[ZEROI:.+]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : tensor<3xf64>
-// CHECK-NEXT:    %[[FWD:.+]]:3 = stablehlo.while(%iterArg = %[[ZEROI]], %iterArg_4 = %[[ARG0]], %iterArg_5 = %cst) : tensor<i64>, tensor<3xf64>, tensor<10x3xf64>
+// CHECK: module {
+// CHECK-NEXT:   func.func @main(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<9> : tensor<i64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<10x3xf64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<10> : tensor<i64>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %cst_3 = arith.constant dense<0.000000e+00> : tensor<3xf64>
+// CHECK-NEXT:     %0:3 = stablehlo.while(%iterArg = %c_2, %iterArg_4 = %arg0, %iterArg_5 = %cst) : tensor<i64>, tensor<3xf64>, tensor<10x3xf64>
 // CHECK-NEXT:     cond {
-// CHECK-NEXT:      %[[CMP:.+]] = stablehlo.compare  LT, %iterArg, %c_1,  SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %[[CMP]] : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %[[v6:.+]] = stablehlo.reshape %iterArg_4 : (tensor<3xf64>) -> tensor<1x3xf64>
-// CHECK-NEXT:      %[[v7:.+]] = stablehlo.dynamic_update_slice %iterArg_5, %[[v6]], %iterArg, %c_2 : (tensor<10x3xf64>, tensor<1x3xf64>, tensor<i64>, tensor<i64>) -> tensor<10x3xf64>
-// CHECK-NEXT:      %[[v8:.+]] = stablehlo.add %iterArg, %c_0 : tensor<i64>
-// CHECK-NEXT:      %[[v9:.+]] = stablehlo.cosine %iterArg_4 : tensor<3xf64>
-// CHECK-NEXT:      %[[v10:.+]] = stablehlo.multiply %[[v9]], %[[v9]] : tensor<3xf64>
-// CHECK-NEXT:      stablehlo.return %[[v8]], %[[v10]], %[[v7]] : tensor<i64>, tensor<3xf64>, tensor<10x3xf64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %[[ADD:.+]] = arith.addf %[[ARG1]], %[[ZERO]] : tensor<3xf64>
-// CHECK-NEXT:    %[[REV:.+]]:3 = stablehlo.while(%iterArg = %[[ZEROI]], %iterArg_4 = %[[ADD]], %iterArg_5 = %c) : tensor<i64>, tensor<3xf64>, tensor<i64>
+// CHECK-NEXT:       %4 = stablehlo.compare LT, %iterArg, %c_1, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %4 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %4 = stablehlo.reshape %iterArg_4 : (tensor<3xf64>) -> tensor<1x3xf64>
+// CHECK-NEXT:       %5 = stablehlo.dynamic_update_slice %iterArg_5, %4, %iterArg, %c_2 : (tensor<10x3xf64>, tensor<1x3xf64>, tensor<i64>, tensor<i64>) -> tensor<10x3xf64>
+// CHECK-NEXT:       %6 = stablehlo.add %iterArg, %c_0 : tensor<i64>
+// CHECK-NEXT:       %7 = stablehlo.cosine %iterArg_4 : tensor<3xf64>
+// CHECK-NEXT:       %8 = stablehlo.multiply %7, %7 : tensor<3xf64>
+// CHECK-NEXT:       stablehlo.return %6, %8, %5 : tensor<i64>, tensor<3xf64>, tensor<10x3xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1 = arith.addf %arg1, %cst_3 : tensor<3xf64>
+// CHECK-NEXT:     %2:2 = stablehlo.while(%iterArg = %c_2, %iterArg_4 = %1) : tensor<i64>, tensor<3xf64>
 // CHECK-NEXT:     cond {
-// CHECK-NEXT:      %[[CMP:.+]] = stablehlo.compare  LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %[[CMP]] : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %[[v6:.+]] = stablehlo.dynamic_slice %[[FWD]]#2, %iterArg_5, %c_2, sizes = [1, 3] : (tensor<10x3xf64>, tensor<i64>, tensor<i64>) -> tensor<1x3xf64>
-// CHECK-NEXT:      %[[v7:.+]] = stablehlo.reshape %[[v6]] : (tensor<1x3xf64>) -> tensor<3xf64>
-// CHECK-NEXT:      %[[v8:.+]] = stablehlo.cosine %[[v7]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v9:.+]] = stablehlo.add %iterArg, %c_0 : tensor<i64>
-// CHECK-NEXT:      %[[a4:.+]] = arith.addf %iterArg_4, %[[ZERO]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v10:.+]] = stablehlo.multiply %[[a4]], %[[v8]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v11:.+]] = arith.addf %[[v10]], %[[ZERO]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v12:.+]] = stablehlo.multiply %[[a4]], %[[v8]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v13:.+]] = arith.addf %[[v11]], %[[v12]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v14:.+]] = stablehlo.sine %[[v7]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v15:.+]] = stablehlo.negate %[[v14]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v16:.+]] = stablehlo.multiply %[[v13]], %[[v15]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v17:.+]] = arith.addf %[[v16]], %[[ZERO]] : tensor<3xf64>
-// CHECK-NEXT:      %[[v18:.+]] = stablehlo.subtract %iterArg_5, %c_0 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %[[v9]], %[[v17]], %[[v18]] : tensor<i64>, tensor<3xf64>, tensor<i64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %[[v5:.+]] = arith.addf %[[REV]]#1, %[[ZERO]] : tensor<3xf64>
-// CHECK-NEXT:    return %[[v5]] : tensor<3xf64>
-// CHECK-NEXT:  }
+// CHECK-NEXT:       %4 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %4 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %4 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %5 = stablehlo.dynamic_slice %0#2, %4, %c_2, sizes = [1, 3] : (tensor<10x3xf64>, tensor<i64>, tensor<i64>) -> tensor<1x3xf64>
+// CHECK-NEXT:       %6 = stablehlo.reshape %5 : (tensor<1x3xf64>) -> tensor<3xf64>
+// CHECK-NEXT:       %7 = stablehlo.cosine %6 : tensor<3xf64>
+// CHECK-NEXT:       %8 = stablehlo.add %iterArg, %c_0 : tensor<i64>
+// CHECK-NEXT:       %9 = arith.addf %iterArg_4, %cst_3 : tensor<3xf64>
+// CHECK-NEXT:       %10 = stablehlo.multiply %9, %7 : tensor<3xf64>
+// CHECK-NEXT:       %11 = arith.addf %10, %cst_3 : tensor<3xf64>
+// CHECK-NEXT:       %12 = stablehlo.multiply %9, %7 : tensor<3xf64>
+// CHECK-NEXT:       %13 = arith.addf %11, %12 : tensor<3xf64>
+// CHECK-NEXT:       %14 = stablehlo.sine %6 : tensor<3xf64>
+// CHECK-NEXT:       %15 = stablehlo.negate %14 : tensor<3xf64>
+// CHECK-NEXT:       %16 = stablehlo.multiply %13, %15 : tensor<3xf64>
+// CHECK-NEXT:       %17 = arith.addf %16, %cst_3 : tensor<3xf64>
+// CHECK-NEXT:       stablehlo.return %8, %17 : tensor<i64>, tensor<3xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %3 = arith.addf %2#1, %cst_3 : tensor<3xf64>
+// CHECK-NEXT:     return %3 : tensor<3xf64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/while_one_iter.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_one_iter.mlir
@@ -38,34 +38,36 @@ module {
   }
 }
 
-// CHECK:  func.func public @main(%arg0: tensor<3xf64>) -> tensor<3xf64> {
-// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<1x3xf64>
-// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %cst_1 = stablehlo.constant dense<1.000000e+00> : tensor<3xf64>
-// CHECK-NEXT:    %cst_2 = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
-// CHECK-NEXT:    %0:3 = stablehlo.while(%iterArg = %c, %iterArg_3 = %cst_1, %iterArg_4 = %cst) : tensor<i64>, tensor<3xf64>, tensor<1x3xf64>
-// CHECK-NEXT:    cond {
-// CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_0, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %2 = stablehlo.multiply %iterArg_3, %arg0 : tensor<3xf64>
-// CHECK-NEXT:      %3 = stablehlo.reshape %2 : (tensor<3xf64>) -> tensor<1x3xf64>
-// CHECK-NEXT:      %4 = stablehlo.dynamic_update_slice %iterArg_4, %3, %iterArg, %c : (tensor<1x3xf64>, tensor<1x3xf64>, tensor<i64>, tensor<i64>) -> tensor<1x3xf64>
-// CHECK-NEXT:      %5 = stablehlo.add %iterArg, %c_0 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %5, %2, %4 : tensor<i64>, tensor<3xf64>, tensor<1x3xf64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %1:3 = stablehlo.while(%iterArg = %c, %iterArg_3 = %cst_2, %iterArg_4 = %c) : tensor<i64>, tensor<3xf64>, tensor<i64>
-// CHECK-NEXT:    cond {
-// CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_0, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %2 = stablehlo.dynamic_slice %0#2, %iterArg_4, %c, sizes = [1, 3] : (tensor<1x3xf64>, tensor<i64>, tensor<i64>) -> tensor<1x3xf64>
-// CHECK-NEXT:      %3 = stablehlo.reshape %2 : (tensor<1x3xf64>) -> tensor<3xf64>
-// CHECK-NEXT:      %4 = stablehlo.add %iterArg_3, %3 : tensor<3xf64>
-// CHECK-NEXT:      %5 = stablehlo.add %iterArg, %c_0 : tensor<i64>
-// CHECK-NEXT:      %6 = stablehlo.subtract %iterArg_4, %c_0 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %5, %4, %6 : tensor<i64>, tensor<3xf64>, tensor<i64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    return %1#1 : tensor<3xf64>
-// CHECK-NEXT:  }
+// CHECK: module {
+// CHECK-NEXT:   func.func public @main(%arg0: tensor<3xf64>) -> tensor<3xf64> {
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<1x3xf64>
+// CHECK-NEXT:     %c = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<1.000000e+00> : tensor<3xf64>
+// CHECK-NEXT:     %cst_2 = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
+// CHECK-NEXT:     %0:3 = stablehlo.while(%iterArg = %c, %iterArg_3 = %cst_1, %iterArg_4 = %cst) : tensor<i64>, tensor<3xf64>, tensor<1x3xf64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_0, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.multiply %iterArg_3, %arg0 : tensor<3xf64>
+// CHECK-NEXT:       %3 = stablehlo.reshape %2 : (tensor<3xf64>) -> tensor<1x3xf64>
+// CHECK-NEXT:       %4 = stablehlo.dynamic_update_slice %iterArg_4, %3, %iterArg, %c : (tensor<1x3xf64>, tensor<1x3xf64>, tensor<i64>, tensor<i64>) -> tensor<1x3xf64>
+// CHECK-NEXT:       %5 = stablehlo.add %iterArg, %c_0 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %5, %2, %4 : tensor<i64>, tensor<3xf64>, tensor<1x3xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1:2 = stablehlo.while(%iterArg = %c, %iterArg_3 = %cst_2) : tensor<i64>, tensor<3xf64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_0, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.subtract %c, %iterArg : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.dynamic_slice %0#2, %2, %c, sizes = [1, 3] : (tensor<1x3xf64>, tensor<i64>, tensor<i64>) -> tensor<1x3xf64>
+// CHECK-NEXT:       %4 = stablehlo.reshape %3 : (tensor<1x3xf64>) -> tensor<3xf64>
+// CHECK-NEXT:       %5 = stablehlo.add %iterArg_3, %4 : tensor<3xf64>
+// CHECK-NEXT:       %6 = stablehlo.add %iterArg, %c_0 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %6, %5 : tensor<i64>, tensor<3xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %1#1 : tensor<3xf64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/diffrules/stablehlo/whiledf.mlir
+++ b/test/lit_tests/diffrules/stablehlo/whiledf.mlir
@@ -43,57 +43,97 @@ module @reactant_differe... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
   }
 }
 
-// REVERSE:  func.func private @"diffeConst{typeof(estimate_tracer_error)}(Main.estimate_tracer_error)_autodiff"(%arg0: tensor<63x63xf64>, %arg1: tensor<f64>, %arg2: tensor<63x63xf64>) -> (tensor<63x63xf64>, tensor<63x63xf64>) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
-// REVERSE-DAG:    %[[c2:.+]] = stablehlo.constant dense<2> : tensor<i64>
-// REVERSE-DAG:    %[[c0:.+]] = stablehlo.constant dense<0> : tensor<i64>
-// REVERSE-DAG:    %[[c7:.+]] = stablehlo.constant dense<7> : tensor<i32>
-// REVERSE-DAG:    %[[c14:.+]] = stablehlo.constant dense<14> : tensor<i32>
-// REVERSE-DAG:    %[[c1:.+]] = stablehlo.constant dense<1> : tensor<i64>
-// REVERSE-DAG:    %[[c3:.+]] = stablehlo.constant dense<3> : tensor<i64>
-// REVERSE-DAG:    %[[cst0:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// REVERSE-DAG:    %[[cst5:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<63x63x16xf64>
-// REVERSE-DAG:    %[[cst6:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<78x78x31xf64>
-// REVERSE-NEXT:    %0 = stablehlo.broadcast_in_dim %arg1, dims = [] : (tensor<f64>) -> tensor<63x63x16xf64>
-// REVERSE-NEXT:    %1:4 = stablehlo.while(%iterArg = %[[c0]], %iterArg_7 = %[[cst6]], %iterArg_8 = %0, %iterArg_9 = %[[c2]]) : tensor<i64>, tensor<78x78x31xf64>, tensor<63x63x16xf64>, tensor<i64>
+// REVERSE: module @reactant_differe... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
+// REVERSE-NEXT:   func.func private @"Const{typeof(estimate_tracer_error)}(Main.estimate_tracer_error)_autodiff"(%arg0: tensor<63x63xf64>) -> (tensor<f64>, tensor<63x63xf64>) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// REVERSE-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// REVERSE-NEXT:     %c = stablehlo.constant dense<0> : tensor<i64>
+// REVERSE-NEXT:     %c_0 = stablehlo.constant dense<3> : tensor<i64>
+// REVERSE-NEXT:     %c_1 = stablehlo.constant dense<1> : tensor<i64>
+// REVERSE-NEXT:     %c_2 = stablehlo.constant dense<14> : tensor<i32>
+// REVERSE-NEXT:     %c_3 = stablehlo.constant dense<7> : tensor<i32>
+// REVERSE-NEXT:     %cst_4 = stablehlo.constant dense<0.000000e+00> : tensor<78x78x31xf64>
+// REVERSE-NEXT:     %cst_5 = stablehlo.constant dense<0.000000e+00> : tensor<63x63x16xf64>
+// REVERSE-NEXT:     %0 = stablehlo.broadcast_in_dim %arg0, dims = [1, 0] : (tensor<63x63xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:     %1 = stablehlo.dynamic_update_slice %cst_4, %0, %c_3, %c_3, %c_2 : (tensor<78x78x31xf64>, tensor<63x63x1xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:     %2:3 = stablehlo.while(%iterArg = %c, %iterArg_6 = %1, %iterArg_7 = %cst_5) : tensor<i64>, tensor<78x78x31xf64>, tensor<63x63x16xf64> attributes {enzyme.disable_mincut}
 // REVERSE-NEXT:     cond {
-// REVERSE-NEXT:      %8 = stablehlo.compare  LT, %iterArg, %[[c3]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// REVERSE-NEXT:      stablehlo.return %8 : tensor<i1>
-// REVERSE-NEXT:    } do {
-// REVERSE-NEXT:      %8 = stablehlo.add %iterArg, %[[c1]] : tensor<i64>
-// REVERSE-NEXT:      %9 = stablehlo.dynamic_update_slice %iterArg_7, %[[cst5]], %[[c7]], %[[c7]], %[[c7]] : (tensor<78x78x31xf64>, tensor<63x63x16xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<78x78x31xf64>
-// REVERSE-NEXT:      %10 = stablehlo.dynamic_slice %iterArg_7, %[[c7]], %[[c7]], %[[c7]], sizes = [63, 63, 16] : (tensor<78x78x31xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<63x63x16xf64>
-// REVERSE-NEXT:      %11 = stablehlo.reduce(%10 init: %[[cst0]]) applies stablehlo.add across dimensions = [2] : (tensor<63x63x16xf64>, tensor<f64>) -> tensor<63x63xf64>
-// REVERSE-NEXT:      %12 = stablehlo.reshape %11 : (tensor<63x63xf64>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:      %13 = stablehlo.transpose %12, dims = [1, 0, 2] : (tensor<63x63x1xf64>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:      %14 = stablehlo.reshape %13 : (tensor<63x63x1xf64>) -> tensor<63x63xf64>
-// REVERSE-NEXT:      %15 = stablehlo.reshape %14 : (tensor<63x63xf64>) -> tensor<1x63x63xf64>
-// REVERSE-NEXT:      %16 = stablehlo.pad %15, %[[cst0]], low = [8, 7, 7], high = [22, 8, 8], interior = [0, 0, 0] : (tensor<1x63x63xf64>, tensor<f64>) -> tensor<31x78x78xf64>
-// REVERSE-NEXT:      %17 = stablehlo.transpose %16, dims = [2, 1, 0] : (tensor<31x78x78xf64>) -> tensor<78x78x31xf64>
-// REVERSE-NEXT:      %18 = stablehlo.slice %iterArg_8 [0:63, 0:63, 0:1] : (tensor<63x63x16xf64>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:      %19 = stablehlo.reshape %18 : (tensor<63x63x1xf64>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:      %20 = stablehlo.slice %iterArg_8 [0:63, 0:63, 1:2] : (tensor<63x63x16xf64>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:      %21 = stablehlo.reshape %20 : (tensor<63x63x1xf64>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:      %22 = stablehlo.slice %iterArg_8 [0:63, 0:63, 2:16] : (tensor<63x63x16xf64>) -> tensor<63x63x14xf64>
-// REVERSE-NEXT:      %23 = stablehlo.reshape %22 : (tensor<63x63x14xf64>) -> tensor<63x63x14xf64>
-// REVERSE-NEXT:      %24 = stablehlo.pad %23, %[[cst0]], low = [8, 6, 9], high = [7, 9, 8], interior = [0, 0, 0] : (tensor<63x63x14xf64>, tensor<f64>) -> tensor<78x78x31xf64>
-// REVERSE-NEXT:      %25 = stablehlo.add %17, %24 : tensor<78x78x31xf64>
-// REVERSE-NEXT:      %26 = stablehlo.pad %19, %[[cst0]], low = [8, 6, 7], high = [7, 9, 23], interior = [0, 0, 0] : (tensor<63x63x1xf64>, tensor<f64>) -> tensor<78x78x31xf64>
-// REVERSE-NEXT:      %27 = stablehlo.add %25, %26 : tensor<78x78x31xf64>
-// REVERSE-NEXT:      %28 = stablehlo.pad %21, %[[cst0]], low = [8, 6, 14], high = [7, 9, 16], interior = [0, 0, 0] : (tensor<63x63x1xf64>, tensor<f64>) -> tensor<78x78x31xf64>
-// REVERSE-NEXT:      %29 = stablehlo.add %27, %28 : tensor<78x78x31xf64>
-// REVERSE-NEXT:      %30 = stablehlo.dynamic_update_slice %29, %[[cst5]], %[[c7]], %[[c7]], %[[c7]] : (tensor<78x78x31xf64>, tensor<63x63x16xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<78x78x31xf64>
-// REVERSE-NEXT:      %31 = stablehlo.add %9, %30 : tensor<78x78x31xf64>
-// REVERSE-NEXT:      %32 = stablehlo.dynamic_slice %29, %[[c7]], %[[c7]], %[[c7]], sizes = [63, 63, 16] : (tensor<78x78x31xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<63x63x16xf64>
-// REVERSE-NEXT:      %33 = stablehlo.pad %32, %[[cst0]], low = [7, 7, 7], high = [8, 8, 8], interior = [0, 0, 0] : (tensor<63x63x16xf64>, tensor<f64>) -> tensor<78x78x31xf64>
-// REVERSE-NEXT:      %34 = stablehlo.add %31, %33 : tensor<78x78x31xf64>
-// REVERSE-NEXT:      %35 = stablehlo.subtract %iterArg_9, %[[c1]] : tensor<i64>
-// REVERSE-NEXT:      stablehlo.return %8, %34, %32, %35 : tensor<i64>, tensor<78x78x31xf64>, tensor<63x63x16xf64>, tensor<i64>
-// REVERSE-NEXT:    }
-// REVERSE-NEXT:    %2 = stablehlo.dynamic_slice %1#1, %[[c7]], %[[c7]], %[[c14]], sizes = [63, 63, 1] : (tensor<78x78x31xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:    %3 = stablehlo.reduce(%2 init: %[[cst0]]) applies stablehlo.add across dimensions = [2] : (tensor<63x63x1xf64>, tensor<f64>) -> tensor<63x63xf64>
-// REVERSE-NEXT:    %4 = stablehlo.reshape %3 : (tensor<63x63xf64>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:    %5 = stablehlo.transpose %4, dims = [1, 0, 2] : (tensor<63x63x1xf64>) -> tensor<63x63x1xf64>
-// REVERSE-NEXT:    %6 = stablehlo.reshape %5 : (tensor<63x63x1xf64>) -> tensor<63x63xf64>
-// REVERSE-NEXT:    %7 = stablehlo.add %arg2, %6 : tensor<63x63xf64>
-// REVERSE-NEXT:    return %arg0, %7 : tensor<63x63xf64>, tensor<63x63xf64>
-// REVERSE-NEXT:  }
+// REVERSE-NEXT:       %4 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       stablehlo.return %4 : tensor<i1>
+// REVERSE-NEXT:     } do {
+// REVERSE-NEXT:       %4 = stablehlo.add %iterArg, %c_1 : tensor<i64>
+// REVERSE-NEXT:       %5 = stablehlo.slice %iterArg_6 [7:70, 7:70, 7:23] : (tensor<78x78x31xf64>) -> tensor<63x63x16xf64>
+// REVERSE-NEXT:       %6 = stablehlo.add %5, %iterArg_7 : tensor<63x63x16xf64>
+// REVERSE-NEXT:       %7 = stablehlo.dynamic_update_slice %iterArg_6, %6, %c_3, %c_3, %c_3 : (tensor<78x78x31xf64>, tensor<63x63x16xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       %8 = stablehlo.slice %7 [8:71, 6:69, 14:15] : (tensor<78x78x31xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:       %9 = stablehlo.slice %7 [8:71, 6:69, 7:8] : (tensor<78x78x31xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:       %10 = stablehlo.slice %7 [8:71, 6:69, 9:23] : (tensor<78x78x31xf64>) -> tensor<63x63x14xf64>
+// REVERSE-NEXT:       %11 = stablehlo.concatenate %9, %8, %10, dim = 2 : (tensor<63x63x1xf64>, tensor<63x63x1xf64>, tensor<63x63x14xf64>) -> tensor<63x63x16xf64>
+// REVERSE-NEXT:       %12 = stablehlo.transpose %7, dims = [2, 1, 0] : (tensor<78x78x31xf64>) -> tensor<31x78x78xf64>
+// REVERSE-NEXT:       %13 = stablehlo.slice %12 [8:9, 7:70, 7:70] : (tensor<31x78x78xf64>) -> tensor<1x63x63xf64>
+// REVERSE-NEXT:       %14 = stablehlo.reshape %13 : (tensor<1x63x63xf64>) -> tensor<63x63xf64>
+// REVERSE-NEXT:       %15 = stablehlo.broadcast_in_dim %14, dims = [1, 0] : (tensor<63x63xf64>) -> tensor<63x63x16xf64>
+// REVERSE-NEXT:       %16 = stablehlo.dynamic_update_slice %iterArg_6, %15, %c_3, %c_3, %c_3 : (tensor<78x78x31xf64>, tensor<63x63x16xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       stablehlo.return %4, %16, %11 : tensor<i64>, tensor<78x78x31xf64>, tensor<63x63x16xf64>
+// REVERSE-NEXT:     }
+// REVERSE-NEXT:     %3 = stablehlo.reduce(%2#2 init: %cst) applies stablehlo.add across dimensions = [0, 1, 2] : (tensor<63x63x16xf64>, tensor<f64>) -> tensor<f64>
+// REVERSE-NEXT:     return %3, %arg0 : tensor<f64>, tensor<63x63xf64>
+// REVERSE-NEXT:   }
+// REVERSE-NEXT:   func.func @main(%arg0: tensor<63x63xf64> {tf.aliasing_output = 1 : i32}) -> (tensor<63x63xf64>, tensor<63x63xf64>) {
+// REVERSE-NEXT:     %cst = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// REVERSE-NEXT:     %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<63x63xf64>
+// REVERSE-NEXT:     %0:2 = call @"diffeConst{typeof(estimate_tracer_error)}(Main.estimate_tracer_error)_autodiff"(%arg0, %cst, %cst_0) : (tensor<63x63xf64>, tensor<f64>, tensor<63x63xf64>) -> (tensor<63x63xf64>, tensor<63x63xf64>)
+// REVERSE-NEXT:     return %0#1, %0#0 : tensor<63x63xf64>, tensor<63x63xf64>
+// REVERSE-NEXT:   }
+// REVERSE-NEXT:   func.func private @"diffeConst{typeof(estimate_tracer_error)}(Main.estimate_tracer_error)_autodiff"(%arg0: tensor<63x63xf64>, %arg1: tensor<f64>, %arg2: tensor<63x63xf64>) -> (tensor<63x63xf64>, tensor<63x63xf64>) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// REVERSE-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<63x63x16xf64>
+// REVERSE-NEXT:     %c = stablehlo.constant dense<7> : tensor<i32>
+// REVERSE-NEXT:     %c_0 = stablehlo.constant dense<14> : tensor<i32>
+// REVERSE-NEXT:     %c_1 = stablehlo.constant dense<1> : tensor<i64>
+// REVERSE-NEXT:     %c_2 = stablehlo.constant dense<3> : tensor<i64>
+// REVERSE-NEXT:     %c_3 = stablehlo.constant dense<0> : tensor<i64>
+// REVERSE-NEXT:     %cst_4 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// REVERSE-NEXT:     %cst_5 = stablehlo.constant dense<0.000000e+00> : tensor<78x78x31xf64>
+// REVERSE-NEXT:     %0 = stablehlo.broadcast_in_dim %arg1, dims = [] : (tensor<f64>) -> tensor<63x63x16xf64>
+// REVERSE-NEXT:     %1:3 = stablehlo.while(%iterArg = %c_3, %iterArg_6 = %cst_5, %iterArg_7 = %0) : tensor<i64>, tensor<78x78x31xf64>, tensor<63x63x16xf64>
+// REVERSE-NEXT:     cond {
+// REVERSE-NEXT:       %8 = stablehlo.compare LT, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       stablehlo.return %8 : tensor<i1>
+// REVERSE-NEXT:     } do {
+// REVERSE-NEXT:       %8 = stablehlo.add %iterArg, %c_1 : tensor<i64>
+// REVERSE-NEXT:       %9 = stablehlo.dynamic_update_slice %iterArg_6, %cst, %c, %c, %c : (tensor<78x78x31xf64>, tensor<63x63x16xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       %10 = stablehlo.dynamic_slice %iterArg_6, %c, %c, %c, sizes = [63, 63, 16] : (tensor<78x78x31xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<63x63x16xf64>
+// REVERSE-NEXT:       %11 = stablehlo.reduce(%10 init: %cst_4) applies stablehlo.add across dimensions = [2] : (tensor<63x63x16xf64>, tensor<f64>) -> tensor<63x63xf64>
+// REVERSE-NEXT:       %12 = stablehlo.reshape %11 : (tensor<63x63xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:       %13 = stablehlo.transpose %12, dims = [1, 0, 2] : (tensor<63x63x1xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:       %14 = stablehlo.reshape %13 : (tensor<63x63x1xf64>) -> tensor<63x63xf64>
+// REVERSE-NEXT:       %15 = stablehlo.reshape %14 : (tensor<63x63xf64>) -> tensor<1x63x63xf64>
+// REVERSE-NEXT:       %16 = stablehlo.pad %15, %cst_4, low = [8, 7, 7], high = [22, 8, 8], interior = [0, 0, 0] : (tensor<1x63x63xf64>, tensor<f64>) -> tensor<31x78x78xf64>
+// REVERSE-NEXT:       %17 = stablehlo.transpose %16, dims = [2, 1, 0] : (tensor<31x78x78xf64>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       %18 = stablehlo.slice %iterArg_7 [0:63, 0:63, 0:1] : (tensor<63x63x16xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:       %19 = stablehlo.reshape %18 : (tensor<63x63x1xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:       %20 = stablehlo.slice %iterArg_7 [0:63, 0:63, 1:2] : (tensor<63x63x16xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:       %21 = stablehlo.reshape %20 : (tensor<63x63x1xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:       %22 = stablehlo.slice %iterArg_7 [0:63, 0:63, 2:16] : (tensor<63x63x16xf64>) -> tensor<63x63x14xf64>
+// REVERSE-NEXT:       %23 = stablehlo.reshape %22 : (tensor<63x63x14xf64>) -> tensor<63x63x14xf64>
+// REVERSE-NEXT:       %24 = stablehlo.pad %23, %cst_4, low = [8, 6, 9], high = [7, 9, 8], interior = [0, 0, 0] : (tensor<63x63x14xf64>, tensor<f64>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       %25 = stablehlo.add %17, %24 : tensor<78x78x31xf64>
+// REVERSE-NEXT:       %26 = stablehlo.pad %19, %cst_4, low = [8, 6, 7], high = [7, 9, 23], interior = [0, 0, 0] : (tensor<63x63x1xf64>, tensor<f64>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       %27 = stablehlo.add %25, %26 : tensor<78x78x31xf64>
+// REVERSE-NEXT:       %28 = stablehlo.pad %21, %cst_4, low = [8, 6, 14], high = [7, 9, 16], interior = [0, 0, 0] : (tensor<63x63x1xf64>, tensor<f64>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       %29 = stablehlo.add %27, %28 : tensor<78x78x31xf64>
+// REVERSE-NEXT:       %30 = stablehlo.dynamic_update_slice %29, %cst, %c, %c, %c : (tensor<78x78x31xf64>, tensor<63x63x16xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       %31 = stablehlo.add %9, %30 : tensor<78x78x31xf64>
+// REVERSE-NEXT:       %32 = stablehlo.dynamic_slice %29, %c, %c, %c, sizes = [63, 63, 16] : (tensor<78x78x31xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<63x63x16xf64>
+// REVERSE-NEXT:       %33 = stablehlo.pad %32, %cst_4, low = [7, 7, 7], high = [8, 8, 8], interior = [0, 0, 0] : (tensor<63x63x16xf64>, tensor<f64>) -> tensor<78x78x31xf64>
+// REVERSE-NEXT:       %34 = stablehlo.add %31, %33 : tensor<78x78x31xf64>
+// REVERSE-NEXT:       stablehlo.return %8, %34, %32 : tensor<i64>, tensor<78x78x31xf64>, tensor<63x63x16xf64>
+// REVERSE-NEXT:     }
+// REVERSE-NEXT:     %2 = stablehlo.dynamic_slice %1#1, %c, %c, %c_0, sizes = [63, 63, 1] : (tensor<78x78x31xf64>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:     %3 = stablehlo.reduce(%2 init: %cst_4) applies stablehlo.add across dimensions = [2] : (tensor<63x63x1xf64>, tensor<f64>) -> tensor<63x63xf64>
+// REVERSE-NEXT:     %4 = stablehlo.reshape %3 : (tensor<63x63xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:     %5 = stablehlo.transpose %4, dims = [1, 0, 2] : (tensor<63x63x1xf64>) -> tensor<63x63x1xf64>
+// REVERSE-NEXT:     %6 = stablehlo.reshape %5 : (tensor<63x63x1xf64>) -> tensor<63x63xf64>
+// REVERSE-NEXT:     %7 = stablehlo.add %arg2, %6 : tensor<63x63xf64>
+// REVERSE-NEXT:     return %arg0, %7 : tensor<63x63xf64>, tensor<63x63xf64>
+// REVERSE-NEXT:   }
+// REVERSE-NEXT: }


### PR DESCRIPTION
Reverse-mode AD of `stablehlo.while` added a *second* counter to the reverse loop — initialised to `numIters-1` and decremented each iteration — purely to index the caches. But the reverse loop already counts `0, 1, ... numIters-1` to drive its own condition, so the index can just be computed from it:

```
reverseIndex = (numIters - 1) - iv
```

This removes a loop-carried value, and with it the rebuild of the reverse `while` that appending an operand required.

### Why it matters beyond the extra carry

It makes the index **visible to `WhileLoopInfo`**. Both `propagateAffineIndexInfo` and `propagateBounds` seed from the induction variable and propagate forward through *users*, so a separately carried counter is invisible to both. Any pattern relying on those analyses was blind to what the cache index actually ranged over — including whether it stayed in bounds. With this change the index is an ordinary affine function of the induction variable and both analyses cover it.

Example, from `while_mincut.mlir` — the reverse loop drops from three carries to two:

```mlir
// before
%rev:3 = stablehlo.while(%iterArg = %zero, %iterArg_4 = %add, %iterArg_5 = %c) : tensor<i64>, tensor<3xf64>, tensor<i64>
// after
%rev:2 = stablehlo.while(%iterArg = %c_2, %iterArg_4 = %1) : tensor<i64>, tensor<3xf64>
```

and the index becomes `stablehlo.subtract %c, %iterArg`.

### Scope

Only taken when the trip count is constant and the reverse loop has a canonical zero-based unit-step induction variable. Otherwise the previous carried-counter path is kept unchanged, so loops that don't meet those conditions are unaffected.

### Testing

Nine `diffrules/stablehlo/while*` goldens were regenerated mechanically (raw SSA names; several previously used `%[[...]]` captures — happy to restore that style if preferred).

**One caveat, stated plainly:** `while_checkpointing_iv_dependent.mlir` is flaky *independently of this change*. The order in which values are pushed into the caches varies between runs on `main` as well — I ran the unmodified pipeline three times on `main` and got two different outputs. Its golden therefore matches only some of the time, before and after. That looks like a separate bug (iteration over an unordered container in the cache construction) and is worth fixing on its own.

Everything else: 1092/1094, with the remaining failure being the pre-existing `mem2reg_transfers.mlir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)