### PR TITLE
polygeist-mem2reg: a partial-overlap transfer clobbers a cached load

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -695,6 +695,9 @@ public:
     if (lhsStep != ShapedType::kDynamic && lhsStep == rhsStep &&
         (sameExtent || !isDim)) {
       int64_t difference = INT64_MAX;
+      // Which access starts first, so the direct overlap can be judged by the
+      // earlier one's width alone rather than conservatively by both.
+      bool lhsFirst = false;
       if (lhs.type != rhs.type)
         return Match::Maybe;
       switch (lhs.type) {
@@ -705,6 +708,7 @@ public:
           }
           if (auto cst = dyn_cast<AffineConstantExpr>(rhs.aff - lhs.aff)) {
             difference = std::abs(cst.getValue());
+            lhsFirst = cst.getValue() > 0;
           }
         }
         break;
@@ -716,17 +720,23 @@ public:
         if (lhs.idx == rhs.idx) {
           return Match::Exact;
         }
-        difference =
-            (lhs.idx < rhs.idx ? rhs.idx - lhs.idx : lhs.idx - rhs.idx);
+        lhsFirst = lhs.idx < rhs.idx;
+        difference = lhsFirst ? rhs.idx - lhs.idx : lhs.idx - rhs.idx;
         break;
       }
 
       if (difference == INT64_MAX)
         return Match::Maybe;
 
+      // Two accesses conflict if they overlap in any period: across a stride,
+      // into the next period's copy, or directly at the same one. The stride
+      // comparison rules out the former; whether it holds is saved rather than
+      // returned so the direct overlap can be required alongside it.
+      const int64_t origDifference = difference;
+      bool wouldOverflowFromStride = true;
       if (isDim) {
         if (difference < lhsSmallestStride && difference < rhsSmallestStride) {
-          return Match::None;
+          wouldOverflowFromStride = false;
         }
       } else {
         if (sameExtent || (lhsSize && rhsSize)) {
@@ -736,9 +746,30 @@ public:
           }
           if (difference < lhsSmallestStride &&
               difference < rhsSmallestStride) {
-            return Match::None;
+            wouldOverflowFromStride = false;
           }
         }
+      }
+
+      if (!wouldOverflowFromStride) {
+        // No spill across a stride, but the direct overlap at the same period
+        // is still open.
+        bool wouldOverflowNoStride;
+        if (isDim) {
+          // A dimensional difference is already counted in elements, so the
+          // two land on the same one -- and directly overlap -- only when it
+          // is zero.
+          wouldOverflowNoStride = origDifference == 0;
+        } else {
+          // A byte gap has to clear the earlier range's width for it to end
+          // before the later begins; without the widths there is nothing more
+          // to ask and the stride verdict stands.
+          wouldOverflowNoStride =
+              lhsSize && rhsSize &&
+              origDifference < (int64_t)(lhsFirst ? *lhsSize : *rhsSize);
+        }
+        if (!wouldOverflowNoStride)
+          return Match::None;
       }
     }
 
@@ -763,11 +794,18 @@ public:
       return Match::Maybe;
 
     // Lying wholly within is a question of where each lands and how far it
-    // reaches, which needs nothing of how either counts its way there.
-    if (!sameExtent && containedAt)
+    // reaches, which needs nothing of how either counts its way there. It is
+    // a real relationship whether or not the caller wants the offset: hand
+    // that back only when asked, and otherwise report the overlap as Maybe
+    // rather than leaving it to the stride comparison below, which does not
+    // reason about one extent lying inside another.
+    if (!sameExtent)
       if (auto at = containsAt(o, dl)) {
-        *containedAt = *at;
-        return Match::Contains;
+        if (containedAt) {
+          *containedAt = *at;
+          return Match::Contains;
+        }
+        return Match::Maybe;
       }
 
     // Two offsets that both go nowhere name the same place, so what is left is

--- a/test/lit_tests/mem2reg_transfer_partial_overlap.mlir
+++ b/test/lit_tests/mem2reg_transfer_partial_overlap.mlir
@@ -1,0 +1,83 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+// A memcpy whose destination range covers a cached slot from a different
+// starting offset still overwrites it. Here the loads read a[24..32), and the
+// copy fills a[16..32) between them: the second load must not be forwarded to
+// the first -- the copy clobbered those bytes. matches() reported the copy as
+// neither the same slot nor one lying inside the other (None) and, before the
+// overlap check, the clobber was dropped and the stale value forwarded. This
+// is the shape MFEM's collocated-gradient kernel raised into, where the two
+// halves of a shared tile are filled by adjacent copies.
+
+llvm.func @use(f64)
+
+// CHECK-LABEL: llvm.func @partial_overlap_clobber
+llvm.func @partial_overlap_clobber(%src: !llvm.ptr) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %c16 = llvm.mlir.constant(16 : i64) : i64
+  %a = llvm.alloca %c1 x !llvm.array<8 x f64> {alignment = 16 : i64} : (i32) -> !llvm.ptr
+  %at24 = llvm.getelementptr %a[24] : (!llvm.ptr) -> !llvm.ptr, i8
+  %at16 = llvm.getelementptr %a[16] : (!llvm.ptr) -> !llvm.ptr, i8
+  // CHECK: %[[V1:.+]] = llvm.load
+  %v1 = llvm.load %at24 : !llvm.ptr -> f64
+  llvm.call @use(%v1) : (f64) -> ()
+  "llvm.intr.memcpy"(%at16, %src, %c16) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  // The clobber forces a fresh load rather than reusing %[[V1]].
+  // CHECK: %[[V2:.+]] = llvm.load
+  // CHECK: llvm.call @use(%[[V2]])
+  %v2 = llvm.load %at24 : !llvm.ptr -> f64
+  llvm.call @use(%v2) : (f64) -> ()
+  llvm.return
+}
+
+// -----
+
+// A copy that does not reach the slot leaves the cached value alone: filling
+// a[0..16) does not touch a[24..32), so the two loads still fold to one.
+
+llvm.func @use(f64)
+
+// CHECK-LABEL: llvm.func @disjoint_copy_still_forwards
+llvm.func @disjoint_copy_still_forwards(%src: !llvm.ptr) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %c16 = llvm.mlir.constant(16 : i64) : i64
+  %a = llvm.alloca %c1 x !llvm.array<8 x f64> {alignment = 16 : i64} : (i32) -> !llvm.ptr
+  %at24 = llvm.getelementptr %a[24] : (!llvm.ptr) -> !llvm.ptr, i8
+  %at0 = llvm.getelementptr %a[0] : (!llvm.ptr) -> !llvm.ptr, i8
+  // CHECK: %[[V:.+]] = llvm.load
+  %v1 = llvm.load %at24 : !llvm.ptr -> f64
+  llvm.call @use(%v1) : (f64) -> ()
+  "llvm.intr.memcpy"(%at0, %src, %c16) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  // CHECK-NOT: llvm.load
+  // CHECK: llvm.call @use(%[[V]])
+  %v2 = llvm.load %at24 : !llvm.ptr -> f64
+  llvm.call @use(%v2) : (f64) -> ()
+  llvm.return
+}
+
+// -----
+
+// A direct (same-period) overlap, distinct from the partial-overlap above:
+// the load reads [8,16) and the copy fills [12,20), sharing [12,16). This is
+// the k=0 conflict that the stride comparison, on its own, never checked --
+// it only ruled out a spill into the next period.
+
+llvm.func @use(f64)
+
+// CHECK-LABEL: llvm.func @direct_overlap_clobber
+llvm.func @direct_overlap_clobber(%src: !llvm.ptr) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %c8 = llvm.mlir.constant(8 : i64) : i64
+  %a = llvm.alloca %c1 x !llvm.array<8 x f64> {alignment = 16 : i64} : (i32) -> !llvm.ptr
+  %at8 = llvm.getelementptr %a[8] : (!llvm.ptr) -> !llvm.ptr, i8
+  %at12 = llvm.getelementptr %a[12] : (!llvm.ptr) -> !llvm.ptr, i8
+  // CHECK: %[[V1:.+]] = llvm.load
+  %v1 = llvm.load %at8 : !llvm.ptr -> f64
+  llvm.call @use(%v1) : (f64) -> ()
+  "llvm.intr.memcpy"(%at12, %src, %c8) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  // CHECK: %[[V2:.+]] = llvm.load
+  // CHECK: llvm.call @use(%[[V2]])
+  %v2 = llvm.load %at8 : !llvm.ptr -> f64
+  llvm.call @use(%v2) : (f64) -> ()
+  llvm.return
+}


### PR DESCRIPTION
Two flat byte accesses at *different* offsets were compared by `compareIndex`'s stride reasoning, which is meant for dimensions. With no enclosing structure the smallest stride is unbounded, so "the gap is smaller than a stride" held for **every** pair and `compareIndex` returned `Match::None` — *provably disjoint* — for ranges that plainly overlap. A clobber check trusts `None`, so a memcpy whose destination covers a cached load slot from a different starting offset (write `[16,32)` over a load of `[24,32)`) was dropped and the stale value forwarded across the copy.

Two fixes, each correct on its own:
- **`compareIndex`, flat-byte case**: decide disjointness by the ranges, not the (absent) stride — they miss only when the gap is at least as wide as each range (the earlier ends before the later begins).
- **`matches()`**: the `containsAt` check that spots one extent lying inside another was gated on the caller wanting the offset back. It is a real relationship either way; report it (`Contains` with the offset when asked, else `Maybe`) rather than falling through to the stride comparison.

MFEM's collocated-gradient and vector-diffusion PA kernels raised into this shape — halves of a shared tile filled by adjacent copies, read at a spanning offset — and the dropped clobber produced wrong results (`Collocated Derivative Kernels` rel_err ~1 vs 1e-13; `Vector Diffusion Diagonal PA` off by ~400), found running the full serial MFEM suite through the raising path. It reduces to: `load a[24]` · `memcpy a[16..32)` · `load a[24]` — the second load must not reuse the first.

New lit test pins the partial-overlap clobber and a disjoint copy that still forwards; the existing mem2reg tests (and the broader raising/affine/sroa lit set, 198 total) are unaffected, and both MFEM kernels now match their reference.