### PR TITLE
Carry alloca/access alignment through GPU lowering and delinearization

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1738,6 +1738,8 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
                                     /* memspace */ 5);
         auto newAlloca =
             memref::AllocaOp::create(rewriter, alloca.getLoc(), type);
+        if (auto align = alloca.getAlignment())
+          newAlloca.setAlignment(*align);
         auto cast = memref::CastOp::create(rewriter, alloca.getLoc(),
                                            alloca.getType(), newAlloca);
         it->replaceAllUsesWith(cast);

--- a/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
+++ b/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
@@ -187,14 +187,20 @@ reshapeMemref2(Value memref, ArrayRef<int64_t> shape,
       ainfo.updated_indices.push_back(ainfo.last_dim_key);
       std::reverse(ainfo.updated_indices.begin(), ainfo.updated_indices.end());
       rewriter.setInsertionPoint(load);
-      rewriter.replaceOpWithNewOp<memref::LoadOp>(load, load.getMemref(),
-                                                  ainfo.updated_indices);
+      auto align = load.getAlignment();
+      auto newLoad = rewriter.replaceOpWithNewOp<memref::LoadOp>(
+          load, load.getMemref(), ainfo.updated_indices);
+      if (align)
+        newLoad.setAlignment(*align);
     } else if (auto store = dyn_cast<memref::StoreOp>(ainfo.mOpInst)) {
       ainfo.updated_indices.push_back(ainfo.last_dim_key);
       std::reverse(ainfo.updated_indices.begin(), ainfo.updated_indices.end());
       rewriter.setInsertionPoint(store);
-      rewriter.replaceOpWithNewOp<memref::StoreOp>(
+      auto align = store.getAlignment();
+      auto newStore = rewriter.replaceOpWithNewOp<memref::StoreOp>(
           store, store.getValue(), store.getMemref(), ainfo.updated_indices);
+      if (align)
+        newStore.setAlignment(*align);
     } else {
       llvm_unreachable("unexpected memref access");
     }

--- a/src/enzyme_ad/jax/Passes/ParallelLower.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLower.cpp
@@ -856,6 +856,8 @@ void ParallelLower::runOnOperation() {
               MemRefType::get(alop.getType().getShape(),
                               alop.getType().getElementType(),
                               alop.getType().getLayout(), Attribute()));
+          if (auto align = alop.getAlignment())
+            newAlloca.setAlignment(*align);
           builder.replaceOpWithNewOp<memref::CastOp>(alop, alop.getType(),
                                                      newAlloca);
         }
@@ -869,6 +871,8 @@ void ParallelLower::runOnOperation() {
             builder, alop.getLoc(),
             LLVM::LLVMPointerType::get(alop.getContext(), 0),
             alop.getArraySize());
+        if (auto align = alop.getAlignment())
+          newAlloca.setAlignment(*align);
         builder.replaceOpWithNewOp<LLVM::AddrSpaceCastOp>(alop, PT, newAlloca);
       }
     });
@@ -890,6 +894,8 @@ void ParallelLower::runOnOperation() {
           }
           auto newAlloca = memref::AllocaOp::create(
               builder, alop.getLoc(), MemRefType::get(size, elType));
+          if (auto align = glob.getAlignment())
+            newAlloca.setAlignment(*align);
           sharedmems[glob.getName()] = newAlloca;
         }
         builder.replaceOpWithNewOp<enzymexla::Memref2PointerOp>(

--- a/test/lit_tests/raising/llvm_to_memref_both_delinearize.mlir
+++ b/test/lit_tests/raising/llvm_to_memref_both_delinearize.mlir
@@ -50,7 +50,7 @@ module {
     // CHECK-NEXT:     %c10 = arith.constant 10 : index
     // CHECK-NEXT:     %10 = arith.remui %8, %c10 : index
     // CHECK-NEXT:     %11 = arith.divui %8, %c10 : index
-    // CHECK-NEXT:     %12 = memref.load %9[%11, %10] : memref<100x10xf64, 1>
+    // CHECK-NEXT:     %12 = memref.load %9[%11, %10] {alignment = 8 : i64} : memref<100x10xf64, 1>
     // CHECK-NEXT:     %13 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr<1>) -> memref<100x10xf64, 1>
     // CHECK-NEXT:     %14 = affine.load %13[(%arg2 * 8) floordiv 10, (%arg2 * 8) mod 10] : memref<100x10xf64, 1>
     // CHECK-NEXT:     %15 = arith.cmpi eq, %arg2, %c99 : index

--- a/test/lit_tests/raising/masked_affine_for.mlir
+++ b/test/lit_tests/raising/masked_affine_for.mlir
@@ -88,7 +88,7 @@ module {
 // CHECK-NEXT:      %10 = arith.divui %8, %c2 : index
 // CHECK-NEXT:      %11 = arith.remui %10, %c2 : index
 // CHECK-NEXT:      %12 = arith.divui %10, %c2 : index
-// CHECK-NEXT:      %13 = memref.load %arg1[%12, %11, %9] : memref<2x2x2xf64, 1>
+// CHECK-NEXT:      %13 = memref.load %arg1[%12, %11, %9] {alignment = 8 : i64} : memref<2x2x2xf64, 1>
 // CHECK-NEXT:      %14 = arith.select %2, %cst, %13 {fastmathFlags = #llvm.fastmath<none>} : f64
 // CHECK-NEXT:      %15 = affine.load %arg0[%arg3, %arg4, %arg5] : memref<3x2x2xf64, 1>
 // CHECK-NEXT:      %16 = arith.addf %15, %14 {fastmathFlags = #llvm.fastmath<none>} : f64


### PR DESCRIPTION
An alignment audit prompted by #2817 (an over-aligned alloca lost its alignment when rewritten and faulted under an aligned vector access) found more rewrite sites that build a new memref/LLVM alloc or load/store from an aligned source without carrying the alignment — so the new op falls back to the element's natural alignment, the same fault shape.

- **`ParallelLower.cpp`**: the addrspace-5 → default `memref.alloca` and `llvm.alloca` conversions, and the shared-memory (addrspace 3) global → `memref.alloca`, now forward the source alignment.
- **`ConvertParallelToGPU.cpp`**: the `memref.alloca` memory-space rewrite forwards it.
- **`DelinearizeIndexing.cpp`**: the `memref.load`/`store` rebuild carries the owned alignment (captured before `replaceOpWithNewOp` erases the original).

Each only copies the alignment the source op already had — a no-op where nothing was over-aligned, the missing carry where something was. These live in match-heavy GPU-lowering passes that are hard to isolate in a minimal lit repro; coverage is the raising/GPU-lowering/delinearize lit set (60 tests, unaffected) plus MFEM's GPU-lowering path end-to-end. A companion **draft** PR handles the affine-op sites, which need the upstream affine-alignment attribute (merged to LLVM, not yet in our pinned LLVM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD