### PR TITLE
canonicalize-scf-for: the extra do-while iteration is at the top either way

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1693,11 +1693,15 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
       SmallVector<Type> initTypes;
       for (auto T : loop.getInits())
         initTypes.push_back(T.getType());
-      Value cond =
-          arith::CmpIOp::create(rewriter, forloop.getLoc(),
-                                helper.negativeStep ? arith::CmpIPredicate::sgt
-                                                    : arith::CmpIPredicate::slt,
-                                forloop.getInductionVar(), helper.ub);
+      // The after region runs on every iteration but the extra one appended
+      // for the do-while. prepareFor negated a negative step, so the for
+      // always ascends and the extra iteration is always the one at the top:
+      // the original counter rides along as an iter arg either way. (sgt
+      // against the ub held for no iteration at all, so a descending
+      // do-while ran nothing but its before region.)
+      Value cond = arith::CmpIOp::create(rewriter, forloop.getLoc(),
+                                         arith::CmpIPredicate::slt,
+                                         forloop.getInductionVar(), helper.ub);
       if (lookThrough) {
         cond = AndIOp::create(rewriter, loop.getLoc(), cond, nextLookThrough);
       }

--- a/test/lit_tests/canonicalizefor/dowhile_negative_step_after.mlir
+++ b/test/lit_tests/canonicalizefor/dowhile_negative_step_after.mlir
@@ -1,0 +1,44 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for | FileCheck %s
+
+// A descending do-while: the before region reads row j = c-1, the after
+// region writes it, and the final evaluation's row is written after the
+// loop from the forwarded results. prepareFor negates the negative step, so
+// the converted for ascends with the counter riding along as an iter arg,
+// and the extra appended iteration -- the one whose after region must not
+// run -- is the one at the top: the guard is iv < ub whichever way the
+// original loop counted. Guarded sgt-against-ub instead, the after region
+// ran for no iteration at all: this loop is CholeskyFactors::LMult, where
+// only row zero was ever written, every white-noise sample kept its raw
+// entries, and MFEM's white_noise statistics test failed its mean bound.
+
+llvm.func @lmult_rows(%x: !llvm.ptr, %m: i64) {
+  %c1 = arith.constant 1 : i64
+  %cm1 = arith.constant -1 : i64
+  %cst2 = arith.constant 2.0 : f64
+  %r:2 = scf.while (%c = %m) : (i64) -> (i64, f64) {
+    %j = arith.addi %c, %cm1 : i64
+    %p = llvm.getelementptr %x[%j] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    %v = llvm.load %p : !llvm.ptr -> f64
+    %cont = arith.cmpi sgt, %c, %c1 : i64
+    scf.condition(%cont) %j, %v : i64, f64
+  } do {
+  ^bb0(%j: i64, %v: f64):
+    %two = arith.mulf %v, %cst2 : f64
+    %q = llvm.getelementptr %x[%j] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    llvm.store %two, %q : f64, !llvm.ptr
+    scf.yield %j : i64
+  }
+  %pf = llvm.getelementptr %x[%r#0] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+  llvm.store %r#1, %pf : f64, !llvm.ptr
+  llvm.return
+}
+
+// The after region runs on every iteration but the extra top one.
+// CHECK-LABEL: llvm.func @lmult_rows
+// CHECK:         %[[UB0:.+]] = arith.addi %arg1, %c1{{.*}} : i64
+// CHECK:         %[[MAX:.+]] = arith.maxsi %[[UB0]], %c2{{.*}} : i64
+// CHECK:         %[[UB:.+]] = arith.addi %[[MAX]], %c1{{.*}} : i64
+// CHECK:         scf.for %[[IV:.+]] = %c2{{.*}} to %[[UB]] step %c1
+// CHECK:           %[[GUARD:.+]] = arith.cmpi slt, %[[IV]], %[[UB0]] : i64
+// CHECK:           scf.if %[[GUARD]]
+// CHECK:             llvm.store

--- a/test/lit_tests/canonicalizefor/rotate_while_and.mlir
+++ b/test/lit_tests/canonicalizefor/rotate_while_and.mlir
@@ -123,7 +123,7 @@ func.func @"negative_step"() {
 // CHECK:           } else {
 // CHECK:             scf.yield %[[ARG2]], %[[ARG3]], %[[FALSE]]
 // CHECK:           }
-// CHECK:           %[[BOUND_CHECK:.+]] = arith.cmpi sgt, %[[I]], %[[C29]]
+// CHECK:           %[[BOUND_CHECK:.+]] = arith.cmpi slt, %[[I]], %[[C29]]
 // CHECK:           %[[BREAK_COND:.+]] = arith.andi %[[BOUND_CHECK]], %[[IF1]]#2
 // CHECK:           %[[IF2:.+]] = scf.if %[[BREAK_COND]] -> (i64) {
 // CHECK:             scf.yield %[[IF1]]#0


### PR DESCRIPTION
The converted for always ascends — `prepareFor` negates a negative step, and the original counter rides along as an iter arg — so the extra iteration appended for a do-while is always the one at the top, and the guard that keeps the after region out of it is `iv < ub` whichever way the original loop counted. Guarding descending loops with `sgt` against the ub instead held for **no iteration at all**, so their after region never ran.

Found via MFEM: `CholeskyFactors::LMult` walks rows from m-1 down to 1 in its after region, with row 0's store placed after the loop from the forwarded results. With the after region gone, `X <- L X` wrote only row 0: every white-noise sample kept its raw entries above row 0, and MFEM's `white_noise` statistics test failed its mean bound.

`rotate_while_and`'s `negative_step` case had CHECKed the sgt guard in — an if that could never be entered, feeding poison into the counter from the second iteration on; its expectation is updated to the corrected guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD