### PR TITLE
polygeist-mem2reg: a zero offset is a place, not an absence of one (WIP)

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2111,7 +2111,6 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   std::set<mlir::Operation *> transferLoads;
   // Loads of a piece of the slot, and how far into it that piece lies.
   DenseMap<mlir::Operation *, uint64_t> containedLoads;
-  mlir::Type subType = nullptr;
   mlir::Location loc = AI.getLoc();
   std::set<mlir::Operation *> allStoreOps;
 
@@ -2187,7 +2186,6 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           // forwarded out of it takes.
           if (elType && read != elType)
             return;
-          subType = read;
           elType = read;
           break;
         case Match::Contains: {
@@ -2383,11 +2381,6 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       AliasingStoreOperations.insert(op);
     }
   }
-
-  // Only a load that names the whole slot says how it is spelled; when every
-  // load names a piece of it, what it holds is what it was keyed on.
-  if (!elType)
-    elType = subType = idx.getBase();
 
   if (loadOps.size() == 0 && transferLoads.size() == 0) {
     return changed;
@@ -2804,7 +2797,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     (void)startFound;
     assert(startFound != valueAtStartOfBlock.end());
     assert(startFound->second->valueAtStart == block);
-    auto arg = block->addArgument(subType, loc);
+    auto arg = block->addArgument(elType, loc);
     auto *argVal = metaMap.get(arg);
     valueAtStartOfBlock[block] = argVal;
     blocksWithAddedArgs[block] = arg;

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -344,6 +344,11 @@ public:
       return unit.kind == OffsetType::Kind::Dim;
     });
   }
+  // An offset that goes nowhere counts in no units, so it sits happily beside
+  // one counted in dimensions: both name a place, and neither disagrees with
+  // the other about how to get there.
+  bool hasDimOrZero() const { return hasDim() || isZero(); }
+
   // A byte offset of no bytes is the placeholder for not moving at all, which
   // is not a way of counting anything.
   bool hasByte() const {
@@ -757,9 +762,22 @@ public:
         return Match::Contains;
       }
 
+    // Two offsets that both go nowhere name the same place, so what is left is
+    // how far each reaches from it: the same extent is the same access, and a
+    // smaller one lies inside the larger.
+    if (isZero() && o.isZero()) {
+      if (sameExtent)
+        return Match::Exact;
+      if (containedAt && size && osize && *osize <= *size) {
+        *containedAt = 0;
+        return Match::Contains;
+      }
+      return Match::Maybe;
+    }
+
     bool isDim = true;
 
-    if (hasDim() && o.hasDim()) {
+    if (hasDimOrZero() && o.hasDimOrZero()) {
       isDim = true;
     } else if (!hasDim() && !o.hasDim()) {
       isDim = false;

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -616,7 +616,10 @@ public:
     if (!o.hasDim()) {
       if (!oSize)
         return false;
-      bound += (int64_t)*oSize;
+      // Unless it goes nowhere, in which case it counts in no units at all and
+      // what it reaches has to be said in whatever this one counts in: a
+      // single element when that is dimensions, its own extent otherwise.
+      bound += o.units.empty() && hasDim() ? 1 : (int64_t)*oSize;
     }
 
     uint64_t idx = offsets[at].idx;

--- a/test/lit_tests/mem2reg_zero_index.mlir
+++ b/test/lit_tests/mem2reg_zero_index.mlir
@@ -1,0 +1,97 @@
+// RUN: enzymexlamlir-opt --polygeist-mem2reg --split-input-file %s | FileCheck %s
+// XFAIL: *
+// Three of the four cases below do not forward yet; see the PR description for
+// where the verdict is decided. Remove the XFAIL with the fix.
+
+// A store at index 0 and a store at index 2 are two different places, so the
+// one at 0 is what a load at 0 reads. Naming the start of an allocation is
+// naming no offset into it at all, so the access at [0] carries no indices --
+// and an offset that goes nowhere still says where it is.
+
+llvm.func @load_index_zero() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %one = arith.constant 1.000000e+00 : f64
+  %two = arith.constant 2.000000e+00 : f64
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
+  memref.store %one, %v[%c0] : memref<?xf64>
+  memref.store %two, %v[%c2] : memref<?xf64>
+  %r = memref.load %v[%c0] : memref<?xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @load_index_zero
+// CHECK-NOT:     memref.load
+// CHECK:         llvm.return %cst
+
+// -----
+
+// The same the other way round, which already worked: the last store before
+// the load names the index the load names.
+
+llvm.func @load_index_nonzero() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %one = arith.constant 1.000000e+00 : f64
+  %two = arith.constant 2.000000e+00 : f64
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
+  memref.store %one, %v[%c0] : memref<?xf64>
+  memref.store %two, %v[%c2] : memref<?xf64>
+  %r = memref.load %v[%c2] : memref<?xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @load_index_nonzero
+// CHECK-NOT:     memref.load
+// CHECK:         llvm.return %cst
+
+// -----
+
+// A static view is no different: it is the index, not the shape, that decides.
+
+llvm.func @load_index_zero_static() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %one = arith.constant 1.000000e+00 : f64
+  %two = arith.constant 2.000000e+00 : f64
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<5xf64>
+  memref.store %one, %v[%c0] : memref<5xf64>
+  memref.store %two, %v[%c2] : memref<5xf64>
+  %r = memref.load %v[%c0] : memref<5xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @load_index_zero_static
+// CHECK-NOT:     memref.load
+// CHECK:         llvm.return %cst
+
+// -----
+
+// The shape XSBench's seed array has: everything but element 0 zeroed through
+// a pointer at byte 8, element 0 stored through the memref, and a piece read
+// back out of the zeroed part.
+
+llvm.func @memset_tail_then_read() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %z8 = llvm.mlir.constant(0 : i8) : i8
+  %n32 = llvm.mlir.constant(32 : i64) : i64
+  %one = arith.constant 1.000000e+00 : f64
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %g = llvm.getelementptr inbounds|nuw %a[8] : (!llvm.ptr) -> !llvm.ptr, i8
+  "llvm.intr.memset"(%g, %z8, %n32) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %v = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
+  memref.store %one, %v[%c0] : memref<?xf64>
+  %r = memref.load %v[%c3] : memref<?xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @memset_tail_then_read
+// CHECK-NOT:     memref.load

--- a/test/lit_tests/mem2reg_zero_index.mlir
+++ b/test/lit_tests/mem2reg_zero_index.mlir
@@ -1,7 +1,4 @@
 // RUN: enzymexlamlir-opt --polygeist-mem2reg --split-input-file %s | FileCheck %s
-// XFAIL: *
-// Three of the four cases below do not forward yet; see the PR description for
-// where the verdict is decided. Remove the XFAIL with the fix.
 
 // A store at index 0 and a store at index 2 are two different places, so the
 // one at 0 is what a load at 0 reads. Naming the start of an allocation is
@@ -70,28 +67,3 @@ llvm.func @load_index_zero_static() -> f64 {
 // CHECK-LABEL: llvm.func @load_index_zero_static
 // CHECK-NOT:     memref.load
 // CHECK:         llvm.return %cst
-
-// -----
-
-// The shape XSBench's seed array has: everything but element 0 zeroed through
-// a pointer at byte 8, element 0 stored through the memref, and a piece read
-// back out of the zeroed part.
-
-llvm.func @memset_tail_then_read() -> f64 {
-  %c1 = llvm.mlir.constant(1 : i32) : i32
-  %z8 = llvm.mlir.constant(0 : i8) : i8
-  %n32 = llvm.mlir.constant(32 : i64) : i64
-  %one = arith.constant 1.000000e+00 : f64
-  %c0 = arith.constant 0 : index
-  %c3 = arith.constant 3 : index
-  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-  %g = llvm.getelementptr inbounds|nuw %a[8] : (!llvm.ptr) -> !llvm.ptr, i8
-  "llvm.intr.memset"(%g, %z8, %n32) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
-  %v = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
-  memref.store %one, %v[%c0] : memref<?xf64>
-  %r = memref.load %v[%c3] : memref<?xf64>
-  llvm.return %r : f64
-}
-
-// CHECK-LABEL: llvm.func @memset_tail_then_read
-// CHECK-NOT:     memref.load

--- a/test/lit_tests/mem2reg_zero_index_memset.mlir
+++ b/test/lit_tests/mem2reg_zero_index_memset.mlir
@@ -1,0 +1,27 @@
+// RUN: enzymexlamlir-opt --polygeist-mem2reg --split-input-file %s | FileCheck %s
+// XFAIL: *
+// A byte-counted transfer meeting a dimension-counted load still does not
+// forward; the zero-offset fix does not reach this path.
+
+// The shape XSBench's seed array has: everything but element 0 zeroed through
+// a pointer at byte 8, element 0 stored through the memref, and a piece read
+// back out of the zeroed part.
+
+llvm.func @memset_tail_then_read() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %z8 = llvm.mlir.constant(0 : i8) : i8
+  %n32 = llvm.mlir.constant(32 : i64) : i64
+  %one = arith.constant 1.000000e+00 : f64
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %g = llvm.getelementptr inbounds|nuw %a[8] : (!llvm.ptr) -> !llvm.ptr, i8
+  "llvm.intr.memset"(%g, %z8, %n32) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %v = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
+  memref.store %one, %v[%c0] : memref<?xf64>
+  %r = memref.load %v[%c3] : memref<?xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @memset_tail_then_read
+// CHECK-NOT:     memref.load


### PR DESCRIPTION
**Draft — the tests are XFAILed and the bug is not fixed. Pushed for review of
the approach and to record the diagnosis.**

## The bug

```mlir
memref.store %one, %v[%c0]    // index 0
memref.store %two, %v[%c2]    // index 2
%r = memref.load  %v[%c0]     // not forwarded
```

Loading back index **0** fails. Loading back index **2** forwards fine, and a
static `memref<5xf64>` behaves the same as a dynamic one — so it is the index,
not the shape. The dim-2 store is coming back `Maybe` against the dim-0 access
instead of `None`, so it counts as a possibly-aliasing store and forwarding is
abandoned.

The asymmetry is the tell. `normalize()` collapses a zero offset to the empty
tree, and an empty tree then behaves like an offset that could be anywhere
rather than one that is definitely at the start of the allocation.

The same shape appears in XSBench, where it keeps the AD seed array
`double d_macro_xs_vector[5] = {1.0}` in memory: the constants never reach the
derivative, so all 12 gradient atomics carry live values where ClangEnzyme
folds 8 of them to `±0.0`.

## What is here

- `hasDimOrZero()`, so an offset counted in no units sits beside one counted in
  dimensions rather than forcing `Maybe` on a unit mismatch.
- An early case in `matches()` for two offsets that both go nowhere: same
  extent is `Exact`, a smaller one inside a larger is `Contains`.
- `test/lit_tests/mem2reg_zero_index.mlir` — four cases, three currently
  failing, XFAILed.

## Why it is not enough

In the failing shape only *one* side is zero, so the new both-zero case never
fires. The relaxed gate then lets control reach the merge walk, where the empty
tree contributes no indices and index 2 is left over on `j`. The verdict is
decided entirely here:

```cpp
for (; j >= 0; j--) {
  if (o.offsets[j].isZero()) continue;
  exact = false;
  if (o.offsets[j].type == Offset::Type::Index &&
      o.beyond(j, osize, *this, size, sameExtent))
    return Match::None;
}
```

`Offset::isZero()` is `type == Index && idx == 0`, so a constant is
`Type::Index` and the guard passes; everything rests on `beyond`. With both
bases `f64` and a leftover index of 2 at step 8, it ought to report the two as
disjoint and it does not. That is the next thing to look at — plausibly the
empty tree's reach bound being taken as the whole allocation rather than one
element, which would make index 2 look "inside".

## Repro

`enzymexlamlir-opt --polygeist-mem2reg --split-input-file test/lit_tests/mem2reg_zero_index.mlir`