### PR TITLE
Recognise backward-stepping counters in WhileOpInductionReplacement

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -16113,23 +16113,34 @@ struct WhileOpInductionReplacement
       Value yieldedValue = returnOp.getOperand(i);
       Value result = whileOp.getResult(i);
 
-      // Look for a simple addition pattern: either iter_arg + step or step +
-      // iter_arg
-      auto addOp = yieldedValue.getDefiningOp<stablehlo::AddOp>();
-      if (!addOp)
+      // Look for a simple step pattern: iter_arg + step, step + iter_arg, or
+      // iter_arg - step. A counter that walks backwards is exactly as redundant
+      // as one that walks forwards; reverse-mode AD emits the backwards form,
+      // indexing rows from the end while the loop counter runs from the start.
+      Operation *stepOp = yieldedValue.getDefiningOp();
+      if (!isa_and_nonnull<stablehlo::AddOp, stablehlo::SubtractOp>(stepOp))
         continue;
 
-      if (!addOp.getType().getElementType().isInteger())
+      if (!cast<RankedTensorType>(stepOp->getResult(0).getType())
+               .getElementType()
+               .isInteger())
         continue;
 
       // Check which operand is the iteration argument and which is the step
       Value stepValue;
-      if (addOp.getLhs() == iterArg) {
+      bool negateStep = false;
+      if (isa<stablehlo::SubtractOp>(stepOp)) {
+        // Pattern: iter_arg - step. (step - iter_arg is not a counter.)
+        if (stepOp->getOperand(0) != iterArg)
+          continue;
+        stepValue = stepOp->getOperand(1);
+        negateStep = true;
+      } else if (stepOp->getOperand(0) == iterArg) {
         // Pattern: iter_arg + step
-        stepValue = addOp.getRhs();
-      } else if (addOp.getRhs() == iterArg) {
+        stepValue = stepOp->getOperand(1);
+      } else if (stepOp->getOperand(1) == iterArg) {
         // Pattern: step + iter_arg
-        stepValue = addOp.getLhs();
+        stepValue = stepOp->getOperand(0);
       } else {
         // Neither operand is the iteration argument
         continue;
@@ -16139,6 +16150,24 @@ struct WhileOpInductionReplacement
       auto constOp = stepValue.getDefiningOp<stablehlo::ConstantOp>();
       if (!constOp)
         continue;
+
+      // Fold the sign into the constant rather than emitting a negate, so the
+      // rewritten index stays a plain affine expression of the counter.
+      if (negateStep) {
+        DenseIntElementsAttr stepAttr;
+        if (!matchPattern(constOp.getResult(), m_Constant(&stepAttr)))
+          continue;
+        SmallVector<APInt> negated;
+        for (auto v : stepAttr.getValues<APInt>())
+          negated.push_back(-v);
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(whileOp);
+        constOp = stablehlo::ConstantOp::create(
+            rewriter, constOp.getLoc(),
+            DenseIntElementsAttr::get(cast<ShapedType>(constOp.getType()),
+                                      negated));
+        stepValue = constOp.getResult();
+      }
 
       // Similarly replace uses of the result outside the loop
       // with a calculation based on the final counter value

--- a/test/lit_tests/diffrules/stablehlo/while6.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while6.mlir
@@ -20,53 +20,57 @@ func.func @main(%arg0: tensor<12x16x4xf32>) -> (tensor<12x4xf32>) {
   return %8#1 : tensor<12x4xf32>
 }
 
-// FORWARD: func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x16x4xf32>) -> (tensor<12x4xf32>, tensor<12x4xf32>) {
-// FORWARD-NEXT:   %c = stablehlo.constant dense<0> : tensor<i32>
-// FORWARD-NEXT:   %c_0 = stablehlo.constant dense<15> : tensor<i32>
-// FORWARD-NEXT:   %c_1 = stablehlo.constant dense<1> : tensor<i32>
-// FORWARD-NEXT:   %0 = stablehlo.slice %arg1 [0:12, 0:1, 0:4] : (tensor<12x16x4xf32>) -> tensor<12x1x4xf32>
-// FORWARD-NEXT:   %1 = stablehlo.slice %arg0 [0:12, 0:1, 0:4] : (tensor<12x16x4xf32>) -> tensor<12x1x4xf32>
-// FORWARD-NEXT:   %2 = stablehlo.reshape %0 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
-// FORWARD-NEXT:   %3 = stablehlo.reshape %1 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
-// FORWARD-NEXT:   %4:3 = stablehlo.while(%iterArg = %c, %iterArg_2 = %3, %iterArg_3 = %2) : tensor<i32>, tensor<12x4xf32>, tensor<12x4xf32>
-// FORWARD-NEXT:   cond {
-// FORWARD-NEXT:     %5 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i32>, tensor<i32>) -> tensor<i1>
-// FORWARD-NEXT:     stablehlo.return %5 : tensor<i1>
-// FORWARD-NEXT:   } do {
-// FORWARD-NEXT:     %5 = stablehlo.add %c_1, %iterArg {enzymexla.bounds = {{.*}}} : tensor<i32>
-// FORWARD-NEXT:     %6 = stablehlo.dynamic_slice %arg1, %c, %5, %c, sizes = [12, 1, 4] : (tensor<12x16x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x1x4xf32>
-// FORWARD-NEXT:     %7 = stablehlo.dynamic_slice %arg0, %c, %5, %c, sizes = [12, 1, 4] : (tensor<12x16x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x1x4xf32>
-// FORWARD-NEXT:     %8 = stablehlo.reshape %6 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
-// FORWARD-NEXT:     %9 = stablehlo.reshape %7 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
-// FORWARD-NEXT:     stablehlo.return %5, %9, %8 : tensor<i32>, tensor<12x4xf32>, tensor<12x4xf32>
+// FORWARD: module {
+// FORWARD-NEXT:   func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x16x4xf32>) -> (tensor<12x4xf32>, tensor<12x4xf32>) {
+// FORWARD-NEXT:     %c = stablehlo.constant dense<0> : tensor<i32>
+// FORWARD-NEXT:     %c_0 = stablehlo.constant dense<15> : tensor<i32>
+// FORWARD-NEXT:     %c_1 = stablehlo.constant dense<1> : tensor<i32>
+// FORWARD-NEXT:     %0 = stablehlo.slice %arg1 [0:12, 0:1, 0:4] : (tensor<12x16x4xf32>) -> tensor<12x1x4xf32>
+// FORWARD-NEXT:     %1 = stablehlo.slice %arg0 [0:12, 0:1, 0:4] : (tensor<12x16x4xf32>) -> tensor<12x1x4xf32>
+// FORWARD-NEXT:     %2 = stablehlo.reshape %0 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
+// FORWARD-NEXT:     %3 = stablehlo.reshape %1 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
+// FORWARD-NEXT:     %4:3 = stablehlo.while(%iterArg = %c, %iterArg_2 = %3, %iterArg_3 = %2) : tensor<i32>, tensor<12x4xf32>, tensor<12x4xf32>
+// FORWARD-NEXT:     cond {
+// FORWARD-NEXT:       %5 = stablehlo.compare LT, %iterArg, %c_0 : (tensor<i32>, tensor<i32>) -> tensor<i1>
+// FORWARD-NEXT:       stablehlo.return %5 : tensor<i1>
+// FORWARD-NEXT:     } do {
+// FORWARD-NEXT:       %5 = stablehlo.add %c_1, %iterArg {enzymexla.bounds = {{\[\[}}1 : i32, 15 : i32]]} : tensor<i32>
+// FORWARD-NEXT:       %6 = stablehlo.dynamic_slice %arg1, %c, %5, %c, sizes = [12, 1, 4] : (tensor<12x16x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x1x4xf32>
+// FORWARD-NEXT:       %7 = stablehlo.dynamic_slice %arg0, %c, %5, %c, sizes = [12, 1, 4] : (tensor<12x16x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x1x4xf32>
+// FORWARD-NEXT:       %8 = stablehlo.reshape %6 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
+// FORWARD-NEXT:       %9 = stablehlo.reshape %7 : (tensor<12x1x4xf32>) -> tensor<12x4xf32>
+// FORWARD-NEXT:       stablehlo.return %5, %9, %8 : tensor<i32>, tensor<12x4xf32>, tensor<12x4xf32>
+// FORWARD-NEXT:     }
+// FORWARD-NEXT:     return %4#1, %4#2 : tensor<12x4xf32>, tensor<12x4xf32>
 // FORWARD-NEXT:   }
-// FORWARD-NEXT:   return %4#1, %4#2 : tensor<12x4xf32>, tensor<12x4xf32>
 // FORWARD-NEXT: }
 
-// REVERSE: func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x4xf32>) -> tensor<12x16x4xf32> {
-// REVERSE-NEXT:   %c = stablehlo.constant dense<14> : tensor<i64>
-// REVERSE-NEXT:   %cst = stablehlo.constant dense<0.000000e+00> : tensor<12x16x4xf32>
-// REVERSE-NEXT:   %c_0 = stablehlo.constant dense<1> : tensor<i64>
-// REVERSE-NEXT:   %c_1 = stablehlo.constant dense<15> : tensor<i64>
-// REVERSE-NEXT:   %c_2 = stablehlo.constant dense<0> : tensor<i64>
-// REVERSE-NEXT:   %c_3 = stablehlo.constant dense<1> : tensor<i32>
-// REVERSE-NEXT:   %c_4 = stablehlo.constant dense<0> : tensor<i32>
-// REVERSE-NEXT:   %cst_5 = stablehlo.constant dense<0.000000e+00> : tensor<12x4xf32>
-// REVERSE-NEXT:   %0:3 = stablehlo.while(%iterArg = %c_2, %iterArg_6 = %cst, %iterArg_7 = %c) : tensor<i64>, tensor<12x16x4xf32>, tensor<i64>
-// REVERSE-NEXT:   cond {
-// REVERSE-NEXT:     %1 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// REVERSE-NEXT:     stablehlo.return %1 : tensor<i1>
-// REVERSE-NEXT:   } do {
-// REVERSE-NEXT:     %1 = stablehlo.compare EQ, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// REVERSE-NEXT:     %2 = stablehlo.select %1, %arg1, %cst_5 : tensor<i1>, tensor<12x4xf32>
-// REVERSE-NEXT:     %3 = stablehlo.convert %iterArg_7 : (tensor<i64>) -> tensor<i32>
-// REVERSE-NEXT:     %4 = stablehlo.add %c_3, %3 {enzymexla.bounds = {{.*}}} : tensor<i32>
-// REVERSE-NEXT:     %5 = stablehlo.add %iterArg, %c_0 {enzymexla.bounds = {{.*}}} : tensor<i64>
-// REVERSE-NEXT:     %6 = stablehlo.reshape %2 : (tensor<12x4xf32>) -> tensor<12x1x4xf32>
-// REVERSE-NEXT:     %7 = stablehlo.dynamic_update_slice %cst, %6, %c_4, %4, %c_4 : (tensor<12x16x4xf32>, tensor<12x1x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x16x4xf32>
-// REVERSE-NEXT:     %8 = stablehlo.add %iterArg_6, %7 : tensor<12x16x4xf32>
-// REVERSE-NEXT:     %9 = stablehlo.subtract %iterArg_7, %c_0 : tensor<i64>
-// REVERSE-NEXT:     stablehlo.return %5, %8, %9 : tensor<i64>, tensor<12x16x4xf32>, tensor<i64>
+// REVERSE: module {
+// REVERSE-NEXT:   func.func @main(%arg0: tensor<12x16x4xf32>, %arg1: tensor<12x4xf32>) -> tensor<12x16x4xf32> {
+// REVERSE-NEXT:     %c = stablehlo.constant dense<14> : tensor<i64>
+// REVERSE-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<12x16x4xf32>
+// REVERSE-NEXT:     %c_0 = stablehlo.constant dense<1> : tensor<i64>
+// REVERSE-NEXT:     %c_1 = stablehlo.constant dense<15> : tensor<i64>
+// REVERSE-NEXT:     %c_2 = stablehlo.constant dense<0> : tensor<i64>
+// REVERSE-NEXT:     %c_3 = stablehlo.constant dense<1> : tensor<i32>
+// REVERSE-NEXT:     %c_4 = stablehlo.constant dense<0> : tensor<i32>
+// REVERSE-NEXT:     %cst_5 = stablehlo.constant dense<0.000000e+00> : tensor<12x4xf32>
+// REVERSE-NEXT:     %0:2 = stablehlo.while(%iterArg = %c_2, %iterArg_6 = %cst) : tensor<i64>, tensor<12x16x4xf32>
+// REVERSE-NEXT:     cond {
+// REVERSE-NEXT:       %1 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       stablehlo.return %1 : tensor<i1>
+// REVERSE-NEXT:     } do {
+// REVERSE-NEXT:       %1 = stablehlo.compare EQ, %iterArg, %c_2 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// REVERSE-NEXT:       %2 = stablehlo.select %1, %arg1, %cst_5 : tensor<i1>, tensor<12x4xf32>
+// REVERSE-NEXT:       %3 = stablehlo.subtract %c, %iterArg {enzymexla.bounds = {{\[\[}}0, 14]]} : tensor<i64>
+// REVERSE-NEXT:       %4 = stablehlo.convert %3 {enzymexla.bounds = {{\[\[}}0, 14]]} : (tensor<i64>) -> tensor<i32>
+// REVERSE-NEXT:       %5 = stablehlo.add %c_3, %4 {enzymexla.bounds = {{\[\[}}1, 15]]} : tensor<i32>
+// REVERSE-NEXT:       %6 = stablehlo.add %iterArg, %c_0 {enzymexla.bounds = {{\[\[}}1, 15]]} : tensor<i64>
+// REVERSE-NEXT:       %7 = stablehlo.reshape %2 : (tensor<12x4xf32>) -> tensor<12x1x4xf32>
+// REVERSE-NEXT:       %8 = stablehlo.dynamic_update_slice %cst, %7, %c_4, %5, %c_4 : (tensor<12x16x4xf32>, tensor<12x1x4xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<12x16x4xf32>
+// REVERSE-NEXT:       %9 = stablehlo.add %iterArg_6, %8 : tensor<12x16x4xf32>
+// REVERSE-NEXT:       stablehlo.return %6, %9 : tensor<i64>, tensor<12x16x4xf32>
+// REVERSE-NEXT:     }
+// REVERSE-NEXT:     return %0#1 : tensor<12x16x4xf32>
 // REVERSE-NEXT:   }
-// REVERSE-NEXT:   return %0#1 : tensor<12x16x4xf32>
 // REVERSE-NEXT: }

--- a/test/lit_tests/while_induction_replacement_subtract.mlir
+++ b/test/lit_tests/while_induction_replacement_subtract.mlir
@@ -1,0 +1,80 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-generate-td{patterns=while_op_induction_replacement},transform-interpreter,enzyme-hlo-remove-transform,canonicalize)" %s | FileCheck %s
+
+// A counter that walks backwards is as redundant as one that walks forwards:
+// %ri is 7, 6, ... 0 while %iv is 0, 1, ... 7, so uses of %ri can be rewritten
+// as an expression of %iv and the carry dropped.
+func.func @backward_counter(%row: tensor<1x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c7 = stablehlo.constant dense<7> : tensor<i64>
+  %c8 = stablehlo.constant dense<8> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:3 = stablehlo.while(%iv = %c0, %a = %wide, %ri = %c7) : tensor<i64>, tensor<8x4xf32>, tensor<i64>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %ri, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %rnext = stablehlo.subtract %ri, %c1 : tensor<i64>
+    stablehlo.return %next, %sa, %rnext : tensor<i64>, tensor<8x4xf32>, tensor<i64>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// The scatter index is now derived from the loop counter rather than read from
+// a carry, and no negate is emitted -- the sign is folded into the constant.
+// CHECK-LABEL: func.func @backward_counter
+// CHECK-NOT: stablehlo.negate
+// CHECK: stablehlo.while
+// CHECK: stablehlo.dynamic_update_slice
+
+// A forward counter keeps working exactly as before.
+func.func @forward_counter(%row: tensor<1x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c8 = stablehlo.constant dense<8> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:3 = stablehlo.while(%iv = %c0, %a = %wide, %ri = %c0) : tensor<i64>, tensor<8x4xf32>, tensor<i64>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %ri, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %rnext = stablehlo.add %ri, %c1 : tensor<i64>
+    stablehlo.return %next, %sa, %rnext : tensor<i64>, tensor<8x4xf32>, tensor<i64>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @forward_counter
+// CHECK: stablehlo.while
+// CHECK: stablehlo.dynamic_update_slice
+
+// `step - iter_arg` is not a counter -- it alternates rather than stepping --
+// so it must be left alone.
+func.func @not_a_counter(%row: tensor<1x4xf32>) -> tensor<8x4xf32> {
+  %c0 = stablehlo.constant dense<0> : tensor<i64>
+  %c1 = stablehlo.constant dense<1> : tensor<i64>
+  %c7 = stablehlo.constant dense<7> : tensor<i64>
+  %c8 = stablehlo.constant dense<8> : tensor<i64>
+  %wide = stablehlo.constant dense<0.000000e+00> : tensor<8x4xf32>
+
+  %w:3 = stablehlo.while(%iv = %c0, %a = %wide, %ri = %c7) : tensor<i64>, tensor<8x4xf32>, tensor<i64>
+   cond {
+    %p = stablehlo.compare LT, %iv, %c8 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %p : tensor<i1>
+  } do {
+    %next = stablehlo.add %iv, %c1 : tensor<i64>
+    %sa = stablehlo.dynamic_update_slice %wide, %row, %ri, %c0 : (tensor<8x4xf32>, tensor<1x4xf32>, tensor<i64>, tensor<i64>) -> tensor<8x4xf32>
+    %rnext = stablehlo.subtract %c7, %ri : tensor<i64>
+    stablehlo.return %next, %sa, %rnext : tensor<i64>, tensor<8x4xf32>, tensor<i64>
+  }
+  return %w#1 : tensor<8x4xf32>
+}
+
+// CHECK-LABEL: func.func @not_a_counter
+// CHECK: stablehlo.subtract %{{.+}}, %iterArg


### PR DESCRIPTION
`WhileOpInductionReplacement` replaces a redundant induction variable with an expression of the loop counter, but only matched

```mlir
yield[i] = add(iter_arg, const)
```

A counter that walks *backwards* is exactly as redundant as one that walks forwards — and reverse-mode AD emits the backwards form, indexing rows from the end while the loop counter runs from the start. So that carry survived every pass.

This also matches `yield[i] = subtract(iter_arg, const)`, folding the sign into the constant rather than emitting a `negate`, so the rewritten index stays a plain affine expression of the counter — which is what `WhileLoopInfo::propagateAffineIndexInfo` can actually follow. (Emitting a `negate` would work too, but the surrounding rewrite then divides by the counter step, and a `divide` stops the affine propagation.)

`subtract(const, iter_arg)` is deliberately **not** matched: it alternates rather than stepping, so it is not a counter.

### Testing

New `test/lit_tests/while_induction_replacement_subtract.mlir`: a backward counter is folded with no `negate` emitted, a forward counter still behaves as before, and `subtract(const, iter_arg)` is left alone.

`diffrules/stablehlo/while6.mlir` regenerated — it contains a backward counter that now gets folded.

Full lit suite: 1094/1095, the remaining failure being the pre-existing `mem2reg_transfers.mlir`.

### Note

This overlaps in effect with making the AD rule emit the index in terms of the reverse loop's own induction variable (separate PR). They are complementary: that one stops the redundant carry being created, this one cleans it up wherever it still appears, including in loops Enzyme did not build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)