### PR TITLE
llvm-to-affine-access: leave padded-type accesses in llvm form

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1859,6 +1859,17 @@ convertLLVMToAffineAccess(Operation *op,
 
       Type ty = load.getType();
       auto tySize = dl.getTypeSize(ty);
+      // Memref indexing strides by the element's allocation size, and every
+      // downstream form -- the affine map division here, and the
+      // canonicalizations that fold byte GEPs into element GEPs -- assumes
+      // that stride equals the store size. A type that stores fewer bytes
+      // than its stride (i480 stores 60 but strides 64) breaks that
+      // assumption at every element but the first, and its memref form also
+      // loses the op's explicit sub-ABI alignment. Leave such accesses in
+      // llvm dialect form.
+      if (llvm::alignTo(static_cast<uint64_t>(tySize),
+                        dl.getTypeABIAlignment(ty)) != tySize)
+        continue;
       if (MemRefType::isValidElementType(ty) && aab.isLegal() && aab.base) {
         auto memref0 = mc(aab.base);
         Value memref = memref0;
@@ -1937,6 +1948,17 @@ convertLLVMToAffineAccess(Operation *op,
       Type ty = store.getValue().getType();
       IRRewriter rewriter(store);
       auto tySize = dl.getTypeSize(ty);
+      // Memref indexing strides by the element's allocation size, and every
+      // downstream form -- the affine map division here, and the
+      // canonicalizations that fold byte GEPs into element GEPs -- assumes
+      // that stride equals the store size. A type that stores fewer bytes
+      // than its stride (i480 stores 60 but strides 64) breaks that
+      // assumption at every element but the first, and its memref form also
+      // loses the op's explicit sub-ABI alignment. Leave such accesses in
+      // llvm dialect form.
+      if (llvm::alignTo(static_cast<uint64_t>(tySize),
+                        dl.getTypeABIAlignment(ty)) != tySize)
+        continue;
       if (MemRefType::isValidElementType(ty) && aab.isLegal() && aab.base) {
         auto memref0 = mc(aab.base);
         Value memref = memref0;

--- a/test/lit_tests/padded_int_access.mlir
+++ b/test/lit_tests/padded_int_access.mlir
@@ -1,0 +1,34 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+// Memref indexing strides by an element's allocation size, and both the
+// affine-map division here and the later byte-GEP folds assume that stride
+// equals the store size. i480 stores 60 bytes but strides 64: indexed as a
+// memref it reads element k at byte 64k instead of 60k, and its memref form
+// also trades the op's explicit align 4 for the type's preferred 16. SROA
+// coalesces struct copies into exactly such wide stores -- libstdc++'s
+// stable_sort moving 60-byte values handed MFEM reads of freed memory that
+// way -- so accesses of padded types must stay in llvm dialect form.
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, "dlti.endianness" = "little", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>>} {
+  llvm.func @padded_stays_llvm(%src: !llvm.ptr, %dst: !llvm.ptr, %i: i64) {
+    %p = llvm.getelementptr inbounds %src[%i] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %v = llvm.load %p {alignment = 4 : i64} : !llvm.ptr -> i480
+    %q = llvm.getelementptr inbounds %dst[%i] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    llvm.store %v, %q {alignment = 4 : i64} : i480, !llvm.ptr
+    llvm.return
+  }
+
+  llvm.func @unpadded_converts(%src: !llvm.ptr, %i: i64) -> i32 {
+    %p = llvm.getelementptr inbounds %src[%i] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+    %v = llvm.load %p {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.return %v : i32
+  }
+}
+
+// CHECK-LABEL: llvm.func @padded_stays_llvm
+// CHECK: llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr -> i480
+// CHECK: llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : i480, !llvm.ptr
+
+// CHECK-LABEL: llvm.func @unpadded_converts
+// CHECK: %[[M:.+]] = "enzymexla.pointer2memref"(%arg0)
+// CHECK: affine.load %[[M]][symbol(%{{.+}})] {alignment = 4 : i64


### PR DESCRIPTION
Memref indexing strides by an element's **allocation size**, and every downstream consumer — the affine-map division in the conversion, and the canonicalizations that fold byte GEPs into element GEPs — assumes that stride equals the **store size**. A type that stores fewer bytes than its stride breaks that at every element but the first: `i480` stores 60 bytes but strides 64, so element `k` of a `memref<?xi480>` lives at byte `64k` while the raised map placed it at `60k`. The memref form also trades the op's explicit sub-ABI alignment (`align 4`) for the type's preferred 16.

SROA coalesces struct copies into exactly such wide stores. In MFEM, libstdc++'s `stable_sort` moving 60-byte values through `SubMeshUtils::ConstructFaceTree<ParNCSubMesh>` produced an `i480` store whose misaddressed elements corrupted the sort's temporary buffer bookkeeping — valgrind shows reads 36 bytes into a freed 44-byte block, and the `ExteriorSurfaceParNCSubMesh` unit test segfaults. With this change the full test passes through the raising path.

Fix: skip the memref conversion for types whose store size is not their stride; such accesses stay in llvm dialect form, which is byte-exact. The lit test pins both directions: `i480` load/store stay `llvm.load`/`llvm.store` with their original alignment, while an ordinary `i32` access still raises to `affine.load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD