### PR TITLE
canonicalize-scf-for: results of a converted while observe its final evaluation

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1580,6 +1580,59 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
     if (lookThrough && !loop->use_empty())
       doWhile = true;
 
+    // The same holds without an extra condition. A do-while's results are the
+    // condition args of that final evaluation -- the one whose comparison
+    // fails -- while the converted loop's results are snapshots from the last
+    // evaluation it runs. A used result is the same value either way only if
+    // its condition arg cannot change between one evaluation and the next: a
+    // value from outside the loop, a passthrough of a slot the loop refills
+    // with itself, or a slot advanced by a loop-invariant step, whose result
+    // ForOpInductionReplacement rewrites in closed form afterwards. Anything
+    // else -- a value the before region computes, a permuted slot, an
+    // accumulator -- observes the final evaluation and needs the extra
+    // iteration, pure or not.
+    if (!doWhile) {
+      auto afterYield =
+          cast<scf::YieldOp>(loop.getAfter().front().getTerminator());
+      auto definedOutside = [&](Value v) {
+        if (auto ba = dyn_cast<BlockArgument>(v))
+          return !loop->isAncestor(ba.getOwner()->getParentOp());
+        Operation *def = v.getDefiningOp();
+        return def && !loop->isAncestor(def);
+      };
+      // The after-region arg at position p carries before-arg `ba` iff the
+      // condition forwards `ba` in position p.
+      auto carriesSlot = [&](Value v, BlockArgument ba) {
+        auto aa = dyn_cast<BlockArgument>(v);
+        return aa && aa.getOwner() == &loop.getAfter().front() &&
+               condOp.getArgs()[aa.getArgNumber()] == ba;
+      };
+      for (auto [res, arg] : llvm::zip(loop.getResults(), condOp.getArgs())) {
+        if (res.use_empty())
+          continue;
+        if (definedOutside(arg))
+          continue;
+        if (auto ba = dyn_cast<BlockArgument>(arg)) {
+          if (ba.getOwner() == &loop.getBefore().front()) {
+            Value next = afterYield.getOperand(ba.getArgNumber());
+            if (carriesSlot(next, ba))
+              continue;
+            if (auto add = next.getDefiningOp<AddIOp>()) {
+              bool induction = false;
+              for (int k = 0; k < 2; k++)
+                if (carriesSlot(add->getOperand(k), ba) &&
+                    definedOutside(add->getOperand(1 - k)))
+                  induction = true;
+              if (induction)
+                continue;
+            }
+          }
+        }
+        doWhile = true;
+        break;
+      }
+    }
+
     bool mutableAfter = false;
     if (doWhile) {
       for (auto &blk : loop.getAfter()) {

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1585,12 +1585,15 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
     // fails -- while the converted loop's results are snapshots from the last
     // evaluation it runs. A used result is the same value either way only if
     // its condition arg cannot change between one evaluation and the next: a
-    // value from outside the loop, a passthrough of a slot the loop refills
-    // with itself, or a slot advanced by a loop-invariant step, whose result
-    // ForOpInductionReplacement rewrites in closed form afterwards. Anything
-    // else -- a value the before region computes, a permuted slot, an
-    // accumulator -- observes the final evaluation and needs the extra
-    // iteration, pure or not.
+    // value from outside the loop, or a passthrough of a slot the loop
+    // refills with itself. Anything else -- a value the before region
+    // computes, a permuted slot, an accumulator, even a slot advanced by a
+    // loop-invariant step -- observes the final evaluation and needs the
+    // extra iteration, pure or not. (An advancing slot looks recoverable in
+    // closed form, but nothing downstream is obliged to do so:
+    // ForOpInductionReplacement only rewrites a result whose post-conversion
+    // yield is addi(iterarg, step), and the conversion does not produce that
+    // shape -- counting on it returned one step short.)
     if (!doWhile) {
       auto afterYield =
           cast<scf::YieldOp>(loop.getAfter().front().getTerminator());
@@ -1617,15 +1620,6 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
             Value next = afterYield.getOperand(ba.getArgNumber());
             if (carriesSlot(next, ba))
               continue;
-            if (auto add = next.getDefiningOp<AddIOp>()) {
-              bool induction = false;
-              for (int k = 0; k < 2; k++)
-                if (carriesSlot(add->getOperand(k), ba) &&
-                    definedOutside(add->getOperand(1 - k)))
-                  induction = true;
-              if (induction)
-                continue;
-            }
           }
         }
         doWhile = true;

--- a/test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir
+++ b/test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir
@@ -62,9 +62,12 @@ func.func @trip_count_exit(%p: i1) -> i64 {
 
 // -----
 
-// Without an extra condition the loop can only exit by trip count, the before
-// region is just the comparison, and the results are plain block arguments, so
-// no extra iteration is needed.
+// Without an extra condition the loop can only exit by trip count, but the
+// result is still the failing evaluation's view: counting 0, 1, 2 against a
+// bound of 3 hands out 3, the value the comparison rejected, not 2, the last
+// the body saw. The before region being just the comparison, the extra
+// iteration costs no more than a bound one past the comparison's, clamped so
+// the zero-trip loop still returns its init.
 
 func.func @no_extra_condition(%ub: i64) -> i64 {
   %c0 = arith.constant 0 : i64
@@ -84,7 +87,9 @@ func.func @no_extra_condition(%ub: i64) -> i64 {
 // CHECK-SAME:                                  %[[UB:.*]]: i64) -> i64 {
 // CHECK-NEXT:      %[[LB:.*]] = arith.constant 0 : i64
 // CHECK-NEXT:      %[[STEP:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:      %[[LOOP:.*]] = scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%[[ITER:.*]] = %[[LB]]) -> (i64)  : i64 {
+// CHECK-NEXT:      %[[CLAMP:.*]] = arith.maxsi %[[UB]], %[[LB]] : i64
+// CHECK-NEXT:      %[[PAST:.*]] = arith.addi %[[CLAMP]], %[[STEP]] : i64
+// CHECK-NEXT:      %[[LOOP:.*]] = scf.for %[[I:.*]] = %[[LB]] to %[[PAST]] step %[[STEP]] iter_args(%[[ITER:.*]] = %[[LB]]) -> (i64)  : i64 {
 // CHECK-NEXT:        scf.yield %[[I]] : i64
 // CHECK-NEXT:      }
 // CHECK-NEXT:      return %[[LOOP]] : i64

--- a/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
+++ b/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
@@ -43,9 +43,9 @@ func.func @popcount_range(%lo: i32, %hi: i32, %bits: i32) -> i32 {
 // are pure passthroughs -- but the loop permutes two slots each iteration, so
 // which evaluation the results come from still matters: for %n = 1 the answer
 // is (%x, %y), taken at the failing evaluation after one swap-back. Only a
-// slot that refills with itself, or advances by a loop-invariant step (whose
-// result ForOpInductionReplacement rewrites in closed form), can do without
-// the extra iteration.
+// value from outside the loop, or a slot that refills with itself, can do
+// without the extra iteration -- even a slot advanced by a loop-invariant
+// step observes the final evaluation, one step past the last the body saw.
 
 func.func @swap(%n: i32, %x: i32, %y: i32) -> (i32, i32) {
   %c0 = arith.constant 0 : i32
@@ -65,3 +65,33 @@ func.func @swap(%n: i32, %x: i32, %y: i32) -> (i32, i32) {
 // CHECK:         %[[MAX:.+]] = arith.maxsi %arg0, %{{.+}} : i32
 // CHECK:         %[[UB:.+]] = arith.addi %[[MAX]], %{{.+}} : i32
 // CHECK:         scf.for %{{.+}} to %[[UB]]
+
+// -----
+
+// The plainest shape of all: the condition forwards the slot itself and the
+// body advances it by one. The result is the failing evaluation's value --
+// count to 3 and the answer is 3, the value the comparison rejected, not 2,
+// the last the body saw. An advancing slot is not exempt: the conversion
+// yields the induction variable, so the result would come out one step short
+// without the widened bound.
+
+func.func @count(%n: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r = scf.while (%i = %c0) : (i32) -> i32 {
+    %cont = arith.cmpi slt, %i, %n : i32
+    scf.condition(%cont) %i : i32
+  } do {
+  ^bb0(%i0: i32):
+    %i2 = arith.addi %i0, %c1 : i32
+    scf.yield %i2 : i32
+  }
+  return %r : i32
+}
+
+// CHECK-LABEL: func.func @count
+// CHECK:         %[[CLAMP:.+]] = arith.maxsi %arg0, %c0_i32 : i32
+// CHECK:         %[[PAST:.+]] = arith.addi %[[CLAMP]], %c1_i32 : i32
+// CHECK:         %[[FOR:.+]] = scf.for %[[IV:.+]] = %c0_i32 to %[[PAST]] step %c1_i32
+// CHECK:           scf.yield %[[IV]] : i32
+// CHECK:         return %[[FOR]] : i32

--- a/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
+++ b/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
@@ -1,0 +1,67 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for --split-input-file | FileCheck %s
+
+// A do-while's results are the condition args of its final evaluation -- the
+// one whose comparison fails -- so the before region has run once more than
+// the comparison held. The extra iteration was only forced for impure before
+// regions, as if purity made the run unobservable; but the values are what is
+// observed. This loop is MFEM's Mesh::GetNumGeometries after LICM has hoisted
+// the load: counting the set bits of %bits in [%lo, %hi) with a pure body.
+// Converted with a trip count one short, a quadrilateral mesh counted zero
+// geometries and every FiniteElementSpace refused the mesh as unfinalized.
+//
+// The count for lo=2, hi=4 is over g in {2, 3}: two iterations, not one.
+
+func.func @popcount_range(%lo: i32, %hi: i32, %bits: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r:2 = scf.while (%g = %lo, %acc = %c0) : (i32, i32) -> (i32, i32) {
+    %bit0 = arith.shrui %bits, %g : i32
+    %bit = arith.andi %bit0, %c1 : i32
+    %acc2 = arith.addi %bit, %acc : i32
+    %g2 = arith.addi %g, %c1 : i32
+    %cont = arith.cmpi ne, %g2, %hi : i32
+    scf.condition(%cont) %g2, %acc2 : i32, i32
+  } do {
+  ^bb0(%g2: i32, %acc2: i32):
+    scf.yield %g2, %acc2 : i32, i32
+  }
+  return %r#1 : i32
+}
+
+// The upper bound gets the do-while treatment: one past the comparison bound,
+// clamped so at least one iteration runs.
+
+// CHECK-LABEL: func.func @popcount_range
+// CHECK:         %[[LB:.+]] = arith.addi %arg0, %c1_i32 : i32
+// CHECK:         %[[MAX:.+]] = arith.maxsi %arg1, %[[LB]] : i32
+// CHECK:         %[[UB:.+]] = arith.addi %[[MAX]], %c1_i32 : i32
+// CHECK:         scf.for %{{.+}} = %[[LB]] to %[[UB]] step %c1_i32
+
+// -----
+
+// No value here is computed in the before region at all -- the condition args
+// are pure passthroughs -- but the loop permutes two slots each iteration, so
+// which evaluation the results come from still matters: for %n = 1 the answer
+// is (%x, %y), taken at the failing evaluation after one swap-back. Only a
+// slot that refills with itself, or advances by a loop-invariant step (whose
+// result ForOpInductionReplacement rewrites in closed form), can do without
+// the extra iteration.
+
+func.func @swap(%n: i32, %x: i32, %y: i32) -> (i32, i32) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r:3 = scf.while (%i = %c0, %a = %x, %b = %y) : (i32, i32, i32) -> (i32, i32, i32) {
+    %cont = arith.cmpi slt, %i, %n : i32
+    scf.condition(%cont) %i, %b, %a : i32, i32, i32
+  } do {
+  ^bb0(%i0: i32, %b2: i32, %a2: i32):
+    %i2 = arith.addi %i0, %c1 : i32
+    scf.yield %i2, %b2, %a2 : i32, i32, i32
+  }
+  return %r#1, %r#2 : i32, i32
+}
+
+// CHECK-LABEL: func.func @swap
+// CHECK:         %[[MAX:.+]] = arith.maxsi %arg0, %{{.+}} : i32
+// CHECK:         %[[UB:.+]] = arith.addi %[[MAX]], %{{.+}} : i32
+// CHECK:         scf.for %{{.+}} to %[[UB]]


### PR DESCRIPTION
A do-while's results are the condition args of its final evaluation — the one whose comparison fails — so the before region has run **once more** than the comparison held. `MoveWhileToFor` forces that extra iteration (`ub = max(ub, lb) + step`) only when the before region is *impure*, treating the final run as observable only through side effects. But the values are what is observed.

**The counterexample, from MFEM.** `Mesh::GetNumGeometries` counts set bits of `mesh_geoms` over `[DimStart[dim], DimStart[dim+1])`. LICM hoists the load, leaving a pure before region accumulating through the condition args:

```mlir
%r:2 = scf.while (%g = %lo, %acc = %c0) : (i32, i32) -> (i32, i32) {
  %bit  = arith.andi (arith.shrui %bits, %g), %c1
  %acc2 = arith.addi %bit, %acc
  %g2   = arith.addi %g, %c1
  %cont = arith.cmpi ne, %g2, %hi
  scf.condition(%cont) %g2, %acc2
} do { ... }
return %r#1
```

Converted with `doWhile = false`, the for loop ran `hi-lo-1` iterations: for `lo=2, hi=4, bits=8` the true answer is 1, the converted answer 0. A quadrilateral mesh counted **zero geometries**, and every `FiniteElementSpace` refused the mesh:

```
Verification failed: ((mesh->GetNumGeometries(dim) > 0) || (mesh->GetNE() == 0))
 --> Mesh was not correctly finalized.
```

One wrong integer from one function of one file among libmfem's 269, isolated by bisecting the linked unit tests: TU (8 rounds) → function (9 rounds over 474 candidates) → pass-prefix (`canonicalize-scf-for`) → this pattern. Notably the mesh itself was fine — only the measuring stick was miscompiled.

**The fix** walks the loop results jointly with `condOp.getArgs()`. A used result keeps the conversion honest unless its condition arg cannot change between one evaluation and the next:
- a value defined outside the loop,
- a passthrough of a slot the loop refills with itself, or
- a slot advanced by a loop-invariant step — whose result `ForOpInductionReplacement` rewrites in closed form afterwards, the contract plain induction loops already rely on, which keeps their converted shape unchanged (all 20 existing `canonicalize-for` lit tests pass with no CHECK churn).

Anything else — a value the before region computes, a **permuted slot**, an accumulator — forces the extra iteration, pure or not. The permutation case matters: a loop that just swaps two iter args each iteration computes nothing in its before region, yet which evaluation the results come from decides the answer; an earlier draft of this patch that only looked for before-region-computed args missed it (returns `(y, x)` instead of `(x, y)` for a single-iteration swap). Both the accumulator and the swap are in the lit test.

Validated end-to-end on MFEM: with only `GetNumGeometries` raised, and with all 474 raiseable functions of `mesh.cpp` raised, the NC-refinement reproducer now runs correctly.

---

**Why this doesn't subsume the existing `lookThrough && !use_empty()` clause** (and vice versa): removing that clause with this fix in place fails `canonicalizefor_whiletofor2.mlir` — a compound-condition loop whose condition args are pure passthroughs. With an extra exit condition, results are captured through the wrapping `scf.if`, and only a final flag-true iteration distinguishes "exhausted the trip count" from "killed by the flag" — even for passthrough args. The two clauses guard different mechanisms; both stay.
