### PR TITLE
llvm-to-affine-access: carry an alloca's alignment onto the memref

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -272,9 +272,18 @@ convertLLVMAllocaToMemrefAlloca(FromAlloc alloc, RewriterBase &rewriter,
         MemRefLayoutAttrInterface{}, alloc.getType().getMemorySpace());
   }
   Value newAlloc;
-  if constexpr (!inPlace)
-    newAlloc = memref::AllocaOp::create(rewriter, alloc->getLoc(), memrefType);
-  else {
+  if constexpr (!inPlace) {
+    // Carry the allocation's alignment onto the memref: an llvm.alloca is
+    // often over-aligned past its element type (a stack array gets 16 for
+    // vectorization), and a memref.alloca without it falls back to the
+    // element's natural alignment. Lowered back, the under-aligned slot shifts
+    // the frame and leaves an adjacent aligned alloca on a misaligned address.
+    IntegerAttr alignAttr;
+    if (auto al = alloc.getAlignment())
+      alignAttr = rewriter.getI64IntegerAttr(*al);
+    newAlloc = memref::AllocaOp::create(rewriter, alloc->getLoc(), memrefType,
+                                        ValueRange{}, alignAttr);
+  } else {
 
     auto tys = llvm::to_vector(alloc->getResultTypes());
     tys[0] = memrefType;

--- a/test/lit_tests/llvm_to_affine_alloca_alignment.mlir
+++ b/test/lit_tests/llvm_to_affine_alloca_alignment.mlir
@@ -1,0 +1,39 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access --allow-unregistered-dialect --split-input-file | FileCheck %s
+
+// An llvm.alloca is often over-aligned past its element type -- a stack array
+// gets 16 for vectorization. Converting it to a memref.alloca must carry that
+// alignment: without it the memref falls back to the element's natural
+// alignment (4 for i32), and lowered back the under-aligned slot shifts the
+// frame, leaving an adjacent aligned alloca on a misaligned address (an
+// aligned SSE load there faults -- MFEM's NCMesh::CountSplits did).
+
+// CHECK-LABEL: func.func @over_aligned
+func.func @over_aligned() {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %a = llvm.alloca %c1 x !llvm.array<12 x i32> {alignment = 16 : i64} : (i32) -> !llvm.ptr
+  %m = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi32>
+  %i = arith.constant 0 : index
+  %v = memref.load %m[%i] : memref<?xi32>
+  "test.use"(%v) : (i32) -> ()
+  return
+}
+
+// CHECK: memref.alloca() {alignment = 16 : i64} : memref<12xi32>
+
+// -----
+
+// A natural-alignment alloca carries no alignment attribute, so none is added.
+
+// CHECK-LABEL: func.func @natural_aligned
+func.func @natural_aligned() {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %a = llvm.alloca %c1 x !llvm.array<12 x i32> : (i32) -> !llvm.ptr
+  %m = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi32>
+  %i = arith.constant 0 : index
+  %v = memref.load %m[%i] : memref<?xi32>
+  "test.use"(%v) : (i32) -> ()
+  return
+}
+
+// CHECK: memref.alloca() : memref<12xi32>
+// CHECK-NOT: alignment


### PR DESCRIPTION
An `llvm.alloca` is often over-aligned past its element type — clang gives a stack array `align 16` for vectorization even though its element wants only 4. Converting it to a `memref.alloca` dropped that: the new op carried no alignment attribute, so it fell back to the element's natural alignment. Lowered back to an `llvm.alloca` the slot is under-aligned, which shifts the stack frame and leaves an adjacent *still-16-aligned* alloca on an 8-misaligned address — and an aligned SSE load there faults.

MFEM's `NCMesh::CountSplits` hit exactly this: an `int[12]` (align 16) next to an `int[6][2]` (align 16); the first lost its alignment through the round trip (`array<12 x i32> {alignment = 16}` → `memref.alloca() : memref<12xi32>`, no alignment → align 4 when lowered), the second ended up at `rsp+0x48` and the vectorized `movdqa` reading it segfaulted. Found running the full serial MFEM suite through the raising path.

Carry the alignment attribute onto the `memref.alloca`; an alloca with no explicit alignment still gets none (natural). New lit test pins both. The full raising/affine/mem2reg/sroa lit set (204 tests) is unaffected, the MFEM `CountSplits` crash is gone, and LBM's adjoint output stays bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD