### PR TITLE
Work a shift's power of two out at the width the expression holds

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -182,6 +182,29 @@ private:
   AffineMap affineMap;
 };
 
+// A shift by k stands for a multiply or divide by 2^k, which has to be worked
+// out at the width the affine expression holds. Taken as an int, `1 << 31` is
+// the largest negative number there is, and a shift by 31 is how a sign bit is
+// read; past 62 there is no power of two a signed affine constant can hold.
+static bool shiftScale(Value amount, int64_t &scale) {
+  APInt amt;
+  if (!matchPattern(amount, m_ConstantInt(&amt)))
+    return false;
+  if (amt.uge(63))
+    return false;
+  scale = int64_t(1) << amt.getZExtValue();
+  return true;
+}
+
+// Whether `op` is a shift this can say as a power of two. Anything else is not
+// a shift and has nothing to answer for.
+static bool shiftScaleOK(Operation *op) {
+  if (!isa<ShRUIOp, ShLIOp>(op))
+    return true;
+  int64_t scale;
+  return shiftScale(op->getOperand(1), scale);
+}
+
 static bool isAffineForArg(Value val) {
   if (!isa<BlockArgument>(val))
     return false;
@@ -635,7 +658,8 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
                .getDefiningOp<ConstantIntOp>() ||
            decast.getDefiningOp()
                ->getOperand(1)
-               .getDefiningOp<ConstantIndexOp>())))) {
+               .getDefiningOp<ConstantIndexOp>()) &&
+          shiftScaleOK(decast.getDefiningOp())))) {
       t = decast;
       LLVM_DEBUG(llvm::dbgs() << " Replacing: " << t << "\n");
 
@@ -757,27 +781,23 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
         }
       } else if (auto op = t.getDefiningOp<ShRUIOp>()) {
 
-        APInt iattr;
-        if (!matchPattern(op.getRhs(), m_ConstantInt(&iattr))) {
-          llvm_unreachable("shr rhs needed to be constant int");
+        int64_t scale;
+        if (!shiftScale(op.getRhs(), scale)) {
+          llvm_unreachable("shr rhs needed to be a constant int that fits");
         }
 
-        affineApplyMap =
-            AffineMap::get(0, 1,
-                           getAffineSymbolExpr(0, op.getContext())
-                               .floorDiv(1 << iattr.getZExtValue()));
+        affineApplyMap = AffineMap::get(
+            0, 1, getAffineSymbolExpr(0, op.getContext()).floorDiv(scale));
         affineApplyOperands.push_back(op.getLhs());
       } else if (auto op = t.getDefiningOp<ShLIOp>()) {
 
-        APInt iattr;
-        if (!matchPattern(op.getRhs(), m_ConstantInt(&iattr))) {
-          llvm_unreachable("shl rhs needed to be constant int");
+        int64_t scale;
+        if (!shiftScale(op.getRhs(), scale)) {
+          llvm_unreachable("shl rhs needed to be a constant int that fits");
         }
 
-        affineApplyMap =
-            AffineMap::get(0, 1,
-                           getAffineSymbolExpr(0, op.getContext()) *
-                               (1 << iattr.getZExtValue()));
+        affineApplyMap = AffineMap::get(
+            0, 1, getAffineSymbolExpr(0, op.getContext()) * scale);
         affineApplyOperands.push_back(op.getLhs());
       } else if (auto op = t.getDefiningOp<ConstantIntOp>()) {
         affineApplyMap = AffineMap::get(

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1018,13 +1018,20 @@ struct AffineExprBuilder {
           auto cexpr = dyn_cast<AffineConstantExpr>(*rhs);
           if (!cexpr)
             return failure();
+          // The power of two the shift stands for has to be worked out at the
+          // width the expression holds. Taken as an int, `1 << 31` is the
+          // largest negative number there is, and a shift by 31 is how a sign
+          // bit is read -- MFEM does it and got `floordiv -2147483648`.
+          int64_t shift = cexpr.getValue();
+          if (shift < 0 || shift >= 63)
+            return failure();
+          int64_t scale = int64_t(1) << shift;
           if (isa<arith::ShLIOp, LLVM::ShlOp>(op)) {
-            return (*lhs) * getAffineConstantExpr(1 << cexpr.getValue(),
-                                                  op->getContext());
+            return (*lhs) * getAffineConstantExpr(scale, op->getContext());
           } else if (isa<arith::ShRUIOp, arith::ShRSIOp, LLVM::LShrOp,
                          LLVM::AShrOp>(op)) {
             return (*lhs).floorDiv(
-                getAffineConstantExpr(1 << cexpr.getValue(), op->getContext()));
+                getAffineConstantExpr(scale, op->getContext()));
           } else {
             llvm_unreachable("unknown operation");
           }

--- a/test/lit_tests/raising/llvm_to_affine_negative_divisor.mlir
+++ b/test/lit_tests/raising/llvm_to_affine_negative_divisor.mlir
@@ -65,3 +65,45 @@ llvm.func @dim_times_dim(%p: !llvm.ptr) {
 // CHECK:         %[[M:.+]] = arith.muli
 // CHECK:         llvm.getelementptr inbounds %arg0[%[[M]]]
 // CHECK:         memref.store
+
+// -----
+
+// The power of two a shift stands for is worked out at the width the expression
+// holds. Taken as an int, `1 << 31` is the largest negative number there is,
+// and a shift by 31 is how a sign bit is read.
+
+llvm.func @shr_31(%p: !llvm.ptr, %n: i64) {
+  %c31 = arith.constant 31 : i64
+  %cst = arith.constant 0.000000e+00 : f64
+  affine.for %i = 0 to 16 {
+    %iv = arith.index_cast %i : index to i64
+    %d = arith.shrui %iv, %c31 : i64
+    %g = llvm.getelementptr inbounds %p[%d] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    llvm.store %cst, %g : f64, !llvm.ptr
+  }
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @shr_31
+// CHECK:         affine.store %{{.*}}[%{{.*}} floordiv 2147483648]
+
+// -----
+
+// Past 62 there is no power of two a signed affine constant can hold.
+
+llvm.func @shr_63(%p: !llvm.ptr) {
+  %c63 = arith.constant 63 : i64
+  %cst = arith.constant 0.000000e+00 : f64
+  affine.for %i = 0 to 16 {
+    %iv = arith.index_cast %i : index to i64
+    %d = arith.shrui %iv, %c63 : i64
+    %g = llvm.getelementptr inbounds %p[%d] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    llvm.store %cst, %g : f64, !llvm.ptr
+  }
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @shr_63
+// CHECK:         %[[S:.+]] = arith.shrui
+// CHECK:         llvm.getelementptr inbounds %arg0[%[[S]]]
+// CHECK:         memref.store


### PR DESCRIPTION
A shift by `k` stands for a multiply or divide by `2^k`. Both the raiser and the affine normalizer wrote that as `1 << k`:

```cpp
return (*lhs).floorDiv(getAffineConstantExpr(1 << cexpr.getValue(), op->getContext()));
```

`1` there is an `int`. At `k == 31` that is the largest negative number there is, and a shift by 31 is exactly how a sign bit is read — MFEM reads one, and got

```
affine.store ... [%arg1 floordiv -2147483648]
```

which then went the way any negative divisor does: `error: division by non-positive value is not supported`, twice, and a segfault further down in `convert-polygeist-to-llvm`, several passes from where the expression was built. Past 62 there is no power of two a signed affine constant can hold at all.

## The change

`llvm-to-affine-access`: work the scale out in `int64_t` and refuse a shift amount outside `[0, 63)`. A refused access simply stays a GEP and a `memref.store`, as with anything else the pass cannot read.

`affine-cfg`: the same mistake, in `AffineApplyNormalizer`'s `ShRUIOp`/`ShLIOp` branches. There the bound has to go on the condition that lets a shift into the normalizer at all — by the time the constant is read in the constructor there is nowhere left to say no, only `llvm_unreachable`.

## Tests

Two cases appended to `test/lit_tests/raising/llvm_to_affine_negative_divisor.mlir`: a shift by 31, which now raises to `floordiv 2147483648`, and a shift by 63, which is left alone.

1108/1108 lit tests pass.

## Context

Found building MFEM through the raising path (#2778) — the last of the failures, on `tests/unit/fem/test_sparse_matrix.cpp`. With this the whole of MFEM, library and unit tests, compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD