### PR TITLE
raise: promote after the tape ops are gone, not before

### DIFF
--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -148,8 +148,6 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       if (options->markReadonly)
         pass_pipeline += "markReadonly";
       pass_pipeline += "},"
-        "inline{default-pipeline=canonicalize max-iterations=4},"
-        "polygeist-mem2reg,canonicalize,symbol-dce,"
         "lower-llvm-ext,canonicalize,";
       if (options->splitMultiResults)
         pass_pipeline += "split-multi-results,";
@@ -158,6 +156,8 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
         // no lowering of its own further down, so expand it here.
         "flatten-enzyme-caches,lower-enzyme-binomial-progress,"
         "enzyme-simplify-math,"
+        "inline{default-pipeline=canonicalize max-iterations=4},"
+        "polygeist-mem2reg,canonicalize,symbol-dce,"
         // canonicalize here folds away memref.subview ops before gpu-kernel-outlining
         "canonicalize,cse";
       if (options->removeAtomics)


### PR DESCRIPTION
`inline` and `polygeist-mem2reg` ran directly after `enzyme{}`, while the tape was still spelled in `enzyme.init` / `enzyme.push` / `enzyme.pop`. A push holds the buffer it caches, so a slot that reaches one reads as captured and nothing forwards through it — and the allocations the differentiation leaves behind are exactly what promotion is wanted for.

This moves the pair to after `remove-unnecessary-enzyme-ops` / `flatten-enzyme-caches` / `lower-enzyme-binomial-progress`, so they run on IR where those ops are gone.

Draft: opened for CI while the local end-to-end measurement on XSBench is still running. I'll post the before/after numbers here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD