### PR TITLE
polygeist-mem2reg: offsets of different kinds have no known difference

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -695,6 +695,8 @@ public:
     if (lhsStep != ShapedType::kDynamic && lhsStep == rhsStep &&
         (sameExtent || !isDim)) {
       int64_t difference = INT64_MAX;
+      if (lhs.type != rhs.type)
+        return Match::Maybe;
       switch (lhs.type) {
       case Offset::Type::Affine:
         if (lhs.dim == rhs.dim && lhs.sym == rhs.sym) {

--- a/test/lit_tests/mem2reg_mixed_offset_kinds.mlir
+++ b/test/lit_tests/mem2reg_mixed_offset_kinds.mlir
@@ -1,0 +1,27 @@
+// RUN: enzymexlamlir-opt %s --polygeist-mem2reg | FileCheck %s
+
+// A store at a loop-carried index writes some slot every iteration; which one
+// is exactly what is not known. Comparing that index against a constant slot
+// has no answer but "maybe", and answering anything else forwarded the value
+// stored before the loop across the loop that overwrote it: MFEM's
+// Values3D quadrature kernel read its pre-loop scratch values instead of the
+// interpolated ones, every partial-assembly operator disagreed with full
+// assembly, and iterative solvers span forever on the mismatch.
+
+module {
+  func.func @no_forward_across_symbolic_store(%v: f64, %w: f64) -> f64 {
+    %a = memref.alloca() : memref<16xf64>
+    %z = arith.constant 1 : index
+    affine.store %v, %a[1] : memref<16xf64>
+    affine.parallel (%i) = (0) to (4) {
+      affine.store %w, %a[%i] : memref<16xf64>
+    }
+    %r = affine.load %a[1] : memref<16xf64>
+    return %r : f64
+  }
+}
+
+// CHECK-LABEL: func.func @no_forward_across_symbolic_store
+// CHECK:         affine.parallel
+// CHECK:         %[[R:.+]] = affine.load
+// CHECK:         return %[[R]]


### PR DESCRIPTION
`compareIndex` switched on the left offset's kind and read the same field of the right without asking what kind it was. A constant slot against a loop-carried index read the constant field of a value-kind offset — never set — and the garbage difference passed the stride check as proof of disjointness. The store that overwrites some slot every iteration was ruled out of every slot but one, and the loads of the rest forwarded straight across it.

Found via MFEM: the `Values3D` quadrature kernel read its pre-loop scratch values instead of the interpolated ones — every partial-assembly operator disagreed with full assembly (the `Sparse Matrix` test), and the parallel solver tests (`HypreBoomerAMG`, `HypreAMS`, …) spun forever on operators that could not converge.

Two offsets speak the same language only when they are of the same kind; anything else is `Maybe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD