### PR TITLE
RemoveIVs: count iterations in the type the count is multiplied in

### DIFF
--- a/src/enzyme_ad/jax/TransformOps/RaisingTransformOps.cpp
+++ b/src/enzyme_ad/jax/TransformOps/RaisingTransformOps.cpp
@@ -37,6 +37,30 @@ LogicalResult RemoveIVs::matchAndRewrite(scf::ForOp forOp,
   llvm::SetVector<unsigned> removed;
   llvm::MapVector<unsigned, Value> steps;
   auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+
+  // The iteration count comes out in the induction variable's type and is
+  // multiplied by a step in the iter arg's, which need not be the same type.
+  // Narrowing the count loses nothing that was ever read: the arg's arithmetic
+  // wraps, so only the low bits of the count reach the result either way.
+  // Widening it loses nothing either -- a count is not negative and it fit in
+  // the narrower type it was counted in.
+  auto castToType = [&](Value v, Type ty) -> Value {
+    if (v.getType() == ty)
+      return v;
+    if (isa<IndexType>(v.getType()) || isa<IndexType>(ty)) {
+      Value cast = arith::IndexCastOp::create(rewriter, loc, ty, v);
+      return cast;
+    }
+    unsigned from = cast<IntegerType>(v.getType()).getWidth();
+    unsigned to = cast<IntegerType>(ty).getWidth();
+    if (from > to) {
+      Value trunc = arith::TruncIOp::create(rewriter, loc, ty, v);
+      return trunc;
+    }
+    Value ext = arith::ExtSIOp::create(rewriter, loc, ty, v);
+    return ext;
+  };
+
   for (unsigned i = 0; i < numIterArgs; i++) {
     auto ba = forOp.getRegionIterArgs()[i];
     auto init = forOp.getInits()[i];
@@ -63,6 +87,7 @@ LogicalResult RemoveIVs::matchAndRewrite(scf::ForOp forOp,
     Value iterNum = arith::SubIOp::create(
         rewriter, loc, forOp.getInductionVar(), forOp.getLowerBound());
     iterNum = arith::DivSIOp::create(rewriter, loc, iterNum, forOp.getStep());
+    iterNum = castToType(iterNum, step.getType());
 
     Value replacementIV = arith::MulIOp::create(rewriter, loc, iterNum, step);
     replacementIV = arith::AddIOp::create(rewriter, loc, replacementIV, init);
@@ -118,6 +143,7 @@ LogicalResult RemoveIVs::matchAndRewrite(scf::ForOp forOp,
       Value iterNum = arith::SubIOp::create(
           rewriter, loc, forOp.getUpperBound(), forOp.getLowerBound());
       iterNum = arith::DivSIOp::create(rewriter, loc, iterNum, forOp.getStep());
+      iterNum = castToType(iterNum, steps[i].getType());
 
       Value afterLoop = arith::MulIOp::create(rewriter, loc, iterNum, steps[i]);
       afterLoop =

--- a/src/enzyme_ad/jax/TransformOps/RaisingTransformOps.cpp
+++ b/src/enzyme_ad/jax/TransformOps/RaisingTransformOps.cpp
@@ -27,6 +27,24 @@ using namespace mlir;
 namespace mlir {
 namespace transform {
 
+// The iteration count comes out in the induction variable's type and is
+// multiplied by a step in the iter arg's, which need not be the same type.
+// Narrowing the count loses nothing that was ever read: the arg's arithmetic
+// wraps, so only the low bits of the count reach the result either way.
+// Widening it loses nothing either -- a count is not negative and it fit in
+// the narrower type it was counted in.
+static Value castToType(OpBuilder &builder, Location loc, Value v, Type ty) {
+  if (v.getType() == ty)
+    return v;
+  if (isa<IndexType>(v.getType()) || isa<IndexType>(ty))
+    return arith::IndexCastOp::create(builder, loc, ty, v);
+  unsigned from = cast<IntegerType>(v.getType()).getWidth();
+  unsigned to = cast<IntegerType>(ty).getWidth();
+  if (from > to)
+    return arith::TruncIOp::create(builder, loc, ty, v);
+  return arith::ExtSIOp::create(builder, loc, ty, v);
+}
+
 LogicalResult RemoveIVs::matchAndRewrite(scf::ForOp forOp,
                                          PatternRewriter &rewriter) const {
   if (!forOp.getRegion().hasOneBlock())
@@ -37,29 +55,6 @@ LogicalResult RemoveIVs::matchAndRewrite(scf::ForOp forOp,
   llvm::SetVector<unsigned> removed;
   llvm::MapVector<unsigned, Value> steps;
   auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-
-  // The iteration count comes out in the induction variable's type and is
-  // multiplied by a step in the iter arg's, which need not be the same type.
-  // Narrowing the count loses nothing that was ever read: the arg's arithmetic
-  // wraps, so only the low bits of the count reach the result either way.
-  // Widening it loses nothing either -- a count is not negative and it fit in
-  // the narrower type it was counted in.
-  auto castToType = [&](Value v, Type ty) -> Value {
-    if (v.getType() == ty)
-      return v;
-    if (isa<IndexType>(v.getType()) || isa<IndexType>(ty)) {
-      Value cast = arith::IndexCastOp::create(rewriter, loc, ty, v);
-      return cast;
-    }
-    unsigned from = cast<IntegerType>(v.getType()).getWidth();
-    unsigned to = cast<IntegerType>(ty).getWidth();
-    if (from > to) {
-      Value trunc = arith::TruncIOp::create(rewriter, loc, ty, v);
-      return trunc;
-    }
-    Value ext = arith::ExtSIOp::create(rewriter, loc, ty, v);
-    return ext;
-  };
 
   for (unsigned i = 0; i < numIterArgs; i++) {
     auto ba = forOp.getRegionIterArgs()[i];
@@ -87,7 +82,7 @@ LogicalResult RemoveIVs::matchAndRewrite(scf::ForOp forOp,
     Value iterNum = arith::SubIOp::create(
         rewriter, loc, forOp.getInductionVar(), forOp.getLowerBound());
     iterNum = arith::DivSIOp::create(rewriter, loc, iterNum, forOp.getStep());
-    iterNum = castToType(iterNum, step.getType());
+    iterNum = castToType(rewriter, loc, iterNum, step.getType());
 
     Value replacementIV = arith::MulIOp::create(rewriter, loc, iterNum, step);
     replacementIV = arith::AddIOp::create(rewriter, loc, replacementIV, init);
@@ -143,7 +138,7 @@ LogicalResult RemoveIVs::matchAndRewrite(scf::ForOp forOp,
       Value iterNum = arith::SubIOp::create(
           rewriter, loc, forOp.getUpperBound(), forOp.getLowerBound());
       iterNum = arith::DivSIOp::create(rewriter, loc, iterNum, forOp.getStep());
-      iterNum = castToType(iterNum, steps[i].getType());
+      iterNum = castToType(rewriter, loc, iterNum, steps[i].getType());
 
       Value afterLoop = arith::MulIOp::create(rewriter, loc, iterNum, steps[i]);
       afterLoop =

--- a/test/lit_tests/raising/removeivs_mixed_width.mlir
+++ b/test/lit_tests/raising/removeivs_mixed_width.mlir
@@ -1,0 +1,43 @@
+// RUN: enzymexlamlir-opt --llvm-to-affine-access --split-input-file %s | FileCheck %s
+
+// An iteration argument stepping by a loop-invariant amount is rewritten as a
+// closed form over the iteration count. The count comes out in the induction
+// variable's type and the step is in the argument's, and the two need not be
+// the same type -- here an i64 loop carrying an i32 sum.
+
+func.func @narrower_arg(%ub: i64, %s: i32) -> i32 {
+  %c0_i64 = arith.constant 0 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %r = scf.for %i = %c0_i64 to %ub step %c1_i64 iter_args(%acc = %c0_i32) -> (i32) : i64 {
+    %n = arith.addi %acc, %s : i32
+    scf.yield %n : i32
+  }
+  return %r : i32
+}
+
+// CHECK-LABEL: func.func @narrower_arg
+// CHECK-NEXT:    %[[T:.+]] = arith.trunci %arg0 : i64 to i32
+// CHECK-NEXT:    %[[M:.+]] = arith.muli %[[T]], %arg1 : i32
+// CHECK-NEXT:    return %[[M]]
+
+// -----
+
+// The other way round: an i32 loop carrying an i64 sum. A count is not negative
+// and fit in the type it was counted in, so widening it keeps it whole.
+
+func.func @wider_arg(%ub: i32, %s: i64) -> i64 {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %c0_i64 = arith.constant 0 : i64
+  %r = scf.for %i = %c0_i32 to %ub step %c1_i32 iter_args(%acc = %c0_i64) -> (i64) : i32 {
+    %n = arith.addi %acc, %s : i64
+    scf.yield %n : i64
+  }
+  return %r : i64
+}
+
+// CHECK-LABEL: func.func @wider_arg
+// CHECK-NEXT:    %[[E:.+]] = arith.extsi %arg0 : i32 to i64
+// CHECK-NEXT:    %[[M:.+]] = arith.muli %[[E]], %arg1 : i64
+// CHECK-NEXT:    return %[[M]]


### PR DESCRIPTION
`RemoveIVs` rewrites an iteration argument that steps by a loop-invariant amount into a closed form over the iteration count:

```cpp
Value iterNum = arith::SubIOp::create(rewriter, loc, forOp.getInductionVar(), forOp.getLowerBound());
iterNum = arith::DivSIOp::create(rewriter, loc, iterNum, forOp.getStep());
Value replacementIV = arith::MulIOp::create(rewriter, loc, iterNum, step);
```

The count comes out in the **induction variable's** type. The `step` it is multiplied by is in the **iteration argument's**. The two need not be the same type — MFEM has an i64 loop carrying an i32 sum:

```mlir
scf.for %arg2 = %c1_i64 to %217 step %c1_i64 iter_args(%arg3 = %c0_i32) -> (i32) : i64
```

and the multiply built over the pair did not verify:

```
error: 'arith.muli' op requires the same type for all operands and results
note: see current operation: %543 = "arith.muli"(%542, %59) : (i64, i32) -> i64
```

## The change

Carry the count over to the type it is multiplied in, at both sites (the in-loop replacement and the after-loop value).

Narrowing loses nothing that was ever read: the argument's arithmetic wraps, so `init + trunc(k)*step` and `init + k*step` agree mod 2^width. Widening loses nothing either — a count is not negative, and it fit in the narrower type it was counted in.

## Test

`test/lit_tests/raising/removeivs_mixed_width.mlir` — an i64 loop carrying an i32 sum and an i32 loop carrying an i64 sum. Both produce invalid IR on main.

1110/1110 lit tests pass.

## Context

Found building MFEM through the raising path (#2778), on `fem/lor/lor_batched.cpp` — the last of the 16 files that would not compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD