### PR TITLE
canonicalize-scf-for: a call that stays keeps what it names

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -3448,9 +3448,15 @@ struct ForLoopApplyEnzymeAttributes
       return success();
     }
 
+    // The calls whose attribute has been read out and put on the loop, which
+    // are the ones there is no longer anything to say through.
+    SmallVector<Operation *> read;
+    unsigned called = 0;
+
     for (auto use : *uses) {
       auto user = use.getUser();
       assert(isa<LLVM::CallOp>(user));
+      called++;
 
       APInt ckptType;
       if (!matchPattern(user->getOperand(0), m_ConstantInt(&ckptType))) {
@@ -3475,29 +3481,36 @@ struct ForLoopApplyEnzymeAttributes
         if (isMincutAttr) {
           if (!enable)
             loop->setAttr("enzyme.disable_mincut", rewriter.getUnitAttr());
+        } else {
+          assert(isCheckpointingAttr);
+          loop->setAttr("enzyme.enable_checkpointing",
+                        rewriter.getBoolAttr(enable));
 
-          continue;
-        }
-
-        assert(isCheckpointingAttr);
-        loop->setAttr("enzyme.enable_checkpointing",
-                      rewriter.getBoolAttr(enable));
-
-        if (enableBinomial) {
-          loop->setAttr("enzyme.binomial_checkpointing",
-                        rewriter.getUnitAttr());
-        }
-        if (hasPeriod && !checkpointingPeriod.isAllOnes()) {
-          loop->setAttr("enzyme.checkpoint_period",
-                        rewriter.getIntegerAttr(rewriter.getI64Type(),
-                                                checkpointingPeriod));
+          if (enableBinomial) {
+            loop->setAttr("enzyme.binomial_checkpointing",
+                          rewriter.getUnitAttr());
+          }
+          if (hasPeriod && !checkpointingPeriod.isAllOnes()) {
+            loop->setAttr("enzyme.checkpoint_period",
+                          rewriter.getIntegerAttr(rewriter.getI64Type(),
+                                                  checkpointingPeriod));
+          }
         }
       }
 
-      rewriter.eraseOp(user);
+      read.push_back(user);
     }
 
-    rewriter.eraseOp(func);
+    if (read.empty())
+      return failure();
+
+    for (auto *user : read)
+      rewriter.eraseOp(user);
+
+    // A call the attribute could not be read out of is still a call, and what
+    // it names has to stay for it to name anything.
+    if (read.size() == called)
+      rewriter.eraseOp(func);
 
     return success();
   }

--- a/test/lit_tests/raising/mincut_attr.mlir
+++ b/test/lit_tests/raising/mincut_attr.mlir
@@ -1,0 +1,80 @@
+// RUN: enzymexlamlir-opt %s --split-input-file --pass-pipeline='builtin.module(canonicalize-scf-for)' | FileCheck %s
+
+// Reading the attribute off the call is what the call was there for, so it
+// goes with what it said -- and so does the declaration it named, but only
+// once nothing calls it any more.
+
+module {
+  llvm.func local_unnamed_addr @body(!llvm.ptr)
+
+  llvm.func local_unnamed_addr @mincut_off(%n: i32, %p: !llvm.ptr) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %m = llvm.mlir.constant(0 : i64) : i64
+    scf.for %i = %c0 to %n step %c1  : i32 {
+      llvm.call @_Z26__enzyme_set_mincutm(%m) : (i64 {llvm.noundef}) -> ()
+      llvm.call @body(%p) : (!llvm.ptr) -> ()
+    }
+    llvm.return
+  }
+
+  llvm.func local_unnamed_addr @_Z26__enzyme_set_mincutm(i64 {llvm.noundef})
+}
+
+// CHECK-LABEL: llvm.func local_unnamed_addr @mincut_off
+// CHECK-NOT:     __enzyme_set_mincut
+// CHECK:         scf.for
+// CHECK:           llvm.call @body
+// CHECK:         } {enzyme.disable_mincut}
+// CHECK-NOT:   llvm.func local_unnamed_addr @_Z26__enzyme_set_mincutm
+
+// -----
+
+// Left on, there is no attribute to add, and the call still goes.
+
+module {
+  llvm.func local_unnamed_addr @body(!llvm.ptr)
+
+  llvm.func local_unnamed_addr @mincut_on(%n: i32, %p: !llvm.ptr) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %m = llvm.mlir.constant(1 : i64) : i64
+    scf.for %i = %c0 to %n step %c1  : i32 {
+      llvm.call @_Z26__enzyme_set_mincutm(%m) : (i64 {llvm.noundef}) -> ()
+      llvm.call @body(%p) : (!llvm.ptr) -> ()
+    }
+    llvm.return
+  }
+
+  llvm.func local_unnamed_addr @_Z26__enzyme_set_mincutm(i64 {llvm.noundef})
+}
+
+// CHECK-LABEL: llvm.func local_unnamed_addr @mincut_on
+// CHECK-NOT:     __enzyme_set_mincut
+// CHECK:         scf.for
+// CHECK-NOT:     enzyme.disable_mincut
+
+// -----
+
+// A call whose setting cannot be read stays, so the declaration it names stays
+// with it rather than leaving it pointing at nothing.
+
+module {
+  llvm.func local_unnamed_addr @body(!llvm.ptr)
+
+  llvm.func local_unnamed_addr @mincut_dynamic(%n: i32, %p: !llvm.ptr, %d: i64) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    scf.for %i = %c0 to %n step %c1  : i32 {
+      llvm.call @_Z26__enzyme_set_mincutm(%d) : (i64 {llvm.noundef}) -> ()
+      llvm.call @body(%p) : (!llvm.ptr) -> ()
+    }
+    llvm.return
+  }
+
+  llvm.func local_unnamed_addr @_Z26__enzyme_set_mincutm(i64 {llvm.noundef})
+}
+
+// CHECK-LABEL: llvm.func local_unnamed_addr @mincut_dynamic
+// CHECK:         llvm.call @_Z26__enzyme_set_mincutm
+// CHECK:       llvm.func local_unnamed_addr @_Z26__enzyme_set_mincutm


### PR DESCRIPTION
Fixes the LBM build failure on https://github.com/EnzymeAD/Reactant/pull/65:

```
error: 'llvm.call' op '_ZZ26CUDA_LBM_kernel_loop_inneriPfS_E19__enzyme_set_mincutm'
       does not reference a symbol in the current scope
```

`ForLoopApplyEnzymeAttributes` reads the setting off an `__enzyme_set_mincut` / `__enzyme_set_checkpointing` call, puts it on the enclosing loop, and erases both the call and the declaration. The mincut branch `continue`d after setting the attribute, skipping `rewriter.eraseOp(user)` — but `rewriter.eraseOp(func)` at the end ran unconditionally. So whenever a mincut call was still inside an `scf.for`/`scf.while` when the pattern fired, the declaration went and the call stayed, pointing at nothing.

Reduced to twelve lines, on main before this change:

```mlir
scf.for %i = %c0 to %n step %c1 : i32 {
  llvm.call @_Z26__enzyme_set_mincutm(%m) : (i64) -> ()
}
llvm.func @_Z26__enzyme_set_mincutm(i64)
```
→ `error: 'llvm.call' op ... does not reference a symbol in the current scope`

The same shape is reachable from the non-constant path, which also `continue`s. So the declaration is now erased only once every call to it has been, and a use the pattern could not read keeps both.

This is not new to the commit range being bumped — it needs only that the call still be in a recognised loop at that point, and the existing `raise-loop-attributes.mlir` covers checkpointing but never mincut. `mincut_attr.mlir` adds the off / on / dynamic cases. Suite is 1103/1103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD