### PR TITLE
Raise a forward-mode enzyme call, and seed a reverse one

### DIFF
--- a/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
+++ b/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
@@ -17,6 +17,7 @@
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "src/enzyme_ad/jax/Passes/SelectPatterns.h"
 
+#include "Enzyme/EnzymeCallMarkers.h"
 #include "Enzyme/MLIR/Dialect/Dialect.h"
 #include "Enzyme/MLIR/Dialect/Ops.h"
 
@@ -189,58 +190,156 @@ private:
   StringAttr funcName;
 };
 
+// The name of the enzyme_* marker global `v` reads, where it reads one. The
+// markers reach here as a load of the address of a global, sometimes through a
+// cast into another address space.
+std::optional<StringRef> getEnzymeMarker(Value v) {
+  auto loadOp = dyn_cast_if_present<LLVM::LoadOp>(v.getDefiningOp());
+  if (!loadOp)
+    return std::nullopt;
+
+  Value address = loadOp.getAddr();
+  if (auto castOp =
+          dyn_cast_if_present<LLVM::AddrSpaceCastOp>(address.getDefiningOp()))
+    address = castOp.getArg();
+
+  auto addressOf =
+      dyn_cast_if_present<LLVM::AddressOfOp>(address.getDefiningOp());
+  if (!addressOf)
+    return std::nullopt;
+
+  StringRef name = addressOf.getGlobalName();
+  if (!name.starts_with("enzyme_"))
+    return std::nullopt;
+  return name;
+}
+
+// The activity the shared grammar names, said the way the MLIR ops say it.
+enzyme::Activity toMLIRActivity(enzyme_markers::MarkerActivity activity) {
+  switch (activity) {
+  case enzyme_markers::MarkerActivity::Const:
+    return enzyme::Activity::enzyme_const;
+  case enzyme_markers::MarkerActivity::Dup:
+    return enzyme::Activity::enzyme_dup;
+  case enzyme_markers::MarkerActivity::DupNoNeed:
+    return enzyme::Activity::enzyme_dupnoneed;
+  case enzyme_markers::MarkerActivity::Out:
+    return enzyme::Activity::enzyme_active;
+  }
+  llvm_unreachable("unknown marker activity");
+}
+
+// Markers that say something about the call rather than about one argument.
+struct EnzymeCallFlags {
+  bool runtimeActivity = false;
+  bool strongZero = false;
+};
+
 // Given an LLVM dialect __enzyme_* call with optional enzyme_const/dup/active
 // configurations, recover:
 //    1) the actual arguments to go into the enzyme.*diff op
 //    2) the activities (annotated or inferred) for the arguments and return
 //       value(s)
+//    3) the markers that configure the call as a whole
 void parseEnzymeCall(FunctionOpInterface funcToDiff, ValueRange eoperands,
                      SmallVectorImpl<Value> &arguments,
                      SmallVectorImpl<enzyme::Activity> &argActivities,
-                     SmallVectorImpl<enzyme::Activity> &retActivities) {
-  // The first eoperand is a pointer to funcToDiff, so we skip over it.
-  for (unsigned argIdx = 1; argIdx < eoperands.size(); ++argIdx) {
-    Value autodiffArg = eoperands[argIdx];
-    if (auto loadOp =
-            dyn_cast_if_present<LLVM::LoadOp>(autodiffArg.getDefiningOp())) {
-      Value address = loadOp.getAddr();
-      if (auto castOp = dyn_cast_if_present<LLVM::AddrSpaceCastOp>(
-              address.getDefiningOp()))
-        address = castOp.getArg();
+                     SmallVectorImpl<enzyme::Activity> &retActivities,
+                     EnzymeCallFlags &flags) {
+  auto markerAt = [&](unsigned i) { return getEnzymeMarker(eoperands[i]); };
 
-      if (auto addressOf =
-              dyn_cast_if_present<LLVM::AddressOfOp>(address.getDefiningOp())) {
-        if (addressOf.getGlobalName() == "enzyme_const") {
-          argActivities.push_back(enzyme::Activity::enzyme_const);
-          arguments.push_back(eoperands[argIdx + 1]);
-          argIdx += 1;
-        } else if (addressOf.getGlobalName() == "enzyme_dup") {
-          argActivities.push_back(enzyme::Activity::enzyme_dup);
-          arguments.push_back(eoperands[argIdx + 1]);
-          arguments.push_back(eoperands[argIdx + 2]);
-          argIdx += 2;
-        } else if (addressOf.getGlobalName() == "enzyme_dupnoneed") {
-          argActivities.push_back(enzyme::Activity::enzyme_dupnoneed);
-          arguments.push_back(eoperands[argIdx + 1]);
-          arguments.push_back(eoperands[argIdx + 2]);
-          argIdx += 2;
-        }
+  // Where the shadows are has to be settled before walking, since it decides
+  // how every argument is read. The first eoperand is a pointer to funcToDiff,
+  // so the arguments start after it.
+  enzyme_markers::InterleaveSplit split =
+      enzyme_markers::findEnzymeInterleave(1, eoperands.size(), markerAt);
+  unsigned shadowIdx = split.shadowStart;
+
+  // An activity marker holds until the next one, so one marker can cover a
+  // whole group of arguments. That only applies where the shadows were
+  // interleaved: written one by one, an unmarked argument is read off its type
+  // as it always was.
+  enzyme::Activity sticky = enzyme::Activity::enzyme_dup;
+
+  auto takeArgument = [&](unsigned argIdx, enzyme::Activity activity,
+                          unsigned &cursor) {
+    argActivities.push_back(activity);
+    arguments.push_back(eoperands[argIdx]);
+    if (activity != enzyme::Activity::enzyme_dup &&
+        activity != enzyme::Activity::enzyme_dupnoneed)
+      return;
+    if (split.interleaved)
+      arguments.push_back(eoperands[shadowIdx++]);
+    else
+      arguments.push_back(eoperands[++cursor]);
+  };
+
+  for (unsigned argIdx = 1; argIdx < split.primalEnd; ++argIdx) {
+    Value autodiffArg = eoperands[argIdx];
+
+    if (auto name = markerAt(argIdx)) {
+      auto marker = enzyme_markers::lookupEnzymeMarker(*name);
+      if (!marker) {
+        // Reading an unknown marker as an argument is how a derivative goes
+        // quietly wrong, so say so instead.
+        funcToDiff.emitError()
+            << "unknown enzyme marker '" << *name << "' in a call to it";
+        return;
       }
-    } else {
-      // Use default activities based on the types
-      arguments.push_back(autodiffArg);
-      argActivities.push_back(
-          llvm::TypeSwitch<Type, enzyme::Activity>(autodiffArg.getType())
-              .Case<FloatType, ComplexType>(
-                  [](auto type) { return enzyme::Activity::enzyme_active; })
-              .Case<LLVM::LLVMPointerType, MemRefType>([&](auto type) {
-                // Skip the shadow
-                arguments.push_back(eoperands[argIdx + 1]);
-                argIdx += 1;
-                return enzyme::Activity::enzyme_dup;
-              })
-              .Default(
-                  [](Type type) { return enzyme::Activity::enzyme_const; }));
+
+      // Whatever the marker takes for itself is not an argument.
+      argIdx += marker->extraOperands;
+
+      switch (marker->role) {
+      case enzyme_markers::MarkerRole::Activity: {
+        enzyme::Activity activity = toMLIRActivity(*marker->activity);
+        sticky = activity;
+        if (argIdx + 1 >= split.primalEnd)
+          break;
+        ++argIdx;
+        takeArgument(argIdx, activity, argIdx);
+        break;
+      }
+      case enzyme_markers::MarkerRole::CallFlag:
+        if (*name == "enzyme_runtime_activity")
+          flags.runtimeActivity = true;
+        else if (*name == "enzyme_strong_zero")
+          flags.strongZero = true;
+        break;
+      case enzyme_markers::MarkerRole::Interleave:
+      case enzyme_markers::MarkerRole::Modifier:
+        break;
+      }
+      continue;
+    }
+
+    if (split.interleaved) {
+      takeArgument(argIdx, sticky, argIdx);
+      continue;
+    }
+
+    // Use default activities based on the types
+    arguments.push_back(autodiffArg);
+    argActivities.push_back(
+        llvm::TypeSwitch<Type, enzyme::Activity>(autodiffArg.getType())
+            .Case<FloatType, ComplexType>(
+                [](auto type) { return enzyme::Activity::enzyme_active; })
+            .Case<LLVM::LLVMPointerType, MemRefType>([&](auto type) {
+              // Skip the shadow
+              arguments.push_back(eoperands[argIdx + 1]);
+              argIdx += 1;
+              return enzyme::Activity::enzyme_dup;
+            })
+            .Default([](Type type) { return enzyme::Activity::enzyme_const; }));
+  }
+
+  // Past the shadows there may be more whole-call markers.
+  for (unsigned i = shadowIdx; split.interleaved && i < eoperands.size(); ++i) {
+    if (auto name = markerAt(i)) {
+      if (*name == "enzyme_runtime_activity")
+        flags.runtimeActivity = true;
+      else if (*name == "enzyme_strong_zero")
+        flags.strongZero = true;
     }
   }
 
@@ -263,6 +362,25 @@ ArrayAttr getActivityArrayAttr(MLIRContext *ctx,
   return ArrayAttr::get(ctx, attrs);
 }
 
+// The function `op` names, or null where the operand is not the address of one
+// this can see.
+FunctionOpInterface getEnzymeCallTarget(LLVM::CallOp op, StringRef intrinsic,
+                                        FlatSymbolRefAttr &symbol) {
+  Operation::operand_range operands = op.getArgOperands();
+  if (operands.empty())
+    return nullptr;
+  auto targetAddr =
+      dyn_cast_if_present<LLVM::AddressOfOp>(operands.front().getDefiningOp());
+  if (!targetAddr) {
+    op.emitError() << "first operand of " << intrinsic
+                   << " was not an llvm.mlir.addressof op";
+    return nullptr;
+  }
+  symbol = targetAddr.getGlobalNameAttr();
+  auto mod = op->getParentOfType<ModuleOp>();
+  return dyn_cast_or_null<FunctionOpInterface>(mod.lookupSymbol(symbol));
+}
+
 class EnzymeAutodiffOpRaising : public OpRewritePattern<LLVM::CallOp> {
 public:
   using OpRewritePattern<LLVM::CallOp>::OpRewritePattern;
@@ -276,26 +394,42 @@ public:
     if (!callee.getLeafReference().strref().contains("__enzyme_autodiff"))
       return failure();
     Operation::operand_range operands = op.getArgOperands();
-    auto targetAddr = dyn_cast_if_present<LLVM::AddressOfOp>(
-        operands.front().getDefiningOp());
-    if (!targetAddr) {
-      op.emitError() << "first operand of __enzyme_autodiff was not an "
-                        "llvm.mlir.addressof op";
-      return failure();
-    }
-
-    FlatSymbolRefAttr funcToDiffSymbol = targetAddr.getGlobalNameAttr();
-    auto mod = op->getParentOfType<ModuleOp>();
+    FlatSymbolRefAttr funcToDiffSymbol;
     auto funcToDiff =
-        cast<FunctionOpInterface>(mod.lookupSymbol(funcToDiffSymbol));
+        getEnzymeCallTarget(op, "__enzyme_autodiff", funcToDiffSymbol);
+    if (!funcToDiff)
+      return failure();
 
     // Infer the argument activities
     SmallVector<Value> arguments;
     SmallVector<enzyme::Activity> argActivities, retActivities;
+    EnzymeCallFlags flags;
     argActivities.reserve(funcToDiff.getNumArguments());
     retActivities.reserve(funcToDiff.getNumResults());
     parseEnzymeCall(funcToDiff, operands, arguments, argActivities,
-                    retActivities);
+                    retActivities, flags);
+
+    // An active return is differentiated from a seed, and enzyme.autodiff
+    // takes one operand for each. __enzyme_autodiff does not name them: the C
+    // interface seeds every active return with one, which is what makes its
+    // result the gradient rather than a directional derivative. Say the one.
+    for (auto [retType, activity] :
+         llvm::zip_equal(funcToDiff.getResultTypes(), retActivities)) {
+      if (activity != enzyme::Activity::enzyme_active &&
+          activity != enzyme::Activity::enzyme_activenoneed)
+        continue;
+      auto floatType = dyn_cast<FloatType>(retType);
+      if (!floatType) {
+        op.emitError() << "cannot seed an active return of type " << retType
+                       << " in __enzyme_autodiff";
+        return failure();
+      }
+      Value seed =
+          LLVM::ConstantOp::create(rewriter, op.getLoc(), floatType,
+                                   rewriter.getFloatAttr(floatType, 1.0));
+      arguments.push_back(seed);
+    }
+
     MLIRContext *ctx = rewriter.getContext();
     bool atomicAdd = false;
     if (auto llFunc = dyn_cast<LLVM::LLVMFuncOp>(funcToDiff.getOperation())) {
@@ -307,7 +441,57 @@ public:
         op, op.getResultTypes(), funcToDiffSymbol.getValue(), arguments,
         getActivityArrayAttr(ctx, argActivities),
         getActivityArrayAttr(ctx, retActivities),
-        /*width=*/1, /*strong_zero=*/false, atomicAdd);
+        /*width=*/1, flags.strongZero, atomicAdd);
+    return success();
+  }
+};
+
+// Forward mode differs from the reverse above in what it says and in what it
+// needs said: the shadows come in with the arguments and nothing seeds a
+// return, so there is only the op to build.
+class EnzymeFwddiffOpRaising : public OpRewritePattern<LLVM::CallOp> {
+public:
+  using OpRewritePattern<LLVM::CallOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rewriter) const override {
+    CallInterfaceCallable callable = op.getCallableForCallee();
+    auto callee = dyn_cast<SymbolRefAttr>(callable);
+    if (!callee)
+      return failure();
+    if (!callee.getLeafReference().strref().contains("__enzyme_fwddiff"))
+      return failure();
+    Operation::operand_range operands = op.getArgOperands();
+    FlatSymbolRefAttr funcToDiffSymbol;
+    auto funcToDiff =
+        getEnzymeCallTarget(op, "__enzyme_fwddiff", funcToDiffSymbol);
+    if (!funcToDiff)
+      return failure();
+
+    SmallVector<Value> arguments;
+    SmallVector<enzyme::Activity> argActivities, retActivities;
+    EnzymeCallFlags flags;
+    argActivities.reserve(funcToDiff.getNumArguments());
+    retActivities.reserve(funcToDiff.getNumResults());
+    parseEnzymeCall(funcToDiff, operands, arguments, argActivities,
+                    retActivities, flags);
+
+    // A return with no shadow to put anywhere is not differentiated.
+    for (auto &activity : retActivities)
+      if (activity == enzyme::Activity::enzyme_active)
+        activity = enzyme::Activity::enzyme_dup;
+
+    if (flags.runtimeActivity)
+      op.emitWarning() << "enzyme_runtime_activity is not modelled by the MLIR "
+                          "pipeline; the activities given are taken as they "
+                          "stand";
+
+    MLIRContext *ctx = rewriter.getContext();
+    rewriter.replaceOpWithNewOp<enzyme::ForwardDiffOp>(
+        op, op.getResultTypes(), funcToDiffSymbol.getValue(), arguments,
+        getActivityArrayAttr(ctx, argActivities),
+        getActivityArrayAttr(ctx, retActivities),
+        /*width=*/1, flags.strongZero);
     return success();
   }
 };
@@ -1251,7 +1435,8 @@ struct LibDeviceFuncsRaisingPass
     populateLibDeviceFuncsToOpsPatterns(getOperation()->getContext(), patterns);
     if (remove_freeze)
       patterns.add<RemoveFreeze>(getOperation()->getContext());
-    patterns.add<EnzymeAutodiffOpRaising>(getOperation()->getContext());
+    patterns.add<EnzymeAutodiffOpRaising, EnzymeFwddiffOpRaising>(
+        getOperation()->getContext());
     GreedyRewriteConfig config;
     // We disable region simplification to avoid inadvertently merging
     // llvm.cond_br now that there is an index type.

--- a/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
+++ b/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
@@ -215,15 +215,15 @@ std::optional<StringRef> getEnzymeMarker(Value v) {
 }
 
 // The activity the shared grammar names, said the way the MLIR ops say it.
-enzyme::Activity toMLIRActivity(enzyme_markers::MarkerActivity activity) {
+enzyme::Activity toMLIRActivity(DIFFE_TYPE activity) {
   switch (activity) {
-  case enzyme_markers::MarkerActivity::Const:
+  case DIFFE_TYPE::CONSTANT:
     return enzyme::Activity::enzyme_const;
-  case enzyme_markers::MarkerActivity::Dup:
+  case DIFFE_TYPE::DUP_ARG:
     return enzyme::Activity::enzyme_dup;
-  case enzyme_markers::MarkerActivity::DupNoNeed:
+  case DIFFE_TYPE::DUP_NONEED:
     return enzyme::Activity::enzyme_dupnoneed;
-  case enzyme_markers::MarkerActivity::Out:
+  case DIFFE_TYPE::OUT_DIFF:
     return enzyme::Activity::enzyme_active;
   }
   llvm_unreachable("unknown marker activity");

--- a/test/lit_tests/raising/enzyme_call_raising.mlir
+++ b/test/lit_tests/raising/enzyme_call_raising.mlir
@@ -1,0 +1,68 @@
+// RUN: enzymexlamlir-opt --libdevice-funcs-raise --split-input-file %s | FileCheck %s
+
+// An active return is differentiated from a seed, and enzyme.autodiff takes one
+// operand for each. __enzyme_autodiff does not name them -- the C interface
+// seeds every active return with one, which is what makes its result the
+// gradient rather than a directional derivative -- so the raising has to say
+// the one itself.
+
+module {
+  llvm.mlir.global external constant @enzyme_const() : i8
+
+  llvm.func @sq(%x: f64) -> f64 {
+    %r = arith.mulf %x, %x : f64
+    llvm.return %r : f64
+  }
+
+  llvm.func @__enzyme_autodiff(...) -> f64
+
+  llvm.func @dsq(%x: f64) -> f64 {
+    %f = llvm.mlir.addressof @sq : !llvm.ptr
+    %r = llvm.call @__enzyme_autodiff(%f, %x) vararg(!llvm.func<f64 (...)>) : (!llvm.ptr, f64) -> f64
+    llvm.return %r : f64
+  }
+}
+
+// CHECK-LABEL: llvm.func @dsq
+// CHECK:         %[[one:.+]] = arith.constant 1.000000e+00 : f64
+// CHECK:         enzyme.autodiff @sq(%arg0, %[[one]])
+// CHECK-SAME:      activity = [#enzyme<activity enzyme_active>]
+// CHECK-SAME:      ret_activity = [#enzyme<activity enzyme_active>]
+
+// -----
+
+// Forward mode was not raised at all. MFEM writes its calls in the interleaved
+// form: one sticky activity marker, then every primal, then enzyme_interleave,
+// then every shadow in the same order, then whole-call markers.
+
+module {
+  llvm.mlir.global external constant @enzyme_dup() : i8
+  llvm.mlir.global external constant @enzyme_interleave() : i8
+  llvm.mlir.global external constant @enzyme_runtime_activity() : i8
+
+  llvm.func @kern(%a: !llvm.ptr, %b: !llvm.ptr) {
+    llvm.return
+  }
+
+  llvm.func @__enzyme_fwddiff(...)
+
+  llvm.func @dkern(%a: !llvm.ptr, %da: !llvm.ptr, %b: !llvm.ptr, %db: !llvm.ptr) {
+    %f = llvm.mlir.addressof @kern : !llvm.ptr
+    %dupaddr = llvm.mlir.addressof @enzyme_dup : !llvm.ptr
+    %dup = llvm.load %dupaddr : !llvm.ptr -> i8
+    %ilvaddr = llvm.mlir.addressof @enzyme_interleave : !llvm.ptr
+    %ilv = llvm.load %ilvaddr : !llvm.ptr -> i8
+    %rtaaddr = llvm.mlir.addressof @enzyme_runtime_activity : !llvm.ptr
+    %rta = llvm.load %rtaaddr : !llvm.ptr -> i8
+    llvm.call @__enzyme_fwddiff(%f, %dup, %a, %b, %ilv, %da, %db, %rta) vararg(!llvm.func<void (...)>) : (!llvm.ptr, i8, !llvm.ptr, !llvm.ptr, i8, !llvm.ptr, !llvm.ptr, i8) -> ()
+    llvm.return
+  }
+}
+
+// Each primal is paired with the shadow that sat at the same place after the
+// separator, and the sticky marker covers both.
+
+// CHECK-LABEL: llvm.func @dkern
+// CHECK:         enzyme.fwddiff @kern(%arg0, %arg1, %arg2, %arg3)
+// CHECK-SAME:      activity = [#enzyme<activity enzyme_dup>, #enzyme<activity enzyme_dup>]
+// CHECK-SAME:      ret_activity = []


### PR DESCRIPTION
Two gaps in what `__enzyme_*` calls the raising understands.

## Forward mode was not raised at all

`EnzymeAutodiffOpRaising` matched only `__enzyme_autodiff`:

```cpp
if (!callee.getLeafReference().strref().contains("__enzyme_autodiff"))
  return failure();
```

so an `__enzyme_fwddiff` call and its marker globals survived to link as undefined symbols. Every one of MFEM's dFEM tests reaches forward mode that way (`fem/dfem/backends/local_qf/fwddiff_transformer.hpp`), so none of them linked — 3209 undefined references to `__enzyme_fwddiff`, `enzyme_dup`, `enzyme_const`, `enzyme_dupnoneed`, `enzyme_interleave`, `enzyme_runtime_activity`, long after everything compiled. See EnzymeAD/Enzyme-JAX#2778.

## An active return was never seeded

An active return is differentiated from a seed, and `enzyme.autodiff` takes one operand for each — `HandleAutoDiffReverse` walks `getInputs()` and consumes one more per `OUT_DIFF` return. `__enzyme_autodiff` does not name them, since the C interface seeds every active return with one. Nothing said the one, so a reverse call over a function returning a float raised to an op with too few operands ("Too few arguments to autodiff op").

## Markers

The markers are now read through the description shared with Enzyme (EnzymeAD/Enzyme#3086) rather than a second list of names here. That also brings the grammar this did not have:

- an activity marker holds until the next one, so one can cover a group;
- `enzyme_interleave` says the shadows come after all of the primals rather than beside each one.

MFEM writes its calls that way:

```cpp
__enzyme_fwddiff<void>(fn, enzyme_dup, primal_ptrs..., enzyme_interleave,
                       shadow_ptrs..., enzyme_runtime_activity);
```

`enzyme_runtime_activity` is recognised rather than mistaken for an argument, but the MLIR pipeline has nothing to honour it with, so a warning is all this does.

## Test

`test/lit_tests/raising/enzyme_call_raising.mlir` — the seed for an active return, and an interleaved forward call whose primals and shadows have to be paired back up.

1111/1111 lit tests pass.

## Where this gets MFEM

The undefined symbols are gone and the dFEM tests now reach forward-mode AD, which is as far as this change goes: `test_diffusion.cpp` then hits a null shadow in `memoryIdentityForwardHandler`, a separate matter in the AD pass itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD