### PR TITLE
canonicalize-scf-for: forget the induction variable between comparisons

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1155,6 +1155,13 @@ struct WhileToForHelper {
   }
 
   void initVariables() {
+    // One helper is asked about several comparisons in turn.  The induction
+    // variable and its increment are found together and are worth nothing
+    // apart: left behind from a comparison that was turned down, the variable
+    // reads as a detection that succeeded while the step it was found with is
+    // gone, and everything below reads the step.
+    indVar = nullptr;
+    addIOp = nullptr;
     step = nullptr;
     lb = nullptr;
     lb_addOne = false;

--- a/test/lit_tests/canonicalizefor_stale_indvar.mlir
+++ b/test/lit_tests/canonicalizefor_stale_indvar.mlir
@@ -1,0 +1,28 @@
+// RUN: enzymexlamlir-opt --canonicalize-scf-for --split-input-file %s | FileCheck %s
+
+// A condition of two comparisons is tried one at a time on the same helper.
+// The first finds an induction variable and is turned down later, on its
+// predicate; the second finds none, and has to be left with none. What it was
+// told about the first is not an answer to the second.
+
+func.func @stale_indvar(%n: i32, %m: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r = scf.while (%i = %c0) : (i32) -> i32 {
+    %eq = arith.cmpi eq, %i, %n : i32
+    %lt = arith.cmpi slt, %m, %n : i32
+    %c = arith.andi %eq, %lt : i1
+    scf.condition(%c) %i : i32
+  } do {
+  ^bb0(%a: i32):
+    %next = arith.addi %a, %c1 : i32
+    scf.yield %next : i32
+  }
+  return %r : i32
+}
+
+// Neither comparison gives a for, so the while stands.
+
+// CHECK-LABEL: func.func @stale_indvar
+// CHECK:         scf.while
+// CHECK:         scf.condition


### PR DESCRIPTION
`MoveWhileToFor` asks one `WhileToForHelper` about each comparison of an `andi` condition in turn:

```cpp
for (int i = 0; i < 2; i++) {
  helper.cmpIOp = andOp->getOperand(i).getDefiningOp<CmpIOp>();
  ...
  if (!helper.computeLegality(rewriter, /*sizeCheck*/ true, lookThrough, /*doWhile*/ true))
    continue;
```

`computeLegality` starts with `initVariables()`, which clears the step, the bounds and the flags — but leaves `indVar` and `addIOp` from the previous comparison.

The two are found together in `considerStep` and are worth nothing apart. A comparison that finds an induction variable and is then turned down later — on its predicate, say — leaves that variable behind. The next comparison finds none, reads the leftover as a detection that succeeded:

```cpp
if (!indVar) { ... return false; }   // passes on the stale value
assert(step);                        // says nothing in a release build
if (auto *op = step.getDefiningOp()) // null dereference
```

## Test

`test/lit_tests/canonicalizefor_stale_indvar.mlir` — a 22-line `scf.while` whose condition is `andi(cmpi eq, cmpi slt)`. The `eq` comparison finds the induction variable and is turned down on its predicate; the `slt` compares two function arguments and finds none. Segfaults on main, passes here, and the `while` is correctly left alone.

1108/1108 lit tests pass.

## Context

Found building MFEM through the raising path (#2778), on `fem/hybridization.cpp` — the one crash there that was not the `affine-cfg` bug in #2779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD