### PR TITLE
raise: lower invoke, and keep bitcast from changing shape

### DIFF
--- a/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
+++ b/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
@@ -54,6 +54,14 @@ public:
     if (isa<LLVM::LLVMArrayType, mlir::VectorType>(llvmNDVectorTy)) {
       return failure();
     }
+    // What comes out counts elements as much as what goes in, and an op free to
+    // change one without the other -- a bitcast of an integer to a vector of
+    // floats -- cannot be said with one that holds its shape.
+    if (llvm::any_of(op->getResultTypes(), [](Type type) {
+          return isa<LLVM::LLVMArrayType, mlir::VectorType>(type);
+        })) {
+      return failure();
+    }
 
     Operation *newOp = rewriter.create(
         op->getLoc(), rewriter.getStringAttr(TargetOp::getOperationName()),

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -20,8 +20,12 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IRReader/IRReader.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Transforms/Scalar/SimplifyCFG.h"
+#include "llvm/Transforms/Utils/LowerInvoke.h"
 
 #include "src/enzyme_ad/jax/RegistryUtils.h"
 #include "llvm/Support/TargetSelect.h"
@@ -47,6 +51,32 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
     err_stream.flush();
     exit(1);
   }
+  // Raising has no way to read an unwind edge, so a call that may throw stops
+  // it here rather than further along: an invoke left standing is not a module
+  // that gets compiled at all.
+  {
+    llvm::PassBuilder PB;
+    llvm::LoopAnalysisManager LAM;
+    llvm::FunctionAnalysisManager FAM;
+    llvm::CGSCCAnalysisManager CGAM;
+    llvm::ModuleAnalysisManager MAM;
+    PB.registerModuleAnalyses(MAM);
+    PB.registerCGSCCAnalyses(CGAM);
+    PB.registerFunctionAnalyses(FAM);
+    PB.registerLoopAnalyses(LAM);
+    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+    llvm::FunctionPassManager FPM;
+    FPM.addPass(llvm::LowerInvokePass());
+    // The landing pads the lowering leaves behind are unreachable, and what
+    // reads the module next has no more use for them than it had for the edge.
+    FPM.addPass(llvm::SimplifyCFGPass());
+
+    llvm::ModulePassManager MPM;
+    MPM.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(FPM)));
+    MPM.run(*llvmModule, MAM);
+  }
+
   llvm::InitializeNativeTarget();
   llvm::InitializeNativeTargetAsmPrinter();
 

--- a/test/lit_tests/raising/bitcast_shape.mlir
+++ b/test/lit_tests/raising/bitcast_shape.mlir
@@ -1,0 +1,39 @@
+// RUN: enzymexlamlir-opt --libdevice-funcs-raise --split-input-file %s | FileCheck %s
+
+// arith.bitcast holds its shape, so only a cast whose two ends agree on one can
+// be said with it. An integer reinterpreted as a vector of floats is a cast
+// LLVM allows and arith has no spelling for, and it stays as it was.
+
+llvm.func @scalar_to_vector(%a: i64) -> vector<2xf32> {
+  %r = llvm.bitcast %a : i64 to vector<2xf32>
+  llvm.return %r : vector<2xf32>
+}
+
+// CHECK-LABEL: llvm.func @scalar_to_vector
+// CHECK:         llvm.bitcast
+// CHECK-NOT:     arith.bitcast
+
+// -----
+
+// The other way round is no better.
+
+llvm.func @vector_to_scalar(%a: vector<2xf32>) -> i64 {
+  %r = llvm.bitcast %a : vector<2xf32> to i64
+  llvm.return %r : i64
+}
+
+// CHECK-LABEL: llvm.func @vector_to_scalar
+// CHECK:         llvm.bitcast
+// CHECK-NOT:     arith.bitcast
+
+// -----
+
+// Two ends of one shape still raise.
+
+llvm.func @scalar_to_scalar(%a: i32) -> f32 {
+  %r = llvm.bitcast %a : i32 to f32
+  llvm.return %r : f32
+}
+
+// CHECK-LABEL: llvm.func @scalar_to_scalar
+// CHECK:         arith.bitcast


### PR DESCRIPTION
Two blockers hit while trying to build [MFEM](https://github.com/mfem/mfem) (`dfem-dev`) through the Reactant/EnzymeMLIR path — the first codebase we've pointed it at that compiles with C++ exceptions.

### `invoke` never reaches the pipeline

14 files failed with:

```
error: 'llvm.invoke' op transformation does not support terminators with side effects
error: Reactant: failed to run mlir passes
```

from upstream `mlir/lib/Transforms/Utils/CFGToSCF.cpp:1264`, driven by `enzyme-lift-cf-to-scf`. `llvm.invoke` is a side-effecting terminator.

`LowerInvokePass` + `SimplifyCFGPass` now run on the LLVM module before `translateLLVMIRToModule`. This is unconditional: an invoke that survives does not give a program with working exceptions, it gives no compiled module at all, so there is no behaviour being traded away by lowering it.

### `arith.bitcast` built with mismatched shapes

With the above in place, one file (`linalg/blockoperator.cpp`) then failed:

```
error: 'arith.bitcast' op requires the same shape for all operands and results
  see current operation: %23 = "arith.bitcast"(%14) : (i64) -> vector<2xf32>
```

`VectorConvertFromLLVMPattern` declines to convert an op whose *operand* is a vector or array, but never looked at what it writes. For every other op it is used with the two agree; `bitcast` is the one free to change shape between them. The guard now covers the result types as well.

`bitcast_shape.mlir` covers scalar→vector, vector→scalar, and the same-shape case that must still raise. Suite is 1104/1104.

Note the `invoke` half is in `raise.cpp` rather than a pass, so it is not reachable from `enzymexlamlir-opt` and has no lit coverage; it is exercised by the MFEM build, where it takes the failures from 14 to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD