### PR TITLE
polygeist-mem2reg: look a callee up once, not once per call

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -1142,7 +1142,8 @@ struct PolygeistMem2Reg
   bool forwardStoreToLoad(
       mlir::Value AI, OffsetTree idx,
       SmallVectorImpl<Operation *> &loadOpsToErase,
-      DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing);
+      DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing,
+      SymbolTableCollection &symbolTables);
 };
 
 } // end anonymous namespace
@@ -2055,10 +2056,11 @@ Value castToType(Type elType, Value val, Operation *op) {
 
 // Check if call captures alloca instance by checking for llvm.nocapture
 // attribute
-bool isCallNonCapturing(CallOpInterface callOp, Value val) {
+bool isCallNonCapturing(CallOpInterface callOp, Value val,
+                        SymbolTableCollection &symbolTables) {
   auto calleeAttr = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
   if (calleeAttr) {
-    auto callee = SymbolTable::lookupSymbolIn(
+    auto callee = symbolTables.lookupSymbolIn(
         callOp->getParentOfType<ModuleOp>(), calleeAttr);
     auto fn = dyn_cast_or_null<FunctionOpInterface>(callee);
     if (!fn)
@@ -2127,7 +2129,8 @@ static bool extractPath(Type from, uint64_t at, Type want, const DataLayout &dl,
 bool PolygeistMem2Reg::forwardStoreToLoad(
     mlir::Value AI, OffsetTree idx,
     SmallVectorImpl<Operation *> &loadOpsToErase,
-    DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing) {
+    DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing,
+    SymbolTableCollection &symbolTables) {
   bool changed = false;
   std::set<mlir::Operation *> loadOps;
   // Transfers that read exactly one slot, which act as a load of it.
@@ -2291,7 +2294,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       if (auto callOp = dyn_cast<CallOpInterface>(user)) {
         auto callee = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
         if (!callee || callee.getLeafReference() != "free") {
-          if (!isCallNonCapturing(callOp, val)) {
+          if (!isCallNonCapturing(callOp, val, symbolTables)) {
             LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << callOp << "\n");
             AliasingStoreOperations.insert(callOp.getOperation());
             if (!callee || !getNonCapturingFunctions().count(
@@ -2964,7 +2967,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   return changed;
 }
 
-bool isPromotable(mlir::Value AI) {
+bool isPromotable(mlir::Value AI, SymbolTableCollection &symbolTables) {
   std::deque<mlir::Value> list = {AI};
 
   while (list.size()) {
@@ -2998,7 +3001,7 @@ bool isPromotable(mlir::Value AI) {
       } else if (auto callOp = dyn_cast<CallOpInterface>(U)) {
         if (auto sym = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee())) {
           if (StringAttr callee = sym.getLeafReference())
-            if (isCallNonCapturing(callOp, val) ||
+            if (isCallNonCapturing(callOp, val, symbolTables) ||
                 getNonCapturingFunctions().count(callee.str()))
               continue;
         }
@@ -3100,6 +3103,11 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
 void PolygeistMem2Reg::runOnOperation() {
   auto *f = getOperation();
 
+  // Resolving a callee by name walks every symbol the module has, and there is
+  // a callee to resolve for each call each allocation reaches. Nothing here
+  // adds or removes a symbol, so one collection serves the whole run.
+  SymbolTableCollection symbolTables;
+
   // Variable indicating that a memref has had a load removed
   // and or been deleted. Because there can be memrefs of
   // memrefs etc, we may need to do multiple passes (first
@@ -3117,22 +3125,22 @@ void PolygeistMem2Reg::runOnOperation() {
     // Walk all load's and perform store to load forwarding.
     SmallVector<mlir::Value, 4> toPromote;
     f->walk([&](mlir::memref::AllocaOp AI) {
-      if (isPromotable(AI)) {
+      if (isPromotable(AI, symbolTables)) {
         toPromote.push_back(AI);
       }
     });
     f->walk([&](mlir::memref::AllocOp AI) {
-      if (isPromotable(AI)) {
+      if (isPromotable(AI, symbolTables)) {
         toPromote.push_back(AI);
       }
     });
     f->walk([&](LLVM::AllocaOp AI) {
-      if (isPromotable(AI)) {
+      if (isPromotable(AI, symbolTables)) {
         toPromote.push_back(AI);
       }
     });
     f->walk([&](memref::GetGlobalOp AI) {
-      if (isPromotable(AI)) {
+      if (isPromotable(AI, symbolTables)) {
         toPromote.push_back(AI);
       }
     });
@@ -3148,8 +3156,8 @@ void PolygeistMem2Reg::runOnOperation() {
                                 << "} of " << AI << "\n");
         // llvm::errs() << " PRE " << AI << "\n";
         // f.dump();
-        changed |=
-            forwardStoreToLoad(AI, vec, loadOpsToErase, capturedAliasing);
+        changed |= forwardStoreToLoad(AI, vec, loadOpsToErase, capturedAliasing,
+                                      symbolTables);
         // llvm::errs() << " POST " << AI << "\n";
         // f.dump();
       }


### PR DESCRIPTION
`isCallNonCapturing` resolves the callee through `SymbolTable::lookupSymbolIn`, which walks every symbol in the module and compares its name. It is asked once for each call each allocation reaches, from both `isPromotable` and `forwardStoreToLoad`, so that walk is paid over and over for the same handful of answers.

On a module with a symbol table of any size, that is most of the pass. Profiling `polygeist-mem2reg` over MFEM's `mesh.cpp` — 1635 symbols, 1624 allocations, 11045 calls — puts about half the samples in the lookup and the string comparisons beneath it:

```
21.62%  LLVMFuncOp::getInherentAttr
17.56%  operator==(StringRef, StringRef)
 4.92%  GlobalOp::getInherentAttr
 2.94%  SymbolTable::lookupSymbolIn
 2.19%  RegisteredOperationName::Model<GlobalOp>::getInherentAttr
```

A `SymbolTableCollection` builds each table once and answers from it thereafter. Nothing in this pass adds or removes a symbol, so one collection serves the whole run. It is held as a local in `runOnOperation` rather than a member because a pass has to stay copy-constructible.

Re-profiled after the change, symbol resolution is gone from the top of the profile entirely.

### Caveat

This does not on its own make `mesh.cpp` compile. That module still does not finish `polygeist-mem2reg` in 900s, before or after — the remaining time is in `forwardStoreToLoad`'s per-block walk, which is a separate problem I am still reducing. This removes one of the two costs.

### Testing

Compile-time change only — the same symbol resolves to the same function. `bazel test -c opt //test/lit_tests:all` → 1104/1104 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD