### PR TITLE
affine-cfg: a question the normalizer cannot answer is not a crash

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -165,6 +165,11 @@ struct AffineApplyNormalizer {
     return res;
   }
 
+  /// Whether every operand ended up a valid affine dim or symbol.  Making one
+  /// valid can mean hoisting the op that defines it, which needs a rewriter;
+  /// asked without one, the normalizer answers what it can and says so here.
+  bool isLegalized() const { return legalized; }
+
 private:
   /// Helper function to insert `v` into the coordinate system of the current
   /// AffineApplyNormalizer. Returns the AffineDimExpr with the corresponding
@@ -180,6 +185,8 @@ private:
   SmallVector<Value, 8> concatenatedSymbols;
 
   AffineMap affineMap;
+
+  bool legalized = true;
 };
 
 static bool isAffineForArg(Value val) {
@@ -469,8 +476,10 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
       // ops now holds the legalized condition and arms: replaceOp rewrote the
       // entries as their defining ops were hoisted.
       if (!rewriter) {
+        // The select standing for the conditional is the whole of what makes
+        // this value a symbol, and there is no rewriter to write it with.
         operationContext.pop_back();
-        return v;
+        return isValidSymbolInt(v, /*recur*/ false, scope) ? v : Value();
       }
       Value selTrueFixed = ops[numCondOperands];
       Value selFalseFixed = ops[numCondOperands + 1];
@@ -513,9 +522,11 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
       return sel;
     }
     if (!rewriter) {
+      // Everything below this point moves the op; without a rewriter it stays
+      // where it is, and so is a symbol only where it already was one.
       operationContext.pop_back();
-      assert(isValidSymbolInt(op->getResult(0), /*recur*/ false, scope));
-      return op->getResult(0);
+      Value res = op->getResult(0);
+      return isValidSymbolInt(res, /*recur*/ false, scope) ? res : Value();
     } else {
       PatternRewriter::InsertionGuard B(*rewriter);
       rewriter->setInsertionPoint(front);
@@ -857,6 +868,13 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
                            << " to become valid symbol\n";
               llvm_unreachable("cannot move");
             }
+          } else if (!rewriter) {
+            // Asked without a rewriter this is a question, not a rewrite:
+            // nothing may be moved, so an operand that would have had to move
+            // simply has no answer.  Keep the original in the map so it stays
+            // well formed and let the caller read `legalized` and give up.
+            t = orig;
+            legalized = false;
           } else {
             // Reaching here means a pattern committed to a rewrite whose
             // operand cannot be made a valid affine symbol.  llvm_unreachable
@@ -873,7 +891,9 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
                 "AffineApplyNormalizer: cannot move operand to become a valid "
                 "affine symbol");
           }
-        } else
+        } else if (!rewriter)
+          legalized = false;
+        else
           llvm_unreachable("cannot move2");
       }
       if (i < numDims) {
@@ -918,11 +938,16 @@ AffineDimExpr AffineApplyNormalizer::renumberOneDim(Value v) {
   return cast<AffineDimExpr>(getAffineDimExpr(iterPos->second, v.getContext()));
 }
 
-static void composeAffineMapAndOperands(AffineMap *map,
+// Returns whether every operand came out a valid affine dim or symbol.  On
+// false the map and operands are left as they came in: a normalizer that could
+// not legalize an operand has composed nothing worth keeping.
+static bool composeAffineMapAndOperands(AffineMap *map,
                                         SmallVectorImpl<Value> *operands,
                                         PatternRewriter *rewriter,
                                         DominanceInfo *DI, Region *scope) {
   AffineApplyNormalizer normalizer(*map, *operands, rewriter, DI, scope);
+  if (!normalizer.isLegalized())
+    return false;
   auto normalizedMap = normalizer.getAffineMap();
   auto normalizedOperands = normalizer.getOperands();
   affine::canonicalizeMapAndOperands(&normalizedMap, &normalizedOperands);
@@ -930,6 +955,7 @@ static void composeAffineMapAndOperands(AffineMap *map,
   *map = normalizedMap;
   *operands = normalizedOperands;
   assert(*map);
+  return true;
 }
 
 bool need(AffineMap *map, SmallVectorImpl<Value> *operands, Region *scope) {
@@ -950,7 +976,11 @@ bool need(IntegerSet *map, SmallVectorImpl<Value> *operands, Region *scope) {
   return false;
 }
 
-void fully2ComposeAffineMapAndOperands(
+// Returns whether composition ran to completion; see
+// composeAffineMapAndOperands.  A caller passing no builder is asking a
+// question and has to read this, since without one the normalizer cannot move
+// an operand to make it legal.
+bool fully2ComposeAffineMapAndOperands(
     PatternRewriter *builder, AffineMap *map, SmallVectorImpl<Value> *operands,
     DominanceInfo *DI, Region *scope,
     SmallVectorImpl<Operation *> *insertedOps = nullptr) {
@@ -978,7 +1008,8 @@ void fully2ComposeAffineMapAndOperands(
     }
   assert(map->getNumInputs() == operands->size());
   while (need(map, operands, scope)) {
-    composeAffineMapAndOperands(map, operands, builder, DI, scope);
+    if (!composeAffineMapAndOperands(map, operands, builder, DI, scope))
+      return false;
     assert(map->getNumInputs() == operands->size());
   }
   *map = simplifyAffineMap(*map);
@@ -1012,6 +1043,7 @@ void fully2ComposeAffineMapAndOperands(
         }
       }
     }
+  return true;
 }
 
 void fully2ComposeAffineMapAndOperands(
@@ -1717,11 +1749,11 @@ bool handle(PatternRewriter &b, CmpIOp cmpi, SmallVectorImpl<AffineExpr> &exprs,
                                        exprTmp, b.getContext());
           SmallVector<Value> tmp = {lhspack.v_val};
 
-          fully2ComposeAffineMapAndOperands(nullptr, &mapTmp, &tmp, nullptr,
-                                            scope);
+          bool composed = fully2ComposeAffineMapAndOperands(
+              nullptr, &mapTmp, &tmp, nullptr, scope);
           mapTmp = recreateExpr(mapTmp);
-          if (valueCmp(Cmp::GE, mapTmp.getResult(0), mapTmp.getNumDims(), tmp,
-                       0)) {
+          if (composed && valueCmp(Cmp::GE, mapTmp.getResult(0),
+                                   mapTmp.getNumDims(), tmp, 0)) {
             atLeastZero = true;
           } else {
             LLVM_DEBUG(llvm::dbgs()

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -152,9 +152,14 @@ bool isValidSymbolInt(Value value, bool recur, Region *scope) {
 }
 
 struct AffineApplyNormalizer {
-  AffineApplyNormalizer(AffineMap map, ArrayRef<Value> operands,
-                        PatternRewriter *rewriter, DominanceInfo *DI,
-                        Region *scope);
+  /// Builds a normalizer for `map` over `operands`, or std::nullopt where
+  /// none exists.  Making an operand a valid affine dim or symbol can mean
+  /// hoisting the op that defines it, which needs a rewriter; asked without
+  /// one, a map whose operand would have had to move has no normalization,
+  /// and returning std::nullopt makes that impossible to overlook.
+  static std::optional<AffineApplyNormalizer>
+  Create(AffineMap map, ArrayRef<Value> operands, PatternRewriter *rewriter,
+         DominanceInfo *DI, Region *scope);
 
   /// Returns the AffineMap resulting from normalization.
   AffineMap getAffineMap() { return affineMap; }
@@ -165,12 +170,11 @@ struct AffineApplyNormalizer {
     return res;
   }
 
-  /// Whether every operand ended up a valid affine dim or symbol.  Making one
-  /// valid can mean hoisting the op that defines it, which needs a rewriter;
-  /// asked without one, the normalizer answers what it can and says so here.
-  bool isLegalized() const { return legalized; }
-
 private:
+  AffineApplyNormalizer(AffineMap map, ArrayRef<Value> operands,
+                        PatternRewriter *rewriter, DominanceInfo *DI,
+                        Region *scope);
+
   /// Helper function to insert `v` into the coordinate system of the current
   /// AffineApplyNormalizer. Returns the AffineDimExpr with the corresponding
   /// renumbered position.
@@ -927,6 +931,16 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
   LLVM_DEBUG(llvm::dbgs() << "\n");
 }
 
+std::optional<AffineApplyNormalizer>
+AffineApplyNormalizer::Create(AffineMap map, ArrayRef<Value> operands,
+                              PatternRewriter *rewriter, DominanceInfo *DI,
+                              Region *scope) {
+  AffineApplyNormalizer normalizer(map, operands, rewriter, DI, scope);
+  if (!normalizer.legalized)
+    return std::nullopt;
+  return normalizer;
+}
+
 AffineDimExpr AffineApplyNormalizer::renumberOneDim(Value v) {
   DenseMap<Value, unsigned>::iterator iterPos;
   bool inserted = false;
@@ -941,15 +955,16 @@ AffineDimExpr AffineApplyNormalizer::renumberOneDim(Value v) {
 // Returns whether every operand came out a valid affine dim or symbol.  On
 // false the map and operands are left as they came in: a normalizer that could
 // not legalize an operand has composed nothing worth keeping.
-static bool composeAffineMapAndOperands(AffineMap *map,
-                                        SmallVectorImpl<Value> *operands,
-                                        PatternRewriter *rewriter,
-                                        DominanceInfo *DI, Region *scope) {
-  AffineApplyNormalizer normalizer(*map, *operands, rewriter, DI, scope);
-  if (!normalizer.isLegalized())
+[[nodiscard]] static bool
+composeAffineMapAndOperands(AffineMap *map, SmallVectorImpl<Value> *operands,
+                            PatternRewriter *rewriter, DominanceInfo *DI,
+                            Region *scope) {
+  auto normalizer =
+      AffineApplyNormalizer::Create(*map, *operands, rewriter, DI, scope);
+  if (!normalizer)
     return false;
-  auto normalizedMap = normalizer.getAffineMap();
-  auto normalizedOperands = normalizer.getOperands();
+  auto normalizedMap = normalizer->getAffineMap();
+  auto normalizedOperands = normalizer->getOperands();
   affine::canonicalizeMapAndOperands(&normalizedMap, &normalizedOperands);
   normalizedMap = recreateExpr(normalizedMap);
   *map = normalizedMap;
@@ -978,9 +993,9 @@ bool need(IntegerSet *map, SmallVectorImpl<Value> *operands, Region *scope) {
 
 // Returns whether composition ran to completion; see
 // composeAffineMapAndOperands.  A caller passing no builder is asking a
-// question and has to read this, since without one the normalizer cannot move
-// an operand to make it legal.
-bool fully2ComposeAffineMapAndOperands(
+// question, since without one the normalizer cannot move an operand to make
+// it legal -- and the attribute keeps the answer from being dropped.
+[[nodiscard]] static bool fully2ComposeAffineMapAndOperands(
     PatternRewriter *builder, AffineMap *map, SmallVectorImpl<Value> *operands,
     DominanceInfo *DI, Region *scope,
     SmallVectorImpl<Operation *> *insertedOps = nullptr) {
@@ -1050,8 +1065,10 @@ void fully2ComposeAffineMapAndOperands(
     PatternRewriter &builder, AffineMap *map, SmallVectorImpl<Value> *operands,
     DominanceInfo &DI, Region *scope,
     SmallVectorImpl<Operation *> *insertedOps) {
-  fully2ComposeAffineMapAndOperands(&builder, map, operands, &DI, scope,
-                                    insertedOps);
+  bool composed = fully2ComposeAffineMapAndOperands(&builder, map, operands,
+                                                    &DI, scope, insertedOps);
+  (void)composed;
+  assert(composed && "a rewriter can always move an operand into legality");
 }
 
 void fully2ComposeIntegerSetAndOperands(
@@ -1082,7 +1099,10 @@ void fully2ComposeIntegerSetAndOperands(
   auto map = AffineMap::get(set->getNumDims(), set->getNumSymbols(),
                             set->getConstraints(), set->getContext());
   while (need(&map, operands, scope)) {
-    composeAffineMapAndOperands(&map, operands, &builder, &DI, scope);
+    bool composed =
+        composeAffineMapAndOperands(&map, operands, &builder, &DI, scope);
+    (void)composed;
+    assert(composed && "a rewriter can always move an operand into legality");
   }
   map = simplifyAffineMap(map);
   *set = IntegerSet::get(map.getNumDims(), map.getNumSymbols(),

--- a/test/lit_tests/affinecfg_ne_probe.mlir
+++ b/test/lit_tests/affinecfg_ne_probe.mlir
@@ -1,0 +1,36 @@
+// RUN: enzymexlamlir-opt --affine-cfg --split-input-file %s | FileCheck %s
+
+// Turning `icmp ne %s, 0` into a constraint needs %s known non-negative, which
+// the pass asks by composing an affine map over it with no rewriter. Making an
+// operand a valid symbol can mean hoisting the op that defines it, and with no
+// rewriter there is nothing to hoist it with, so the question has no answer.
+// %s lives inside the loop and is one of those: the pass has to take that for a
+// no rather than for a value it may go on to use.
+
+func.func @ne_probe(%a: i32, %b: i32, %m: memref<?xi32>) {
+  %c0_i32 = arith.constant 0 : i32
+  affine.for %i = 0 to 16 {
+    %p = arith.cmpi sgt, %a, %c0_i32 : i32
+    %q = arith.cmpi sgt, %b, %c0_i32 : i32
+    %pi = arith.extui %p : i1 to i32
+    %qi = arith.extui %q : i1 to i32
+    %s = arith.select %p, %pi, %qi : i32
+    %ne = arith.cmpi ne, %s, %c0_i32 : i32
+    scf.if %ne {
+      memref.store %a, %m[%i] : memref<?xi32>
+    }
+  }
+  return
+}
+
+// The answer taken for a no, the select is hoisted on a later round and the
+// conditional does become affine over it.
+
+// CHECK:       #[[SET:.+]] = affine_set<()[s0] : (s0 == 0)>
+// CHECK-LABEL: func.func @ne_probe
+// CHECK:         %[[S:.+]] = arith.select
+// CHECK:         %[[I:.+]] = arith.index_cast %[[S]] : i32 to index
+// CHECK:         affine.parallel (%[[IV:.+]]) = (0) to (16)
+// CHECK-NEXT:      affine.if #[[SET]]()[%[[I]]]
+// CHECK:           } else {
+// CHECK-NEXT:        affine.store %arg0, %arg2[%[[IV]]]


### PR DESCRIPTION
Deciding whether `icmp ne %x, 0` can become an affine constraint means knowing `%x` is non-negative. `handle(CmpIOp)` asks that by composing an affine map over the value **with no rewriter** — it is a question, and nothing should be rewritten to answer it:

```cpp
fully2ComposeAffineMapAndOperands(nullptr, &mapTmp, &tmp, nullptr, scope);
```

But making an operand a valid affine symbol can mean hoisting the op that defines it, and hoisting needs a rewriter. Without one, `AffineApplyNormalizer::fix` walked the operand and handed it back exactly as it found it. The caller then checked and found it still wasn't a valid symbol, and reached `llvm_unreachable("cannot move")` — which in a release build is UB. Execution fell through into `renumberOne{Dim,Symbol}` and segfaulted in `mlir::Type::getContext()`, several frames from the actual mistake.

## The change

Say what is true instead:

- Without a rewriter, `fix` returns a value only where it is *already* valid, and `Value()` otherwise.
- The normalizer records on `legalized` that an operand had no answer, keeping the original in the map so it stays well formed.
- `composeAffineMapAndOperands` / `fully2ComposeAffineMapAndOperands` report that up.
- The `ne` probe reads a failed composition as a no and leaves the conditional alone.

The hard failure stays for the case that *does* have a rewriter, where an operand that cannot be legalized means a pattern committed to a rewrite it should not have.

## Test

`test/lit_tests/affinecfg_ne_probe.mlir` — a 27-line function whose `scf.if` condition is `cmpi ne` over an `arith.select` defined inside an `affine.for`. Segfaults on main; passes here, and the select does get hoisted on a later round so the conditional still becomes affine.

1107/1107 lit tests pass.

## Context

Found building MFEM through the raising path (#2778), where this accounted for 14 of the 16 remaining compile failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD