### PR TITLE
llvm-to-affine-access: build only expressions affine has

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -994,13 +994,27 @@ struct AffineExprBuilder {
           return (*lhs) + (*rhs);
         else if (isa<LLVM::SubOp, arith::SubIOp>(op))
           return (*lhs) - (*rhs);
-        else if (isa<LLVM::MulOp, arith::MulIOp>(op))
+        else if (isa<LLVM::MulOp, arith::MulIOp>(op)) {
+          // A product is affine only where one side is free of dims.
+          if (!lhs->isSymbolicOrConstant() && !rhs->isSymbolicOrConstant())
+            return failure();
           return (*lhs) * (*rhs);
-        else if (isa<LLVM::UDivOp, LLVM::SDivOp, arith::DivUIOp,
-                     arith::DivSIOp>(op))
+        } else if (isa<LLVM::UDivOp, LLVM::SDivOp, arith::DivUIOp,
+                       arith::DivSIOp>(op)) {
+          // An affine floordiv divides by a positive value: it is the only
+          // divisor its lowering, and the flattening the maps go through,
+          // are written for.  A negative one does reach here -- `-x / c` is
+          // `x / -c` to instcombine -- and is the same division with the
+          // sign taken out, which the expression can say instead.
+          if (auto cexpr = dyn_cast<AffineConstantExpr>(*rhs)) {
+            if (cexpr.getValue() == 0)
+              return failure();
+            if (cexpr.getValue() < 0)
+              return -((*lhs).floorDiv(-cexpr.getValue()));
+          }
           return (*lhs).floorDiv(*rhs);
-        else if (isa<arith::ShRUIOp, arith::ShRSIOp, LLVM::LShrOp,
-                     LLVM::AShrOp>(op)) {
+        } else if (isa<arith::ShRUIOp, arith::ShRSIOp, LLVM::LShrOp,
+                       LLVM::AShrOp>(op)) {
           auto cexpr = dyn_cast<AffineConstantExpr>(*rhs);
           if (!cexpr)
             return failure();
@@ -1016,6 +1030,14 @@ struct AffineExprBuilder {
           }
         } else if (isa<LLVM::URemOp, arith::RemSIOp, LLVM::SRemOp,
                        arith::RemUIOp>(op)) {
+          // As with floordiv above: a remainder is taken against a positive
+          // value, and against a negative one it is the same remainder.
+          if (auto cexpr = dyn_cast<AffineConstantExpr>(*rhs)) {
+            if (cexpr.getValue() == 0)
+              return failure();
+            if (cexpr.getValue() < 0)
+              return (*lhs) % (-cexpr.getValue());
+          }
           return (*lhs) % (*rhs);
         } else if (isa<arith::OrIOp>(op)) {
           auto cexpr = dyn_cast<AffineConstantExpr>(*rhs);

--- a/test/lit_tests/raising/llvm_to_affine_negative_divisor.mlir
+++ b/test/lit_tests/raising/llvm_to_affine_negative_divisor.mlir
@@ -1,0 +1,67 @@
+// RUN: enzymexlamlir-opt --llvm-to-affine-access --split-input-file %s | FileCheck %s
+
+// An affine floordiv divides by a positive value -- it is what its lowering and
+// the flattening the maps go through are written for, and a negative divisor
+// gets as far as "division by non-positive value is not supported". One reaches
+// here all the same: instcombine says `-x / c` as `x / -c`. It is the same
+// division with the sign taken out, and the expression can say that instead.
+
+llvm.func @neg_div(%p: !llvm.ptr) {
+  %cm2 = arith.constant -2 : i64
+  %cst = arith.constant 0.000000e+00 : f64
+  affine.for %i = 0 to 16 {
+    %iv = arith.index_cast %i : index to i64
+    %d = arith.divsi %iv, %cm2 : i64
+    %g = llvm.getelementptr inbounds %p[%d] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    llvm.store %cst, %g : f64, !llvm.ptr
+  }
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @neg_div
+// CHECK:         affine.store %{{.*}}[-(%{{.*}} floordiv 2)]
+
+// -----
+
+// Dividing by zero is not a division this can say at all.
+
+llvm.func @zero_div(%p: !llvm.ptr) {
+  %c0 = arith.constant 0 : i64
+  %cst = arith.constant 0.000000e+00 : f64
+  affine.for %i = 0 to 16 {
+    %iv = arith.index_cast %i : index to i64
+    %d = arith.divsi %iv, %c0 : i64
+    %g = llvm.getelementptr inbounds %p[%d] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    llvm.store %cst, %g : f64, !llvm.ptr
+  }
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @zero_div
+// CHECK:         %[[D:.+]] = arith.divsi
+// CHECK:         llvm.getelementptr inbounds %arg0[%[[D]]]
+// CHECK:         memref.store
+
+// -----
+
+// Neither side of this product is free of the loop variable, so it is not a
+// product an affine expression has.
+
+llvm.func @dim_times_dim(%p: !llvm.ptr) {
+  %cst = arith.constant 0.000000e+00 : f64
+  affine.for %i = 0 to 16 {
+    affine.for %j = 0 to 16 {
+      %a = arith.index_cast %i : index to i64
+      %b = arith.index_cast %j : index to i64
+      %m = arith.muli %a, %b : i64
+      %g = llvm.getelementptr inbounds %p[%m] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+      llvm.store %cst, %g : f64, !llvm.ptr
+    }
+  }
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @dim_times_dim
+// CHECK:         %[[M:.+]] = arith.muli
+// CHECK:         llvm.getelementptr inbounds %arg0[%[[M]]]
+// CHECK:         memref.store


### PR DESCRIPTION
`AffineExprBuilder::buildExpr` reads an address computation and says it again as an affine expression. Three of the operations it accepts have a shape affine does not, and it built them anyway.

**A floordiv divides by a positive value.** That is what its lowering and the flattening the maps go through are written for. MFEM got as far as `error: division by non-positive value is not supported`, seven times in one file. A negative divisor reaches here all the same — instcombine says `-x / c` as `x / -c`. It is the same division with the sign taken out, and the expression can say that instead:

```
%arg1 floordiv -2    -->    -(%arg1 floordiv 2)
```

**A remainder is taken against a positive value**, and against a negative one it is the same remainder.

**A product is affine only where one side is free of dims.** MLIR asserts as much in `getAffineBinaryOpExpr` ("at least one of the multiplicands has to be either a constant or symbolic"), which says nothing in a release build. Neither side of

```
affine_map<(d0)[s0, s1, s2, s3] -> (((-d0 + s2 + 1) * (-d0 + s3)) floordiv -2 + s0 + s1)>
```

is free of `d0`, and the `affine.store` built over it did not verify: `'affine.store' op operand cannot be used as a dimension id`.

Division by zero is not a division this can say at all, and is refused rather than turned into `x floordiv 0`.

Where an expression is refused the access simply stays a GEP and a `memref.store`, which is what the pass does with anything else it cannot read.

## Test

`test/lit_tests/raising/llvm_to_affine_negative_divisor.mlir` — three cases: the negative divisor (raised, sign moved out), zero (left alone), and a product of two loop variables (left alone). On main the first two become `floordiv -2` and `floordiv 0`.

1110/1110 lit tests pass.

## Context

Found building MFEM through the raising path (#2778), on `fem/fe/fe_pos.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD