### PR TITLE
canonicalize-scf-for: a result yielding the IV is the last executed IV

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1580,6 +1580,59 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
     if (lookThrough && !loop->use_empty())
       doWhile = true;
 
+    // The same holds without an extra condition. A do-while's results are the
+    // condition args of that final evaluation -- the one whose comparison
+    // fails -- while the converted loop's results are snapshots from the last
+    // evaluation it runs. A used result is the same value either way only if
+    // its condition arg cannot change between one evaluation and the next: a
+    // value from outside the loop, a passthrough of a slot the loop refills
+    // with itself, or a slot advanced by a loop-invariant step, whose result
+    // ForOpInductionReplacement rewrites in closed form afterwards. Anything
+    // else -- a value the before region computes, a permuted slot, an
+    // accumulator -- observes the final evaluation and needs the extra
+    // iteration, pure or not.
+    if (!doWhile) {
+      auto afterYield =
+          cast<scf::YieldOp>(loop.getAfter().front().getTerminator());
+      auto definedOutside = [&](Value v) {
+        if (auto ba = dyn_cast<BlockArgument>(v))
+          return !loop->isAncestor(ba.getOwner()->getParentOp());
+        Operation *def = v.getDefiningOp();
+        return def && !loop->isAncestor(def);
+      };
+      // The after-region arg at position p carries before-arg `ba` iff the
+      // condition forwards `ba` in position p.
+      auto carriesSlot = [&](Value v, BlockArgument ba) {
+        auto aa = dyn_cast<BlockArgument>(v);
+        return aa && aa.getOwner() == &loop.getAfter().front() &&
+               condOp.getArgs()[aa.getArgNumber()] == ba;
+      };
+      for (auto [res, arg] : llvm::zip(loop.getResults(), condOp.getArgs())) {
+        if (res.use_empty())
+          continue;
+        if (definedOutside(arg))
+          continue;
+        if (auto ba = dyn_cast<BlockArgument>(arg)) {
+          if (ba.getOwner() == &loop.getBefore().front()) {
+            Value next = afterYield.getOperand(ba.getArgNumber());
+            if (carriesSlot(next, ba))
+              continue;
+            if (auto add = next.getDefiningOp<AddIOp>()) {
+              bool induction = false;
+              for (int k = 0; k < 2; k++)
+                if (carriesSlot(add->getOperand(k), ba) &&
+                    definedOutside(add->getOperand(1 - k)))
+                  induction = true;
+              if (induction)
+                continue;
+            }
+          }
+        }
+        doWhile = true;
+        break;
+      }
+    }
+
     bool mutableAfter = false;
     if (doWhile) {
       for (auto &blk : loop.getAfter()) {

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -312,6 +312,44 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
                    yieldOp.getOperands()      // iter yield
                    )) {
 
+      // A result that hands out the induction variable itself is the last
+      // executed IV -- or the init when the loop ran zero times. With a unit
+      // step and the iter arg starting at the lower bound (the shape a
+      // converted while has), the two cases meet in max(ub - step, lb) with
+      // no guard; otherwise the last IV is lb + ((ub-lb-1) / step) * step,
+      // selected against the init on whether the loop ran. The division is
+      // unsigned and its operands poison-free, so computing it speculatively
+      // on the zero-trip path is meaningless but harmless.
+      if (yld == forOp.getInductionVar()) {
+        if (res.use_empty())
+          continue;
+        rewriter.setInsertionPoint(forOp);
+        Location loc = forOp.getLoc();
+        Value lb = forOp.getLowerBound(), ub = forOp.getUpperBound(),
+              step = forOp.getStep();
+        Value replacement;
+        if (matchPattern(step, m_One()) && outiter == lb) {
+          Value last = SubIOp::create(rewriter, loc, ub, step);
+          replacement = MaxSIOp::create(rewriter, loc, last, lb);
+        } else {
+          Value one = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getIntegerAttr(ub.getType(), 1));
+          Value span = SubIOp::create(rewriter, loc, ub, lb);
+          Value m1 = SubIOp::create(rewriter, loc, span, one);
+          Value q = DivUIOp::create(rewriter, loc, m1, step);
+          Value off = MulIOp::create(rewriter, loc, q, step);
+          Value last = AddIOp::create(rewriter, loc, lb, off);
+          Value ran = CmpIOp::create(rewriter, loc, CmpIPredicate::sgt, ub, lb);
+          Value init = castValue(rewriter, outiter, yld, loc);
+          replacement = SelectOp::create(rewriter, loc, ran, last, init);
+        }
+        Value resCopy = res;
+        rewriter.modifyOpInPlace(
+            forOp, [&] { resCopy.replaceAllUsesWith(replacement); });
+        canonicalize = true;
+        continue;
+      }
+
       AddIOp addOp = yld.getDefiningOp<AddIOp>();
       if (!addOp)
         continue;

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1585,12 +1585,15 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
     // fails -- while the converted loop's results are snapshots from the last
     // evaluation it runs. A used result is the same value either way only if
     // its condition arg cannot change between one evaluation and the next: a
-    // value from outside the loop, a passthrough of a slot the loop refills
-    // with itself, or a slot advanced by a loop-invariant step, whose result
-    // ForOpInductionReplacement rewrites in closed form afterwards. Anything
-    // else -- a value the before region computes, a permuted slot, an
-    // accumulator -- observes the final evaluation and needs the extra
-    // iteration, pure or not.
+    // value from outside the loop, or a passthrough of a slot the loop
+    // refills with itself. Anything else -- a value the before region
+    // computes, a permuted slot, an accumulator, even a slot advanced by a
+    // loop-invariant step -- observes the final evaluation and needs the
+    // extra iteration, pure or not. (An advancing slot looks recoverable in
+    // closed form, but nothing downstream is obliged to do so:
+    // ForOpInductionReplacement only rewrites a result whose post-conversion
+    // yield is addi(iterarg, step), and the conversion does not produce that
+    // shape -- counting on it returned one step short.)
     if (!doWhile) {
       auto afterYield =
           cast<scf::YieldOp>(loop.getAfter().front().getTerminator());
@@ -1617,15 +1620,6 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
             Value next = afterYield.getOperand(ba.getArgNumber());
             if (carriesSlot(next, ba))
               continue;
-            if (auto add = next.getDefiningOp<AddIOp>()) {
-              bool induction = false;
-              for (int k = 0; k < 2; k++)
-                if (carriesSlot(add->getOperand(k), ba) &&
-                    definedOutside(add->getOperand(1 - k)))
-                  induction = true;
-              if (induction)
-                continue;
-            }
           }
         }
         doWhile = true;

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -321,32 +321,56 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
       // unsigned and its operands poison-free, so computing it speculatively
       // on the zero-trip path is meaningless but harmless.
       if (yld == forOp.getInductionVar()) {
-        if (res.use_empty())
-          continue;
-        rewriter.setInsertionPoint(forOp);
         Location loc = forOp.getLoc();
         Value lb = forOp.getLowerBound(), ub = forOp.getUpperBound(),
               step = forOp.getStep();
-        Value replacement;
-        if (matchPattern(step, m_One()) && outiter == lb) {
-          Value last = SubIOp::create(rewriter, loc, ub, step);
-          replacement = MaxSIOp::create(rewriter, loc, last, lb);
-        } else {
-          Value one = arith::ConstantOp::create(
-              rewriter, loc, rewriter.getIntegerAttr(ub.getType(), 1));
-          Value span = SubIOp::create(rewriter, loc, ub, lb);
-          Value m1 = SubIOp::create(rewriter, loc, span, one);
-          Value q = DivUIOp::create(rewriter, loc, m1, step);
-          Value off = MulIOp::create(rewriter, loc, q, step);
-          Value last = AddIOp::create(rewriter, loc, lb, off);
-          Value ran = CmpIOp::create(rewriter, loc, CmpIPredicate::sgt, ub, lb);
-          Value init = castValue(rewriter, outiter, yld, loc);
-          replacement = SelectOp::create(rewriter, loc, ran, last, init);
+
+        // Inside the body the iter arg is the previous iteration's IV -- or
+        // the init on the first one. When the init is the lower bound the
+        // two meet in max(iv - step, lb) with no first-iteration test.
+        if (!iterarg.use_empty()) {
+          rewriter.setInsertionPointToStart(&forOp.getRegion().front());
+          Value iv = forOp.getInductionVar();
+          Value prev = SubIOp::create(rewriter, loc, iv, step);
+          Value replacement;
+          if (outiter == lb) {
+            replacement = MaxSIOp::create(rewriter, loc, prev, lb);
+          } else {
+            Value first =
+                CmpIOp::create(rewriter, loc, CmpIPredicate::eq, iv, lb);
+            Value init = castValue(rewriter, outiter, yld, loc);
+            replacement = SelectOp::create(rewriter, loc, first, init, prev);
+          }
+          Value iterargCopy = iterarg;
+          rewriter.modifyOpInPlace(
+              forOp, [&] { iterargCopy.replaceAllUsesWith(replacement); });
+          canonicalize = true;
         }
-        Value resCopy = res;
-        rewriter.modifyOpInPlace(
-            forOp, [&] { resCopy.replaceAllUsesWith(replacement); });
-        canonicalize = true;
+
+        if (!res.use_empty()) {
+          rewriter.setInsertionPoint(forOp);
+          Value replacement;
+          if (matchPattern(step, m_One()) && outiter == lb) {
+            Value last = SubIOp::create(rewriter, loc, ub, step);
+            replacement = MaxSIOp::create(rewriter, loc, last, lb);
+          } else {
+            Value one = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getIntegerAttr(ub.getType(), 1));
+            Value span = SubIOp::create(rewriter, loc, ub, lb);
+            Value m1 = SubIOp::create(rewriter, loc, span, one);
+            Value q = DivUIOp::create(rewriter, loc, m1, step);
+            Value off = MulIOp::create(rewriter, loc, q, step);
+            Value last = AddIOp::create(rewriter, loc, lb, off);
+            Value ran =
+                CmpIOp::create(rewriter, loc, CmpIPredicate::sgt, ub, lb);
+            Value init = castValue(rewriter, outiter, yld, loc);
+            replacement = SelectOp::create(rewriter, loc, ran, last, init);
+          }
+          Value resCopy = res;
+          rewriter.modifyOpInPlace(
+              forOp, [&] { resCopy.replaceAllUsesWith(replacement); });
+          canonicalize = true;
+        }
         continue;
       }
 

--- a/test/lit_tests/canonicalizefor/doWhile.mlir
+++ b/test/lit_tests/canonicalizefor/doWhile.mlir
@@ -18,19 +18,6 @@ module @simple{
     return %result : index
   }
 }
-// CHECK-LABEL:   module @simple {
-// CHECK:           func.func @do_while() -> index {
-// CHECK-DAG:             %[[c6:.*]] = arith.constant 6 : index
-// CHECK-DAG:             %[[c1:.*]] = arith.constant 1 : index
-// CHECK-DAG:             %[[ub:.+]] = ub.poison : index
-// CHECK:             %[[f:.+]] = scf.for %[[VAL_3:.*]] = %[[c1]] to %[[c6]] step %[[c1]] iter_args(%arg1 = %[[ub]]) -> (index) {
-// CHECK:               %[[id2:.+]] = arith.subi %[[VAL_3]], %[[c1]] : index
-// CHECK:               "before.keepalive"(%[[id2]]) : (index) -> ()
-// CHECK:               scf.yield %[[VAL_3]] : index 
-// CHECK:             }
-// CHECK:             return %[[f]] : index
-// CHECK:           }
-// CHECK:         }
 
 //----
 
@@ -54,18 +41,6 @@ module @multiple_iter_args{
   }
 }
 
-// CHECK-LABEL:   module @multiple_iter_args {
-// CHECK:           func.func @do_while() -> i32 {
-// CHECK-DAG:             %[[c11:.*]] = arith.constant 11 : i32
-// CHECK-DAG:             %[[cm1:.*]] = arith.constant -1 : i32
-// CHECK-DAG:             %[[c1:.*]] = arith.constant 1 : i32
-// CHECK:             scf.for %[[arg:.*]] = %[[c1]] to %[[c11]] step %[[c1]] : i32 {
-// CHECK:               %[[id2:.+]] = arith.addi %[[arg]], %[[cm1]] : i32
-// CHECK:               "before.keepalive"(%[[id2]], %[[c1]]) : (i32, i32) -> ()
-// CHECK:             }
-// CHECK:             return %[[c1]] : i32
-// CHECK:           }
-// CHECK:         }
 
 //----
 
@@ -90,21 +65,6 @@ module @negative_step{
   }
 }
 
-// CHECK-LABEL:   module @negative_step {
-// CHECK:           func.func @do_while() -> i32 {
-// CHECK-DAG:             %[[cm1:.*]] = arith.constant -1 : i32
-// CHECK-DAG:             %[[c4:.*]] = arith.constant 4 : i32
-// CHECK-DAG:             %[[cm4:.*]] = arith.constant -4 : i32
-// CHECK-DAG:             %[[c1:.*]] = arith.constant 1 : i32
-// CHECK:             %[[ub:.+]] = ub.poison : i32
-// CHECK:             %[[fr:.+]] = scf.for %[[arg:.*]] = %[[cm4]] to %[[c1]] step %[[c1]] iter_args(%arg1 = %[[ub]]) -> (i32) : i32 {
-// CHECK:               %[[VAL_6:.*]] = arith.addi %[[arg]], %[[c4]] : i32
-// CHECK:               %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[cm1]] : i32
-// CHECK:               "before.keepalive"(%[[VAL_7]]) : (i32) -> ()
-// CHECK:             }
-// CHECK:             return %[[fr]] : i32
-// CHECK:           }
-// CHECK:         }
 
 //----
 
@@ -129,19 +89,6 @@ module @execute_once{
   }
 }
 
-// CHECK-LABEL:   module @execute_once {
-// CHECK:           func.func @do_while() -> index {
-// CHECK-DAG:             %[[c2:.*]] = arith.constant 2 : index
-// CHECK-DAG:             %[[c1:.*]] = arith.constant 1 : index
-// CHECK-DAG:             %[[VAL_2:.*]] = ub.poison : index
-// CHECK:             %[[FOR:.*]] = scf.for %[[arg:.*]] = %[[c1]] to %[[c2]] step %[[c1]] iter_args(%{{.*}} = %[[VAL_2]]) -> (index) {
-// CHECK:               %[[RES:.*]] = arith.subi %[[arg]], %[[c1]] : index
-// CHECK:               "before.keepalive"(%[[RES]]) : (index) -> ()
-// CHECK:               scf.yield %[[arg]] : index
-// CHECK:             }
-// CHECK:             return %[[FOR]] : index
-// CHECK:           }
-// CHECK:         }
 
 // ----
 
@@ -165,21 +112,6 @@ module @execute_once{
    }
  }
 
-// CHECK-LABEL:   module @multiple_iter_args_2 {
-// CHECK:           func.func @do_while() -> i32 {
-// CHECK-DAG:             %[[c11:.*]] = arith.constant 11 : i32
-// CHECK-DAG:             %[[c1:.*]] = arith.constant 1 : i32
-// CHECK-DAG:             %[[cm1:.*]] = arith.constant -1 : i32
-// CHECK-DAG:             %[[ub:.*]] = ub.poison : i32
-// CHECK:             %[[F:.*]]:2 = scf.for %[[arg:.*]] = %[[c1]] to %[[c11]] step %[[c1]] iter_args(%[[arg1:.*]] = %[[c1]], %arg2 = %[[ub]]) -> (i32, i32)  : i32 {
-// CHECK:               %[[RES:.*]] = arith.addi %[[arg]], %[[cm1]] : i32
-// CHECK:               %[[KA:.*]] = "before.keepalive"(%[[arg1]], %[[RES]]) : (i32, i32) -> i32
-// CHECK:               %[[A2:.*]] = arith.addi %[[RES]], %[[c1]] : i32
-// CHECK:               scf.yield %[[KA]], %[[A2]] : i32
-// CHECK:             }
-// CHECK:             return %[[F]]#1 : i32
-// CHECK:           }
-// CHECK:         }
 
 //----
 
@@ -202,19 +134,6 @@ module @cmpi_ne{
     return %result : index
   }
 }
-// CHECK-LABEL:   module @cmpi_ne {
-// CHECK:           func.func @do_while() -> index {
-// CHECK-DAG:             %[[c1:.*]] = arith.constant 1 : index
-// CHECK-DAG:             %[[c6:.*]] = arith.constant 6 : index
-// CHECK-DAG:             %[[ub:.+]] = ub.poison : index
-// CHECK:             %[[f3:.+]] = scf.for %[[arg:.*]] = %[[c1]] to %[[c6]] step %[[c1]] iter_args(%arg1 = %0) -> (index) {
-// CHECK:               %[[RES:.*]] = arith.subi %[[arg]], %[[c1]] : index
-// CHECK:               "before.keepalive"(%[[RES]]) : (index) -> ()
-// CHECK:                scf.yield %[[arg]] : index
-// CHECK:             }
-// CHECK:             return %[[f3]] : index
-// CHECK:           }
-// CHECK:         }
 
 //----
 
@@ -238,23 +157,6 @@ module @cmpi_ne_neg{
   }
 }
 
-// CHECK-LABEL:   module @cmpi_ne_neg {
-// CHECK:           func.func @do_while2() -> i32 {
-// CHECK-DAG:             %[[c4:.*]] = arith.constant 4 : i32
-// CHECK-DAG:             %[[cm4:.*]] = arith.constant -4 : i32
-// CHECK-DAG:             %[[c1:.*]] = arith.constant 1 : i32
-// CHECK-DAG:             %[[cm1:.*]] = arith.constant -1 : i32
-// CHECK-DAG:             %[[ub:.+]] = ub.poison : i32
-// CHECK:             %[[f4:.+]] = scf.for %[[arg:.*]] = %[[cm4]] to %[[c1]] step %[[c1]] iter_args(%arg1 = %[[ub]]) -> (i32) : i32
-// CHECK-NEXT:               %[[VAL_6:.*]] = arith.addi %[[arg]], %[[c4]] : i32
-// CHECK-NEXT:               %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[cm1]] : i32
-// CHECK-NEXT:               "before.keepalive"(%[[VAL_7]]) : (i32) -> ()
-// CHECK-NEXT:               %[[i4:.+]] = arith.addi %[[VAL_7]], %[[cm1]] : i32
-// CHECK-NEXT:               scf.yield %[[i4]] : i32
-// CHECK-NEXT:             }
-// CHECK:             return %[[f4]] : i32
-// CHECK:           }
-// CHECK:         }
 
 //----
 
@@ -278,24 +180,6 @@ module @cmpi_ne_neg_step{
   }
 }
 
-// CHECK-LABEL:   module @cmpi_ne_neg_step {
-// CHECK:           func.func @do_while2() -> i32 {
-// CHECK-DAG:             %[[c49:.*]] = arith.constant 49 : i32
-// CHECK-DAG:             %[[cm1:.*]] = arith.constant -1 : i32
-// CHECK-DAG:             %[[c1:.*]] = arith.constant 1 : i32
-// CHECK-DAG:             %[[c50:.*]] = arith.constant 50 : i32
-// CHECK-DAG:             %[[ub:.+]] = ub.poison : i32
-// CHECK:             %[[f4:.+]] = scf.for %[[VAL_5:.*]] = %[[c1]] to %[[c50]] step %[[c1]] iter_args(%arg1 = %[[ub]]) -> (i32) : i32
-// CHECK-NEXT:               %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[cm1]] : i32
-// CHECK-NEXT:               %[[VAL_7:.*]] = arith.muli %[[VAL_6]], %[[cm1]] : i32
-// CHECK-NEXT:               %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[c49]] : i32
-// CHECK-NEXT:               "before.keepalive"(%[[VAL_8]]) : (i32) -> ()
-// CHECK-NEXT:               %[[i4:.+]] = arith.addi %[[VAL_8]], %[[cm1]] : i32
-// CHECK-NEXT:               scf.yield %[[i4]] : i32
-// CHECK-NEXT:             }
-// CHECK:             return %[[f4]] : i32
-// CHECK:           }
-// CHECK:         }
 
 //----
 
@@ -319,16 +203,6 @@ module @cmpi_ne_i{
   }
 }
 
-// CHECK-LABEL:  module @cmpi_ne_i {
-// CHECK:    func.func @do_while2() -> i32 {
-// CHECK-DAG:      %[[ONE:.+]] = arith.constant 1 : i32
-// CHECK-DAG:      %[[C50:.+]] = arith.constant 50 : i32
-// CHECK-NEXT:      scf.for %[[IV:.+]] = %[[ONE]] to %[[C50]] step %[[ONE]] : i32 {
-// CHECK-NEXT:        "before.keepalive"(%[[IV]]) : (i32) -> ()
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return %[[C50]] : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 //----
 
@@ -351,20 +225,6 @@ module @test_dynamic_ub {
   }
 }
 
-// CHECK-LABEL: module @test_dynamic_ub {
-// CHECK:         func.func @do_while(%[[UB:.+]]: index) -> index {
-// CHECK-DAG:       %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:       %[[POISON:.+]] = ub.poison : index
-// CHECK-NEXT:      %[[MAX1:.+]] = arith.maxsi %[[UB]], %[[C1]] : index
-// CHECK-NEXT:      %[[ADJ_UB:.+]] = arith.addi %[[MAX1]], %[[C1]] : index
-// CHECK-NEXT:      %[[FOR:.+]] = scf.for %[[IV:.+]] = %[[C1]] to %[[ADJ_UB]] step %[[C1]] iter_args(%{{.*}} = %[[POISON]]) -> (index) {
-// CHECK-NEXT:        %[[SUB:.+]] = arith.subi %[[IV]], %[[C1]] : index
-// CHECK-NEXT:        "before.keepalive"(%[[SUB]]) : (index) -> ()
-// CHECK-NEXT:        scf.yield %[[IV]] : index
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return %[[FOR]] : index
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 //----
 
@@ -386,25 +246,8 @@ module @test_fully_dynamic {
   }
 }
 
-// CHECK-LABEL: module @test_fully_dynamic {
-// CHECK:         func.func @do_while(%[[LB:.+]]: index, %[[UB:.+]]: index) -> index {
-// CHECK-DAG:       %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:       %[[POISON:.+]] = ub.poison : index
-// CHECK-NEXT:      %[[LBP1:.+]] = arith.addi %[[LB]], %[[C1]] : index
-// CHECK-NEXT:      %[[maxi:.+]] = arith.maxsi %[[UB]], %[[LBP1]] : index
-// CHECK-NEXT:      %[[ADJ_UB:.+]] = arith.addi %[[maxi]], %[[C1]] : index
-// CHECK-NEXT:      %[[FOR:.+]] = scf.for %[[IV:.+]] = %[[LBP1]] to %[[ADJ_UB]] step %[[C1]] iter_args(%{{.*}} = %[[POISON]]) -> (index) 
 
-// CHECK-NEXT:        %[[a4:.+]] = arith.subi %[[IV]], %[[LBP1]] : index
-// CHECK-NEXT:        %[[NIV:.+]] = arith.addi %[[LB]], %[[a4]] : index
-// CHECK-NEXT:        "before.keepalive"(%[[NIV]]) : (index) -> ()
-// CHECK-NEXT:        %[[NEW:.+]] = arith.addi %[[NIV]], %[[C1]] : index
-// CHECK-NEXT:        scf.yield %[[NEW]] : index
 
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return %[[FOR]] : index
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 //----
 
@@ -427,28 +270,8 @@ module @test_negative_step_dynamic_ub {
   }
 }
 
-// CHECK-LABEL: module @test_negative_step_dynamic_ub {
-// CHECK:         func.func @do_while(%[[UB:.+]]: i32) -> i32 {
-// CHECK-DAG:       %[[C10:.+]] = arith.constant 10 : i32
-// CHECK-DAG:       %[[C1:.+]] = arith.constant 1 : i32
-// CHECK-DAG:       %[[CM1:.+]] = arith.constant -1 : i32
-// CHECK-DAG:       %[[POISON:.+]] = ub.poison : i32
 
-// CHECK-NEXT:      %[[UBP1:.+]] = arith.addi %[[UB]], %[[C1]] : i32
-// CHECK-NEXT:      %[[max:.+]] = arith.maxsi %[[UBP1]], %[[C10]] : i32
-// CHECK-NEXT:      %[[ADJ_UB:.+]] = arith.addi %[[max]], %[[C1]] : i32
 
-// CHECK-NEXT:      %[[FOR:.+]] = scf.for %[[IV:.+]] = %[[UBP1]] to %[[ADJ_UB]] step %[[C1]] iter_args(%{{.*}} = %[[POISON]]) -> (i32) : i32 {
-// CHECK-NEXT:        %[[VAL1:.+]] = arith.subi %[[IV]], %[[UBP1]] : i32
-// CHECK-NEXT:        %[[VAL2:.+]] = arith.muli %[[VAL1]], %[[CM1]] : i32
-// CHECK-NEXT:        %[[VAL3:.+]] = arith.addi %[[VAL2]], %[[C10]] : i32
-// CHECK-NEXT:        "before.keepalive"(%[[VAL3]]) : (i32) -> ()
-// CHECK-NEXT:        %[[NEW:.+]] = arith.addi %[[VAL3]], %[[CM1]] : i32
-// CHECK-NEXT:        scf.yield %[[NEW]] : i32
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return %[[FOR]] : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 //----
 
@@ -473,24 +296,6 @@ module @test_multiple_args_dynamic {
   }
 }
 
-// CHECK-LABEL: module @test_multiple_args_dynamic {
-// CHECK:         func.func @do_while(%[[UB:.+]]: index) -> (index, index) {
-// CHECK-DAG:       %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:       %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:       %[[POISON:.+]] = ub.poison : index
-// CHECK-NEXT:      %[[max:.+]] = arith.maxsi %[[UB]], %[[C1]] : index
-// CHECK-NEXT:      %[[ADJ_UB:.+]] = arith.addi %[[max]], %[[C1]] : index
-// CHECK-NEXT:      %[[FOR:.+]]:2 = scf.for %[[IV:.+]] = %[[C1]] to %[[ADJ_UB]] step %[[C1]] iter_args(%{{.*}} = %[[POISON]], %{{.*}} = %[[POISON]]) -> (index, index) {
-// CHECK-NEXT:        %[[IV2:.+]] = arith.subi %[[IV]], %[[C1]] : index
-// CHECK-NEXT:        %[[SUM:.+]] = arith.muli %[[IV2]], %[[C2]] : index
-// CHECK-NEXT:        %[[IV22:.+]] = arith.subi %[[IV]], %[[C1]] : index
-// CHECK-NEXT:        "before.keepalive"(%[[IV22]], %[[SUM]]) : (index, index) -> ()
-// CHECK-NEXT:        %[[NEW_SUM:.+]] = arith.addi %[[SUM]], %[[C2]] : index
-// CHECK-NEXT:        scf.yield %[[IV]], %[[NEW_SUM]] : index, index
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return %[[FOR]]#0, %[[FOR]]#1 : index, index
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 //----
 
@@ -517,35 +322,230 @@ module @test_and_condition {
   }
 }
 
+// CHECK: module {
+// CHECK-LABEL: module @simple {
+// CHECK-NEXT:     func.func @do_while() -> index {
+// CHECK-NEXT:       %c1 = arith.constant 1 : index
+// CHECK-NEXT:       %c6 = arith.constant 6 : index
+// CHECK-NEXT:       %c5 = arith.constant 5 : index
+// CHECK-NEXT:       scf.for %arg0 = %c1 to %c6 step %c1 {
+// CHECK-NEXT:         %0 = arith.subi %arg0, %c1 : index
+// CHECK-NEXT:         "before.keepalive"(%0) : (index) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %c5 : index
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @multiple_iter_args {
+// CHECK-NEXT:     func.func @do_while() -> i32 {
+// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:       %c11_i32 = arith.constant 11 : i32
+// CHECK-NEXT:       scf.for %arg0 = %c1_i32 to %c11_i32 step %c1_i32  : i32 {
+// CHECK-NEXT:         %0 = arith.addi %arg0, %c-1_i32 : i32
+// CHECK-NEXT:         "before.keepalive"(%0, %c1_i32) : (i32, i32) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %c1_i32 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @negative_step {
+// CHECK-NEXT:     func.func @do_while() -> i32 {
+// CHECK-NEXT:       %c4_i32 = arith.constant 4 : i32
+// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:       %c-4_i32 = arith.constant -4 : i32
+// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:       %0 = ub.poison : i32
+// CHECK-NEXT:       %1 = scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
+// CHECK-NEXT:         %2 = arith.addi %arg0, %c4_i32 : i32
+// CHECK-NEXT:         %3 = arith.muli %2, %c-1_i32 : i32
+// CHECK-NEXT:         "before.keepalive"(%3) : (i32) -> ()
+// CHECK-NEXT:         %4 = arith.addi %3, %c-1_i32 : i32
+// CHECK-NEXT:         scf.yield %4 : i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %1 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @execute_once {
+// CHECK-NEXT:     func.func @do_while() -> index {
+// CHECK-NEXT:       %c1 = arith.constant 1 : index
+// CHECK-NEXT:       %c2 = arith.constant 2 : index
+// CHECK-NEXT:       scf.for %arg0 = %c1 to %c2 step %c1 {
+// CHECK-NEXT:         %0 = arith.subi %arg0, %c1 : index
+// CHECK-NEXT:         "before.keepalive"(%0) : (index) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %c1 : index
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @multiple_iter_args_2 {
+// CHECK-NEXT:     func.func @do_while() -> i32 {
+// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:       %0 = ub.poison : i32
+// CHECK-NEXT:       %c11_i32 = arith.constant 11 : i32
+// CHECK-NEXT:       %1:2 = scf.for %arg0 = %c1_i32 to %c11_i32 step %c1_i32 iter_args(%arg1 = %c1_i32, %arg2 = %0) -> (i32, i32)  : i32 {
+// CHECK-NEXT:         %2 = arith.addi %arg0, %c-1_i32 : i32
+// CHECK-NEXT:         %3 = "before.keepalive"(%arg1, %2) : (i32, i32) -> i32
+// CHECK-NEXT:         %4 = arith.addi %2, %c1_i32 : i32
+// CHECK-NEXT:         scf.yield %3, %4 : i32, i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %1#1 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @cmpi_ne {
+// CHECK-NEXT:     func.func @do_while() -> index {
+// CHECK-NEXT:       %c1 = arith.constant 1 : index
+// CHECK-NEXT:       %c6 = arith.constant 6 : index
+// CHECK-NEXT:       %c5 = arith.constant 5 : index
+// CHECK-NEXT:       scf.for %arg0 = %c1 to %c6 step %c1 {
+// CHECK-NEXT:         %0 = arith.subi %arg0, %c1 : index
+// CHECK-NEXT:         "before.keepalive"(%0) : (index) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %c5 : index
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @cmpi_ne_neg {
+// CHECK-NEXT:     func.func @do_while2() -> i32 {
+// CHECK-NEXT:       %c4_i32 = arith.constant 4 : i32
+// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:       %c-4_i32 = arith.constant -4 : i32
+// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:       %0 = ub.poison : i32
+// CHECK-NEXT:       %1 = scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
+// CHECK-NEXT:         %2 = arith.addi %arg0, %c4_i32 : i32
+// CHECK-NEXT:         %3 = arith.muli %2, %c-1_i32 : i32
+// CHECK-NEXT:         "before.keepalive"(%3) : (i32) -> ()
+// CHECK-NEXT:         %4 = arith.addi %3, %c-1_i32 : i32
+// CHECK-NEXT:         scf.yield %4 : i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %1 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @cmpi_ne_neg_step {
+// CHECK-NEXT:     func.func @do_while2() -> i32 {
+// CHECK-NEXT:       %c49_i32 = arith.constant 49 : i32
+// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:       %0 = ub.poison : i32
+// CHECK-NEXT:       %c50_i32 = arith.constant 50 : i32
+// CHECK-NEXT:       %1 = scf.for %arg0 = %c1_i32 to %c50_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
+// CHECK-NEXT:         %2 = arith.addi %arg0, %c-1_i32 : i32
+// CHECK-NEXT:         %3 = arith.muli %2, %c-1_i32 : i32
+// CHECK-NEXT:         %4 = arith.addi %3, %c49_i32 : i32
+// CHECK-NEXT:         "before.keepalive"(%4) : (i32) -> ()
+// CHECK-NEXT:         %5 = arith.addi %4, %c-1_i32 : i32
+// CHECK-NEXT:         scf.yield %5 : i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %1 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @cmpi_ne_i {
+// CHECK-NEXT:     func.func @do_while2() -> i32 {
+// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:       %c50_i32 = arith.constant 50 : i32
+// CHECK-NEXT:       scf.for %arg0 = %c1_i32 to %c50_i32 step %c1_i32  : i32 {
+// CHECK-NEXT:         "before.keepalive"(%arg0) : (i32) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %c50_i32 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @test_dynamic_ub {
+// CHECK-NEXT:     func.func @do_while(%arg0: index) -> index {
+// CHECK-NEXT:       %c1 = arith.constant 1 : index
+// CHECK-NEXT:       %0 = arith.maxsi %arg0, %c1 : index
+// CHECK-NEXT:       %1 = arith.addi %0, %c1 : index
+// CHECK-NEXT:       scf.for %arg1 = %c1 to %1 step %c1 {
+// CHECK-NEXT:         %2 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:         "before.keepalive"(%2) : (index) -> ()
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %0 : index
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @test_fully_dynamic {
+// CHECK-NEXT:     func.func @do_while(%arg0: index, %arg1: index) -> index {
+// CHECK-NEXT:       %0 = ub.poison : index
+// CHECK-NEXT:       %c1 = arith.constant 1 : index
+// CHECK-NEXT:       %1 = arith.addi %arg0, %c1 : index
+// CHECK-NEXT:       %2 = arith.maxsi %arg1, %1 : index
+// CHECK-NEXT:       %3 = arith.addi %2, %c1 : index
+// CHECK-NEXT:       %4 = scf.for %arg2 = %1 to %3 step %c1 iter_args(%arg3 = %0) -> (index) {
+// CHECK-NEXT:         %5 = arith.subi %arg2, %1 : index
+// CHECK-NEXT:         %6 = arith.addi %arg0, %5 : index
+// CHECK-NEXT:         "before.keepalive"(%6) : (index) -> ()
+// CHECK-NEXT:         %7 = arith.addi %6, %c1 : index
+// CHECK-NEXT:         scf.yield %7 : index
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %4 : index
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @test_negative_step_dynamic_ub {
+// CHECK-NEXT:     func.func @do_while(%arg0: i32) -> i32 {
+// CHECK-NEXT:       %0 = ub.poison : i32
+// CHECK-NEXT:       %c10_i32 = arith.constant 10 : i32
+// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:       %1 = arith.addi %arg0, %c1_i32 : i32
+// CHECK-NEXT:       %2 = arith.maxsi %1, %c10_i32 : i32
+// CHECK-NEXT:       %3 = arith.addi %2, %c1_i32 : i32
+// CHECK-NEXT:       %4 = scf.for %arg1 = %1 to %3 step %c1_i32 iter_args(%arg2 = %0) -> (i32)  : i32 {
+// CHECK-NEXT:         %5 = arith.subi %arg1, %1 : i32
+// CHECK-NEXT:         %6 = arith.muli %5, %c-1_i32 : i32
+// CHECK-NEXT:         %7 = arith.addi %6, %c10_i32 : i32
+// CHECK-NEXT:         "before.keepalive"(%7) : (i32) -> ()
+// CHECK-NEXT:         %8 = arith.addi %7, %c-1_i32 : i32
+// CHECK-NEXT:         scf.yield %8 : i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %4 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-LABEL: module @test_multiple_args_dynamic {
+// CHECK-NEXT:     func.func @do_while(%arg0: index) -> (index, index) {
+// CHECK-NEXT:       %c1 = arith.constant 1 : index
+// CHECK-NEXT:       %c2 = arith.constant 2 : index
+// CHECK-NEXT:       %0 = ub.poison : index
+// CHECK-NEXT:       %1 = arith.maxsi %arg0, %c1 : index
+// CHECK-NEXT:       %2 = arith.addi %1, %c1 : index
+// CHECK-NEXT:       %3 = scf.for %arg1 = %c1 to %2 step %c1 iter_args(%arg2 = %0) -> (index) {
+// CHECK-NEXT:         %4 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:         %5 = arith.muli %4, %c2 : index
+// CHECK-NEXT:         %6 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:         "before.keepalive"(%6, %5) : (index, index) -> ()
+// CHECK-NEXT:         %7 = arith.addi %5, %c2 : index
+// CHECK-NEXT:         scf.yield %7 : index
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %1, %3 : index, index
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
 // CHECK-LABEL: module @test_and_condition {
-// CHECK:         func.func @do_while(%[[UB:.+]]: i32) -> (i32, f32) {
-// CHECK-DAG:       %[[C0:.+]] = arith.constant 0 : i32
-// CHECK-DAG:       %[[C1:.+]] = arith.constant 1 : i32
-// CHECK-DAG:       %[[FALSE:.+]] = arith.constant false
-// CHECK-DAG:       %[[TRUE:.+]] = arith.constant true
-// CHECK-DAG:       %[[CST0:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       %[[CST1:.+]] = arith.constant 1.000000e+00 : f32
-// CHECK-DAG:       %[[UNDEF_I32:.+]] = ub.poison : i32
-// CHECK-DAG:       %[[UNDEF_F32:.+]] = ub.poison : f32
-// CHECK-DAG:       %[[UNDEF_I1:.+]] = ub.poison : i1
-// CHECK-NEXT:      %[[MAX:.+]] = arith.maxsi %[[UB]], %[[C0]] : i32
-// CHECK-NEXT:      %[[ADJ_UB:.+]] = arith.addi %[[MAX]], %[[C1]] : i32
-// CHECK-NEXT:      %[[FOR:.+]]:7 = scf.for %[[IV:.+]] = %[[C0]] to %[[ADJ_UB]] step %[[C1]] iter_args(%[[ARG0:.+]] = %[[C0]], %[[ARG1:.+]] = %[[CST0]], %[[ARG2:.+]] = %[[TRUE]], %[[ARG3:.+]] = %[[UNDEF_I32]], %[[ARG4:.+]] = %[[UNDEF_F32]], %[[ARG5:.+]] = %[[UNDEF_I1]], %[[ARG6:.+]] = %[[TRUE]]) -> (i32, f32, i1, i32, f32, i1, i1)  : i32 {
-// CHECK-NEXT:        %[[IF1:.+]]:4 = scf.if %[[ARG6]] -> (i32, f32, i1, i1) {
-// CHECK-NEXT:          %[[ADDI:.+]] = arith.addi %[[ARG0]], %[[C1]] : i32
-// CHECK-NEXT:          %[[VAL:.+]] = "test.something"() : () -> i1
-// CHECK-NEXT:          %[[ADDF:.+]] = arith.addf %[[ARG1]], %[[CST1]] : f32
-// CHECK-NEXT:          scf.yield %[[ADDI]], %[[ADDF]], %[[VAL]], %[[ARG2]] : i32, f32, i1, i1
-// CHECK-NEXT:        } else {
-// CHECK-NEXT:          scf.yield %[[ARG3]], %[[ARG4]], %[[ARG5]], %[[FALSE]] : i32, f32, i1, i1
-// CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CMP:.+]] = arith.cmpi slt, %[[IV]], %[[UB]] : i32
-// CHECK-NEXT:        %[[COND:.+]] = arith.andi %[[CMP]], %[[IF1]]#3 : i1
-// CHECK-NEXT:        %[[IF2:.+]]:3 = scf.if %[[COND]] -> (i32, f32, i1) {
-// CHECK-NEXT:          scf.yield %[[IF1]]#0, %[[IF1]]#1, %[[IF1]]#2 : i32, f32, i1
-// CHECK-NEXT:        } else {
-// CHECK-NEXT:          scf.yield %[[UNDEF_I32]], %[[UNDEF_F32]], %[[UNDEF_I1]] : i32, f32, i1
-// CHECK-NEXT:        }
-// CHECK-NEXT:      scf.yield %[[IF2]]#0, %[[IF2]]#1, %[[IF2]]#2, %[[IF1]]#0, %[[IF1]]#1, %[[IF1]]#2, %[[IF1]]#3 : i32, f32, i1, i32, f32, i1, i1
-// CHECK-NEXT:    }
-// CHECK-NEXT:    return %[[FOR]]#3, %[[FOR]]#4 : i32, f32
+// CHECK-NEXT:     func.func @do_while(%arg0: i32) -> (i32, f32) {
+// CHECK-NEXT:       %false = arith.constant false
+// CHECK-NEXT:       %cst = arith.constant 0.000000e+00 : f32
+// CHECK-NEXT:       %cst_0 = arith.constant 1.000000e+00 : f32
+// CHECK-NEXT:       %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:       %true = arith.constant true
+// CHECK-NEXT:       %0 = ub.poison : i32
+// CHECK-NEXT:       %1 = ub.poison : f32
+// CHECK-NEXT:       %2 = ub.poison : i1
+// CHECK-NEXT:       %3 = arith.maxsi %arg0, %c0_i32 : i32
+// CHECK-NEXT:       %4 = arith.addi %3, %c1_i32 : i32
+// CHECK-NEXT:       %5:7 = scf.for %arg1 = %c0_i32 to %4 step %c1_i32 iter_args(%arg2 = %c0_i32, %arg3 = %cst, %arg4 = %true, %arg5 = %0, %arg6 = %1, %arg7 = %2, %arg8 = %true) -> (i32, f32, i1, i32, f32, i1, i1)  : i32 {
+// CHECK-NEXT:         %6:4 = scf.if %arg8 -> (i32, f32, i1, i1) {
+// CHECK-NEXT:           %10 = arith.addi %arg2, %c1_i32 : i32
+// CHECK-NEXT:           %11 = "test.something"() : () -> i1
+// CHECK-NEXT:           %12 = arith.addf %arg3, %cst_0 : f32
+// CHECK-NEXT:           scf.yield %10, %12, %11, %arg4 : i32, f32, i1, i1
+// CHECK-NEXT:         } else {
+// CHECK-NEXT:           scf.yield %arg5, %arg6, %arg7, %false : i32, f32, i1, i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         %7 = arith.cmpi slt, %arg1, %arg0 : i32
+// CHECK-NEXT:         %8 = arith.andi %7, %6#3 : i1
+// CHECK-NEXT:         %9:3 = scf.if %8 -> (i32, f32, i1) {
+// CHECK-NEXT:           scf.yield %6#0, %6#1, %6#2 : i32, f32, i1
+// CHECK-NEXT:         } else {
+// CHECK-NEXT:           scf.yield %0, %1, %2 : i32, f32, i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         scf.yield %9#0, %9#1, %9#2, %6#0, %6#1, %6#2, %6#3 : i32, f32, i1, i32, f32, i1, i1
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return %5#3, %5#4 : i32, f32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/canonicalizefor/doWhile.mlir
+++ b/test/lit_tests/canonicalizefor/doWhile.mlir
@@ -18,6 +18,18 @@ module @simple{
     return %result : index
   }
 }
+// CHECK-LABEL: module @simple {
+// CHECK-NEXT:   func.func @do_while() -> index {
+// CHECK-NEXT:     %c1 = arith.constant 1 : index
+// CHECK-NEXT:     %c6 = arith.constant 6 : index
+// CHECK-NEXT:     %c5 = arith.constant 5 : index
+// CHECK-NEXT:     scf.for %arg0 = %c1 to %c6 step %c1 {
+// CHECK-NEXT:       %0 = arith.subi %arg0, %c1 : index
+// CHECK-NEXT:       "before.keepalive"(%0) : (index) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %c5 : index
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -41,6 +53,18 @@ module @multiple_iter_args{
   }
 }
 
+// CHECK-LABEL: module @multiple_iter_args {
+// CHECK-NEXT:   func.func @do_while() -> i32 {
+// CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     %c11_i32 = arith.constant 11 : i32
+// CHECK-NEXT:     scf.for %arg0 = %c1_i32 to %c11_i32 step %c1_i32  : i32 {
+// CHECK-NEXT:       %0 = arith.addi %arg0, %c-1_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%0, %c1_i32) : (i32, i32) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %c1_i32 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -65,6 +89,23 @@ module @negative_step{
   }
 }
 
+// CHECK-LABEL: module @negative_step {
+// CHECK-NEXT:   func.func @do_while() -> i32 {
+// CHECK-NEXT:     %c4_i32 = arith.constant 4 : i32
+// CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:     %c-4_i32 = arith.constant -4 : i32
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     %0 = ub.poison : i32
+// CHECK-NEXT:     %1 = scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
+// CHECK-NEXT:       %2 = arith.addi %arg0, %c4_i32 : i32
+// CHECK-NEXT:       %3 = arith.muli %2, %c-1_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%3) : (i32) -> ()
+// CHECK-NEXT:       %4 = arith.addi %3, %c-1_i32 : i32
+// CHECK-NEXT:       scf.yield %4 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -89,6 +130,17 @@ module @execute_once{
   }
 }
 
+// CHECK-LABEL: module @execute_once {
+// CHECK-NEXT:   func.func @do_while() -> index {
+// CHECK-NEXT:     %c1 = arith.constant 1 : index
+// CHECK-NEXT:     %c2 = arith.constant 2 : index
+// CHECK-NEXT:     scf.for %arg0 = %c1 to %c2 step %c1 {
+// CHECK-NEXT:       %0 = arith.subi %arg0, %c1 : index
+// CHECK-NEXT:       "before.keepalive"(%0) : (index) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %c1 : index
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 // ----
 
@@ -112,6 +164,21 @@ module @execute_once{
    }
  }
 
+// CHECK-LABEL: module @multiple_iter_args_2 {
+// CHECK-NEXT:   func.func @do_while() -> i32 {
+// CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     %0 = ub.poison : i32
+// CHECK-NEXT:     %c11_i32 = arith.constant 11 : i32
+// CHECK-NEXT:     %1:2 = scf.for %arg0 = %c1_i32 to %c11_i32 step %c1_i32 iter_args(%arg1 = %c1_i32, %arg2 = %0) -> (i32, i32)  : i32 {
+// CHECK-NEXT:       %2 = arith.addi %arg0, %c-1_i32 : i32
+// CHECK-NEXT:       %3 = "before.keepalive"(%arg1, %2) : (i32, i32) -> i32
+// CHECK-NEXT:       %4 = arith.addi %2, %c1_i32 : i32
+// CHECK-NEXT:       scf.yield %3, %4 : i32, i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %1#1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -134,6 +201,18 @@ module @cmpi_ne{
     return %result : index
   }
 }
+// CHECK-LABEL: module @cmpi_ne {
+// CHECK-NEXT:   func.func @do_while() -> index {
+// CHECK-NEXT:     %c1 = arith.constant 1 : index
+// CHECK-NEXT:     %c6 = arith.constant 6 : index
+// CHECK-NEXT:     %c5 = arith.constant 5 : index
+// CHECK-NEXT:     scf.for %arg0 = %c1 to %c6 step %c1 {
+// CHECK-NEXT:       %0 = arith.subi %arg0, %c1 : index
+// CHECK-NEXT:       "before.keepalive"(%0) : (index) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %c5 : index
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -157,6 +236,23 @@ module @cmpi_ne_neg{
   }
 }
 
+// CHECK-LABEL: module @cmpi_ne_neg {
+// CHECK-NEXT:   func.func @do_while2() -> i32 {
+// CHECK-NEXT:     %c4_i32 = arith.constant 4 : i32
+// CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:     %c-4_i32 = arith.constant -4 : i32
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     %0 = ub.poison : i32
+// CHECK-NEXT:     %1 = scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
+// CHECK-NEXT:       %2 = arith.addi %arg0, %c4_i32 : i32
+// CHECK-NEXT:       %3 = arith.muli %2, %c-1_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%3) : (i32) -> ()
+// CHECK-NEXT:       %4 = arith.addi %3, %c-1_i32 : i32
+// CHECK-NEXT:       scf.yield %4 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -180,6 +276,24 @@ module @cmpi_ne_neg_step{
   }
 }
 
+// CHECK-LABEL: module @cmpi_ne_neg_step {
+// CHECK-NEXT:   func.func @do_while2() -> i32 {
+// CHECK-NEXT:     %c49_i32 = arith.constant 49 : i32
+// CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     %0 = ub.poison : i32
+// CHECK-NEXT:     %c50_i32 = arith.constant 50 : i32
+// CHECK-NEXT:     %1 = scf.for %arg0 = %c1_i32 to %c50_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
+// CHECK-NEXT:       %2 = arith.addi %arg0, %c-1_i32 : i32
+// CHECK-NEXT:       %3 = arith.muli %2, %c-1_i32 : i32
+// CHECK-NEXT:       %4 = arith.addi %3, %c49_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%4) : (i32) -> ()
+// CHECK-NEXT:       %5 = arith.addi %4, %c-1_i32 : i32
+// CHECK-NEXT:       scf.yield %5 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %1 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -203,6 +317,16 @@ module @cmpi_ne_i{
   }
 }
 
+// CHECK-LABEL: module @cmpi_ne_i {
+// CHECK-NEXT:   func.func @do_while2() -> i32 {
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     %c50_i32 = arith.constant 50 : i32
+// CHECK-NEXT:     scf.for %arg0 = %c1_i32 to %c50_i32 step %c1_i32  : i32 {
+// CHECK-NEXT:       "before.keepalive"(%arg0) : (i32) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %c50_i32 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -225,6 +349,18 @@ module @test_dynamic_ub {
   }
 }
 
+// CHECK-LABEL: module @test_dynamic_ub {
+// CHECK-NEXT:   func.func @do_while(%arg0: index) -> index {
+// CHECK-NEXT:     %c1 = arith.constant 1 : index
+// CHECK-NEXT:     %0 = arith.maxsi %arg0, %c1 : index
+// CHECK-NEXT:     %1 = arith.addi %0, %c1 : index
+// CHECK-NEXT:     scf.for %arg1 = %c1 to %1 step %c1 {
+// CHECK-NEXT:       %2 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:       "before.keepalive"(%2) : (index) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0 : index
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -246,8 +382,23 @@ module @test_fully_dynamic {
   }
 }
 
-
-
+// CHECK-LABEL: module @test_fully_dynamic {
+// CHECK-NEXT:   func.func @do_while(%arg0: index, %arg1: index) -> index {
+// CHECK-NEXT:     %0 = ub.poison : index
+// CHECK-NEXT:     %c1 = arith.constant 1 : index
+// CHECK-NEXT:     %1 = arith.addi %arg0, %c1 : index
+// CHECK-NEXT:     %2 = arith.maxsi %arg1, %1 : index
+// CHECK-NEXT:     %3 = arith.addi %2, %c1 : index
+// CHECK-NEXT:     %4 = scf.for %arg2 = %1 to %3 step %c1 iter_args(%arg3 = %0) -> (index) {
+// CHECK-NEXT:       %5 = arith.subi %arg2, %1 : index
+// CHECK-NEXT:       %6 = arith.addi %arg0, %5 : index
+// CHECK-NEXT:       "before.keepalive"(%6) : (index) -> ()
+// CHECK-NEXT:       %7 = arith.addi %6, %c1 : index
+// CHECK-NEXT:       scf.yield %7 : index
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %4 : index
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -270,8 +421,26 @@ module @test_negative_step_dynamic_ub {
   }
 }
 
-
-
+// CHECK-LABEL: module @test_negative_step_dynamic_ub {
+// CHECK-NEXT:   func.func @do_while(%arg0: i32) -> i32 {
+// CHECK-NEXT:     %0 = ub.poison : i32
+// CHECK-NEXT:     %c10_i32 = arith.constant 10 : i32
+// CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     %1 = arith.addi %arg0, %c1_i32 : i32
+// CHECK-NEXT:     %2 = arith.maxsi %1, %c10_i32 : i32
+// CHECK-NEXT:     %3 = arith.addi %2, %c1_i32 : i32
+// CHECK-NEXT:     %4 = scf.for %arg1 = %1 to %3 step %c1_i32 iter_args(%arg2 = %0) -> (i32)  : i32 {
+// CHECK-NEXT:       %5 = arith.subi %arg1, %1 : i32
+// CHECK-NEXT:       %6 = arith.muli %5, %c-1_i32 : i32
+// CHECK-NEXT:       %7 = arith.addi %6, %c10_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%7) : (i32) -> ()
+// CHECK-NEXT:       %8 = arith.addi %7, %c-1_i32 : i32
+// CHECK-NEXT:       scf.yield %8 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %4 : i32
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -296,6 +465,24 @@ module @test_multiple_args_dynamic {
   }
 }
 
+// CHECK-LABEL: module @test_multiple_args_dynamic {
+// CHECK-NEXT:   func.func @do_while(%arg0: index) -> (index, index) {
+// CHECK-NEXT:     %c1 = arith.constant 1 : index
+// CHECK-NEXT:     %c2 = arith.constant 2 : index
+// CHECK-NEXT:     %0 = ub.poison : index
+// CHECK-NEXT:     %1 = arith.maxsi %arg0, %c1 : index
+// CHECK-NEXT:     %2 = arith.addi %1, %c1 : index
+// CHECK-NEXT:     %3 = scf.for %arg1 = %c1 to %2 step %c1 iter_args(%arg2 = %0) -> (index) {
+// CHECK-NEXT:       %4 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:       %5 = arith.muli %4, %c2 : index
+// CHECK-NEXT:       %6 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:       "before.keepalive"(%6, %5) : (index, index) -> ()
+// CHECK-NEXT:       %7 = arith.addi %5, %c2 : index
+// CHECK-NEXT:       scf.yield %7 : index
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %1, %3 : index, index
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 //----
 
@@ -322,230 +509,37 @@ module @test_and_condition {
   }
 }
 
-// CHECK: module {
-// CHECK-LABEL: module @simple {
-// CHECK-NEXT:     func.func @do_while() -> index {
-// CHECK-NEXT:       %c1 = arith.constant 1 : index
-// CHECK-NEXT:       %c6 = arith.constant 6 : index
-// CHECK-NEXT:       %c5 = arith.constant 5 : index
-// CHECK-NEXT:       scf.for %arg0 = %c1 to %c6 step %c1 {
-// CHECK-NEXT:         %0 = arith.subi %arg0, %c1 : index
-// CHECK-NEXT:         "before.keepalive"(%0) : (index) -> ()
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %c5 : index
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @multiple_iter_args {
-// CHECK-NEXT:     func.func @do_while() -> i32 {
-// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
-// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:       %c11_i32 = arith.constant 11 : i32
-// CHECK-NEXT:       scf.for %arg0 = %c1_i32 to %c11_i32 step %c1_i32  : i32 {
-// CHECK-NEXT:         %0 = arith.addi %arg0, %c-1_i32 : i32
-// CHECK-NEXT:         "before.keepalive"(%0, %c1_i32) : (i32, i32) -> ()
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %c1_i32 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @negative_step {
-// CHECK-NEXT:     func.func @do_while() -> i32 {
-// CHECK-NEXT:       %c4_i32 = arith.constant 4 : i32
-// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
-// CHECK-NEXT:       %c-4_i32 = arith.constant -4 : i32
-// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:       %0 = ub.poison : i32
-// CHECK-NEXT:       %1 = scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
-// CHECK-NEXT:         %2 = arith.addi %arg0, %c4_i32 : i32
-// CHECK-NEXT:         %3 = arith.muli %2, %c-1_i32 : i32
-// CHECK-NEXT:         "before.keepalive"(%3) : (i32) -> ()
-// CHECK-NEXT:         %4 = arith.addi %3, %c-1_i32 : i32
-// CHECK-NEXT:         scf.yield %4 : i32
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %1 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @execute_once {
-// CHECK-NEXT:     func.func @do_while() -> index {
-// CHECK-NEXT:       %c1 = arith.constant 1 : index
-// CHECK-NEXT:       %c2 = arith.constant 2 : index
-// CHECK-NEXT:       scf.for %arg0 = %c1 to %c2 step %c1 {
-// CHECK-NEXT:         %0 = arith.subi %arg0, %c1 : index
-// CHECK-NEXT:         "before.keepalive"(%0) : (index) -> ()
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %c1 : index
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @multiple_iter_args_2 {
-// CHECK-NEXT:     func.func @do_while() -> i32 {
-// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
-// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:       %0 = ub.poison : i32
-// CHECK-NEXT:       %c11_i32 = arith.constant 11 : i32
-// CHECK-NEXT:       %1:2 = scf.for %arg0 = %c1_i32 to %c11_i32 step %c1_i32 iter_args(%arg1 = %c1_i32, %arg2 = %0) -> (i32, i32)  : i32 {
-// CHECK-NEXT:         %2 = arith.addi %arg0, %c-1_i32 : i32
-// CHECK-NEXT:         %3 = "before.keepalive"(%arg1, %2) : (i32, i32) -> i32
-// CHECK-NEXT:         %4 = arith.addi %2, %c1_i32 : i32
-// CHECK-NEXT:         scf.yield %3, %4 : i32, i32
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %1#1 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @cmpi_ne {
-// CHECK-NEXT:     func.func @do_while() -> index {
-// CHECK-NEXT:       %c1 = arith.constant 1 : index
-// CHECK-NEXT:       %c6 = arith.constant 6 : index
-// CHECK-NEXT:       %c5 = arith.constant 5 : index
-// CHECK-NEXT:       scf.for %arg0 = %c1 to %c6 step %c1 {
-// CHECK-NEXT:         %0 = arith.subi %arg0, %c1 : index
-// CHECK-NEXT:         "before.keepalive"(%0) : (index) -> ()
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %c5 : index
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @cmpi_ne_neg {
-// CHECK-NEXT:     func.func @do_while2() -> i32 {
-// CHECK-NEXT:       %c4_i32 = arith.constant 4 : i32
-// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
-// CHECK-NEXT:       %c-4_i32 = arith.constant -4 : i32
-// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:       %0 = ub.poison : i32
-// CHECK-NEXT:       %1 = scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
-// CHECK-NEXT:         %2 = arith.addi %arg0, %c4_i32 : i32
-// CHECK-NEXT:         %3 = arith.muli %2, %c-1_i32 : i32
-// CHECK-NEXT:         "before.keepalive"(%3) : (i32) -> ()
-// CHECK-NEXT:         %4 = arith.addi %3, %c-1_i32 : i32
-// CHECK-NEXT:         scf.yield %4 : i32
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %1 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @cmpi_ne_neg_step {
-// CHECK-NEXT:     func.func @do_while2() -> i32 {
-// CHECK-NEXT:       %c49_i32 = arith.constant 49 : i32
-// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
-// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:       %0 = ub.poison : i32
-// CHECK-NEXT:       %c50_i32 = arith.constant 50 : i32
-// CHECK-NEXT:       %1 = scf.for %arg0 = %c1_i32 to %c50_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
-// CHECK-NEXT:         %2 = arith.addi %arg0, %c-1_i32 : i32
-// CHECK-NEXT:         %3 = arith.muli %2, %c-1_i32 : i32
-// CHECK-NEXT:         %4 = arith.addi %3, %c49_i32 : i32
-// CHECK-NEXT:         "before.keepalive"(%4) : (i32) -> ()
-// CHECK-NEXT:         %5 = arith.addi %4, %c-1_i32 : i32
-// CHECK-NEXT:         scf.yield %5 : i32
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %1 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @cmpi_ne_i {
-// CHECK-NEXT:     func.func @do_while2() -> i32 {
-// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:       %c50_i32 = arith.constant 50 : i32
-// CHECK-NEXT:       scf.for %arg0 = %c1_i32 to %c50_i32 step %c1_i32  : i32 {
-// CHECK-NEXT:         "before.keepalive"(%arg0) : (i32) -> ()
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %c50_i32 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @test_dynamic_ub {
-// CHECK-NEXT:     func.func @do_while(%arg0: index) -> index {
-// CHECK-NEXT:       %c1 = arith.constant 1 : index
-// CHECK-NEXT:       %0 = arith.maxsi %arg0, %c1 : index
-// CHECK-NEXT:       %1 = arith.addi %0, %c1 : index
-// CHECK-NEXT:       scf.for %arg1 = %c1 to %1 step %c1 {
-// CHECK-NEXT:         %2 = arith.subi %arg1, %c1 : index
-// CHECK-NEXT:         "before.keepalive"(%2) : (index) -> ()
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %0 : index
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @test_fully_dynamic {
-// CHECK-NEXT:     func.func @do_while(%arg0: index, %arg1: index) -> index {
-// CHECK-NEXT:       %0 = ub.poison : index
-// CHECK-NEXT:       %c1 = arith.constant 1 : index
-// CHECK-NEXT:       %1 = arith.addi %arg0, %c1 : index
-// CHECK-NEXT:       %2 = arith.maxsi %arg1, %1 : index
-// CHECK-NEXT:       %3 = arith.addi %2, %c1 : index
-// CHECK-NEXT:       %4 = scf.for %arg2 = %1 to %3 step %c1 iter_args(%arg3 = %0) -> (index) {
-// CHECK-NEXT:         %5 = arith.subi %arg2, %1 : index
-// CHECK-NEXT:         %6 = arith.addi %arg0, %5 : index
-// CHECK-NEXT:         "before.keepalive"(%6) : (index) -> ()
-// CHECK-NEXT:         %7 = arith.addi %6, %c1 : index
-// CHECK-NEXT:         scf.yield %7 : index
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %4 : index
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @test_negative_step_dynamic_ub {
-// CHECK-NEXT:     func.func @do_while(%arg0: i32) -> i32 {
-// CHECK-NEXT:       %0 = ub.poison : i32
-// CHECK-NEXT:       %c10_i32 = arith.constant 10 : i32
-// CHECK-NEXT:       %c-1_i32 = arith.constant -1 : i32
-// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:       %1 = arith.addi %arg0, %c1_i32 : i32
-// CHECK-NEXT:       %2 = arith.maxsi %1, %c10_i32 : i32
-// CHECK-NEXT:       %3 = arith.addi %2, %c1_i32 : i32
-// CHECK-NEXT:       %4 = scf.for %arg1 = %1 to %3 step %c1_i32 iter_args(%arg2 = %0) -> (i32)  : i32 {
-// CHECK-NEXT:         %5 = arith.subi %arg1, %1 : i32
-// CHECK-NEXT:         %6 = arith.muli %5, %c-1_i32 : i32
-// CHECK-NEXT:         %7 = arith.addi %6, %c10_i32 : i32
-// CHECK-NEXT:         "before.keepalive"(%7) : (i32) -> ()
-// CHECK-NEXT:         %8 = arith.addi %7, %c-1_i32 : i32
-// CHECK-NEXT:         scf.yield %8 : i32
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %4 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-LABEL: module @test_multiple_args_dynamic {
-// CHECK-NEXT:     func.func @do_while(%arg0: index) -> (index, index) {
-// CHECK-NEXT:       %c1 = arith.constant 1 : index
-// CHECK-NEXT:       %c2 = arith.constant 2 : index
-// CHECK-NEXT:       %0 = ub.poison : index
-// CHECK-NEXT:       %1 = arith.maxsi %arg0, %c1 : index
-// CHECK-NEXT:       %2 = arith.addi %1, %c1 : index
-// CHECK-NEXT:       %3 = scf.for %arg1 = %c1 to %2 step %c1 iter_args(%arg2 = %0) -> (index) {
-// CHECK-NEXT:         %4 = arith.subi %arg1, %c1 : index
-// CHECK-NEXT:         %5 = arith.muli %4, %c2 : index
-// CHECK-NEXT:         %6 = arith.subi %arg1, %c1 : index
-// CHECK-NEXT:         "before.keepalive"(%6, %5) : (index, index) -> ()
-// CHECK-NEXT:         %7 = arith.addi %5, %c2 : index
-// CHECK-NEXT:         scf.yield %7 : index
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return %1, %3 : index, index
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
 // CHECK-LABEL: module @test_and_condition {
-// CHECK-NEXT:     func.func @do_while(%arg0: i32) -> (i32, f32) {
-// CHECK-NEXT:       %false = arith.constant false
-// CHECK-NEXT:       %cst = arith.constant 0.000000e+00 : f32
-// CHECK-NEXT:       %cst_0 = arith.constant 1.000000e+00 : f32
-// CHECK-NEXT:       %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:       %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:       %true = arith.constant true
-// CHECK-NEXT:       %0 = ub.poison : i32
-// CHECK-NEXT:       %1 = ub.poison : f32
-// CHECK-NEXT:       %2 = ub.poison : i1
-// CHECK-NEXT:       %3 = arith.maxsi %arg0, %c0_i32 : i32
-// CHECK-NEXT:       %4 = arith.addi %3, %c1_i32 : i32
-// CHECK-NEXT:       %5:7 = scf.for %arg1 = %c0_i32 to %4 step %c1_i32 iter_args(%arg2 = %c0_i32, %arg3 = %cst, %arg4 = %true, %arg5 = %0, %arg6 = %1, %arg7 = %2, %arg8 = %true) -> (i32, f32, i1, i32, f32, i1, i1)  : i32 {
-// CHECK-NEXT:         %6:4 = scf.if %arg8 -> (i32, f32, i1, i1) {
-// CHECK-NEXT:           %10 = arith.addi %arg2, %c1_i32 : i32
-// CHECK-NEXT:           %11 = "test.something"() : () -> i1
-// CHECK-NEXT:           %12 = arith.addf %arg3, %cst_0 : f32
-// CHECK-NEXT:           scf.yield %10, %12, %11, %arg4 : i32, f32, i1, i1
-// CHECK-NEXT:         } else {
-// CHECK-NEXT:           scf.yield %arg5, %arg6, %arg7, %false : i32, f32, i1, i1
-// CHECK-NEXT:         }
-// CHECK-NEXT:         %7 = arith.cmpi slt, %arg1, %arg0 : i32
-// CHECK-NEXT:         %8 = arith.andi %7, %6#3 : i1
-// CHECK-NEXT:         %9:3 = scf.if %8 -> (i32, f32, i1) {
-// CHECK-NEXT:           scf.yield %6#0, %6#1, %6#2 : i32, f32, i1
-// CHECK-NEXT:         } else {
-// CHECK-NEXT:           scf.yield %0, %1, %2 : i32, f32, i1
-// CHECK-NEXT:         }
-// CHECK-NEXT:         scf.yield %9#0, %9#1, %9#2, %6#0, %6#1, %6#2, %6#3 : i32, f32, i1, i32, f32, i1, i1
+// CHECK-NEXT:   func.func @do_while(%arg0: i32) -> (i32, f32) {
+// CHECK-NEXT:     %false = arith.constant false
+// CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f32
+// CHECK-NEXT:     %cst_0 = arith.constant 1.000000e+00 : f32
+// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:     %true = arith.constant true
+// CHECK-NEXT:     %0 = ub.poison : i32
+// CHECK-NEXT:     %1 = ub.poison : f32
+// CHECK-NEXT:     %2 = ub.poison : i1
+// CHECK-NEXT:     %3 = arith.maxsi %arg0, %c0_i32 : i32
+// CHECK-NEXT:     %4 = arith.addi %3, %c1_i32 : i32
+// CHECK-NEXT:     %5:7 = scf.for %arg1 = %c0_i32 to %4 step %c1_i32 iter_args(%arg2 = %c0_i32, %arg3 = %cst, %arg4 = %true, %arg5 = %0, %arg6 = %1, %arg7 = %2, %arg8 = %true) -> (i32, f32, i1, i32, f32, i1, i1)  : i32 {
+// CHECK-NEXT:       %6:4 = scf.if %arg8 -> (i32, f32, i1, i1) {
+// CHECK-NEXT:         %10 = arith.addi %arg2, %c1_i32 : i32
+// CHECK-NEXT:         %11 = "test.something"() : () -> i1
+// CHECK-NEXT:         %12 = arith.addf %arg3, %cst_0 : f32
+// CHECK-NEXT:         scf.yield %10, %12, %11, %arg4 : i32, f32, i1, i1
+// CHECK-NEXT:       } else {
+// CHECK-NEXT:         scf.yield %arg5, %arg6, %arg7, %false : i32, f32, i1, i1
 // CHECK-NEXT:       }
-// CHECK-NEXT:       return %5#3, %5#4 : i32, f32
+// CHECK-NEXT:       %7 = arith.cmpi slt, %arg1, %arg0 : i32
+// CHECK-NEXT:       %8 = arith.andi %7, %6#3 : i1
+// CHECK-NEXT:       %9:3 = scf.if %8 -> (i32, f32, i1) {
+// CHECK-NEXT:         scf.yield %6#0, %6#1, %6#2 : i32, f32, i1
+// CHECK-NEXT:       } else {
+// CHECK-NEXT:         scf.yield %0, %1, %2 : i32, f32, i1
+// CHECK-NEXT:       }
+// CHECK-NEXT:       scf.yield %9#0, %9#1, %9#2, %6#0, %6#1, %6#2, %6#3 : i32, f32, i1, i32, f32, i1, i1
 // CHECK-NEXT:     }
+// CHECK-NEXT:     return %5#3, %5#4 : i32, f32
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/test/lit_tests/canonicalizefor/doWhile2.mlir
+++ b/test/lit_tests/canonicalizefor/doWhile2.mlir
@@ -19,14 +19,15 @@ module @simple{
   }
 }
 
-// CHECK:  func.func @do_while(%arg0: f64) -> (index, f64) {
-// CHECK-DAG:    %c1 = arith.constant 1 : index
-// CHECK-DAG:    %c6 = arith.constant 6 : index
-// CHECK-DAg:    %0 = ub.poison : index
-// CHECK-NEXT:    %1 = scf.for %arg1 = %c1 to %c6 step %c1 iter_args(%arg2 = %0) -> (index) {
-// CHECK-NEXT:      %[[iv:.+]] = arith.subi %arg1, %c1 : inde
-// CHECK-NEXT:      "before.keepalive"(%[[iv]]) : (index) -> ()
-// CHECK-NEXT:      scf.yield %arg1 : index
-// CHECK-NEXT:    }
-// CHECK-NEXT:    return %1, %arg0 : index, f64
-// CHECK-NEXT:  }
+// CHECK-LABEL: module @simple {
+// CHECK-NEXT:   func.func @do_while(%arg0: f64) -> (index, f64) {
+// CHECK-NEXT:     %c1 = arith.constant 1 : index
+// CHECK-NEXT:     %c6 = arith.constant 6 : index
+// CHECK-NEXT:     %c5 = arith.constant 5 : index
+// CHECK-NEXT:     scf.for %arg1 = %c1 to %c6 step %c1 {
+// CHECK-NEXT:       %0 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:       "before.keepalive"(%0) : (index) -> ()
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %c5, %arg0 : index, f64
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/lit_tests/canonicalizefor/for_iv_result.mlir
+++ b/test/lit_tests/canonicalizefor/for_iv_result.mlir
@@ -1,0 +1,45 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for --split-input-file | FileCheck %s
+
+// Inside the body, an iter arg whose yield is the induction variable is the
+// previous iteration's IV -- or the init on the first one. With the init at
+// the lower bound the two meet in max(iv - step, lb) with no
+// first-iteration test, and the iter arg itself then goes away.
+
+func.func @body_prev(%n: index, %m: memref<?xindex>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%prev = %c0) -> (index) {
+    memref.store %prev, %m[%i] : memref<?xindex>
+    scf.yield %i : index
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @body_prev
+// CHECK:         scf.for %[[IV:.+]] = %c0 to %arg0 step %c1 {
+// CHECK-NEXT:      %[[PREV:.+]] = arith.subi %[[IV]], %c1 : index
+// CHECK-NEXT:      %[[CLAMP:.+]] = arith.maxsi %[[PREV]], %c0 : index
+// CHECK-NEXT:      memref.store %[[CLAMP]], %{{.+}}[%[[IV]]] : memref<?xindex>
+// CHECK-NEXT:    }
+
+// -----
+
+// An init away from the lower bound keeps a first-iteration select.
+
+func.func @body_prev_offset_init(%n: index, %init: index, %m: memref<?xindex>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%prev = %init) -> (index) {
+    memref.store %prev, %m[%i] : memref<?xindex>
+    scf.yield %i : index
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @body_prev_offset_init
+// CHECK:         scf.for %[[IV:.+]] = %c0 to %arg0 step %c1 {
+// CHECK-DAG:       %[[FIRST:.+]] = arith.cmpi eq, %[[IV]], %c0 : index
+// CHECK-DAG:       %[[PREV:.+]] = arith.subi %[[IV]], %c1 : index
+// CHECK:           %[[SEL:.+]] = arith.select %[[FIRST]], %arg1, %[[PREV]] : index
+// CHECK-NEXT:      memref.store %[[SEL]], %{{.+}}[%[[IV]]] : memref<?xindex>
+// CHECK-NEXT:    }

--- a/test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir
+++ b/test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir
@@ -65,9 +65,10 @@ func.func @trip_count_exit(%p: i1) -> i64 {
 // Without an extra condition the loop can only exit by trip count, but the
 // result is still the failing evaluation's view: counting 0, 1, 2 against a
 // bound of 3 hands out 3, the value the comparison rejected, not 2, the last
-// the body saw. The before region being just the comparison, the extra
-// iteration costs no more than a bound one past the comparison's, clamped so
-// the zero-trip loop still returns its init.
+// the body saw. The extra iteration is a bound one past the comparison's,
+// clamped for the zero-trip case -- and with nothing else observable the
+// loop then folds away: the result of a for yielding its own induction
+// variable is the last executed IV in closed form, max(ub, 0) here.
 
 func.func @no_extra_condition(%ub: i64) -> i64 {
   %c0 = arith.constant 0 : i64
@@ -86,13 +87,9 @@ func.func @no_extra_condition(%ub: i64) -> i64 {
 // CHECK-LABEL:   func.func @no_extra_condition(
 // CHECK-SAME:                                  %[[UB:.*]]: i64) -> i64 {
 // CHECK-NEXT:      %[[LB:.*]] = arith.constant 0 : i64
-// CHECK-NEXT:      %[[STEP:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[CLAMP:.*]] = arith.maxsi %[[UB]], %[[LB]] : i64
-// CHECK-NEXT:      %[[PAST:.*]] = arith.addi %[[CLAMP]], %[[STEP]] : i64
-// CHECK-NEXT:      %[[LOOP:.*]] = scf.for %[[I:.*]] = %[[LB]] to %[[PAST]] step %[[STEP]] iter_args(%[[ITER:.*]] = %[[LB]]) -> (i64)  : i64 {
-// CHECK-NEXT:        scf.yield %[[I]] : i64
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return %[[LOOP]] : i64
+// CHECK-NEXT:      %[[LAST:.*]] = arith.maxsi %[[CLAMP]], %[[LB]] : i64
+// CHECK-NEXT:      return %[[LAST]] : i64
 // CHECK-NEXT:    }
 
 // -----

--- a/test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir
+++ b/test/lit_tests/canonicalizefor/while_to_for_final_eval.mlir
@@ -62,9 +62,12 @@ func.func @trip_count_exit(%p: i1) -> i64 {
 
 // -----
 
-// Without an extra condition the loop can only exit by trip count, the before
-// region is just the comparison, and the results are plain block arguments, so
-// no extra iteration is needed.
+// Without an extra condition the loop can only exit by trip count, but the
+// result is still the failing evaluation's view: counting 0, 1, 2 against a
+// bound of 3 hands out 3, the value the comparison rejected, not 2, the last
+// the body saw. The before region being just the comparison, the extra
+// iteration costs no more than a bound one past the comparison's, clamped so
+// the zero-trip loop still returns its init.
 
 func.func @no_extra_condition(%ub: i64) -> i64 {
   %c0 = arith.constant 0 : i64
@@ -84,7 +87,9 @@ func.func @no_extra_condition(%ub: i64) -> i64 {
 // CHECK-SAME:                                  %[[UB:.*]]: i64) -> i64 {
 // CHECK-NEXT:      %[[LB:.*]] = arith.constant 0 : i64
 // CHECK-NEXT:      %[[STEP:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:      %[[LOOP:.*]] = scf.for %[[I:.*]] = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%[[ITER:.*]] = %[[LB]]) -> (i64)  : i64 {
+// CHECK-NEXT:      %[[CLAMP:.*]] = arith.maxsi %[[UB]], %[[LB]] : i64
+// CHECK-NEXT:      %[[PAST:.*]] = arith.addi %[[CLAMP]], %[[STEP]] : i64
+// CHECK-NEXT:      %[[LOOP:.*]] = scf.for %[[I:.*]] = %[[LB]] to %[[PAST]] step %[[STEP]] iter_args(%[[ITER:.*]] = %[[LB]]) -> (i64)  : i64 {
 // CHECK-NEXT:        scf.yield %[[I]] : i64
 // CHECK-NEXT:      }
 // CHECK-NEXT:      return %[[LOOP]] : i64

--- a/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
+++ b/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
@@ -71,9 +71,11 @@ func.func @swap(%n: i32, %x: i32, %y: i32) -> (i32, i32) {
 // The plainest shape of all: the condition forwards the slot itself and the
 // body advances it by one. The result is the failing evaluation's value --
 // count to 3 and the answer is 3, the value the comparison rejected, not 2,
-// the last the body saw. An advancing slot is not exempt: the conversion
-// yields the induction variable, so the result would come out one step short
-// without the widened bound.
+// the last the body saw. An advancing slot is not exempt from the widened
+// bound, and with nothing else observable the loop then folds away entirely:
+// the result of a for that yields its own induction variable is the last
+// executed IV, max(ub - step, lb) here, leaving max(n, 0) -- n counted to,
+// or the init the comparison rejected immediately.
 
 func.func @count(%n: i32) -> i32 {
   %c0 = arith.constant 0 : i32
@@ -90,8 +92,7 @@ func.func @count(%n: i32) -> i32 {
 }
 
 // CHECK-LABEL: func.func @count
+// CHECK-NOT:     scf.for
 // CHECK:         %[[CLAMP:.+]] = arith.maxsi %arg0, %c0_i32 : i32
-// CHECK:         %[[PAST:.+]] = arith.addi %[[CLAMP]], %c1_i32 : i32
-// CHECK:         %[[FOR:.+]] = scf.for %[[IV:.+]] = %c0_i32 to %[[PAST]] step %c1_i32
-// CHECK:           scf.yield %[[IV]] : i32
-// CHECK:         return %[[FOR]] : i32
+// CHECK-NEXT:    %[[LAST:.+]] = arith.maxsi %[[CLAMP]], %c0_i32 : i32
+// CHECK-NEXT:    return %[[LAST]] : i32

--- a/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
+++ b/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
@@ -43,9 +43,9 @@ func.func @popcount_range(%lo: i32, %hi: i32, %bits: i32) -> i32 {
 // are pure passthroughs -- but the loop permutes two slots each iteration, so
 // which evaluation the results come from still matters: for %n = 1 the answer
 // is (%x, %y), taken at the failing evaluation after one swap-back. Only a
-// slot that refills with itself, or advances by a loop-invariant step (whose
-// result ForOpInductionReplacement rewrites in closed form), can do without
-// the extra iteration.
+// value from outside the loop, or a slot that refills with itself, can do
+// without the extra iteration -- even a slot advanced by a loop-invariant
+// step observes the final evaluation, one step past the last the body saw.
 
 func.func @swap(%n: i32, %x: i32, %y: i32) -> (i32, i32) {
   %c0 = arith.constant 0 : i32
@@ -65,3 +65,33 @@ func.func @swap(%n: i32, %x: i32, %y: i32) -> (i32, i32) {
 // CHECK:         %[[MAX:.+]] = arith.maxsi %arg0, %{{.+}} : i32
 // CHECK:         %[[UB:.+]] = arith.addi %[[MAX]], %{{.+}} : i32
 // CHECK:         scf.for %{{.+}} to %[[UB]]
+
+// -----
+
+// The plainest shape of all: the condition forwards the slot itself and the
+// body advances it by one. The result is the failing evaluation's value --
+// count to 3 and the answer is 3, the value the comparison rejected, not 2,
+// the last the body saw. An advancing slot is not exempt: the conversion
+// yields the induction variable, so the result would come out one step short
+// without the widened bound.
+
+func.func @count(%n: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r = scf.while (%i = %c0) : (i32) -> i32 {
+    %cont = arith.cmpi slt, %i, %n : i32
+    scf.condition(%cont) %i : i32
+  } do {
+  ^bb0(%i0: i32):
+    %i2 = arith.addi %i0, %c1 : i32
+    scf.yield %i2 : i32
+  }
+  return %r : i32
+}
+
+// CHECK-LABEL: func.func @count
+// CHECK:         %[[CLAMP:.+]] = arith.maxsi %arg0, %c0_i32 : i32
+// CHECK:         %[[PAST:.+]] = arith.addi %[[CLAMP]], %c1_i32 : i32
+// CHECK:         %[[FOR:.+]] = scf.for %[[IV:.+]] = %c0_i32 to %[[PAST]] step %c1_i32
+// CHECK:           scf.yield %[[IV]] : i32
+// CHECK:         return %[[FOR]] : i32

--- a/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
+++ b/test/lit_tests/canonicalizefor_dowhile_pure_result.mlir
@@ -1,0 +1,67 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for --split-input-file | FileCheck %s
+
+// A do-while's results are the condition args of its final evaluation -- the
+// one whose comparison fails -- so the before region has run once more than
+// the comparison held. The extra iteration was only forced for impure before
+// regions, as if purity made the run unobservable; but the values are what is
+// observed. This loop is MFEM's Mesh::GetNumGeometries after LICM has hoisted
+// the load: counting the set bits of %bits in [%lo, %hi) with a pure body.
+// Converted with a trip count one short, a quadrilateral mesh counted zero
+// geometries and every FiniteElementSpace refused the mesh as unfinalized.
+//
+// The count for lo=2, hi=4 is over g in {2, 3}: two iterations, not one.
+
+func.func @popcount_range(%lo: i32, %hi: i32, %bits: i32) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r:2 = scf.while (%g = %lo, %acc = %c0) : (i32, i32) -> (i32, i32) {
+    %bit0 = arith.shrui %bits, %g : i32
+    %bit = arith.andi %bit0, %c1 : i32
+    %acc2 = arith.addi %bit, %acc : i32
+    %g2 = arith.addi %g, %c1 : i32
+    %cont = arith.cmpi ne, %g2, %hi : i32
+    scf.condition(%cont) %g2, %acc2 : i32, i32
+  } do {
+  ^bb0(%g2: i32, %acc2: i32):
+    scf.yield %g2, %acc2 : i32, i32
+  }
+  return %r#1 : i32
+}
+
+// The upper bound gets the do-while treatment: one past the comparison bound,
+// clamped so at least one iteration runs.
+
+// CHECK-LABEL: func.func @popcount_range
+// CHECK:         %[[LB:.+]] = arith.addi %arg0, %c1_i32 : i32
+// CHECK:         %[[MAX:.+]] = arith.maxsi %arg1, %[[LB]] : i32
+// CHECK:         %[[UB:.+]] = arith.addi %[[MAX]], %c1_i32 : i32
+// CHECK:         scf.for %{{.+}} = %[[LB]] to %[[UB]] step %c1_i32
+
+// -----
+
+// No value here is computed in the before region at all -- the condition args
+// are pure passthroughs -- but the loop permutes two slots each iteration, so
+// which evaluation the results come from still matters: for %n = 1 the answer
+// is (%x, %y), taken at the failing evaluation after one swap-back. Only a
+// slot that refills with itself, or advances by a loop-invariant step (whose
+// result ForOpInductionReplacement rewrites in closed form), can do without
+// the extra iteration.
+
+func.func @swap(%n: i32, %x: i32, %y: i32) -> (i32, i32) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r:3 = scf.while (%i = %c0, %a = %x, %b = %y) : (i32, i32, i32) -> (i32, i32, i32) {
+    %cont = arith.cmpi slt, %i, %n : i32
+    scf.condition(%cont) %i, %b, %a : i32, i32, i32
+  } do {
+  ^bb0(%i0: i32, %b2: i32, %a2: i32):
+    %i2 = arith.addi %i0, %c1 : i32
+    scf.yield %i2, %b2, %a2 : i32, i32, i32
+  }
+  return %r#1, %r#2 : i32, i32
+}
+
+// CHECK-LABEL: func.func @swap
+// CHECK:         %[[MAX:.+]] = arith.maxsi %arg0, %{{.+}} : i32
+// CHECK:         %[[UB:.+]] = arith.addi %[[MAX]], %{{.+}} : i32
+// CHECK:         scf.for %{{.+}} to %[[UB]]


### PR DESCRIPTION
Follow-up to #2794, stacked on it (first commit here is its tip). Once the widened bound makes a converted while hand out the failing evaluation's value, a for-result whose yield is the induction variable itself has a closed form and the loop can fold away entirely.

With a unit step and the iter arg starting at the lower bound — the shape a converted while has — the last executed IV and the zero-trip init meet in `max(ub - step, lb)` with no guard; otherwise it is `lb + ((ub-lb-1) / step) * step` selected against the init on whether the loop ran (the unsigned division is poison-free, so computing it speculatively on the zero-trip path is meaningless but harmless).

`while (i < n) ++i; return i` now folds to `max(n, 0)` with no loop at all — executed via lli: 3 → 3, 0 → 0 — and the pure do-while tests lose their loops the same way (CHECKs regenerated; several now return constants outright). LBM's 10-step adjoint output stays bit-identical through the full raising pipeline and the nested-AD MWE is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD