### PR TITLE
SimpleMem2Reg: forwarding needs the store and load to address the same slot

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1715,18 +1715,21 @@ template <typename T> struct SimpleMem2Reg : public OpRewritePattern<T> {
   LogicalResult matchAndRewrite(T alloc,
                                 PatternRewriter &rewriter) const override {
     SmallVector<Value> stored;
+    SmallVector<Operation *> storeOps;
     SmallVector<Operation *> loads;
     for (auto op : alloc->getUsers()) {
       if (auto storeOp = dyn_cast<memref::StoreOp>(op)) {
         if (storeOp.getValue() == alloc)
           return failure();
         stored.push_back(storeOp.getValue());
+        storeOps.push_back(storeOp);
         continue;
       }
       if (auto storeOp = dyn_cast<affine::AffineStoreOp>(op)) {
         if (storeOp.getValue() == alloc)
           return failure();
         stored.push_back(storeOp.getValue());
+        storeOps.push_back(storeOp);
         continue;
       }
 
@@ -1754,11 +1757,28 @@ template <typename T> struct SimpleMem2Reg : public OpRewritePattern<T> {
     if (loads.size() != 1 || stored.size() != 1)
       return failure();
 
+    // The load reads what the single store wrote only where the store has
+    // always run first -- availability of the stored value proves nothing --
+    // and only where both address the same slot: a store to a[i] says
+    // nothing about a load of a[j]. Identical maps over identical operands
+    // is the one case where sameness is a fact rather than an analysis.
+    auto sameSlot = [](Operation *st, Operation *ld) {
+      if (auto as = dyn_cast<affine::AffineStoreOp>(st)) {
+        auto al = dyn_cast<affine::AffineLoadOp>(ld);
+        return al && as.getAffineMap() == al.getAffineMap() &&
+               llvm::equal(as.getMapOperands(), al.getMapOperands());
+      }
+      if (auto ms = dyn_cast<memref::StoreOp>(st)) {
+        auto ml = dyn_cast<memref::LoadOp>(ld);
+        return ml && llvm::equal(ms.getIndices(), ml.getIndices());
+      }
+      return false;
+    };
     DominanceInfo DI(alloc->getParentOp());
     bool changed = false;
     for (auto load : loads) {
-      if (definedOutsideOrAt(stored[0], alloc->getParentOp()) ||
-          DI.dominates(stored[0], load)) {
+      if (sameSlot(storeOps[0], load) &&
+          DI.properlyDominates(storeOps[0], load)) {
         rewriter.replaceOp(load, stored);
         changed = true;
         continue;

--- a/test/lit_tests/mem2reg_same_slot.mlir
+++ b/test/lit_tests/mem2reg_same_slot.mlir
@@ -1,0 +1,33 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+// A single dominating store lets a load forward its value only when both
+// address the same slot; a store to a[i] says nothing about a load of a[j].
+// Identical maps over identical operands is the one case where sameness is
+// a fact rather than an analysis. MFEM's batched LOR assembly filled a
+// 16-int scratch array at one index and read it back at another -- the
+// forwarded value made every LOR H1/ND/RT system matrix wrong.
+
+module {
+  func.func @no_forward_different_index(%v: i32, %i: index, %j: index) -> i32 {
+    %a = memref.alloca() : memref<16xi32>
+    affine.store %v, %a[symbol(%i)] : memref<16xi32>
+    %r = affine.load %a[symbol(%j)] : memref<16xi32>
+    return %r : i32
+  }
+
+  func.func @forward_same_index(%v: i32, %i: index) -> i32 {
+    %a = memref.alloca() : memref<16xi32>
+    affine.store %v, %a[symbol(%i)] : memref<16xi32>
+    %r = affine.load %a[symbol(%i)] : memref<16xi32>
+    return %r : i32
+  }
+}
+
+// CHECK-LABEL: func.func @no_forward_different_index
+// CHECK:         affine.store
+// CHECK:         %[[R:.+]] = affine.load
+// CHECK:         return %[[R]]
+
+// CHECK-LABEL: func.func @forward_same_index
+// CHECK-NOT:     affine.load
+// CHECK:         return %arg0 : i32


### PR DESCRIPTION
`SimpleMem2Reg` promoted a single-store single-load alloca by handing the load the stored value whenever the value was *available* — defined outside the region or dominating the load — with no look at the **indices**. A store to `a[i]` says nothing about a load of `a[j]`: MFEM's batched LOR assembly fills a 16-int scratch array at one index and reads it back at another, and the forwarded value made every Parallel LOR Batched H1/ND/RT system matrix wrong (errors up to 881 against non-batched assembly).

Two conditions make the forwarding sound, and this PR requires both:
- **Same slot**: identical access maps over identical operands — the one case where slot equality is a fact rather than an analysis.
- **Store dominates load** (not value availability): with a single store and no other writers, every path to the load then passes the store, and same operands name the same address in every iteration. (This also subsumes the `SimpleMem2Reg` hunk of #2800's dominance fix.)

The lit test pins both directions: differing symbolic indices must keep the load; the same index forwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD