### PR TITLE
Carry an access's alignment through raising and lowering

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -1871,6 +1871,24 @@ struct MoveRMWToAffine : public OpRewritePattern<memref::AtomicRMWOp> {
   }
 };
 
+// A rebuilt access keeps everything the old one said about itself. All the
+// discardable attributes ride over as they are. Alignment needs the extra
+// clause only because on memref.load/store it is an inherent attribute, held
+// in properties where getDiscardableAttrs does not see it; going to an affine
+// op, which has no inherent slot for it, it is lifted into the discardable
+// dictionary, where lower-aligned-affine-accesses knows to find it.
+static void copyAccessAttrs(Operation *from, Operation *to) {
+  for (NamedAttribute attr : from->getDiscardableAttrs())
+    to->setAttr(attr.getName(), attr.getValue());
+  if (auto load = dyn_cast<memref::LoadOp>(from)) {
+    if (auto align = load.getAlignmentAttr())
+      to->setAttr("alignment", align);
+  } else if (auto store = dyn_cast<memref::StoreOp>(from)) {
+    if (auto align = store.getAlignmentAttr())
+      to->setAttr("alignment", align);
+  }
+}
+
 struct MoveLoadToAffine : public OpRewritePattern<memref::LoadOp> {
   using OpRewritePattern<memref::LoadOp>::OpRewritePattern;
 
@@ -1912,6 +1930,7 @@ struct MoveLoadToAffine : public OpRewritePattern<memref::LoadOp> {
 
     affine::AffineLoadOp affineLoad = affine::AffineLoadOp::create(
         rewriter, load.getLoc(), load.getMemRef(), map, operands);
+    copyAccessAttrs(load, affineLoad);
     load.getResult().replaceAllUsesWith(affineLoad.getResult());
     rewriter.eraseOp(load);
     return success();
@@ -1951,9 +1970,10 @@ struct MoveStoreToAffine : public OpRewritePattern<memref::StoreOp> {
     affine::canonicalizeMapAndOperands(&map, &operands);
     map = recreateExpr(map);
 
-    affine::AffineStoreOp::create(rewriter, store.getLoc(),
-                                  store.getValueToStore(), store.getMemRef(),
-                                  map, operands);
+    auto affineStore = affine::AffineStoreOp::create(
+        rewriter, store.getLoc(), store.getValueToStore(), store.getMemRef(),
+        map, operands);
+    copyAccessAttrs(store, affineStore);
     rewriter.eraseOp(store);
     return success();
   }
@@ -2011,8 +2031,11 @@ template <>
 void AffineFixup<affine::AffineLoadOp>::replaceAffineOp(
     PatternRewriter &rewriter, affine::AffineLoadOp load, AffineMap map,
     ArrayRef<Value> mapOperands) const {
-  rewriter.replaceOpWithNewOp<affine::AffineLoadOp>(load, load.getMemRef(), map,
-                                                    mapOperands);
+  auto attrs = load->getDiscardableAttrDictionary();
+  auto newLoad = rewriter.replaceOpWithNewOp<affine::AffineLoadOp>(
+      load, load.getMemRef(), map, mapOperands);
+  for (NamedAttribute attr : attrs)
+    newLoad->setAttr(attr.getName(), attr.getValue());
 }
 template <>
 void AffineFixup<affine::AffinePrefetchOp>::replaceAffineOp(
@@ -2027,8 +2050,11 @@ template <>
 void AffineFixup<affine::AffineStoreOp>::replaceAffineOp(
     PatternRewriter &rewriter, affine::AffineStoreOp store, AffineMap map,
     ArrayRef<Value> mapOperands) const {
-  rewriter.replaceOpWithNewOp<affine::AffineStoreOp>(
+  auto attrs = store->getDiscardableAttrDictionary();
+  auto newStore = rewriter.replaceOpWithNewOp<affine::AffineStoreOp>(
       store, store.getValueToStore(), store.getMemRef(), map, mapOperands);
+  for (NamedAttribute attr : attrs)
+    newStore->setAttr(attr.getName(), attr.getValue());
 }
 template <>
 void AffineFixup<affine::AffineVectorLoadOp>::replaceAffineOp(
@@ -6011,8 +6037,14 @@ struct FoldAppliesIntoLoad : public OpRewritePattern<memref::LoadOp> {
     AffineMap combinedMap =
         AffineMap::inferFromExprList({exprs}, getContext())[0];
     llvm::append_range(loadDimOperands, loadSymOperands);
-    rewriter.replaceOpWithNewOp<affine::AffineLoadOp>(
+    auto attrs = loadOp->getDiscardableAttrDictionary();
+    auto alignAttr = loadOp.getAlignmentAttr();
+    auto newLoad = rewriter.replaceOpWithNewOp<affine::AffineLoadOp>(
         loadOp, loadOp.getMemRef(), combinedMap, loadDimOperands);
+    for (NamedAttribute attr : attrs)
+      newLoad->setAttr(attr.getName(), attr.getValue());
+    if (alignAttr)
+      newLoad->setAttr("alignment", alignAttr);
     return success();
   }
 };

--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -824,10 +824,14 @@ public:
     if (!address)
       return failure();
 
+    // The access carries the alignment the original llvm access promised;
+    // without it the load is emitted at the element type's ABI alignment,
+    // which may promise more than the pointer holds.
+    unsigned alignment = loadOp.getAlignment().value_or(0);
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(
         loadOp,
         typeConverter->convertType(loadOp.getMemRefType().getElementType()),
-        address);
+        address, alignment);
     return success();
   }
 };
@@ -937,8 +941,10 @@ public:
     if (!address)
       return failure();
 
+    // See CLoadOpLowering: keep the alignment the original access promised.
+    unsigned alignment = storeOp.getAlignment().value_or(0);
     rewriter.replaceOpWithNewOp<LLVM::StoreOp>(storeOp, adaptor.getValue(),
-                                               address);
+                                               address, alignment);
     return success();
   }
 };

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1835,6 +1835,7 @@ convertLLVMToAffineAccess(Operation *op,
     };
 
     auto dl = dataLayoutAnalysis.getAtOrAbove(aab.user);
+
     if (auto load = dyn_cast<LLVM::LoadOp>(aab.user)) {
       IRRewriter rewriter(load);
 
@@ -1905,7 +1906,13 @@ convertLLVMToAffineAccess(Operation *op,
       ic.replace(load, newLoad);
       rewriter.replaceOp(load, newLoad);
       for (auto attr : attrs) {
-        newLoad->setAttr(attr.getName(), attr.getValue());
+        // memref.load owns an alignment attribute, and only the owned one is
+        // what its lowering reads; a discardable one of the same name is shown
+        // by the printer and seen by nothing.
+        if (attr.getName() == "alignment")
+          newLoad.setAlignmentAttr(cast<IntegerAttr>(attr.getValue()));
+        else
+          newLoad->setAttr(attr.getName(), attr.getValue());
       }
 
     } else if (auto store = dyn_cast<LLVM::StoreOp>(aab.user)) {
@@ -1966,7 +1973,11 @@ convertLLVMToAffineAccess(Operation *op,
               store.getAddr()),
           idxs);
       for (auto attr : attrs) {
-        newStore->setAttr(attr.getName(), attr.getValue());
+        // See the load path above.
+        if (attr.getName() == "alignment")
+          newStore.setAlignmentAttr(cast<IntegerAttr>(attr.getValue()));
+        else
+          newStore->setAttr(attr.getName(), attr.getValue());
       }
     } else {
       llvm_unreachable("Unknown operation to raise");

--- a/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
@@ -1,0 +1,114 @@
+//===- LowerAlignedAffineAccesses.cpp - keep alignment through lowering ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// llvm-to-affine-access records the alignment of the access it raised as an
+// attribute on the affine.load/affine.store it made. Upstream lower-affine
+// rebuilds those as memref accesses without carrying attributes over, so the
+// recorded alignment is lost and the final llvm access is emitted at the
+// element type's ABI alignment -- which may promise more than the pointer
+// holds. clang says `load i128, align 8` for the 16-byte member swap in MFEM's
+// Mesh::Swap, at a struct offset that is 8 mod 16; upgraded to align 16, the
+// backend's movaps traps.
+//
+// Run before lower-affine, this lowers exactly the accesses that carry an
+// alignment attribute, keeping their attributes. The affine.apply it leaves
+// behind, and every access without the attribute, lower as before.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_LOWERALIGNEDAFFINEACCESSESPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+// The map's results become one affine.apply per index, which lower-affine
+// knows how to take apart; the access itself becomes the memref op the
+// attributes can ride on.
+static SmallVector<Value> expandMap(PatternRewriter &rewriter, Location loc,
+                                    AffineMap map, ValueRange operands) {
+  SmallVector<Value> indices;
+  for (unsigned i = 0, e = map.getNumResults(); i < e; ++i)
+    indices.push_back(affine::AffineApplyOp::create(
+        rewriter, loc, map.getSubMap({i}), operands));
+  return indices;
+}
+
+struct LowerAlignedAffineLoad : public OpRewritePattern<affine::AffineLoadOp> {
+  using OpRewritePattern<affine::AffineLoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineLoadOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op->hasAttr("alignment"))
+      return failure();
+    auto indices = expandMap(rewriter, op.getLoc(), op.getAffineMap(),
+                             op.getMapOperands());
+    auto newLoad =
+        memref::LoadOp::create(rewriter, op.getLoc(), op.getMemRef(), indices);
+    // On the affine op the alignment was a discardable attribute; memref.load
+    // owns one, and only the owned one is what its lowering reads.
+    for (NamedAttribute attr : op->getDiscardableAttrs()) {
+      if (attr.getName() == "alignment")
+        newLoad.setAlignmentAttr(cast<IntegerAttr>(attr.getValue()));
+      else
+        newLoad->setAttr(attr.getName(), attr.getValue());
+    }
+    rewriter.replaceOp(op, newLoad);
+    return success();
+  }
+};
+
+struct LowerAlignedAffineStore
+    : public OpRewritePattern<affine::AffineStoreOp> {
+  using OpRewritePattern<affine::AffineStoreOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineStoreOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op->hasAttr("alignment"))
+      return failure();
+    auto indices = expandMap(rewriter, op.getLoc(), op.getAffineMap(),
+                             op.getMapOperands());
+    auto newStore = memref::StoreOp::create(
+        rewriter, op.getLoc(), op.getValueToStore(), op.getMemRef(), indices);
+    // See LowerAlignedAffineLoad.
+    for (NamedAttribute attr : op->getDiscardableAttrs()) {
+      if (attr.getName() == "alignment")
+        newStore.setAlignmentAttr(cast<IntegerAttr>(attr.getValue()));
+      else
+        newStore->setAttr(attr.getName(), attr.getValue());
+    }
+    rewriter.replaceOp(op, newStore);
+    return success();
+  }
+};
+
+struct LowerAlignedAffineAccessesPass
+    : public enzyme::impl::LowerAlignedAffineAccessesPassBase<
+          LowerAlignedAffineAccessesPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<LowerAlignedAffineLoad, LowerAlignedAffineStore>(
+        &getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -337,6 +337,28 @@ def SortMemory : Pass<"sort-memory"> {
   let summary = "Sort memory accesses";
 }
 
+def LowerAlignedAffineAccessesPass
+    : Pass<"lower-aligned-affine-accesses"> {
+  let summary = "Lower affine accesses that carry an alignment attribute to "
+                "memref accesses that keep it";
+  let description = [{
+    llvm-to-affine-access records the alignment of the access it raised as an
+    attribute on the affine.load/affine.store it made. Upstream lower-affine
+    rebuilds those as memref accesses without carrying attributes over, so the
+    recorded alignment is lost and the final llvm access is emitted at the
+    element type's ABI alignment -- which may promise more than the pointer
+    holds (a 16-byte member swap clang emits as `load i128, align 8`).
+
+    Run before lower-affine, this lowers exactly the accesses that carry an
+    alignment attribute, keeping their attributes; lower-affine handles the
+    affine.apply this leaves behind, and everything else, as before.
+  }];
+  let dependentDialects = [
+    "affine::AffineDialect",
+    "memref::MemRefDialect",
+  ];
+}
+
 def HoistAllocasPass : Pass<"hoist-allocas"> {
   let summary = "Move stack allocations to the start of the region that frees "
                 "them";

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -151,7 +151,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       if (outfile.size() && getenv("EXPORT_REACTANT")) {
         pass_pipeline += ",print{filename="+outfile+".mlir}";
       }
-      pass_pipeline += ",lower-affine";
+      pass_pipeline += ",lower-aligned-affine-accesses,lower-affine";
       if (getenv("REACTANT_OMP")) {
         pass_pipeline += ",convert-scf-to-openmp,";
       } else {
@@ -166,7 +166,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       }
       pass_pipeline += "symbol-dce,raise-llvm-ext,outline-enzyme-regions,";
       if (options->preADLowerAffine)
-        pass_pipeline += "lower-affine,";
+        pass_pipeline += "lower-aligned-affine-accesses,lower-affine,";
 
       // A checkpointed loop must not capture both a value and a view of it:
       // it would snapshot the same buffer twice. Has to precede `enzyme`,
@@ -198,7 +198,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
         pass_pipeline += ",affine-cfg,remove-atomics";
       if (options->sortBlockMemory)
         pass_pipeline += ",sort-block-memory";
-      pass_pipeline += ",lower-affine";
+      pass_pipeline += ",lower-aligned-affine-accesses,lower-affine";
       if (backend == "rocm")
         pass_pipeline += ",convert-cudart-to-hiprt";
       if (backend != "cpu") {
@@ -206,7 +206,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
         pass_pipeline += "convert-parallel-to-gpu2{backend=";
         pass_pipeline += backend;
         pass_pipeline += "}";
-        pass_pipeline += ",lower-affine";
+        pass_pipeline += ",lower-aligned-affine-accesses,lower-affine";
       }
       if (getenv("REACTANT_OMP")) {
         pass_pipeline += ",convert-scf-to-openmp,";

--- a/test/lit_tests/raising/affinecfg_ext.mlir
+++ b/test/lit_tests/raising/affinecfg_ext.mlir
@@ -246,15 +246,15 @@ func.func private @"##call__Z40gpu_compute_hydrostatic_free_surface_Gv_16Compile
 // CHECK-NEXT:       %2 = affine.load %arg9[%arg12 + 8, %arg13 + 8, %arg14 + 7] : memref<31x78x78xf32, 1>
 // CHECK-NEXT:       %3 = arith.mulf %2, %cst {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %4 = arith.subf %1, %3 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %5 = affine.load %arg4[%arg13 + 8] : memref<78xf32, 1>
+// CHECK-NEXT:       %5 = affine.load %arg4[%arg13 + 8] {{.*}}: memref<78xf32, 1>
 // CHECK-NEXT:       %6 = affine.load %arg8[%arg12 + 8, %arg13 + 8, %arg14 + 8] : memref<31x78x78xf32, 1>
 // CHECK-NEXT:       %7 = arith.mulf %5, %6 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %8 = affine.load %arg4[%arg13 + 7] : memref<78xf32, 1>
+// CHECK-NEXT:       %8 = affine.load %arg4[%arg13 + 7] {{.*}}: memref<78xf32, 1>
 // CHECK-NEXT:       %9 = affine.load %arg8[%arg12 + 8, %arg13 + 7, %arg14 + 8] : memref<31x78x78xf32, 1>
 // CHECK-NEXT:       %10 = arith.mulf %8, %9 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %11 = arith.subf %7, %10 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %12 = arith.subf %4, %11 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %13 = affine.load %arg7[%arg13 + 8] : memref<78xf32, 1>
+// CHECK-NEXT:       %13 = affine.load %arg7[%arg13 + 8] {{.*}}: memref<78xf32, 1>
 // CHECK-NEXT:       %14 = arith.divf %cst_0, %13 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %15 = arith.mulf %12, %14 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %16 = affine.load %arg9[%arg12 + 8, %arg13 + 8, %arg14 + 9] : memref<31x78x78xf32, 1>
@@ -281,17 +281,17 @@ func.func private @"##call__Z40gpu_compute_hydrostatic_free_surface_Gv_16Compile
 // CHECK-NEXT:       %37 = arith.mulf %36, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %38 = arith.mulf %27, %37 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %39 = arith.mulf %38, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %40 = affine.load %arg5[%arg13 + 7] : memref<78xf32, 1>
+// CHECK-NEXT:       %40 = affine.load %arg5[%arg13 + 7] {{.*}}: memref<78xf32, 1>
 // CHECK-NEXT:       %41 = affine.load %arg10[%arg12 + 8, %arg13 + 7, %arg14 + 8] : memref<31x78x78xf32, 1>
 // CHECK-NEXT:       %42 = arith.mulf %40, %41 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %43 = affine.load %arg5[%arg13 + 8] : memref<78xf32, 1>
+// CHECK-NEXT:       %43 = affine.load %arg5[%arg13 + 8] {{.*}}: memref<78xf32, 1>
 // CHECK-NEXT:       %44 = affine.load %arg10[%arg12 + 8, %arg13 + 8, %arg14 + 8] : memref<31x78x78xf32, 1>
 // CHECK-NEXT:       %45 = arith.mulf %43, %44 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %46 = arith.addf %42, %45 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %47 = arith.mulf %46, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %48 = affine.load %arg9[%arg12 + 7, %arg13 + 8, %arg14 + 8] : memref<31x78x78xf32, 1>
 // CHECK-NEXT:       %49 = arith.subf %0, %48 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %50 = affine.load %arg1[%arg12 + 9] : memref<32xf32, 1>
+// CHECK-NEXT:       %50 = affine.load %arg1[%arg12 + 9] {{.*}}: memref<32xf32, 1>
 // CHECK-NEXT:       %51 = arith.divf %cst_0, %50 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %52 = arith.mulf %49, %51 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %53 = arith.mulf %47, %52 {fastmathFlags = #llvm.fastmath<none>} : f32
@@ -303,13 +303,13 @@ func.func private @"##call__Z40gpu_compute_hydrostatic_free_surface_Gv_16Compile
 // CHECK-NEXT:       %59 = arith.mulf %58, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %60 = affine.load %arg9[%arg12 + 9, %arg13 + 8, %arg14 + 8] : memref<31x78x78xf32, 1>
 // CHECK-NEXT:       %61 = arith.subf %60, %0 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %62 = affine.load %arg1[%arg12 + 10] : memref<32xf32, 1>
+// CHECK-NEXT:       %62 = affine.load %arg1[%arg12 + 10] {{.*}}: memref<32xf32, 1>
 // CHECK-NEXT:       %63 = arith.divf %cst_0, %62 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %64 = arith.mulf %61, %63 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %65 = arith.mulf %59, %64 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %66 = arith.addf %53, %65 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %67 = arith.mulf %66, %cst_1 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %68 = affine.load %arg6[%arg13 + 8] : memref<78xf32, 1>
+// CHECK-NEXT:       %68 = affine.load %arg6[%arg13 + 8] {{.*}}: memref<78xf32, 1>
 // CHECK-NEXT:       %69 = arith.divf %cst_0, %68 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %70 = arith.mulf %67, %69 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %71 = arith.mulf %6, %6 {fastmathFlags = #llvm.fastmath<none>} : f32
@@ -389,16 +389,16 @@ func.func private @"##call__Z40gpu_compute_hydrostatic_free_surface_Gv_16Compile
 // CHECK-NEXT:       %129 = arith.subf %127, %128 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %130 = arith.mulf %129, %cst_2 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %131 = arith.subf %126, %130 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %132 = affine.load %arg2[%arg12 + 8] : memref<31xf32, 1>
+// CHECK-NEXT:       %132 = affine.load %arg2[%arg12 + 8] {{.*}}: memref<31xf32, 1>
 // CHECK-NEXT:       %133 = arith.mulf %68, %132 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %134 = arith.divf %cst_0, %133 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %135 = arith.mulf %132, %cst {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %136 = arith.mulf %135, %cst_9 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %137 = arith.subf %136, %136 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %138 = affine.load %arg3[%arg13 + 8] : memref<78xf32, 1>
+// CHECK-NEXT:       %138 = affine.load %arg3[%arg13 + 8] {{.*}}: memref<78xf32, 1>
 // CHECK-NEXT:       %139 = arith.mulf %138, %132 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %140 = arith.mulf %139, %cst_9 {fastmathFlags = #llvm.fastmath<none>} : f32
-// CHECK-NEXT:       %141 = affine.load %arg3[%arg13 + 7] : memref<78xf32, 1>
+// CHECK-NEXT:       %141 = affine.load %arg3[%arg13 + 7] {{.*}}: memref<78xf32, 1>
 // CHECK-NEXT:       %142 = arith.mulf %141, %132 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %143 = arith.mulf %142, %cst_9 {fastmathFlags = #llvm.fastmath<none>} : f32
 // CHECK-NEXT:       %144 = arith.subf %140, %143 {fastmathFlags = #llvm.fastmath<none>} : f32

--- a/test/lit_tests/raising/llvm_to_affine_access_underaligned.mlir
+++ b/test/lit_tests/raising/llvm_to_affine_access_underaligned.mlir
@@ -1,0 +1,41 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access)" | FileCheck %s --check-prefix=RAISE
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access,lower-aligned-affine-accesses,lower-affine)" | FileCheck %s --check-prefix=MEMREF
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access,lower-aligned-affine-accesses,lower-affine,convert-polygeist-to-llvm{backend=cpu})" | FileCheck %s --check-prefix=LLVM
+
+// An access must come back out of the raising at the alignment it promised
+// going in. clang says `load i128, align 8` for the 16-byte member swap in
+// MFEM's Mesh::Swap, at a struct offset that is 8 mod 16; the raised
+// affine.load carried the alignment only as an attribute, upstream
+// lower-affine rebuilt the access without it, and the final llvm.load was
+// emitted at i128's ABI alignment of 16 -- so the backend's movaps trapped.
+//
+// The alignment rides the attribute through every stage:
+// llvm-to-affine-access records it, lower-aligned-affine-accesses lowers the
+// accesses that carry it before lower-affine can drop it, and the polygeist
+// lowering reads it back onto the llvm access it emits.
+
+module {
+  llvm.func @swap16(%a: !llvm.ptr, %b: !llvm.ptr) {
+    %pa = llvm.getelementptr inbounds|nuw %a[5488] : (!llvm.ptr) -> !llvm.ptr, i8
+    %pb = llvm.getelementptr inbounds|nuw %b[5488] : (!llvm.ptr) -> !llvm.ptr, i8
+    %old = llvm.load %pa {alignment = 8 : i64} : !llvm.ptr -> i128
+    llvm.store %old, %pb {alignment = 8 : i64} : i128, !llvm.ptr
+    llvm.return
+  }
+}
+
+// The raising still converts the access; the alignment is on the attribute.
+// RAISE-LABEL: llvm.func @swap16
+// RAISE:         affine.load %{{.*}}[343] {alignment = 8 : i64, ordering = 0 : i64} : memref<?xi128>
+// RAISE:         affine.store %{{.*}}[343] {alignment = 8 : i64, ordering = 0 : i64} : memref<?xi128>
+
+// lower-aligned-affine-accesses takes the attributed accesses down to memref
+// before lower-affine would have dropped the attribute.
+// MEMREF-LABEL: llvm.func @swap16
+// MEMREF:         memref.load %{{.*}} {alignment = 8 : i64, ordering = 0 : i64} : memref<?xi128>
+// MEMREF:         memref.store %{{.*}} {alignment = 8 : i64, ordering = 0 : i64} : memref<?xi128>
+
+// And the llvm access comes out at the alignment that went in.
+// LLVM-LABEL: llvm.func @swap16
+// LLVM:         llvm.load %{{.*}} {alignment = 8 : i64{{.*}}} : !llvm.ptr -> i128
+// LLVM:         llvm.store %{{.*}} {alignment = 8 : i64{{.*}}} : i128, !llvm.ptr


### PR DESCRIPTION
An access must come back out of the raising at the alignment it promised going in.

**The bug.** clang says `load i128, align 8` for the 16-byte member swap in MFEM's `Mesh::Swap` (a pair of `std::map` headers), at a struct offset that is 8 mod 16. Raised to `memref<?xi128>`, the alignment survived only as a discardable attribute nothing read, and the lowered load came out at i128's ABI alignment of 16:

| | |
|---|---|
| plain clang | `load i128, ptr %179, align 1` |
| raised | `load i128, ptr %359, align 16` |

The backend, entitled by the align-16 promise, selected `movaps` on the 8-aligned address:

```
=> movaps 0x1538(%r14),%xmm0      ; 0x1538 = 5432 ≡ 8 (mod 16) — SIGSEGV
```

One miscompiled function in one file of the 269 in libmfem, found when the fully-raised unit tests segfaulted in ordinary mesh refinement (no AD involved), and bisected file → function → pass → instruction. Ten-line reproducer:

```cpp
mfem::Mesh mesh = mfem::Mesh::MakeCartesian2D(3, 3, mfem::Element::QUADRILATERAL);
mesh.EnsureNCMesh();
mfem::Array<int> el(1); el[0] = 1;
mesh.GeneralRefinement(el, 1, 0);   // segfault in Mesh::Swap
```

**The fix: the alignment rides the access end to end** (rather than refusing to raise under-aligned accesses — raising stays fully enabled):

- `llvm-to-affine-access` sets `memref.load/store`'s **own** alignment attribute on the fallback path. A discardable attribute of the same name is shown by the printer and read by nothing — which also explains why this only ever failed in-process: the parser routes a spelled `alignment` into the inherent slot, so any staged/round-tripped reproduction silently healed itself.
- `affine-cfg`'s rebuild sites (`MoveLoadToAffine`, `MoveStoreToAffine`, the `AffineFixup` specializations, `FoldAppliesIntoLoad`) carry the access's attributes over instead of dropping them.
- A new **`lower-aligned-affine-accesses`** pass runs before every `lower-affine` and lowers exactly the affine accesses that carry an alignment attribute into memref accesses that own it. Upstream `lower-affine` rebuilds accesses without carrying attributes over; this keeps it from having to know.
- `convert-polygeist-to-llvm`'s `CLoadOpLowering`/`CStoreOpLowering` read the alignment and put it on the llvm access they emit.

**Validation.**
- New lit test `raising/llvm_to_affine_access_underaligned.mlir` walks the module through each stage (raise / +aligned-lowering+lower-affine / +convert-polygeist) and checks the alignment is still standing at the end of each.
- On MFEM's `mesh.cpp`, all four i128 accesses in `Mesh::Swap` now come out `align 8`, and the reproducer runs correctly (`NE=9 → 12`).
- All 168 raising/affine/polygeist lit tests pass, and the MFEM reproducer was re-verified after dropping an unneeded benefit bump from the patterns. `affinecfg_ext.mlir`'s CHECKs updated: the rebuilt loads now retain the `{alignment, ordering, tbaa}` attributes their inputs carried, which the old expectations assumed were dropped.
