### PR TITLE
canonicalize-scf-for: exiting a conjunction does not falsify each conjunct

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -2250,13 +2250,6 @@ struct WhileLogicalNegation : public OpRewritePattern<WhileOp> {
       }
     }
 
-    // Entering the after region means the whole conjunction held, so there
-    // every conjunct is true. Exiting only means the conjunction failed --
-    // at least one conjunct is false, with no say in which -- so the value a
-    // result leaves with is only known when the condition is a single
-    // conjunct.
-    bool exitKnown = condOps.size() == 1;
-
     for (auto pair :
          llvm::zip(op.getResults(), term.getArgs(), op.getAfterArguments())) {
       auto termArg = std::get<1>(pair);
@@ -2285,7 +2278,12 @@ struct WhileLogicalNegation : public OpRewritePattern<WhileOp> {
           continue;
       }
 
-      if (exitKnown && !std::get<0>(pair).use_empty()) {
+      // Entering the after region means the whole conjunction held, so there
+      // every conjunct is true. Exiting only means the conjunction failed --
+      // at least one conjunct is false, with no say in which -- so the value
+      // a result leaves with is only known when the condition is a single
+      // conjunct.
+      if (condOps.size() == 1 && !std::get<0>(pair).use_empty()) {
         rewriter.modifyOpInPlace(op, [&] {
           rewriter.setInsertionPoint(op);
           auto truev =

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -2250,21 +2250,21 @@ struct WhileLogicalNegation : public OpRewritePattern<WhileOp> {
       }
     }
 
+    // Entering the after region means the whole conjunction held, so there
+    // every conjunct is true. Exiting only means the conjunction failed --
+    // at least one conjunct is false, with no say in which -- so the value a
+    // result leaves with is only known when the condition is a single
+    // conjunct.
+    bool exitKnown = condOps.size() == 1;
+
     for (auto pair :
          llvm::zip(op.getResults(), term.getArgs(), op.getAfterArguments())) {
       auto termArg = std::get<1>(pair);
       bool afterValue;
-      // Entering the after region means the whole conjunction held, so there
-      // every conjunct is true. Exiting only means the conjunction failed --
-      // at least one conjunct is false, with no say in which -- so a result
-      // is only known when its arg is the root condition itself.
-      bool resultKnown;
       if (condOps.count(termArg)) {
         afterValue = true;
-        resultKnown = termArg == term.getCondition();
       } else {
         bool found = false;
-        resultKnown = false;
         if (auto termCmp = termArg.getDefiningOp<arith::CmpIOp>()) {
           for (auto cond : condOps) {
             if (auto condCmp = cond.getDefiningOp<CmpIOp>()) {
@@ -2275,7 +2275,6 @@ struct WhileLogicalNegation : public OpRewritePattern<WhileOp> {
                     termCmp.getPredicate() == CmpIPredicate::sge) {
                   found = true;
                   afterValue = false;
-                  resultKnown = cond == term.getCondition();
                   break;
                 }
               }
@@ -2286,7 +2285,7 @@ struct WhileLogicalNegation : public OpRewritePattern<WhileOp> {
           continue;
       }
 
-      if (resultKnown && !std::get<0>(pair).use_empty()) {
+      if (exitKnown && !std::get<0>(pair).use_empty()) {
         rewriter.modifyOpInPlace(op, [&] {
           rewriter.setInsertionPoint(op);
           auto truev =

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -2254,10 +2254,17 @@ struct WhileLogicalNegation : public OpRewritePattern<WhileOp> {
          llvm::zip(op.getResults(), term.getArgs(), op.getAfterArguments())) {
       auto termArg = std::get<1>(pair);
       bool afterValue;
+      // Entering the after region means the whole conjunction held, so there
+      // every conjunct is true. Exiting only means the conjunction failed --
+      // at least one conjunct is false, with no say in which -- so a result
+      // is only known when its arg is the root condition itself.
+      bool resultKnown;
       if (condOps.count(termArg)) {
         afterValue = true;
+        resultKnown = termArg == term.getCondition();
       } else {
         bool found = false;
+        resultKnown = false;
         if (auto termCmp = termArg.getDefiningOp<arith::CmpIOp>()) {
           for (auto cond : condOps) {
             if (auto condCmp = cond.getDefiningOp<CmpIOp>()) {
@@ -2268,6 +2275,7 @@ struct WhileLogicalNegation : public OpRewritePattern<WhileOp> {
                     termCmp.getPredicate() == CmpIPredicate::sge) {
                   found = true;
                   afterValue = false;
+                  resultKnown = cond == term.getCondition();
                   break;
                 }
               }
@@ -2278,7 +2286,7 @@ struct WhileLogicalNegation : public OpRewritePattern<WhileOp> {
           continue;
       }
 
-      if (!std::get<0>(pair).use_empty()) {
+      if (resultKnown && !std::get<0>(pair).use_empty()) {
         rewriter.modifyOpInPlace(op, [&] {
           rewriter.setInsertionPoint(op);
           auto truev =

--- a/test/lit_tests/canonicalizefor/while_logical_negation_conjunct.mlir
+++ b/test/lit_tests/canonicalizefor/while_logical_negation_conjunct.mlir
@@ -1,0 +1,67 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for --split-input-file | FileCheck %s
+
+// The loop leaves either because a dependency's flag was clear (%ok false) or
+// because it scanned them all (%i2b reached %n) with every flag set. Exiting
+// only says the conjunction failed -- at least one conjunct is false, with no
+// say in which -- so the forwarded %ok must not be folded to false. This is
+// NCMesh::DofFinalizable after LICM: with its result pinned false, no DoF was
+// ever finalizable and BuildParallelConformingInterpolation spun forever.
+//
+// (The condition arrives as select(%ok, %more, false) and reaches
+// WhileLogicalNegation as andi %ok, %more; the duplicated increment is as the
+// frontend spelled it, and keeps MoveWhileToFor from converting the loop.)
+
+llvm.func @all_set(%deps: !llvm.ptr, %flags: !llvm.ptr, %n: i64) -> i1 {
+  %c0_i32 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %r:2 = scf.while (%i = %c0) : (i64) -> (i64, i1) {
+    %p = llvm.getelementptr inbounds %deps[%i] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+    %d = llvm.load %p {alignment = 4 : i64} : !llvm.ptr -> i32
+    %d64 = arith.extsi %d : i32 to i64
+    %q = llvm.getelementptr inbounds %flags[%d64] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %f8 = llvm.load %q {alignment = 1 : i64} : !llvm.ptr -> i8
+    %ok = arith.trunci %f8 : i8 to i1
+    %i2 = arith.addi %i, %c1 : i64
+    %i2b = arith.addi %i, %c1 : i64
+    %more = arith.cmpi ne, %i2b, %n : i64
+    %more32 = arith.extui %more : i1 to i32
+    %cond32 = arith.select %ok, %more32, %c0_i32 : i32
+    %cond = arith.trunci %cond32 : i32 to i1
+    scf.condition(%cond) %i2, %ok : i64, i1
+  } do {
+  ^bb0(%i2: i64, %ok2: i1):
+    scf.yield %i2 : i64
+  }
+  llvm.return %r#1 : i1
+}
+
+// CHECK-LABEL: llvm.func @all_set
+// CHECK:         %[[R:.+]]:2 = scf.while
+// CHECK:         llvm.return %[[R]]#1 : i1
+
+// -----
+
+// When the forwarded value is the root condition itself, the exit does decide
+// it: the loop ran until the condition failed, so the result is false.
+
+llvm.func @exhausted(%deps: !llvm.ptr, %n: i64) -> i1 {
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %r:2 = scf.while (%i = %c0) : (i64) -> (i64, i1) {
+    %p = llvm.getelementptr inbounds %deps[%i] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+    %d = llvm.load %p {alignment = 4 : i64} : !llvm.ptr -> i32
+    %d64 = arith.extsi %d : i32 to i64
+    %i2 = arith.addi %i, %d64 : i64
+    %cont = arith.cmpi ne, %i2, %n : i64
+    scf.condition(%cont) %i2, %cont : i64, i1
+  } do {
+  ^bb0(%i2: i64, %c: i1):
+    scf.yield %i2 : i64
+  }
+  llvm.return %r#1 : i1
+}
+
+// CHECK-LABEL: llvm.func @exhausted
+// CHECK:         %[[F:.+]] = arith.constant false
+// CHECK:         llvm.return %[[F]] : i1


### PR DESCRIPTION
WhileLogicalNegation collects the loop condition's `andi` conjuncts and, for any condition arg among them, replaced the corresponding loop result with `false`. That is only sound for the root condition itself: exiting says the conjunction failed — at least one conjunct is false, with no say in which. The replacement inside the after region (conjunct → `true` while the loop continues) is sound and stays.

Found via MFEM: `NCMesh::DofFinalizable` scans a DoF's dependencies and leaves early on the first unfinalized one — `cond = select(%ok, i+1 != n, false)`, which reaches this pattern as `andi %ok, %more` with `%ok` forwarded as the result. Pinned `false`, no DoF was ever finalizable, and `ParNCMesh::BuildParallelConformingInterpolation` spun forever on any nonconforming parallel mesh.

The cmp `slt`/`sge` negation arm had the same hole and gets the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD