### PR TITLE
raise: an unwind edge is kept, not lowered away

### DIFF
--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -52,10 +52,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
     err_stream.flush();
     exit(1);
   }
-  // Raising has no way to read an unwind edge, so a call that may throw stops
-  // it here rather than further along: an invoke left standing is not a module
-  // that gets compiled at all.
-  {
+  if (options->lowerInvoke) {
     llvm::PassBuilder PB;
     llvm::LoopAnalysisManager LAM;
     llvm::FunctionAnalysisManager FAM;

--- a/src/enzyme_ad/jax/raise.h
+++ b/src/enzyme_ad/jax/raise.h
@@ -38,6 +38,7 @@ struct MLIRRoundTripOptions {
   bool removeAtomics;
   bool sortBlockMemory;
   bool hoistLoopAllocations;
+  bool lowerInvoke;
 };
 
 extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,


### PR DESCRIPTION
The round trip ran `LowerInvoke` over every module before import (#2774): invoke became call, landing pads went unreachable and were swept — every TU compiled as though nothing ever throws. Catch2's exception-driven test runner compiled into a binary that ran **one test case of 103 and exited clean**, which also means the raised MFEM suite had never actually run end-to-end.

Exception handling now imports as it is, and a function that throws or catches stays in cf form — correct, just never raised — while everything around it raises as usual:

- `enzyme-lift-cf-to-scf` skips regions holding `invoke`/`landingpad`/`resume` rather than failing the whole module on them.
- `llvm-to-affine-access` does not wrap a block of a multi-block region in an affine scope; the wrapping rebuilds the block around its terminator, and here the terminator is a branch or an invoke whose edges the scope has no reading of. The accesses that wanted the scope stay illegal and lower as plain memref accesses.
- What the raising computes from an invoke's result (memref view of an allocation, an index cast) is materialized in the **normal successor**: the result only exists on that edge, and after a terminator is not a place.

Accesses based on invoke results still raise to `affine.load` (see the lit test); only the throwing/catching control flow itself stays cf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD