### PR TITLE
raising: leave unwind edges standing, in every pass that meets one

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -1006,11 +1006,30 @@ void fully2ComposeAffineMapAndOperands(
     for (auto &op : *operands) {
       if (!op.getType().isIndex()) {
         Operation *toInsert;
-        if (auto *o = op.getDefiningOp())
-          toInsert = o->getNextNode();
-        else {
+        if (auto *o = op.getDefiningOp()) {
+          if (auto inv = dyn_cast<LLVM::InvokeOp>(o)) {
+            // An invoke is a terminator: there is no next node, and its
+            // result only exists on the normal edge. The cast goes at the
+            // top of that block -- when that edge is its only way in, and
+            // after the landingpad when the block starts with one.
+            Block *dest = inv.getNormalDest();
+            // Until composition reports failure to its callers (the void
+            // signature predates that), giving up leaves the map as it was.
+            if (dest->getSinglePredecessor() != inv->getBlock())
+              return;
+            toInsert = &dest->front();
+            if (isa<LLVM::LandingpadOp>(toInsert))
+              toInsert = toInsert->getNextNode();
+          } else if (o->hasTrait<OpTrait::IsTerminator>()) {
+            return;
+          } else {
+            toInsert = o->getNextNode();
+          }
+        } else {
           auto BA = cast<BlockArgument>(op);
           toInsert = &BA.getOwner()->front();
+          if (isa<LLVM::LandingpadOp>(toInsert))
+            toInsert = toInsert->getNextNode();
         }
 
         if (auto v = indexMap.lookupOrNull(op))

--- a/src/enzyme_ad/jax/Passes/ControlFlowToSCF.cpp
+++ b/src/enzyme_ad/jax/Passes/ControlFlowToSCF.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Pass/Pass.h"
@@ -126,6 +127,18 @@ struct EnzymeLiftControlFlowToSCF
 
       auto visitor = [&](Operation *innerOp) -> WalkResult {
         for (Region &reg : innerOp->getRegions()) {
+          // An unwind edge has no reading in scf. A region that throws or
+          // catches stays in cf form -- correct, just never raised -- rather
+          // than stopping the module or, worse, losing the edge.
+          bool hasEH = reg.walk([](Operation *op) {
+                            return isa<LLVM::InvokeOp, LLVM::LandingpadOp,
+                                       LLVM::ResumeOp>(op)
+                                       ? WalkResult::interrupt()
+                                       : WalkResult::advance();
+                          })
+                           .wasInterrupted();
+          if (hasEH)
+            continue;
           FailureOr<bool> changedFunc =
               transformCFGToSCF(reg, transformation, domInfo);
           if (failed(changedFunc))

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1930,7 +1930,9 @@ convertLLVMToAffineAccess(Operation *op,
       if (llvm::alignTo(static_cast<uint64_t>(tySize),
                         dl.getTypeABIAlignment(ty)) != tySize)
         continue;
-      if (MemRefType::isValidElementType(ty) && aab.isLegal() && aab.base) {
+      if (MemRefType::isValidElementType(ty) && aab.isLegal() && aab.base &&
+          canMaterializeAfterValue(aab.base) &&
+          llvm::all_of(aab.getMap().operands, canMaterializeAfterValue)) {
         auto memref0 = mc(aab.base);
         Value memref = memref0;
         auto memrefTy = memref0.getType();
@@ -2019,7 +2021,9 @@ convertLLVMToAffineAccess(Operation *op,
       if (llvm::alignTo(static_cast<uint64_t>(tySize),
                         dl.getTypeABIAlignment(ty)) != tySize)
         continue;
-      if (MemRefType::isValidElementType(ty) && aab.isLegal() && aab.base) {
+      if (MemRefType::isValidElementType(ty) && aab.isLegal() && aab.base &&
+          canMaterializeAfterValue(aab.base) &&
+          llvm::all_of(aab.getMap().operands, canMaterializeAfterValue)) {
         auto memref0 = mc(aab.base);
         Value memref = memref0;
         auto memrefTy = memref0.getType();

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -484,14 +484,49 @@ template <typename T> struct SimplifyInPlaceAlloc : public OpRewritePattern<T> {
   }
 };
 
+// Where something computed from a value can be materialized: after its
+// defining op -- except that an invoke is a terminator, and its result only
+// exists on the normal edge, so the successor is where the value lives.
+// A landingpad has to stay the first operation of its block, so the start of
+// a block is after it when it has one.
+static void setInsertionPointToStartSkippingLandingpad(OpBuilder &builder,
+                                                       Block *block) {
+  if (!block->empty() && isa<LLVM::LandingpadOp>(&block->front()))
+    builder.setInsertionPointAfter(&block->front());
+  else
+    builder.setInsertionPointToStart(block);
+}
+
+static void setInsertionPointAfterValue(OpBuilder &builder, Value v) {
+  if (auto ba = dyn_cast<BlockArgument>(v)) {
+    setInsertionPointToStartSkippingLandingpad(builder, ba.getOwner());
+    return;
+  }
+  Operation *def = v.getDefiningOp();
+  if (auto inv = dyn_cast<LLVM::InvokeOp>(def)) {
+    setInsertionPointToStartSkippingLandingpad(builder, inv.getNormalDest());
+    return;
+  }
+  builder.setInsertionPointAfter(def);
+}
+
+// A shared conversion of a value is materialized right after its definition;
+// for an invoke that place is the start of the normal successor, which only
+// exists as a place when that edge is the block's only way in.
+static bool canMaterializeAfterValue(Value v) {
+  Operation *def = v.getDefiningOp();
+  if (!def)
+    return true;
+  if (auto inv = dyn_cast<LLVM::InvokeOp>(def))
+    return inv.getNormalDest()->getSinglePredecessor() == inv->getBlock();
+  return !def->hasTrait<OpTrait::IsTerminator>();
+}
+
 static Value convertToIndex(Value v) {
   OpBuilder builder(v.getContext());
   if (v.getType() == builder.getIndexType())
     return v;
-  if (auto ba = dyn_cast<BlockArgument>(v))
-    builder.setInsertionPointToStart(ba.getOwner());
-  else
-    builder.setInsertionPointAfter(v.getDefiningOp());
+  setInsertionPointAfterValue(builder, v);
   return arith::IndexCastOp::create(builder, v.getLoc(), builder.getIndexType(),
                                     v)
       .getResult();
@@ -776,10 +811,7 @@ struct LoadSelect : public OpRewritePattern<affine::AffineLoadOp> {
 
 static MemRefVal convertToMemref(PtrVal addr) {
   OpBuilder builder(addr.getContext());
-  if (auto ba = dyn_cast<BlockArgument>(addr))
-    builder.setInsertionPointToStart(ba.getOwner());
-  else
-    builder.setInsertionPointAfter(addr.getDefiningOp());
+  setInsertionPointAfterValue(builder, addr);
   Attribute addrSpace;
   if (addr.getType().getAddressSpace() == 0)
     addrSpace = nullptr;
@@ -1850,6 +1882,14 @@ convertLLVMToAffineAccess(Operation *op,
 
     // TODO this looks terribly slow
     for (Block *b : innermostBlocks) {
+      // A function that kept its cf blocks -- one that throws or catches
+      // stays unraised -- cannot have one of them wrapped in a scope: the
+      // wrapping rebuilds the block around its terminator, and here the
+      // terminator is a branch or an invoke whose edges the scope has no
+      // reading of. The accesses that wanted the scope stay illegal and
+      // lower as plain memref accesses instead.
+      if (!llvm::hasSingleElement(*b->getParent()))
+        continue;
       SmallPtrSet<Value, 6> symbols;
       for (auto &aabp : accessBuilders)
         aabp->collectSymbolsForScope(b->getParent(), symbols);

--- a/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
+++ b/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
@@ -263,6 +263,31 @@ ArrayAttr getActivityArrayAttr(MLIRContext *ctx,
   return ArrayAttr::get(ctx, attrs);
 }
 
+// The enzyme entry points are compiler markers, not functions that unwind:
+// raised, they become an op with no unwind edge to keep. An invoke of one
+// becomes the call and the branch it meant, and the block's other exception
+// handling stays as it was.
+class EnzymeInvokeToCall : public OpRewritePattern<LLVM::InvokeOp> {
+public:
+  using OpRewritePattern<LLVM::InvokeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::InvokeOp op,
+                                PatternRewriter &rewriter) const override {
+    auto callee = dyn_cast<SymbolRefAttr>(op.getCallableForCallee());
+    if (!callee)
+      return failure();
+    if (!callee.getLeafReference().strref().contains("__enzyme_"))
+      return failure();
+    auto call =
+        LLVM::CallOp::create(rewriter, op.getLoc(), op.getResultTypes(),
+                             callee.getLeafReference(), op.getCalleeOperands());
+    LLVM::BrOp::create(rewriter, op.getLoc(), op.getNormalDestOperands(),
+                       op.getNormalDest());
+    rewriter.replaceOp(op, call->getResults());
+    return success();
+  }
+};
+
 class EnzymeAutodiffOpRaising : public OpRewritePattern<LLVM::CallOp> {
 public:
   using OpRewritePattern<LLVM::CallOp>::OpRewritePattern;
@@ -1251,7 +1276,8 @@ struct LibDeviceFuncsRaisingPass
     populateLibDeviceFuncsToOpsPatterns(getOperation()->getContext(), patterns);
     if (remove_freeze)
       patterns.add<RemoveFreeze>(getOperation()->getContext());
-    patterns.add<EnzymeAutodiffOpRaising>(getOperation()->getContext());
+    patterns.add<EnzymeInvokeToCall, EnzymeAutodiffOpRaising>(
+        getOperation()->getContext());
     GreedyRewriteConfig config;
     // We disable region simplification to avoid inadvertently merging
     // llvm.cond_br now that there is an index type.

--- a/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
@@ -109,8 +109,8 @@ struct LowerAlignedAffineAccessesPass
     GreedyRewriteConfig config;
     // Merging identical blocks threads the differing values through new
     // block arguments on every predecessor's terminator; an llvm.invoke only
-    // takes LLVM types there. Nothing here needs the merge. TODO: aggressive
-    // is fine once block merging asks the terminator
+    // takes LLVM types there. Nothing here needs the merge. TODO(#2815):
+    // aggressive is fine once block merging asks the terminator
     // (llvm/llvm-project#215036).
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     if (failed(

--- a/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
@@ -106,7 +106,13 @@ struct LowerAlignedAffineAccessesPass
     RewritePatternSet patterns(&getContext());
     patterns.insert<LowerAlignedAffineLoad, LowerAlignedAffineStore>(
         &getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+    GreedyRewriteConfig config;
+    // Merging identical blocks threads the differing values through new
+    // block arguments on every predecessor's terminator; an llvm.invoke only
+    // takes LLVM types there. Nothing here needs the merge.
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
+    if (failed(
+            applyPatternsGreedily(getOperation(), std::move(patterns), config)))
       signalPassFailure();
   }
 };

--- a/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
@@ -109,7 +109,9 @@ struct LowerAlignedAffineAccessesPass
     GreedyRewriteConfig config;
     // Merging identical blocks threads the differing values through new
     // block arguments on every predecessor's terminator; an llvm.invoke only
-    // takes LLVM types there. Nothing here needs the merge.
+    // takes LLVM types there. Nothing here needs the merge. TODO: aggressive
+    // is fine once block merging asks the terminator
+    // (llvm/llvm-project#215036).
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     if (failed(
             applyPatternsGreedily(getOperation(), std::move(patterns), config)))

--- a/src/enzyme_ad/jax/Passes/ParallelSerialization.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelSerialization.cpp
@@ -124,8 +124,8 @@ struct SCFParallelSerializationPass
     // block arguments on every predecessor's terminator. An llvm.invoke is
     // such a terminator, and its successor operands only take LLVM types --
     // handing it a memref or an index is not a merge but a verifier error.
-    // Nothing here needs the merge. TODO: aggressive is fine once block
-    // merging asks the terminator (llvm/llvm-project#215036).
+    // Nothing here needs the merge. TODO(#2815): aggressive is fine once
+    // block merging asks the terminator (llvm/llvm-project#215036).
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
       signalPassFailure();

--- a/src/enzyme_ad/jax/Passes/ParallelSerialization.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelSerialization.cpp
@@ -120,6 +120,12 @@ struct SCFParallelSerializationPass
     patterns.insert<ParallelSerialization>(&getContext());
     GreedyRewriteConfig config;
     config.enableFolding();
+    // Merging identical blocks threads the differing values through new
+    // block arguments on every predecessor's terminator. An llvm.invoke is
+    // such a terminator, and its successor operands only take LLVM types --
+    // handing it a memref or an index is not a merge but a verifier error.
+    // Nothing here needs the merge.
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
       signalPassFailure();
       return;

--- a/src/enzyme_ad/jax/Passes/ParallelSerialization.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelSerialization.cpp
@@ -124,7 +124,8 @@ struct SCFParallelSerializationPass
     // block arguments on every predecessor's terminator. An llvm.invoke is
     // such a terminator, and its successor operands only take LLVM types --
     // handing it a memref or an index is not a merge but a verifier error.
-    // Nothing here needs the merge.
+    // Nothing here needs the merge. TODO: aggressive is fine once block
+    // merging asks the terminator (llvm/llvm-project#215036).
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
       signalPassFailure();

--- a/test/lit_tests/mem2reg_store_must_dominate.mlir
+++ b/test/lit_tests/mem2reg_store_must_dominate.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+// One store and one load is not yet a forwarding: the store has to have run
+// first on every path. Here the store sits on one side of a branch and the
+// load below the merge -- on the other path the slot was never written, and
+// the load must stay a load. (With exception handling kept in cf form, shapes
+// like this reach the raising; the old test was whether the stored value was
+// *available* at the load, which a value from a skipped path can be.)
+
+module {
+  func.func @no_forward(%c: i1, %v: f64) -> f64 {
+    %a = memref.alloca() : memref<1xf64>
+    %z = arith.constant 0 : index
+    cf.cond_br %c, ^store, ^join
+  ^store:
+    memref.store %v, %a[%z] : memref<1xf64>
+    cf.br ^join
+  ^join:
+    %r = memref.load %a[%z] : memref<1xf64>
+    return %r : f64
+  }
+
+  func.func @forward(%v: f64) -> f64 {
+    %a = memref.alloca() : memref<1xf64>
+    %z = arith.constant 0 : index
+    memref.store %v, %a[%z] : memref<1xf64>
+    %r = memref.load %a[%z] : memref<1xf64>
+    return %r : f64
+  }
+}
+
+// CHECK-LABEL: func.func @no_forward
+// CHECK:         memref.store
+// CHECK:       ^{{.*}}:
+// CHECK:         %[[R:.+]] = {{(affine|memref)\.load}}
+// CHECK:         return %[[R]]
+
+// CHECK-LABEL: func.func @forward
+// CHECK-NOT:     memref.load
+// CHECK:         return %arg0 : f64

--- a/test/lit_tests/raising/eh_preserved.mlir
+++ b/test/lit_tests/raising/eh_preserved.mlir
@@ -1,0 +1,75 @@
+// RUN: enzymexlamlir-opt %s --enzyme-lift-cf-to-scf | FileCheck %s --check-prefix=LIFT
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s --check-prefix=ACCESS
+
+// An unwind edge has no reading in scf, and none of the raising passes may
+// pretend it is not there: lowering invoke to call compiled Catch2's
+// exception-driven test runner into a binary that ran one test case of 103
+// and exited clean. A function that throws or catches stays in cf form --
+// correct, just never raised -- and everything around it raises as usual.
+
+module {
+  llvm.func @__gxx_personality_v0(...) -> i32
+  llvm.func @maythrow() -> i32
+  llvm.func @sink(f64)
+  llvm.func @_Znwm(i64) -> !llvm.ptr
+
+  llvm.func @keeps_eh(%c: i1) -> i32 attributes {personality = @__gxx_personality_v0} {
+    %0 = llvm.invoke @maythrow() to ^ok unwind ^lp : () -> i32
+  ^ok:
+    llvm.return %0 : i32
+  ^lp:
+    %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    llvm.resume %1 : !llvm.struct<(ptr, i32)>
+  }
+
+  // The result of an invoke only exists on its normal edge: what the raising
+  // computes from it -- the memref view of the allocation here -- must be
+  // materialized in the successor, not after the terminator.
+  llvm.func @invoke_base(%n: i64) attributes {personality = @__gxx_personality_v0} {
+    %c32 = llvm.mlir.constant(32 : i64) : i64
+    %p = llvm.invoke @_Znwm(%c32) to ^ok unwind ^lp : (i64) -> !llvm.ptr
+  ^ok:
+    %q = llvm.getelementptr inbounds %p[%n] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    %v = llvm.load %q {alignment = 8 : i64} : !llvm.ptr -> f64
+    llvm.call @sink(%v) : (f64) -> ()
+    llvm.return
+  ^lp:
+    %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    llvm.resume %1 : !llvm.struct<(ptr, i32)>
+  }
+
+  // An index computed by the invoke itself: the cast to index the affine
+  // access wants must land in the normal successor too -- there is no
+  // "after" a terminator, and the value does not exist on the unwind edge.
+  llvm.func @invoke_index(%p: !llvm.ptr) attributes {personality = @__gxx_personality_v0} {
+    %i = llvm.invoke @maythrow() to ^ok unwind ^lp : () -> i32
+  ^ok:
+    %q = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i32) -> !llvm.ptr, f64
+    %v = llvm.load %q {alignment = 8 : i64} : !llvm.ptr -> f64
+    llvm.call @sink(%v) : (f64) -> ()
+    llvm.return
+  ^lp:
+    %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    llvm.resume %1 : !llvm.struct<(ptr, i32)>
+  }
+}
+
+// LIFT-LABEL: llvm.func @keeps_eh
+// LIFT:         llvm.invoke @maythrow
+// LIFT:         llvm.landingpad
+// LIFT:         llvm.resume
+
+// ACCESS-LABEL: llvm.func @invoke_base
+// ACCESS:         %[[P:.+]] = llvm.invoke @_Znwm{{.*}} to ^bb1 unwind ^bb2
+// ACCESS:       ^bb1:
+// ACCESS-NEXT:    %[[M:.+]] = "enzymexla.pointer2memref"(%[[P]])
+// ACCESS-NEXT:    %[[V:.+]] = affine.load %[[M]][symbol(%{{.+}})] {alignment = 8 : i64
+// ACCESS:         llvm.landingpad
+
+// ACCESS-LABEL: llvm.func @invoke_index
+// ACCESS:         %[[I:.+]] = llvm.invoke @maythrow{{.*}} to ^bb1 unwind ^bb2
+// ACCESS:       ^bb1:
+// ACCESS-DAG:     %[[IDX:.+]] = arith.index_cast %[[I]] : i32 to index
+// ACCESS-DAG:     "enzymexla.pointer2memref"
+// ACCESS:         affine.load %{{.+}}[symbol(%[[IDX]])] {alignment = 8 : i64
+// ACCESS:         llvm.landingpad

--- a/test/lit_tests/raising/libdevice_invoke_marker.mlir
+++ b/test/lit_tests/raising/libdevice_invoke_marker.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --libdevice-funcs-raise | FileCheck %s
+
+// The enzyme entry points are compiler markers, not functions that unwind:
+// raised, they become an op with no unwind edge to keep. An invoke of one
+// becomes the call and the branch it meant, and the block's other exception
+// handling stays as it was.
+
+module {
+  llvm.func @__gxx_personality_v0(...) -> i32
+  llvm.func @__enzyme_dummy_marker(f64) -> f64
+  llvm.func @maythrow()
+  llvm.func @sink(f64)
+
+  llvm.func @invoked_marker(%x: f64) attributes {personality = @__gxx_personality_v0} {
+    %r = llvm.invoke @__enzyme_dummy_marker(%x) to ^ok unwind ^lp : (f64) -> f64
+  ^ok:
+    llvm.call @sink(%r) : (f64) -> ()
+    llvm.invoke @maythrow() to ^done unwind ^lp : () -> ()
+  ^done:
+    llvm.return
+  ^lp:
+    %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    llvm.resume %1 : !llvm.struct<(ptr, i32)>
+  }
+}
+
+// CHECK-LABEL: llvm.func @invoked_marker
+// CHECK:         %[[R:.+]] = llvm.call @__enzyme_dummy_marker(%{{.+}}) : (f64) -> f64
+// CHECK-NEXT:    llvm.br ^[[OK:.+]]
+// CHECK:       ^[[OK]]:
+// CHECK-NEXT:    llvm.call @sink(%[[R]])
+// A function that really unwinds keeps doing so; only the marker's edge went.
+// CHECK-NEXT:    llvm.invoke @maythrow
+// CHECK:         llvm.landingpad
+// CHECK:         llvm.resume

--- a/test/lit_tests/raising/lower_aligned_eh.mlir
+++ b/test/lit_tests/raising/lower_aligned_eh.mlir
@@ -1,0 +1,39 @@
+// RUN: enzymexlamlir-opt %s --lower-aligned-affine-accesses | FileCheck %s
+
+// Merging identical blocks threads the differing values through new block
+// arguments on every predecessor's terminator. An llvm.invoke is such a
+// terminator, and its successor operands only take LLVM types -- handing it
+// the index that distinguishes these two stores is not a merge but a
+// verifier error. The pass's greedy driver must leave the blocks alone.
+
+module {
+  llvm.func @__gxx_personality_v0(...) -> i32
+  llvm.func @maythrow()
+
+  llvm.func @unmerged(%p: !llvm.ptr, %c: i1) attributes {personality = @__gxx_personality_v0} {
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<4xf32>
+    %cst = arith.constant 1.000000e+00 : f32
+    %i0 = arith.constant 0 : index
+    %i1 = arith.constant 1 : index
+    llvm.cond_br %c, ^direct, ^inv
+  ^inv:
+    llvm.invoke @maythrow() to ^a unwind ^lp : () -> ()
+  ^a:
+    memref.store %cst, %m[%i0] : memref<4xf32>
+    llvm.return
+  ^direct:
+    memref.store %cst, %m[%i1] : memref<4xf32>
+    llvm.return
+  ^lp:
+    %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    llvm.resume %1 : !llvm.struct<(ptr, i32)>
+  }
+}
+
+// Both stores survive in their own blocks, and the invoke still carries no
+// successor operands.
+// CHECK-LABEL: llvm.func @unmerged
+// CHECK:         llvm.invoke @maythrow() to ^{{.+}} unwind
+// CHECK:         memref.store %{{.+}}, %{{.+}}[%[[A:.+]]] : memref<4xf32>
+// CHECK:         memref.store %{{.+}}, %{{.+}}[%[[B:.+]]] : memref<4xf32>
+// CHECK:         llvm.landingpad

--- a/test/lit_tests/raising/parallel_serialization_eh.mlir
+++ b/test/lit_tests/raising/parallel_serialization_eh.mlir
@@ -1,0 +1,39 @@
+// RUN: enzymexlamlir-opt %s --parallel-serialization | FileCheck %s
+
+// Merging identical blocks threads the differing values through new block
+// arguments on every predecessor's terminator. An llvm.invoke is such a
+// terminator, and its successor operands only take LLVM types -- handing it
+// the index that distinguishes these two stores is not a merge but a
+// verifier error. The pass's greedy driver must leave the blocks alone.
+
+module {
+  llvm.func @__gxx_personality_v0(...) -> i32
+  llvm.func @maythrow()
+
+  llvm.func @unmerged(%p: !llvm.ptr, %c: i1) attributes {personality = @__gxx_personality_v0} {
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<4xf32>
+    %cst = arith.constant 1.000000e+00 : f32
+    %i0 = arith.constant 0 : index
+    %i1 = arith.constant 1 : index
+    llvm.cond_br %c, ^direct, ^inv
+  ^inv:
+    llvm.invoke @maythrow() to ^a unwind ^lp : () -> ()
+  ^a:
+    memref.store %cst, %m[%i0] : memref<4xf32>
+    llvm.return
+  ^direct:
+    memref.store %cst, %m[%i1] : memref<4xf32>
+    llvm.return
+  ^lp:
+    %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    llvm.resume %1 : !llvm.struct<(ptr, i32)>
+  }
+}
+
+// Both stores survive in their own blocks, and the invoke still carries no
+// successor operands.
+// CHECK-LABEL: llvm.func @unmerged
+// CHECK:         llvm.invoke @maythrow() to ^{{.+}} unwind
+// CHECK:         memref.store %{{.+}}, %{{.+}}[%[[A:.+]]] : memref<4xf32>
+// CHECK:         memref.store %{{.+}}, %{{.+}}[%[[B:.+]]] : memref<4xf32>
+// CHECK:         llvm.landingpad


### PR DESCRIPTION
The companion of #2800 (which stops lowering invoke away before import, behind an `MLIRRoundTripOptions` field): each raising pass learns to work around exception handling rather than fail on it or, worse, rewrite it.

- `enzyme-lift-cf-to-scf` skips regions holding `invoke`/`landingpad`/`resume`: an unwind edge has no reading in scf, so a throwing or catching function stays in cf form — correct, just never raised.
- `llvm-to-affine-access` materializes what it computes from an invoke's result — an index cast, the memref view of an allocation — in the normal successor: the result only exists on that edge, and after a terminator is not a place. A landingpad stays the first op of its block.
- `affine-cfg`'s shared composition helper does the same for index casts of invoke-defined operands, and gives up rather than move a value past a terminator.
- `libdevice-funcs-raise` turns an invoke of an `__enzyme_*` marker into the call and branch it meant: markers do not unwind, and their edge would otherwise keep the raising from seeing through them.
- `lower-aligned-affine-accesses` and `parallel-serialization` stop the greedy driver's aggressive block merging: merging identical blocks threads the differing values through every predecessor's terminator, and an invoke's successor operands only take LLVM types.

Per-pass lit tests: `eh_preserved.mlir` (lift + both materialization sites, including an access indexed by the invoke's own result), `libdevice_invoke_marker.mlir` (marker edge goes, real unwind stays), `lower_aligned_eh.mlir` / `parallel_serialization_eh.mlir` (no block merge across an invoke), and `mem2reg_store_must_dominate.mlir` (the multi-block dominance case EH regions exposed; main already carries the fix via #2805, the test pins it).

Merge order: this before (or with) #2800 — with the lowering off and these missing, EH-carrying modules fail the pipeline loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD