### PR TITLE
Raising: translate LLVM fast-math and overflow flags into their arith spelling

### DIFF
--- a/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
+++ b/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
@@ -82,21 +82,17 @@ template <typename SourceOp, typename TargetOp>
 class AttrConvertOverflowFromLLVM {
 public:
   AttrConvertOverflowFromLLVM(SourceOp srcOp) {
-    // Copy the source attributes.
+    // Copy the source attributes, minus the flags we are translating. The
+    // accessor rather than the attribute dictionary, since the flags are an
+    // inherent attribute and so live in the op's properties.
     convertedAttr = NamedAttrList{srcOp->getAttrs()};
-    // Get the name of the arith overflow attribute.
-    StringRef arithAttrName = SourceOp::getIntegerOverflowAttrName();
-    // Remove the source overflow attribute.
-    if (auto arithAttr = dyn_cast_if_present<LLVM::IntegerOverflowFlagsAttr>(
-            convertedAttr.erase(arithAttrName))) {
-      if (arithAttr.getValue() != LLVM::IntegerOverflowFlags::none) {
-        StringRef targetAttrName = TargetOp::getOverflowFlagsAttrName();
-        convertedAttr.set(targetAttrName, arith::IntegerOverflowFlagsAttr::get(
-                                              srcOp->getContext(),
-                                              convertArithOverflowFlagsFromLLVM(
-                                                  arithAttr.getValue())));
-      }
-    }
+    convertedAttr.erase(SourceOp::getOverflowFlagsAttrName());
+    LLVM::IntegerOverflowFlags llvmFlags = srcOp.getOverflowFlags();
+    if (llvmFlags != LLVM::IntegerOverflowFlags::none)
+      convertedAttr.set(TargetOp::getIntegerOverflowAttrName(),
+                        arith::IntegerOverflowFlagsAttr::get(
+                            srcOp->getContext(),
+                            convertArithOverflowFlagsFromLLVM(llvmFlags)));
   }
 
   ArrayRef<NamedAttribute> getAttrs() const { return convertedAttr.getAttrs(); }
@@ -468,7 +464,7 @@ template <typename SourceOp, typename TargetOp,
           template <typename, typename> typename AttrConvert =
               AttrConvertPassThrough>
 using InvVectorConvertFromLLVMPattern =
-    VectorConvertFromLLVMPattern<TargetOp, SourceOp, AttrConvertPassThrough>;
+    VectorConvertFromLLVMPattern<TargetOp, SourceOp, AttrConvert>;
 
 template <typename SourceOp, typename TargetOp>
 using ConvertFMFMathFromLLVMPattern =

--- a/test/lit_tests/raising/arith_raise.mlir
+++ b/test/lit_tests/raising/arith_raise.mlir
@@ -2,7 +2,7 @@
 
 module {
   // CHECK: @func_fcmp
-  // CHECK-NEXT: arith.cmpf ogt, %arg0, %arg1 {fastmathFlags = #llvm.fastmath<none>} : f64
+  // CHECK-NEXT: arith.cmpf ogt, %arg0, %arg1 : f64
   func.func @func_fcmp(%arg0: f64, %arg1: f64) -> i1 {
       %res = llvm.fcmp "ogt" %arg0, %arg1 : f64
       func.return %res : i1

--- a/test/lit_tests/raising/libdevice_fastmath.mlir
+++ b/test/lit_tests/raising/libdevice_fastmath.mlir
@@ -1,0 +1,49 @@
+// RUN: enzymexlamlir-opt --libdevice-funcs-raise -split-input-file %s | FileCheck %s
+
+// Raising an LLVM op to arith has to translate its flags, not carry the LLVM
+// spelling across as a discardable attribute: `#llvm.fastmath` on an arith op
+// means nothing to anyone downstream, so the flags are silently lost when the
+// op is lowered back.
+
+llvm.func @fastmath(%a: f64, %b: f64, %c: f64) -> f64 {
+  %0 = llvm.fmul %a, %b {fastmathFlags = #llvm.fastmath<fast>} : f64
+  %1 = llvm.fadd %0, %c {fastmathFlags = #llvm.fastmath<fast>} : f64
+  %2 = llvm.fsub %1, %a {fastmathFlags = #llvm.fastmath<nsz>} : f64
+  %3 = llvm.fdiv %2, %b {fastmathFlags = #llvm.fastmath<fast>} : f64
+  llvm.return %3 : f64
+}
+
+// CHECK-LABEL: llvm.func @fastmath
+// CHECK:         arith.mulf %arg0, %arg1 fastmath<fast>
+// CHECK:         arith.addf %{{.*}}, %arg2 fastmath<fast>
+// CHECK:         arith.subf %{{.*}}, %arg0 fastmath<nsz>
+// CHECK:         arith.divf %{{.*}}, %arg1 fastmath<fast>
+// CHECK-NOT:     fastmathFlags
+
+// -----
+
+// Absent flags stay absent rather than becoming an explicit `none`.
+
+llvm.func @no_flags(%a: f64, %b: f64) -> f64 {
+  %0 = llvm.fmul %a, %b : f64
+  llvm.return %0 : f64
+}
+
+// CHECK-LABEL: llvm.func @no_flags
+// CHECK:         arith.mulf %arg0, %arg1 : f64
+
+// -----
+
+// The same goes for integer overflow flags.
+
+llvm.func @overflow(%a: i32, %b: i32) -> i32 {
+  %0 = llvm.mul %a, %b overflow<nsw> : i32
+  %1 = llvm.add %0, %a overflow<nsw, nuw> : i32
+  %2 = llvm.sub %1, %b overflow<nuw> : i32
+  llvm.return %2 : i32
+}
+
+// CHECK-LABEL: llvm.func @overflow
+// CHECK:         arith.muli %arg0, %arg1 overflow<nsw>
+// CHECK:         arith.addi %{{.*}}, %arg0 overflow<nsw, nuw>
+// CHECK:         arith.subi %{{.*}}, %arg1 overflow<nuw>

--- a/test/lit_tests/raising/libdevice_fastmath.mlir
+++ b/test/lit_tests/raising/libdevice_fastmath.mlir
@@ -38,14 +38,23 @@ llvm.func @compare(%a: f64, %b: f64) -> i1 {
 // Absent flags stay absent rather than becoming an explicit `none`, and a
 // `none` written out on the LLVM op does not survive as one either.
 
-llvm.func @no_flags(%a: f64, %b: f64) -> (f64, i1) {
+llvm.func @no_flags(%a: f64, %b: f64) -> f64 {
   %0 = llvm.fmul %a, %b : f64
-  %1 = llvm.fcmp "ogt" %a, %b {fastmathFlags = #llvm.fastmath<none>} : f64
-  llvm.return %0, %1 : f64, i1
+  llvm.return %0 : f64
 }
 
 // CHECK-LABEL: llvm.func @no_flags
 // CHECK:         arith.mulf %arg0, %arg1 : f64
+// CHECK-NOT:     fastmath
+
+// -----
+
+llvm.func @explicit_none(%a: f64, %b: f64) -> i1 {
+  %0 = llvm.fcmp "ogt" %a, %b {fastmathFlags = #llvm.fastmath<none>} : f64
+  llvm.return %0 : i1
+}
+
+// CHECK-LABEL: llvm.func @explicit_none
 // CHECK:         arith.cmpf ogt, %arg0, %arg1 : f64
 // CHECK-NOT:     fastmath
 

--- a/test/lit_tests/raising/libdevice_fastmath.mlir
+++ b/test/lit_tests/raising/libdevice_fastmath.mlir
@@ -22,15 +22,32 @@ llvm.func @fastmath(%a: f64, %b: f64, %c: f64) -> f64 {
 
 // -----
 
-// Absent flags stay absent rather than becoming an explicit `none`.
+// Comparisons carry them too.
 
-llvm.func @no_flags(%a: f64, %b: f64) -> f64 {
+llvm.func @compare(%a: f64, %b: f64) -> i1 {
+  %0 = llvm.fcmp "ogt" %a, %b {fastmathFlags = #llvm.fastmath<fast>} : f64
+  llvm.return %0 : i1
+}
+
+// CHECK-LABEL: llvm.func @compare
+// CHECK:         arith.cmpf ogt, %arg0, %arg1 fastmath<fast>
+// CHECK-NOT:     fastmathFlags
+
+// -----
+
+// Absent flags stay absent rather than becoming an explicit `none`, and a
+// `none` written out on the LLVM op does not survive as one either.
+
+llvm.func @no_flags(%a: f64, %b: f64) -> (f64, i1) {
   %0 = llvm.fmul %a, %b : f64
-  llvm.return %0 : f64
+  %1 = llvm.fcmp "ogt" %a, %b {fastmathFlags = #llvm.fastmath<none>} : f64
+  llvm.return %0, %1 : f64, i1
 }
 
 // CHECK-LABEL: llvm.func @no_flags
 // CHECK:         arith.mulf %arg0, %arg1 : f64
+// CHECK:         arith.cmpf ogt, %arg0, %arg1 : f64
+// CHECK-NOT:     fastmath
 
 // -----
 


### PR DESCRIPTION
`InvVectorConvertFromLLVMPattern` accepts an attribute converter and then
hardcodes `AttrConvertPassThrough`:

```cpp
template <typename SourceOp, typename TargetOp,
          template <typename, typename> typename AttrConvert =
              AttrConvertPassThrough>
using InvVectorConvertFromLLVMPattern =
    VectorConvertFromLLVMPattern<TargetOp, SourceOp, AttrConvertPassThrough>;
                                                  // ^ AttrConvert unused
```

So the converter each of the 15 arithmetic patterns passes was ignored, and the
LLVM attribute was copied across verbatim — `arith.mulf %a, %b {fastmathFlags =
#llvm.fastmath<fast>}`. That spelling means nothing on an arith op: its own
`fastmath` attribute stays `none`, and `arith-to-llvm` reads that, so lowering
back to the LLVM dialect drops the flags. Every raised kernel lost the
fast-math it was compiled with, whatever `-ffast-math` said.

On XSBench, all 293 floating-point ops in the differentiated kernel reached the
LLVM dialect with no flags; with this they all keep `fastmath<fast>`.

`test/lit_tests/raising/arith_raise.mlir` had the bug written into it —
`// CHECK-NEXT: arith.cmpf ogt, %arg0, %arg1 {fastmathFlags = #llvm.fastmath<none>}`
— and is updated.

The overflow converter had never been instantiated, so enabling it surfaced two
compile errors: it was copied from the lowering direction without swapping
source and target, and it read the flags out of the attribute dictionary, where
an inherent attribute stored in properties does not appear. It now uses the
typed accessor.