### PR TITLE
polygeist-mem2reg: a fill reaching over a slot writes it

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -617,9 +617,11 @@ public:
       if (!oSize)
         return false;
       // Unless it goes nowhere, in which case it counts in no units at all and
-      // what it reaches has to be said in whatever this one counts in: a
-      // single element when that is dimensions, its own extent otherwise.
-      bound += o.units.empty() && hasDim() ? 1 : (int64_t)*oSize;
+      // what it reaches has to be said in whatever this one counts in: a single
+      // element when that is dimensions of what it reads, its own extent
+      // otherwise -- which is what the step has been put into above when the
+      // two read different amounts.
+      bound += o.units.empty() && hasDim() && sameExtent ? 1 : (int64_t)*oSize;
     }
 
     uint64_t idx = offsets[at].idx;
@@ -2329,6 +2331,19 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
             LLVM_FALLTHROUGH;
           case Match::Contains:
           case Match::Maybe:
+            // A fill reaching over the whole slot writes all of it whatever
+            // else it reaches besides, and zero bytes are a zero of whatever
+            // the slot holds however far they run past it.
+            if (auto ms = dyn_cast<LLVM::MemsetOp>(user)) {
+              APInt byte;
+              if (touched.containsAt(idx, dl) &&
+                  matchPattern(ms.getVal(), m_ConstantInt(&byte)) &&
+                  byte.isZero()) {
+                LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << *user << "\n");
+                allStoreOps.insert(user);
+                break;
+              }
+            }
             LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << *user << "\n");
             AliasingStoreOperations.insert(user);
             break;
@@ -3065,13 +3080,16 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
 
   // A slot is worth trying when more than one access names it -- and an access
   // of a piece of a slot is an access of that slot too, since the piece can be
-  // taken out of what is in it.
+  // taken out of what is in it. It counts the other way round as well, since
+  // an access reaching over the whole of a slot may be all that is ever said
+  // about what is in it.
   std::vector<OffsetTree> todo;
   for (auto &pair : lastStored) {
     unsigned count = pair.second;
     for (auto &other : lastStored)
       if (&other != &pair &&
-          pair.first.second.containsAt(other.first.second, dl))
+          (pair.first.second.containsAt(other.first.second, dl) ||
+           other.first.second.containsAt(pair.first.second, dl)))
         count += other.second;
     if (count > 1)
       todo.push_back(pair.first.second);

--- a/test/lit_tests/mem2reg_zero_index_memset.mlir
+++ b/test/lit_tests/mem2reg_zero_index_memset.mlir
@@ -1,7 +1,7 @@
 // RUN: enzymexlamlir-opt --polygeist-mem2reg --split-input-file %s | FileCheck %s
-// XFAIL: *
-// A byte-counted transfer meeting a dimension-counted load still does not
-// forward; the zero-offset fix does not reach this path.
+
+// A fill reaching over the whole of a slot says what is in it: zero bytes are
+// a zero of whatever the slot holds, however far past it they run.
 
 // The shape XSBench's seed array has: everything but element 0 zeroed through
 // a pointer at byte 8, element 0 stored through the memref, and a piece read
@@ -25,3 +25,109 @@ llvm.func @memset_tail_then_read() -> f64 {
 
 // CHECK-LABEL: llvm.func @memset_tail_then_read
 // CHECK-NOT:     memref.load
+// CHECK:         llvm.mlir.zero
+
+// -----
+
+// The slot need not be all the fill wrote: a piece of what a whole-allocation
+// fill covered is zero like the rest of it.
+
+llvm.func @memset_all_read_piece() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %z8 = llvm.mlir.constant(0 : i8) : i8
+  %n40 = llvm.mlir.constant(40 : i64) : i64
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  "llvm.intr.memset"(%a, %z8, %n40) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %r = llvm.load %a : !llvm.ptr -> f64
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @memset_all_read_piece
+// CHECK-NOT:     llvm.load
+// CHECK:         llvm.mlir.zero
+
+// -----
+
+// A fill of the whole allocation reaches an element counted in dimensions the
+// same as one counted in bytes does.
+
+llvm.func @memset_all_read_dim() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %z8 = llvm.mlir.constant(0 : i8) : i8
+  %n40 = llvm.mlir.constant(40 : i64) : i64
+  %c3 = arith.constant 3 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  "llvm.intr.memset"(%a, %z8, %n40) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %v = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
+  %r = memref.load %v[%c3] : memref<?xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @memset_all_read_dim
+// CHECK-NOT:     memref.load
+// CHECK:         llvm.mlir.zero
+
+// -----
+
+// Reaching it is also overwriting it: a fill after a store is what is read
+// back, not what the store put there.
+
+llvm.func @store_then_memset_all() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %z8 = llvm.mlir.constant(0 : i8) : i8
+  %n40 = llvm.mlir.constant(40 : i64) : i64
+  %one = arith.constant 1.000000e+00 : f64
+  %c3 = arith.constant 3 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
+  memref.store %one, %v[%c3] : memref<?xf64>
+  "llvm.intr.memset"(%a, %z8, %n40) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %r = memref.load %v[%c3] : memref<?xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @store_then_memset_all
+// CHECK-NOT:     memref.load
+// CHECK:         %[[Z:.+]] = llvm.mlir.zero : f64
+// CHECK:         llvm.return %[[Z]] : f64
+
+// -----
+
+// A fill that stops short of the slot says nothing about the rest of it, so
+// what a store put there is still what is read back.
+
+llvm.func @memset_part_keeps_rest(%v: !llvm.array<5 x f64>) -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %z8 = llvm.mlir.constant(0 : i8) : i8
+  %n8 = llvm.mlir.constant(8 : i64) : i64
+  %c3 = arith.constant 3 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  llvm.store %v, %a : !llvm.array<5 x f64>, !llvm.ptr
+  "llvm.intr.memset"(%a, %z8, %n8) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %m = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
+  %r = memref.load %m[%c3] : memref<?xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @memset_part_keeps_rest
+// CHECK:         "llvm.intr.memset"
+// CHECK:         memref.load
+
+// -----
+
+// Nor does a fill of anything but zero, whatever it covers.
+
+llvm.func @memset_nonzero_keeps_load() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %b = llvm.mlir.constant(7 : i8) : i8
+  %n40 = llvm.mlir.constant(40 : i64) : i64
+  %c3 = arith.constant 3 : index
+  %a = llvm.alloca %c1 x !llvm.array<5 x f64> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  "llvm.intr.memset"(%a, %b, %n40) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %m = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xf64>
+  %r = memref.load %m[%c3] : memref<?xf64>
+  llvm.return %r : f64
+}
+
+// CHECK-LABEL: llvm.func @memset_nonzero_keeps_load
+// CHECK:         memref.load


### PR DESCRIPTION
A zeroing `memset` that covers the whole of a slot says what is in that slot, whatever else it covers besides. Only `Match::Exact` was taken as a store, so a fill of an allocation left every element of it unforwardable -- the shape XSBench's AD seed array has.

Three parts:

- `forwardStoreToLoad`: a zero fill whose written range contains the slot is a store of a zero of what the slot holds. A fill that lies *inside* the slot still only blocks, since it says nothing about the rest.
- `getLastStored`: a slot is worth trying when an access reaches over the whole of it, not only when it reaches into it -- otherwise the only slot ever tried for `memset`-then-read is the fill's own byte extent, which no typed read can be taken out of.
- `beyond`: an offset that goes nowhere counts as a single element only when both sides read the same amount; when they differ the step has already been put into bytes, so its extent has to be too. Without this a fill of a whole array reads as not reaching an element in the middle of it, which is a miscompile once the slot above is tried: `store 1.0; memset 0; load` forwarded the `1.0`. `store_then_memset_all` covers it.

`mem2reg_zero_index_memset.mlir` loses its XFAIL and gains the covering, non-covering, and non-zero-fill cases. On the XSBench pre-mem2reg IR this promotes one more allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD