### PR TITLE
Add SelectToLogical: fold boolean select into and/or/not

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -548,6 +548,7 @@ static void addBaseTransformPasses(std::vector<std::string> &list,
   list.push_back("select_simplify");
   list.push_back("select_select_same_cond");
   list.push_back("select_select_neg_cond");
+  list.push_back("select_to_logical");
   list.push_back("concatenate_subtract_to_subtract_pad");
   list.push_back("concatenate_add_to_add_pad");
   list.push_back("concatenate_broadcast_in_dim");

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -14333,6 +14333,79 @@ struct SelectSelectNegCond final
   }
 };
 
+// A select whose operands are themselves i1 and whose true-or-false branch is
+// an all-true/all-false constant is pure boolean logic. Rewriting it as such
+// replaces a select with an and/or, which -- unlike the select -- is
+// associative and commutative, so the downstream reassociation, CSE and
+// pad-pushing patterns (reshuffle_ands_compares, and_simplify, cse_compare,
+// and_pad_pad) can all get at it.
+//
+//   select(p, x, false) -> and(p, x)
+//   select(p, true,  x) -> or(p, x)
+//   select(p, false, x) -> and(not(p), x)
+//   select(p, x,  true) -> or(not(p), x)
+//
+// The first two forms are strictly op-count non-increasing. The latter two
+// introduce a not, which is normally absorbed straight back into whatever
+// produced the predicate (not_compare folds not(compare) into the flipped
+// compare, involution_not_simplify cancels a double negation).
+struct SelectToLogical final
+    : CheckedOpRewritePattern<stablehlo::SelectOp, SelectToLogical> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  // Matches an all-true or all-false constant.
+  static bool matchBoolSplat(Value v, bool &out) {
+    DenseIntElementsAttr c;
+    if (!matchPattern(v, m_Constant(&c)) || !c.isSplat())
+      return false;
+    if (!c.getElementType().isInteger(1))
+      return false;
+    out = c.getSplatValue<bool>();
+    return true;
+  }
+
+  LogicalResult matchAndRewriteImpl(stablehlo::SelectOp op,
+                                    PatternRewriter &rewriter) const {
+    auto resTy = dyn_cast<RankedTensorType>(op.getType());
+    if (!resTy || !resTy.getElementType().isInteger(1))
+      return failure();
+
+    // stablehlo::SelectOp permits a rank-0 predicate against ranked operands;
+    // and/or have no such broadcasting, so the predicate has to already be
+    // shaped like the result for the rewrite to be type-correct.
+    Value pred = op.getPred();
+    if (pred.getType() != op.getType())
+      return failure();
+
+    Value onTrue = op.getOnTrue(), onFalse = op.getOnFalse();
+    bool cv;
+
+    if (matchBoolSplat(onFalse, cv)) {
+      if (!cv) { // select(p, x, false) -> and(p, x)
+        rewriter.replaceOpWithNewOp<stablehlo::AndOp>(op, pred, onTrue);
+        return success();
+      }
+      // select(p, x, true) -> or(not(p), x)
+      auto notPred = stablehlo::NotOp::create(rewriter, op.getLoc(), pred);
+      rewriter.replaceOpWithNewOp<stablehlo::OrOp>(op, notPred, onTrue);
+      return success();
+    }
+
+    if (matchBoolSplat(onTrue, cv)) {
+      if (cv) { // select(p, true, x) -> or(p, x)
+        rewriter.replaceOpWithNewOp<stablehlo::OrOp>(op, pred, onFalse);
+        return success();
+      }
+      // select(p, false, x) -> and(not(p), x)
+      auto notPred = stablehlo::NotOp::create(rewriter, op.getLoc(), pred);
+      rewriter.replaceOpWithNewOp<stablehlo::AndOp>(op, notPred, onFalse);
+      return success();
+    }
+
+    return failure();
+  }
+};
+
 struct AndPadPad final : CheckedOpRewritePattern<stablehlo::AndOp, AndPadPad> {
   using CheckedOpRewritePattern::CheckedOpRewritePattern;
 
@@ -36704,6 +36777,7 @@ struct EnzymeHLOOptPass
         SelectPadToDUS,
         SelectSelectSameCond,
         SelectSelectNegCond,
+        SelectToLogical,
         AndPadPad,
         SelectOpUsedWithinIf,
         TransposeBroadcastInDimToBroadcastInDim,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1620,6 +1620,11 @@ def SelectPadToDUS : EnzymeHLOPatternOp<
   let patterns = ["SelectPadToDUS"];
 }
 
+def SelectToLogical : EnzymeHLOPatternOp<
+    "select_to_logical"> {
+  let patterns = ["SelectToLogical"];
+}
+
 def SelectSelectSameCond : EnzymeHLOPatternOp<
     "select_select_same_cond"> {
   let patterns = ["SelectSelectSameCond"];

--- a/test/lit_tests/select_to_logical.mlir
+++ b/test/lit_tests/select_to_logical.mlir
@@ -1,0 +1,83 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=select_to_logical" --transform-interpreter --enzyme-hlo-remove-transform --split-input-file %s | FileCheck %s
+
+// select(p, x, false) -> and(p, x)
+func.func @select_x_false(%p: tensor<4xi1>, %x: tensor<4xi1>) -> tensor<4xi1> {
+  %false = stablehlo.constant dense<false> : tensor<4xi1>
+  %r = stablehlo.select %p, %x, %false : tensor<4xi1>, tensor<4xi1>
+  return %r : tensor<4xi1>
+}
+// CHECK-LABEL: func.func @select_x_false
+// CHECK-NOT: stablehlo.select
+// CHECK: stablehlo.and %arg0, %arg1 : tensor<4xi1>
+
+// -----
+
+// select(p, true, x) -> or(p, x)
+func.func @select_true_x(%p: tensor<4xi1>, %x: tensor<4xi1>) -> tensor<4xi1> {
+  %true = stablehlo.constant dense<true> : tensor<4xi1>
+  %r = stablehlo.select %p, %true, %x : tensor<4xi1>, tensor<4xi1>
+  return %r : tensor<4xi1>
+}
+// CHECK-LABEL: func.func @select_true_x
+// CHECK-NOT: stablehlo.select
+// CHECK: stablehlo.or %arg0, %arg1 : tensor<4xi1>
+
+// -----
+
+// select(p, false, x) -> and(not(p), x)
+func.func @select_false_x(%p: tensor<4xi1>, %x: tensor<4xi1>) -> tensor<4xi1> {
+  %false = stablehlo.constant dense<false> : tensor<4xi1>
+  %r = stablehlo.select %p, %false, %x : tensor<4xi1>, tensor<4xi1>
+  return %r : tensor<4xi1>
+}
+// CHECK-LABEL: func.func @select_false_x
+// CHECK-NOT: stablehlo.select
+// CHECK: %[[N:.+]] = stablehlo.not %arg0 : tensor<4xi1>
+// CHECK: stablehlo.and %[[N]], %arg1 : tensor<4xi1>
+
+// -----
+
+// select(p, x, true) -> or(not(p), x)
+func.func @select_x_true(%p: tensor<4xi1>, %x: tensor<4xi1>) -> tensor<4xi1> {
+  %true = stablehlo.constant dense<true> : tensor<4xi1>
+  %r = stablehlo.select %p, %x, %true : tensor<4xi1>, tensor<4xi1>
+  return %r : tensor<4xi1>
+}
+// CHECK-LABEL: func.func @select_x_true
+// CHECK-NOT: stablehlo.select
+// CHECK: %[[N:.+]] = stablehlo.not %arg0 : tensor<4xi1>
+// CHECK: stablehlo.or %[[N]], %arg1 : tensor<4xi1>
+
+// -----
+
+// A rank-0 predicate against a ranked result relies on select's implicit
+// broadcast, which and/or don't have -- must not fire.
+func.func @scalar_pred(%p: tensor<i1>, %x: tensor<4xi1>) -> tensor<4xi1> {
+  %false = stablehlo.constant dense<false> : tensor<4xi1>
+  %r = stablehlo.select %p, %x, %false : tensor<i1>, tensor<4xi1>
+  return %r : tensor<4xi1>
+}
+// CHECK-LABEL: func.func @scalar_pred
+// CHECK: stablehlo.select
+
+// -----
+
+// Non-i1 operands are not boolean logic -- must not fire.
+func.func @not_i1(%p: tensor<4xi1>, %x: tensor<4xf32>) -> tensor<4xf32> {
+  %zero = stablehlo.constant dense<0.000000e+00> : tensor<4xf32>
+  %r = stablehlo.select %p, %x, %zero : tensor<4xi1>, tensor<4xf32>
+  return %r : tensor<4xf32>
+}
+// CHECK-LABEL: func.func @not_i1
+// CHECK: stablehlo.select
+
+// -----
+
+// A non-splat i1 constant branch is not an all-true/all-false -- must not fire.
+func.func @non_splat(%p: tensor<4xi1>, %x: tensor<4xi1>) -> tensor<4xi1> {
+  %c = stablehlo.constant dense<[true, false, true, false]> : tensor<4xi1>
+  %r = stablehlo.select %p, %x, %c : tensor<4xi1>, tensor<4xi1>
+  return %r : tensor<4xi1>
+}
+// CHECK-LABEL: func.func @non_splat
+// CHECK: stablehlo.select


### PR DESCRIPTION
## Summary
- Adds `SelectToLogical`, a new `EnzymeHLOOpt` pattern that rewrites a `stablehlo.select` whose result type is `i1` and whose true/false branch is an all-true or all-false constant into plain boolean logic:
  - `select(p, x, false) -> and(p, x)`
  - `select(p, true,  x) -> or(p, x)`
  - `select(p, false, x) -> and(not(p), x)`
  - `select(p, x,  true) -> or(not(p), x)`
- Unlike `select`, `and`/`or` are associative and commutative, so this unlocks downstream patterns that only look for `and`/`or` (reassociation, CSE, pad-pushing) on predicates that were previously stuck behind an opaque `select`.
- Registered the pattern under the name `select_to_logical` (transform op + `EnzymeXLA.cpp` pass-name list) and wired it into the default `EnzymeHLOOptPass` pattern set.

## Test plan
- [x] Added `test/lit_tests/select_to_logical.mlir` covering all four rewrite forms plus three negative cases (rank-0 broadcasting predicate, non-i1 operands, non-splat constant branch).
- [x] `bazel test //test/lit_tests:select_to_logical.mlir.test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)