### PR TITLE
restore-preserve-nvvm: PreserveNVVM(End), said in MLIR

### DIFF
--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -368,6 +368,14 @@ def HoistAllocasPass : Pass<"hoist-allocas"> {
   ];
 }
 
+def RestorePreserveNVVMPass : Pass<"restore-preserve-nvvm"> {
+  let summary = "Undo PreserveNVVM(Begin)'s linkage and inlining fixups once "
+                "the raising has consumed the calls they protected";
+  let dependentDialects = [
+    "LLVM::LLVMDialect",
+  ];
+}
+
 def SortBlockMemoryPass : Pass<"sort-block-memory"> {
   let summary = "Hoist non-overlapping loads to the start of their block and "
                 "sink stores to the end";

--- a/src/enzyme_ad/jax/Passes/RestorePreserveNVVM.cpp
+++ b/src/enzyme_ad/jax/Passes/RestorePreserveNVVM.cpp
@@ -37,36 +37,6 @@ using namespace mlir;
 
 namespace {
 
-// llvm::GlobalValue::LinkageTypes, as PreserveNVVM(Begin) recorded it.
-static std::optional<LLVM::Linkage> linkageFromLLVMOrdinal(int64_t v) {
-  switch (v) {
-  case 0:
-    return LLVM::Linkage::External;
-  case 1:
-    return LLVM::Linkage::AvailableExternally;
-  case 2:
-    return LLVM::Linkage::Linkonce;
-  case 3:
-    return LLVM::Linkage::LinkonceODR;
-  case 4:
-    return LLVM::Linkage::Weak;
-  case 5:
-    return LLVM::Linkage::WeakODR;
-  case 6:
-    return LLVM::Linkage::Appending;
-  case 7:
-    return LLVM::Linkage::Internal;
-  case 8:
-    return LLVM::Linkage::Private;
-  case 9:
-    return LLVM::Linkage::ExternWeak;
-  case 10:
-    return LLVM::Linkage::Common;
-  default:
-    return std::nullopt;
-  }
-}
-
 static bool isPrevEntry(Attribute a, StringRef &linkageValue, bool &fixup,
                         bool &alwaysInline, bool &noInline) {
   if (auto s = dyn_cast<StringAttr>(a)) {
@@ -118,9 +88,12 @@ struct RestorePreserveNVVMPass
         return;
 
       if (!linkageValue.empty()) {
-        int64_t v;
+        // prev_linkage holds the llvm::GlobalValue::LinkageTypes ordinal;
+        // the MLIR enum is defined with those same values, and the generated
+        // symbolizer validates them.
+        uint64_t v;
         if (!linkageValue.getAsInteger(10, v))
-          if (auto linkage = linkageFromLLVMOrdinal(v))
+          if (auto linkage = LLVM::linkage::symbolizeLinkage(v))
             fn.setLinkage(*linkage);
       }
 

--- a/src/enzyme_ad/jax/Passes/RestorePreserveNVVM.cpp
+++ b/src/enzyme_ad/jax/Passes/RestorePreserveNVVM.cpp
@@ -1,0 +1,142 @@
+//===- RestorePreserveNVVM.cpp - Undo PreserveNVVM's begin fixups ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// Enzyme's PreserveNVVM(Begin) marks the functions enzyme has a stake in --
+// most of them libdevice math definitions -- so they reach the raising alive
+// and recognizable: noinline so the calls survive, and a promotion to
+// external linkage so nothing internalizes or drops the definitions. It
+// records what it changed in prev_* attributes so PreserveNVVM(End) can put
+// things back.
+//
+// In the raising pipeline the marks are only needed up to
+// libdevice-funcs-raise: past it the math calls have become dialect ops, and
+// what the marks now do is keep every dead libdevice definition alive --
+// externally visible, so symbol-dce must assume someone wants it -- through
+// the whole rest of the pipeline. This pass is PreserveNVVM(End) said in
+// MLIR: restore the recorded linkage and inlining, drop the records, and let
+// the next symbol-dce reap what nothing calls anymore.
+//
+//===---------------------------------------------------------------------===//
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_RESTOREPRESERVENVVMPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+// llvm::GlobalValue::LinkageTypes, as PreserveNVVM(Begin) recorded it.
+static std::optional<LLVM::Linkage> linkageFromLLVMOrdinal(int64_t v) {
+  switch (v) {
+  case 0:
+    return LLVM::Linkage::External;
+  case 1:
+    return LLVM::Linkage::AvailableExternally;
+  case 2:
+    return LLVM::Linkage::Linkonce;
+  case 3:
+    return LLVM::Linkage::LinkonceODR;
+  case 4:
+    return LLVM::Linkage::Weak;
+  case 5:
+    return LLVM::Linkage::WeakODR;
+  case 6:
+    return LLVM::Linkage::Appending;
+  case 7:
+    return LLVM::Linkage::Internal;
+  case 8:
+    return LLVM::Linkage::Private;
+  case 9:
+    return LLVM::Linkage::ExternWeak;
+  case 10:
+    return LLVM::Linkage::Common;
+  default:
+    return std::nullopt;
+  }
+}
+
+static bool isPrevEntry(Attribute a, StringRef &linkageValue, bool &fixup,
+                        bool &alwaysInline, bool &noInline) {
+  if (auto s = dyn_cast<StringAttr>(a)) {
+    if (s.getValue() == "prev_fixup") {
+      fixup = true;
+      return true;
+    }
+    if (s.getValue() == "prev_always_inline") {
+      alwaysInline = true;
+      return true;
+    }
+    if (s.getValue() == "prev_no_inline") {
+      noInline = true;
+      return true;
+    }
+    return false;
+  }
+  if (auto arr = dyn_cast<ArrayAttr>(a)) {
+    if (arr.size() == 2)
+      if (auto key = dyn_cast<StringAttr>(arr[0]))
+        if (key.getValue() == "prev_linkage")
+          if (auto val = dyn_cast<StringAttr>(arr[1])) {
+            linkageValue = val.getValue();
+            return true;
+          }
+    return false;
+  }
+  return false;
+}
+
+struct RestorePreserveNVVMPass
+    : public enzyme::impl::RestorePreserveNVVMPassBase<
+          RestorePreserveNVVMPass> {
+  using RestorePreserveNVVMPassBase::RestorePreserveNVVMPassBase;
+
+  void runOnOperation() override {
+    getOperation()->walk([&](LLVM::LLVMFuncOp fn) {
+      auto pass = fn.getPassthrough();
+      if (!pass)
+        return;
+
+      bool fixup = false, alwaysInline = false, noInline = false;
+      StringRef linkageValue;
+      SmallVector<Attribute> kept;
+      for (Attribute a : *pass)
+        if (!isPrevEntry(a, linkageValue, fixup, alwaysInline, noInline))
+          kept.push_back(a);
+      if (!fixup)
+        return;
+
+      if (!linkageValue.empty()) {
+        int64_t v;
+        if (!linkageValue.getAsInteger(10, v))
+          if (auto linkage = linkageFromLLVMOrdinal(v))
+            fn.setLinkage(*linkage);
+      }
+
+      if (alwaysInline) {
+        fn.setAlwaysInline(true);
+        fn.setNoInline(false);
+      } else if (!noInline) {
+        fn.setNoInline(false);
+      }
+
+      if (kept.empty())
+        fn.removePassthroughAttr();
+      else
+        fn.setPassthroughAttr(ArrayAttr::get(fn.getContext(), kept));
+    });
+  }
+};
+
+} // namespace

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -123,7 +123,8 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
   pass_pipeline += backend;
   pass_pipeline += "}";
   pass_pipeline += ","
-      "canonicalize,libdevice-funcs-raise,canonicalize,inline-enzyme-regions,symbol-dce,";
+      "canonicalize,libdevice-funcs-raise,restore-preserve-nvvm,canonicalize,"
+      "inline-enzyme-regions,symbol-dce,";
   
   if (backend == "cpu")
     pass_pipeline += "parallel-lower{wrapParallelOps=false},";

--- a/test/lit_tests/raising/restore_preserve_nvvm.mlir
+++ b/test/lit_tests/raising/restore_preserve_nvvm.mlir
@@ -1,0 +1,36 @@
+// RUN: enzymexlamlir-opt %s --restore-preserve-nvvm --split-input-file | FileCheck %s
+
+// A libdevice definition as PreserveNVVM(Begin) left it: promoted to external
+// linkage (external is the llvm.func default spelling), noinline, and the
+// prev_* records of what it was. Restored: internal again, alwaysinline
+// again, records gone -- the enzyme_math/implements markers stay.
+
+llvm.func @__nv_sin(%arg0: f64) -> f64 attributes {dso_local, no_inline, passthrough = [["enzyme_math", "sin"], ["implements", "llvm.sin.f64"], ["implements2", "sin"], "prev_always_inline", "prev_fixup", ["prev_linkage", "7"]]} {
+  llvm.return %arg0 : f64
+}
+
+// CHECK: llvm.func internal @__nv_sin(%arg0: f64) -> f64 attributes {always_inline, dso_local, passthrough = {{\[\[}}"enzyme_math", "sin"], {{\[}}"implements", "llvm.sin.f64"], {{\[}}"implements2", "sin"]]}
+// CHECK-NOT: prev_fixup
+// CHECK-NOT: no_inline
+
+// -----
+
+// A function that was noinline before the preservation stays noinline; only
+// the bookkeeping goes away.
+
+llvm.func @was_noinline(%arg0: f64) -> f64 attributes {no_inline, passthrough = ["prev_no_inline", "prev_fixup", ["prev_linkage", "0"]]} {
+  llvm.return %arg0 : f64
+}
+
+// CHECK: llvm.func @was_noinline(%arg0: f64) -> f64 attributes {no_inline}
+// CHECK-NOT: prev_fixup
+
+// -----
+
+// No prev_fixup: not PreserveNVVM's doing, left exactly alone.
+
+llvm.func @untouched(%arg0: f64) -> f64 attributes {no_inline, passthrough = ["something_else"]} {
+  llvm.return %arg0 : f64
+}
+
+// CHECK: llvm.func @untouched(%arg0: f64) -> f64 attributes {no_inline, passthrough = ["something_else"]}


### PR DESCRIPTION
PreserveNVVM(Begin) keeps the libdevice definitions alive and recognizable up to the raising: noinline so the calls survive, external linkage so nothing internalizes or drops the definitions, and `prev_*` records of what it changed. Past `libdevice-funcs-raise` the math calls are dialect ops, and the marks only keep every dead libdevice definition alive — externally visible, so `symbol-dce` must assume someone wants it — through the rest of the pipeline.

This pass is the `Begin=false` restore said in MLIR, placed right after the raising: recorded linkage and inlining come back, the records go away, and the next `symbol-dce` reaps what nothing calls anymore. The libdevice definitions never needed to be marked used here at all — the pipeline deals with keeping what it needs alive itself, and only the noinline half of the preservation was ever load-bearing.

Companion to EnzymeAD/Reactant#67 (which runs `PreserveNVVM(Begin)`); replaces the withdrawn EnzymeAD/Enzyme#3110.

Verified: LBM (binomial checkpointing, hinted device grids) compiles and its 10-step adjoint output is bit-identical to before; the nested-AD MWE is unchanged; lit test covers restore, kept-noinline, and untouched cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD