### PR TITLE
polygeist-mem2reg: drop a transfer read nobody asked for

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -28,6 +28,7 @@
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "src/enzyme_ad/jax/Utils.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include <algorithm>
@@ -2136,6 +2137,18 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   DenseMap<mlir::Operation *, uint64_t> containedLoads;
   mlir::Location loc = AI.getLoc();
   std::set<mlir::Operation *> allStoreOps;
+  // Reads standing for what a transfer moved. One is worth the load it costs
+  // only where something went on to ask for it: left behind unasked for, it is
+  // a read of the other side of the transfer, which promoting that side sees,
+  // sweeps, and counts as progress -- and promoting this side writes again the
+  // round after, so neither side ever settles. There are several ways out of
+  // this function and the reads have to go on all of them.
+  SmallVector<Operation *> transferReads;
+  auto dropUnaskedReads = llvm::make_scope_exit([&transferReads]() {
+    for (auto *read : llvm::reverse(transferReads))
+      if (read->getResult(0).use_empty())
+        read->erase();
+  });
 
   if (idx.isUnknown())
     return changed;
@@ -2652,6 +2665,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
               } else if (Value src = transferSource(a)) {
                 written = LLVM::LoadOp::create(builder, a->getLoc(), moved, src,
                                                transferAlignment(a, 1));
+                transferReads.push_back(written.getDefiningOp());
               } else {
                 written = LLVM::ZeroOp::create(builder, a->getLoc(), moved);
               }

--- a/test/lit_tests/mem2reg_transfer_read.mlir
+++ b/test/lit_tests/mem2reg_transfer_read.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt --polygeist-mem2reg --split-input-file %s | FileCheck %s
+
+// A transfer writing the slot is stood for by a read of what it moved, which is
+// worth the load it costs only where something goes on to ask for it. Here the
+// one read of the destination comes before the copy and so is not replaceable,
+// and the pass leaves without replacing anything -- the read of the source has
+// to leave with it.
+//
+// Left behind it is a read of the source, which promoting the source then sees
+// as a load nobody uses, sweeps, and counts as progress; promoting the
+// destination writes it again the round after, and the two never settle.
+
+llvm.func @use(!llvm.ptr {llvm.nocapture})
+llvm.func @sink(i160)
+
+llvm.func @unasked_read(%p: !llvm.ptr) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %n = llvm.mlir.constant(20 : i64) : i64
+  %src = llvm.alloca %c1 x !llvm.struct<"S", packed (ptr, i32, i32, i32, array<4 x i8>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %dst = llvm.alloca %c1 x !llvm.struct<"S", packed (ptr, i32, i32, i32, array<4 x i8>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  llvm.store %p, %src {alignment = 8 : i64} : !llvm.ptr, !llvm.ptr
+  %v = llvm.load %dst {alignment = 8 : i64} : !llvm.ptr -> i160
+  llvm.call @sink(%v) : (i160) -> ()
+  "llvm.intr.memcpy"(%dst, %src, %n) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  llvm.call @use(%dst) : (!llvm.ptr {llvm.nocapture}) -> ()
+  llvm.return
+}
+
+// The read of the destination is the only load there is any use for, and the
+// copy still stands.
+
+// CHECK-LABEL: llvm.func @unasked_read
+// CHECK:         %[[SRC:.+]] = llvm.alloca
+// CHECK:         %[[DST:.+]] = llvm.alloca
+// CHECK:         llvm.store %arg0, %[[SRC]]
+// CHECK-NEXT:    %[[V:.+]] = llvm.load %[[DST]]
+// CHECK-NEXT:    llvm.call @sink(%[[V]])
+// CHECK-NEXT:    "llvm.intr.memcpy"(%[[DST]], %[[SRC]]
+// CHECK-NEXT:    llvm.call @use(%[[DST]])
+// CHECK-NEXT:    llvm.return


### PR DESCRIPTION
`polygeist-mem2reg` does not terminate on MFEM's `mesh.cpp`. It is an infinite loop, not slowness — the `do { … } while (changed)` in `runOnOperation` reported the same `promote=1379 slots=3668` every round, with the enclosing function's IR **byte-identical** between rounds 6 and 7, for as long as it was left to run. No timeout would have let it through.

### The loop

A transfer writing the slot is stood for by a read of what it moved (`PolygeistMem2Reg.cpp:2657`). That read is worth the load it costs only where something goes on to ask for it, and `forwardStoreToLoad` has several ways out — unknown offset, no loads to forward, nothing replaceable — that leave without asking. `handleBlock` has already run and created the read by then.

Left behind, the read is a load of the *other side* of the transfer:

- promoting `%33` sees `memcpy(%33, %26, 20)` and creates `%223 = llvm.load %26 : i160`
- nothing asks for it, so it is left standing with no uses at all
- promoting `%26` sees a load nobody uses, sweeps it, and counts the sweep as `changed`
- the round after, `%33` writes it again

In the real IR two identical `llvm.load %7 -> i160` end up sitting next to each other in front of the memcpy, neither with a single user.

### The fix

Erase the read wherever it was not asked for. A scope guard, because the several ways out of the function all have to drop it — an earlier attempt that cleaned up just before the final `return` did nothing at all: 12004 reads created, zero reached the cleanup.

### Result

`mesh.cpp` now finishes `polygeist-mem2reg` in **1.57s**, having previously not finished in 900s.

### Testing

- `bazel test -c opt //test/lit_tests:all` → 1105/1105 pass.
- New test `mem2reg_transfer_read.mlir`, reduced from `mesh.cpp` to 17 lines. Before this change the pass leaves a `llvm.load` of the memcpy source that no one uses; after, it does not. The reduction went 594 functions → 2 → 1 (by capturing the module at the loop's steady state) → the shape in the test.
- The test asserts the converged output rather than the absence of a hang, since a lit test cannot express "does not terminate".

### Not fixed here

With the loop gone, `mesh.cpp` reaches passes it never used to and crashes in a different place — `AddIOfIndexUI::matchAndRewrite` in `CanonicalizeLoops.cpp` calls `getIntOrFloatBitWidth()` on what looks like an `index`. Separate bug, separate PR.

Draft because I would like a look at whether dropping the read is the right shape of fix, or whether it should not be created eagerly in the first place. Tests are green either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD