### PR TITLE
polygeist-mem2reg: nocapture does not say the callee will not write

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2090,13 +2090,18 @@ bool isCallNonCapturing(CallOpInterface callOp, Value val,
                              LLVM::LLVMDialect::getNoCaptureAttrName());
 }
 
-// Whether a memory-effects attribute rules out writes through pointer
-// arguments. Later LLVM spells whole-function readonly/readnone this way,
-// and per-location effects can say argument memory is only read even when
-// the function writes elsewhere.
+// Whether a memory-effects attribute rules out writes that could reach a
+// pointer argument's bytes. Later LLVM spells whole-function
+// readonly/readnone this way. argMem covers accesses through the argument
+// pointers themselves; the same bytes can also be written through an access
+// classified as other -- a captured pointer, a global alias -- so both must
+// be write-free. Inaccessible memory cannot alias an argument, so it alone
+// may be written.
+static bool noWrite(LLVM::ModRefInfo mr) {
+  return mr == LLVM::ModRefInfo::NoModRef || mr == LLVM::ModRefInfo::Ref;
+}
 static bool argMemOnlyRead(LLVM::MemoryEffectsAttr me) {
-  return me && (me.getArgMem() == LLVM::ModRefInfo::NoModRef ||
-                me.getArgMem() == LLVM::ModRefInfo::Ref);
+  return me && noWrite(me.getArgMem()) && noWrite(me.getOther());
 }
 
 // nocapture only says the callee does not hold on to the pointer; an out

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2111,8 +2111,9 @@ bool isCallArgOnlyRead(CallOpInterface callOp, Value val,
       return true;
   if (auto calleeAttr =
           dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee())) {
-    if (auto fn = dyn_cast_or_null<LLVM::LLVMFuncOp>(symbolTables.lookupSymbolIn(
-            callOp->getParentOfType<ModuleOp>(), calleeAttr))) {
+    if (auto fn =
+            dyn_cast_or_null<LLVM::LLVMFuncOp>(symbolTables.lookupSymbolIn(
+                callOp->getParentOfType<ModuleOp>(), calleeAttr))) {
       if (argMemOnlyRead(fn.getMemoryEffectsAttr()))
         return true;
       if (auto pass = fn->getAttrOfType<ArrayAttr>("passthrough"))

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2090,11 +2090,38 @@ bool isCallNonCapturing(CallOpInterface callOp, Value val,
                              LLVM::LLVMDialect::getNoCaptureAttrName());
 }
 
+// Whether a memory-effects attribute rules out writes through pointer
+// arguments. Later LLVM spells whole-function readonly/readnone this way,
+// and per-location effects can say argument memory is only read even when
+// the function writes elsewhere.
+static bool argMemOnlyRead(LLVM::MemoryEffectsAttr me) {
+  return me && (me.getArgMem() == LLVM::ModRefInfo::NoModRef ||
+                me.getArgMem() == LLVM::ModRefInfo::Ref);
+}
+
 // nocapture only says the callee does not hold on to the pointer; an out
 // parameter is nocapture and written through. Only readonly (or readnone)
-// says the call leaves the slot's contents alone.
+// says the call leaves the slot's contents alone -- carried per argument,
+// as a memory-effects attribute on the call or the callee, or as the older
+// readonly/readnone function attribute spelled through passthrough.
 bool isCallArgOnlyRead(CallOpInterface callOp, Value val,
                        SymbolTableCollection &symbolTables) {
+  if (auto call = dyn_cast<LLVM::CallOp>(callOp.getOperation()))
+    if (argMemOnlyRead(call.getMemoryEffectsAttr()))
+      return true;
+  if (auto calleeAttr =
+          dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee())) {
+    if (auto fn = dyn_cast_or_null<LLVM::LLVMFuncOp>(symbolTables.lookupSymbolIn(
+            callOp->getParentOfType<ModuleOp>(), calleeAttr))) {
+      if (argMemOnlyRead(fn.getMemoryEffectsAttr()))
+        return true;
+      if (auto pass = fn->getAttrOfType<ArrayAttr>("passthrough"))
+        for (Attribute a : pass)
+          if (auto s = dyn_cast<StringAttr>(a))
+            if (s.getValue() == "readonly" || s.getValue() == "readnone")
+              return true;
+    }
+  }
   return callArgsAllHaveAttr(callOp, val, symbolTables,
                              LLVM::LLVMDialect::getReadonlyAttrName()) ||
          callArgsAllHaveAttr(callOp, val, symbolTables,

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2055,30 +2055,50 @@ Value castToType(Type elType, Value val, Operation *op) {
   llvm_unreachable("mismatched type");
 }
 
+// Whether every position the value is passed at carries the given attribute
+// on the callee. One position without it is enough for the call to do
+// whatever the attribute rules out.
+static bool callArgsAllHaveAttr(CallOpInterface callOp, Value val,
+                                SymbolTableCollection &symbolTables,
+                                StringRef attr) {
+  auto calleeAttr = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
+  if (!calleeAttr)
+    return false;
+  auto callee = symbolTables.lookupSymbolIn(callOp->getParentOfType<ModuleOp>(),
+                                            calleeAttr);
+  auto fn = dyn_cast_or_null<FunctionOpInterface>(callee);
+  if (!fn)
+    return false;
+
+  auto operands = callOp.getArgOperands();
+  bool seen = false;
+  for (int i = 0; i < operands.size(); i++) {
+    if (operands[i] == val) {
+      seen = true;
+      if (i >= fn.getNumArguments() || !fn.getArgAttr(i, attr))
+        return false;
+    }
+  }
+  return seen;
+}
+
 // Check if call captures alloca instance by checking for llvm.nocapture
 // attribute
 bool isCallNonCapturing(CallOpInterface callOp, Value val,
                         SymbolTableCollection &symbolTables) {
-  auto calleeAttr = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
-  if (calleeAttr) {
-    auto callee = symbolTables.lookupSymbolIn(
-        callOp->getParentOfType<ModuleOp>(), calleeAttr);
-    auto fn = dyn_cast_or_null<FunctionOpInterface>(callee);
-    if (!fn)
-      return false;
+  return callArgsAllHaveAttr(callOp, val, symbolTables,
+                             LLVM::LLVMDialect::getNoCaptureAttrName());
+}
 
-    // Find operand that matches value of alloca we are trying to promote and
-    // check for attributes
-    auto operands = callOp.getArgOperands();
-    for (int i = 0; i < operands.size(); i++) {
-      if (operands[i] == val) {
-        if (i < fn.getNumArguments() &&
-            fn.getArgAttr(i, LLVM::LLVMDialect::getNoCaptureAttrName()))
-          return true;
-      }
-    }
-  }
-  return false;
+// nocapture only says the callee does not hold on to the pointer; an out
+// parameter is nocapture and written through. Only readonly (or readnone)
+// says the call leaves the slot's contents alone.
+bool isCallArgOnlyRead(CallOpInterface callOp, Value val,
+                       SymbolTableCollection &symbolTables) {
+  return callArgsAllHaveAttr(callOp, val, symbolTables,
+                             LLVM::LLVMDialect::getReadonlyAttrName()) ||
+         callArgsAllHaveAttr(callOp, val, symbolTables,
+                             LLVM::LLVMDialect::getReadnoneAttrName());
 }
 
 // fopen, fclose
@@ -2313,6 +2333,12 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
             if (!callee || !getNonCapturingFunctions().count(
                                callee.getLeafReference().str()))
               captured = true;
+          } else if (!isCallArgOnlyRead(callOp, val, symbolTables)) {
+            // The callee cannot hold on to the pointer, but nothing says it
+            // does not write through it before returning -- an out parameter
+            // is exactly this. The slot's value is unknown after the call.
+            LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << callOp << "\n");
+            AliasingStoreOperations.insert(callOp.getOperation());
           }
         }
         continue;

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -1,6 +1,6 @@
 // RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
 
-llvm.func @llvm_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) {
+llvm.func @llvm_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture, llvm.readonly}) {
   llvm.return
 }
 llvm.func @llvm_store_to_load_forwarded() -> i32 {
@@ -20,6 +20,35 @@ llvm.func @llvm_store_to_load_forwarded() -> i32 {
 // CHECK-NEXT: llvm.store %[[C2]], %[[AL]] : i32, !llvm.ptr
 // CHECK-NEXT: llvm.call @llvm_foo_nocapture(%[[AL]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT: llvm.return %[[C2]] : i32
+// CHECK-NEXT: }
+
+// -----
+
+// nocapture only says the callee does not hold on to the pointer; an out
+// parameter is nocapture and written through before the call returns, so the
+// store cannot be forwarded past it. ParMesh::ParMesh passed a Table* slot to
+// BuildLocalBoundary(..., Table *&) this way; forwarded, the constructor read
+// the stale initial pointer instead of the Table the callee built, and MFEM's
+// AMGF solver test died dereferencing it.
+llvm.func @llvm_out_param(%arg0: !llvm.ptr {llvm.nocapture})
+llvm.func @llvm_store_not_forwarded_past_out_param() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  llvm.call @llvm_out_param(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK: llvm.func @llvm_store_not_forwarded_past_out_param() -> i32 {
+// CHECK-NEXT: %[[C1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[AL:.*]] = llvm.alloca %[[C1]] x i32 : (i32) -> !llvm.ptr
+// CHECK-NEXT: %[[C2:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK-NEXT: llvm.store %[[C2]], %[[AL]] : i32, !llvm.ptr
+// CHECK-NEXT: llvm.call @llvm_out_param(%[[AL]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[AL]] : !llvm.ptr -> i32
+// CHECK-NEXT: llvm.return %[[LOADED]] : i32
 // CHECK-NEXT: }
 
 // -----
@@ -71,7 +100,7 @@ llvm.func @llvm_indirect_call_not_promoted(%fnptr: !llvm.ptr) -> i32 {
 
 // -----
 
-func.func @func_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) {
+func.func @func_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture, llvm.readonly}) {
   func.return
 }
 func.func @func_store_to_load_forwarded() -> i32 {
@@ -120,7 +149,7 @@ func.func @func_store_to_load_not_forwarded() -> i32 {
 
 // -----
 
-tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture}) attributes {byRefTypes = [!llvm.struct<(i32, i32)>], pure = false} {
+tessera.define @tessera_foo_nocapture(%arg0: !llvm.ptr {llvm.nocapture, llvm.readonly}) attributes {byRefTypes = [!llvm.struct<(i32, i32)>], pure = false} {
   tessera.return
 }
 tessera.define @tessera_store_to_load_forwarded() -> i32 attributes {byRefTypes = [], pure = false} {

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -223,10 +223,11 @@ llvm.func @variadic_call_more_args_than_params() -> i32 {
 
 // -----
 
-// A memory-effects attribute on the callee that leaves argument memory
-// read-only clears the call even when the function writes elsewhere and no
-// argument attribute says anything.
-llvm.func @argmem_reader(!llvm.ptr {llvm.nocapture}) attributes {memory_effects = #llvm.memory_effects<other = readwrite, argMem = read, inaccessibleMem = readwrite, errnoMem = readwrite, targetMem0 = readwrite, targetMem1 = readwrite>}
+// A memory-effects attribute on the callee that leaves argument memory and
+// other aliasable memory read-only clears the call, and writable
+// inaccessible memory does not spoil it: nothing reachable from outside the
+// callee can alias the slot through it.
+llvm.func @argmem_reader(!llvm.ptr {llvm.nocapture}) attributes {memory_effects = #llvm.memory_effects<other = read, argMem = read, inaccessibleMem = readwrite, errnoMem = readwrite, targetMem0 = readwrite, targetMem1 = readwrite>}
 llvm.func @forward_across_argmem_read() -> i32 {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
@@ -260,6 +261,26 @@ llvm.func @no_forward_across_argmem_write() -> i32 {
 // CHECK: llvm.call @argmem_writer
 // CHECK: %[[L:.*]] = llvm.load
 // CHECK: llvm.return %[[L]] : i32
+
+// -----
+
+// argmem: read is not enough on its own -- a write classified as other can
+// still reach the slot through an alias, so the load stays.
+llvm.func @other_writer(!llvm.ptr {llvm.nocapture}) attributes {memory_effects = #llvm.memory_effects<other = readwrite, argMem = read, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>}
+llvm.func @no_forward_across_other_write() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  llvm.call @other_writer(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK: llvm.func @no_forward_across_other_write() -> i32 {
+// CHECK: llvm.call @other_writer
+// CHECK: %[[L2:.*]] = llvm.load
+// CHECK: llvm.return %[[L2]] : i32
 
 // -----
 

--- a/test/lit_tests/mem2reg_capturing.mlir
+++ b/test/lit_tests/mem2reg_capturing.mlir
@@ -220,3 +220,62 @@ llvm.func @variadic_call_more_args_than_params() -> i32 {
 // CHECK-NEXT: %[[LOADED:.*]] = llvm.load %[[AL]] : !llvm.ptr -> i32
 // CHECK-NEXT: llvm.return %[[LOADED]] : i32
 // CHECK-NEXT: }
+
+// -----
+
+// A memory-effects attribute on the callee that leaves argument memory
+// read-only clears the call even when the function writes elsewhere and no
+// argument attribute says anything.
+llvm.func @argmem_reader(!llvm.ptr {llvm.nocapture}) attributes {memory_effects = #llvm.memory_effects<other = readwrite, argMem = read, inaccessibleMem = readwrite, errnoMem = readwrite, targetMem0 = readwrite, targetMem1 = readwrite>}
+llvm.func @forward_across_argmem_read() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  llvm.call @argmem_reader(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK: llvm.func @forward_across_argmem_read() -> i32 {
+// CHECK: %[[V:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK: llvm.call @argmem_reader
+// CHECK: llvm.return %[[V]] : i32
+
+// -----
+
+// Writable argument memory keeps the load.
+llvm.func @argmem_writer(!llvm.ptr {llvm.nocapture}) attributes {memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none, errnoMem = none, targetMem0 = none, targetMem1 = none>}
+llvm.func @no_forward_across_argmem_write() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  llvm.call @argmem_writer(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK: llvm.func @no_forward_across_argmem_write() -> i32 {
+// CHECK: llvm.call @argmem_writer
+// CHECK: %[[L:.*]] = llvm.load
+// CHECK: llvm.return %[[L]] : i32
+
+// -----
+
+// The older spelling: a whole-function readonly riding in passthrough.
+llvm.func @passthrough_reader(!llvm.ptr {llvm.nocapture}) attributes {passthrough = ["readonly"]}
+llvm.func @forward_across_passthrough_readonly() -> i32 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x i32 : (i32) -> !llvm.ptr
+  %val = llvm.mlir.constant(42 : i32) : i32
+  llvm.store %val, %mem : i32, !llvm.ptr
+  llvm.call @passthrough_reader(%mem) : (!llvm.ptr) -> ()
+  %loaded = llvm.load %mem : !llvm.ptr -> i32
+  llvm.return %loaded : i32
+}
+
+// CHECK: llvm.func @forward_across_passthrough_readonly() -> i32 {
+// CHECK: %[[V:.*]] = llvm.mlir.constant(42 : i32) : i32
+// CHECK: llvm.call @passthrough_reader
+// CHECK: llvm.return %[[V]] : i32


### PR DESCRIPTION
`forwardStoreToLoad` dropped a call from the clobber set as soon as the slot was passed at a `nocapture` position. nocapture only says the callee does not hold on to the pointer; an out parameter is nocapture **and written through** before the call returns. The slot's value is unknown after such a call — only `readonly` (or `readnone`) alongside it lets a store be forwarded past.

Also require the attribute at every position the value is passed, not just some position that happens to carry it.

Found via MFEM: `ParMesh::ParMesh(comm, Mesh&, ...)` passes a `Table*` slot to `BuildLocalBoundary(..., Table *&)` and `FindSharedEdges(..., Table *&)`. Forwarded across both, the constructor read back its stale initial pointer instead of the Table the callees built, and the AMGF solver test crashed dereferencing it.

The forwarding cases in `mem2reg_capturing.mlir` now say `llvm.readonly` where they mean it; the new case is the out parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD