### PR TITLE
RemoveIVs: an addi that never reads the iter arg is not an induction

### DIFF
--- a/src/enzyme_ad/jax/TransformOps/RaisingTransformOps.cpp
+++ b/src/enzyme_ad/jax/TransformOps/RaisingTransformOps.cpp
@@ -46,10 +46,13 @@ LogicalResult RemoveIVs::matchAndRewrite(scf::ForOp forOp,
     if (!increment)
       continue;
 
+    // Only ba + step is an induction. An addi of two unrelated values (say,
+    // an outer accumulator plus this loop's IV) also has a final value, but
+    // it is not init + count * step.
     Value step = nullptr;
     if (increment.getLhs() == ba) {
       step = increment.getRhs();
-    } else {
+    } else if (increment.getRhs() == ba) {
       step = increment.getLhs();
     }
     if (!step)

--- a/test/lit_tests/patterns/remove_ivs.mlir
+++ b/test/lit_tests/patterns/remove_ivs.mlir
@@ -27,3 +27,46 @@ module {
 // CHECK: %[[MUL:.*]] = arith.muli %[[BOUND]], %[[STEP]]
 // CHECK: %[[RET:.*]] = arith.addi %[[MUL]], %[[START]]
 // CHECK: return %[[RET]]
+
+// -----
+
+// An iter arg whose yield is an addi of two other values entirely -- here an
+// outer accumulator plus the inner loop's IV, the flattened counter of a
+// nested tensor-product loop -- is not an induction variable, and its final
+// value is not init + count * step. Treating it as one replaced MFEM's
+// H1_QuadrilateralElement::CalcShape counter with poison: every row of shape
+// values landed in row zero's slots and the rest stayed unwritten, so every
+// element mass matrix went singular and CholeskyFactors::Factor aborted.
+
+module {
+  func.func @flat_counter(%n: index, %m: index) -> index {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %flat = scf.for %j = %c0 to %n step %c1 iter_args(%o = %c0) -> (index) {
+      %inner = scf.for %i = %c0 to %m step %c1 iter_args(%u = %o) -> (index) {
+        %next = arith.addi %o, %i : index
+        scf.yield %next : index
+      }
+      scf.yield %inner : index
+    }
+    return %flat : index
+  }
+
+  builtin.module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg2: !transform.any_op) {
+      %4 = transform.structured.match ops{["func.func"]} in %arg2 : (!transform.any_op) -> !transform.any_op
+      transform.apply_patterns to %4 {
+        transform.apply_patterns.raising.remove_ivs
+      } : !transform.any_op
+      transform.yield
+    }
+  }
+}
+
+// CHECK-LABEL: func @flat_counter(
+// CHECK: %[[OUT:.*]] = scf.for %{{.*}} iter_args(%[[O:.*]] = %{{.*}}) -> (index) {
+// CHECK:   %[[IN:.*]] = scf.for %[[I:.*]] = %{{.*}} iter_args(%{{.*}} = %[[O]]) -> (index) {
+// CHECK:     %[[NEXT:.*]] = arith.addi %[[O]], %[[I]]
+// CHECK:     scf.yield %[[NEXT]]
+// CHECK:   scf.yield %[[IN]]
+// CHECK: return %[[OUT]]


### PR DESCRIPTION
RemoveIVs takes any iter arg whose yield is an `addi` and calls the other operand the step:

```cpp
if (increment.getLhs() == ba) {
  step = increment.getRhs();
} else {
  step = increment.getLhs();   // never checks getRhs() == ba
}
```

When neither operand is the iter arg there is no induction: the final value is whatever the body computed, not `init + count * step`. The flattened counter of a nested tensor-product loop yields (outer accumulator + inner IV); both dominate the inner loop, so the dominance check let it through, and the counter's result was rewritten to a multiple of its init — `ub.poison`.

Found via MFEM: that counter is the H1 tensor-product shape evaluation (`shape(dof_map[o++]) = shape_x(i)*shape_y(j)`, `fe_h1.cpp`). Every row of shape values landed in row zero's slots, the rest of the shape vector stayed unwritten, every element mass matrix went singular, and `CholeskyFactors::Factor` aborted `not SPD` on any H1 assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD