### PR TITLE
llvm-to-affine-access: distribute a select over both addends, not one

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -6472,6 +6472,10 @@ bool valueCmp(Cmp cmp, Value bval, ValueOrInt val) {
   }
 
   if (cmp == Cmp::GE && !val.isValue && val.i_val == 0) {
+    // A zero extension leaves the sign bit clear whatever it widened.
+    if (bval.getDefiningOp<arith::ExtUIOp>() ||
+        bval.getDefiningOp<LLVM::ZExtOp>())
+      return true;
     if (auto baval = bval.getDefiningOp<arith::AddIOp>()) {
       return valueCmp(cmp, baval.getLhs(), val) &&
              valueCmp(cmp, baval.getRhs(), val);

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -681,7 +681,7 @@ struct SelectCSE : public OpRewritePattern<arith::SelectOp> {
                                 lhs->getOperand(0), rhs->getOperand(0));
     auto op1 =
         arith::SelectOp::create(rewriter, rhs->getLoc(), sel.getCondition(),
-                                rhs->getOperand(1), rhs->getOperand(1));
+                                lhs->getOperand(1), rhs->getOperand(1));
     if (isa<arith::AddIOp>(lhs)) {
       rewriter.replaceOpWithNewOp<arith::AddIOp>(sel, op0, op1);
     } else {
@@ -1001,6 +1001,13 @@ struct AffineExprBuilder {
           return (*lhs) * (*rhs);
         } else if (isa<LLVM::UDivOp, LLVM::SDivOp, arith::DivUIOp,
                        arith::DivSIOp>(op)) {
+          // An affine floordiv agrees with sdiv only for a non-negative
+          // numerator -- sdiv rounds toward zero -- and with udiv only
+          // when the number is not a negative one read as enormous.
+          // MFEM's Hilbert-curve ordering divides direction deltas that
+          // go negative on every odd-sized grid.
+          if (!valueCmp(Cmp::GE, op->getOperand(0), 0))
+            return failure();
           // An affine floordiv divides by a positive value: it is the only
           // divisor its lowering, and the flattening the maps go through,
           // are written for.  A negative one does reach here -- `-x / c` is
@@ -1030,6 +1037,12 @@ struct AffineExprBuilder {
             return (*lhs) * getAffineConstantExpr(scale, op->getContext());
           } else if (isa<arith::ShRUIOp, arith::ShRSIOp, LLVM::LShrOp,
                          LLVM::AShrOp>(op)) {
+            // An arithmetic shift right is a floor division whatever the
+            // sign; a logical one reads a negative number as enormous and
+            // is one only for non-negative values.
+            if (isa<arith::ShRUIOp, LLVM::LShrOp>(op) &&
+                !valueCmp(Cmp::GE, op->getOperand(0), 0))
+              return failure();
             return (*lhs).floorDiv(
                 getAffineConstantExpr(scale, op->getContext()));
           } else {
@@ -1037,6 +1050,11 @@ struct AffineExprBuilder {
           }
         } else if (isa<LLVM::URemOp, arith::RemSIOp, LLVM::SRemOp,
                        arith::RemUIOp>(op)) {
+          // An affine mod is never negative; srem takes the numerator's
+          // sign and the unsigned forms read a negative number as
+          // enormous. They agree only for a non-negative numerator.
+          if (!valueCmp(Cmp::GE, op->getOperand(0), 0))
+            return failure();
           // As with floordiv above: a remainder is taken against a positive
           // value, and against a negative one it is the same remainder.
           if (auto cexpr = dyn_cast<AffineConstantExpr>(*rhs)) {

--- a/test/lit_tests/raising/affine_div_signs.mlir
+++ b/test/lit_tests/raising/affine_div_signs.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+// An affine floordiv agrees with sdiv only for a non-negative numerator --
+// sdiv rounds toward zero, floordiv toward minus infinity -- and an affine
+// mod is never negative where srem takes its numerator's sign. A numerator
+// that may be negative stays untranslated, and one that provably is not
+// still raises.
+
+module {
+  func.func @maybe_negative(%m: memref<10xf64>, %x: i32) -> f64 {
+    %c2 = arith.constant 2 : i32
+    %d = arith.divsi %x, %c2 : i32
+    %i = arith.index_cast %d : i32 to index
+    %v = memref.load %m[%i] : memref<10xf64>
+    func.return %v : f64
+  }
+
+  func.func @known_nonneg(%m: memref<10xf64>, %x: i16) -> f64 {
+    %c2 = arith.constant 2 : i32
+    %nn = arith.extui %x : i16 to i32
+    %d = arith.divsi %nn, %c2 : i32
+    %i = arith.index_cast %d : i32 to index
+    %v = memref.load %m[%i] : memref<10xf64>
+    func.return %v : f64
+  }
+}
+
+// CHECK-LABEL: func.func @maybe_negative
+// CHECK:         arith.divsi
+// CHECK-NOT:     floordiv
+
+// The translated form of the non-negative case is exercised by rembug.mlir,
+// whose kernel divides affine.parallel indices; here it is enough that the
+// possibly-negative case above kept its division ops.
+// CHECK-LABEL: func.func @known_nonneg

--- a/test/lit_tests/raising/select_cse_operands.mlir
+++ b/test/lit_tests/raising/select_cse_operands.mlir
@@ -1,0 +1,21 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+// select(c, a+b, x+y) distributes to select(c,a,x) + select(c,b,y) -- both
+// selects, not one: taking the second addend from the false side whatever
+// the condition rewrote MFEM's Hilbert-curve ordering into a different
+// curve on every odd-sized grid, and the elements it permuted with it.
+
+module {
+  llvm.func @distribute(%c: i1, %a: i32, %b: i32, %x: i32, %y: i32) -> i32 {
+    %s1 = arith.addi %a, %b : i32
+    %s2 = arith.addi %x, %y : i32
+    %r = arith.select %c, %s1, %s2 : i32
+    llvm.return %r : i32
+  }
+}
+
+// CHECK-LABEL: llvm.func @distribute
+// CHECK-DAG:     %[[S0:.+]] = arith.select %arg0, %arg1, %arg3 : i32
+// CHECK-DAG:     %[[S1:.+]] = arith.select %arg0, %arg2, %arg4 : i32
+// CHECK:         %[[R:.+]] = arith.addi %[[S0]], %[[S1]] : i32
+// CHECK:         llvm.return %[[R]]


### PR DESCRIPTION
`SelectCSE` turns `select(c, a+b, x+y)` into `select(c,a,x) + select(c,b,y)`. The second select was built from the false side's operand **twice** — `select(c, y, y)` — so whichever way the condition went, the false branch's addend was the one added.

MFEM's Hilbert-curve element ordering (`NCMesh::GridSfcOrdering3D`), all select chains over direction deltas, came out as a different curve on every odd-sized grid; `Make3D` laid out elements with it, and the mismatch between the ordering and everything derived from it corrupted the heap far from the cause (`HypreBoomerAMG` and friends crashed in `STable3D::Push`).

Also gates the affine spellings of division and remainder on a provably non-negative numerator: sdiv rounds toward zero and floordiv toward minus infinity, srem takes its numerator's sign and mod has none, and the unsigned forms read a negative number as enormous. Only an arithmetic shift right is a floor division whatever the sign. A numerator that cannot be shown non-negative stays untranslated and the access lowers as a plain memref access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD