### PR TITLE
affine-cfg: do not ask index for a width

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
@@ -351,6 +351,16 @@ LogicalResult AffineIntegerRangeAnalysis::visitOperation(
 
 namespace {
 
+// These rewrites read an op on integers one of whose operands came from an
+// index, and say the op again in index. The width they check is the width of
+// the integer the index was cast to; index itself has no width to ask for, and
+// an op already in index has the cast the other way round, so rewriting it
+// would put an integer where an index belongs. Neither is a rewrite to make.
+static bool tooNarrowFor(mlir::Type ty, int64_t max) {
+  auto intTy = dyn_cast<mlir::IntegerType>(ty);
+  return !intTy || APInt::getMaxValue(intTy.getWidth()).ult(max);
+}
+
 std::optional<int64_t> maxSize(mlir::Value v) {
   if (auto ba = dyn_cast<BlockArgument>(v)) {
     if (auto par =
@@ -457,8 +467,7 @@ public:
     auto maxSizeOpt = maxSize(operand.getOperand());
     if (!maxSizeOpt)
       return failure();
-    if (APInt::getMaxValue(operand.getType().getIntOrFloatBitWidth())
-            .ult(*maxSizeOpt))
+    if (tooNarrowFor(operand.getType(), *maxSizeOpt))
       return failure();
 
     rewriter.replaceOpWithNewOp<arith::IndexCastUIOp>(ext, ext.getType(),
@@ -479,8 +488,7 @@ public:
     auto maxSizeOpt = maxSize(operand.getOperand());
     if (!maxSizeOpt)
       return failure();
-    if (APInt::getMaxValue(ext.getType().getIntOrFloatBitWidth())
-            .ult(*maxSizeOpt))
+    if (tooNarrowFor(ext.getType(), *maxSizeOpt))
       return failure();
 
     rewriter.replaceOpWithNewOp<arith::IndexCastUIOp>(ext, ext.getType(),
@@ -501,8 +509,7 @@ public:
     auto maxSizeOpt = maxSize(operand.getOperand());
     if (!maxSizeOpt)
       return failure();
-    if (APInt::getMaxValue(operand.getType().getIntOrFloatBitWidth())
-            .ult(*maxSizeOpt))
+    if (tooNarrowFor(operand.getType(), *maxSizeOpt))
       return failure();
 
     IntegerAttr constValue;
@@ -531,8 +538,7 @@ public:
     auto maxSizeOpt = maxSize(operand.getOperand());
     if (!maxSizeOpt)
       return failure();
-    if (APInt::getMaxValue(operand.getType().getIntOrFloatBitWidth())
-            .ult(*maxSizeOpt))
+    if (tooNarrowFor(operand.getType(), *maxSizeOpt))
       return failure();
 
     IntegerAttr constValue;
@@ -565,8 +571,7 @@ public:
     if (!maxSizeOpt)
       return failure();
     if (!operand.getType().isIndex())
-      if (APInt::getMaxValue(operand.getType().getIntOrFloatBitWidth())
-              .ult(*maxSizeOpt))
+      if (tooNarrowFor(operand.getType(), *maxSizeOpt))
         return failure();
     if (operand.getRhs() != ext.getRhs())
       return failure();
@@ -588,8 +593,7 @@ public:
     auto maxSizeOpt = maxSize(operandOp->getOperand(0));
     if (!maxSizeOpt)
       return failure();
-    if (APInt::getMaxValue(operand.getType().getIntOrFloatBitWidth())
-            .ult(*maxSizeOpt))
+    if (tooNarrowFor(operand.getType(), *maxSizeOpt))
       return failure();
 
     IntegerAttr constValue;
@@ -638,8 +642,7 @@ public:
     auto maxSizeOpt = maxSize(operand.getOperand());
     if (!maxSizeOpt)
       return failure();
-    if (APInt::getMaxValue(operand.getType().getIntOrFloatBitWidth())
-            .ult(*maxSizeOpt))
+    if (tooNarrowFor(operand.getType(), *maxSizeOpt))
       return failure();
 
     APInt constValue;
@@ -670,9 +673,7 @@ public:
     auto maxSizeOpt = maxSize(operand->getOperand(0));
     if (!maxSizeOpt)
       return failure();
-    if (APInt::getMaxValue(
-            operand->getResult(0).getType().getIntOrFloatBitWidth())
-            .ult(*maxSizeOpt))
+    if (tooNarrowFor(operand->getResult(0).getType(), *maxSizeOpt))
       return failure();
 
     IntegerAttr constValue;
@@ -708,8 +709,7 @@ public:
     auto maxSizeOpt = maxSize(operand.getOperand());
     if (!maxSizeOpt)
       return failure();
-    if (APInt::getMaxValue(operand.getType().getIntOrFloatBitWidth())
-            .ult(*maxSizeOpt))
+    if (tooNarrowFor(operand.getType(), *maxSizeOpt))
       return failure();
 
     IntegerAttr constValue;

--- a/test/lit_tests/canonicalizeloops_index_width.mlir
+++ b/test/lit_tests/canonicalizeloops_index_width.mlir
@@ -1,0 +1,111 @@
+// RUN: enzymexlamlir-opt --affine-cfg --split-input-file %s | FileCheck %s
+
+// These rewrites read an op on integers one of whose operands came from an
+// index and say the op again in index. The width they check against is the
+// width of the integer the index was cast to. Where the op is itself in index
+// the cast runs the other way, and index has no width to be asked for -- asking
+// read it as a float and took the crash that follows.
+
+func.func @addi_index(%n: i64) -> index {
+  %c8 = arith.constant 8 : i64
+  %c4 = arith.constant 4 : index
+  %r = arith.remui %n, %c8 : i64
+  %x = arith.index_castui %r : i64 to index
+  %a = arith.addi %x, %c4 : index
+  return %a : index
+}
+
+// CHECK-LABEL: func.func @addi_index
+// CHECK:         %[[X:.+]] = arith.index_castui
+// CHECK-NEXT:    arith.addi %[[X]]
+
+// -----
+
+func.func @subi_index(%n: i64) -> index {
+  %c8 = arith.constant 8 : i64
+  %c0 = arith.constant 0 : index
+  %r = arith.remui %n, %c8 : i64
+  %x = arith.index_castui %r : i64 to index
+  %a = arith.subi %c0, %x : index
+  return %a : index
+}
+
+// CHECK-LABEL: func.func @subi_index
+// CHECK:         arith.subi
+
+// -----
+
+func.func @muli_index(%n: i64) -> index {
+  %c8 = arith.constant 8 : i64
+  %c4 = arith.constant 4 : index
+  %r = arith.remui %n, %c8 : i64
+  %x = arith.index_castui %r : i64 to index
+  %a = arith.muli %x, %c4 : index
+  return %a : index
+}
+
+// CHECK-LABEL: func.func @muli_index
+// CHECK:         arith.muli
+
+// -----
+
+func.func @shli_index(%n: i64) -> index {
+  %c8 = arith.constant 8 : i64
+  %c4 = arith.constant 4 : index
+  %r = arith.remui %n, %c8 : i64
+  %x = arith.index_castui %r : i64 to index
+  %a = arith.shli %x, %c4 : index
+  return %a : index
+}
+
+// CHECK-LABEL: func.func @shli_index
+// CHECK:         arith.shli
+
+// -----
+
+func.func @shrui_index(%n: i64) -> index {
+  %c8 = arith.constant 8 : i64
+  %c4 = arith.constant 4 : index
+  %r = arith.remui %n, %c8 : i64
+  %x = arith.index_castui %r : i64 to index
+  %a = arith.shrui %x, %c4 : index
+  return %a : index
+}
+
+// CHECK-LABEL: func.func @shrui_index
+// CHECK:         arith.shrui
+
+// -----
+
+func.func @divui_index(%n: i64) -> index {
+  %c8 = arith.constant 8 : i64
+  %c4 = arith.constant 4 : index
+  %r = arith.remui %n, %c8 : i64
+  %x = arith.index_castui %r : i64 to index
+  %a = arith.divui %x, %c4 : index
+  return %a : index
+}
+
+// CHECK-LABEL: func.func @divui_index
+// CHECK:         arith.divui
+
+// -----
+
+// An op on integers over an index that fits still moves into index.
+
+func.func @addi_integer(%m: memref<?xi64>) {
+  affine.parallel (%i) = (0) to (16) {
+    %c4 = arith.constant 4 : i64
+    %x = arith.index_castui %i : index to i64
+    %a = arith.addi %x, %c4 : i64
+    memref.store %a, %m[%i] : memref<?xi64>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @addi_integer
+// CHECK:         %[[C4:.+]] = arith.constant 4 : index
+// CHECK:         affine.parallel (%[[I:.+]]) = (0) to (16)
+// CHECK-NEXT:      %[[A:.+]] = arith.addi %[[I]], %[[C4]] : index
+// CHECK-NEXT:      %[[C:.+]] = arith.index_castui %[[A]] : index to i64
+// CHECK-NEXT:      affine.store %[[C]]


### PR DESCRIPTION
The index-cast rewrites in `CanonicalizeLoops.cpp` read an op on integers one of whose operands came from an index, and say the op again in index. Each first checks that the integer the index was cast to is wide enough to hold it, reaching for that width with `getIntOrFloatBitWidth`.

Where the op is **itself** in index the cast runs the other way, and index has no width to be asked for. In a release build the ask is unchecked — it reads index as a float, calls `getFloatSemantics` on it, and segfaults:

```
 #4 mlir::FloatType::getFloatSemantics() const
 #5 mlir::FloatType::getWidth()
 #6 mlir::Type::getIntOrFloatBitWidth() const
 #7 (anonymous namespace)::AddIOfIndexUI::matchAndRewrite(mlir::arith::AddIOp, ...)
...
#12 (anonymous namespace)::AffineCFGPass::runOnOperation()
```

Rewriting would have been wrong there in any case: it would put the integer the cast came from where an index belongs.

Answering for the type rather than asking it turns both into the failure they should have been. `DivMul`, which allows index deliberately, keeps its own guard and is unaffected.

### Reproducer

```mlir
func.func @f(%n: i64) -> index {
  %c8 = arith.constant 8 : i64
  %c4 = arith.constant 4 : index
  %r = arith.remui %n, %c8 : i64
  %x = arith.index_castui %r : i64 to index
  %a = arith.addi %x, %c4 : index
  return %a : index
}
```

`enzymexlamlir-opt --affine-cfg` on this segfaults before the change. `arith.remui` is what makes it reachable — `maxSize` returns a bound for it whatever its operand is, so the width check is reached with an ordinary integer as the cast source.

Five more of the six index-capable ops crash the same way: `arith.subi`, `arith.muli`, `arith.shli`, `arith.shrui`, `arith.divui`. `arith.extui` and `arith.trunci` cannot be in index and go through the same helper only to keep the rule in one place.

### Testing

- `bazel test -c opt //test/lit_tests:all` → 1106/1106 pass.
- New test covers all six crashing ops plus a positive case, which still moves the op into index with byte-identical output to before the change.
- This crashed compiling MFEM's `mesh.cpp`, which now builds (67s).

### Relationship to #2776

Independent — the reproducer above stands on its own. It surfaced because #2776 fixes a non-terminating loop in `polygeist-mem2reg` that meant `mesh.cpp` never reached this pass. Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD