### PR TITLE
[DRAFT] Affine alignment via the owned API (carries + discardable migration)

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -1942,19 +1942,18 @@ struct MoveRMWToAffine : public OpRewritePattern<memref::AtomicRMWOp> {
 
 // A rebuilt access keeps everything the old one said about itself. All the
 // discardable attributes ride over as they are. Alignment needs the extra
-// clause only because on memref.load/store it is an inherent attribute, held
-// in properties where getDiscardableAttrs does not see it; going to an affine
-// op, which has no inherent slot for it, it is lifted into the discardable
-// dictionary, where lower-aligned-affine-accesses knows to find it.
+// clause only because it is an inherent attribute held in properties, where
+// getDiscardableAttrs does not see it: it is read off the memref op and set on
+// the affine op's own alignment slot (callers pair load->load, store->store).
 static void copyAccessAttrs(Operation *from, Operation *to) {
   for (NamedAttribute attr : from->getDiscardableAttrs())
     to->setAttr(attr.getName(), attr.getValue());
   if (auto load = dyn_cast<memref::LoadOp>(from)) {
     if (auto align = load.getAlignmentAttr())
-      to->setAttr("alignment", align);
+      cast<affine::AffineLoadOp>(to).setAlignmentAttr(align);
   } else if (auto store = dyn_cast<memref::StoreOp>(from)) {
     if (auto align = store.getAlignmentAttr())
-      to->setAttr("alignment", align);
+      cast<affine::AffineStoreOp>(to).setAlignmentAttr(align);
   }
 }
 
@@ -6133,7 +6132,7 @@ struct FoldAppliesIntoLoad : public OpRewritePattern<memref::LoadOp> {
     for (NamedAttribute attr : attrs)
       newLoad->setAttr(attr.getName(), attr.getValue());
     if (alignAttr)
-      newLoad->setAttr("alignment", alignAttr);
+      newLoad.setAlignmentAttr(alignAttr);
     return success();
   }
 };

--- a/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
+++ b/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
@@ -170,13 +170,19 @@ reshapeMemref2(Value memref, ArrayRef<int64_t> shape,
   for (auto &ainfo : affineAccesses) {
     if (auto load = dyn_cast<AffineLoadOp>(ainfo.access.opInst)) {
       rewriter.setInsertionPoint(load);
-      rewriter.replaceOpWithNewOp<AffineLoadOp>(
+      auto align = load.getAlignment();
+      auto newLoad = rewriter.replaceOpWithNewOp<AffineLoadOp>(
           load, load.getMemref(), ainfo.map, load.getMapOperands());
+      if (align)
+        newLoad.setAlignment(*align);
     } else if (auto store = dyn_cast<AffineStoreOp>(ainfo.access.opInst)) {
       rewriter.setInsertionPoint(store);
-      rewriter.replaceOpWithNewOp<AffineStoreOp>(store, store.getValue(),
-                                                 store.getMemref(), ainfo.map,
-                                                 store.getMapOperands());
+      auto align = store.getAlignment();
+      auto newStore = rewriter.replaceOpWithNewOp<AffineStoreOp>(
+          store, store.getValue(), store.getMemref(), ainfo.map,
+          store.getMapOperands());
+      if (align)
+        newStore.setAlignment(*align);
     } else {
       llvm_unreachable("unexpected affine access");
     }

--- a/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerAlignedAffineAccesses.cpp
@@ -54,20 +54,17 @@ struct LowerAlignedAffineLoad : public OpRewritePattern<affine::AffineLoadOp> {
 
   LogicalResult matchAndRewrite(affine::AffineLoadOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!op->hasAttr("alignment"))
+    if (!op.getAlignment())
       return failure();
     auto indices = expandMap(rewriter, op.getLoc(), op.getAffineMap(),
                              op.getMapOperands());
     auto newLoad =
         memref::LoadOp::create(rewriter, op.getLoc(), op.getMemRef(), indices);
-    // On the affine op the alignment was a discardable attribute; memref.load
-    // owns one, and only the owned one is what its lowering reads.
-    for (NamedAttribute attr : op->getDiscardableAttrs()) {
-      if (attr.getName() == "alignment")
-        newLoad.setAlignmentAttr(cast<IntegerAttr>(attr.getValue()));
-      else
-        newLoad->setAttr(attr.getName(), attr.getValue());
-    }
+    // Both ops own their alignment; carry it across, then the remaining
+    // discardable attributes.
+    newLoad.setAlignmentAttr(op.getAlignmentAttr());
+    for (NamedAttribute attr : op->getDiscardableAttrs())
+      newLoad->setAttr(attr.getName(), attr.getValue());
     rewriter.replaceOp(op, newLoad);
     return success();
   }
@@ -79,19 +76,16 @@ struct LowerAlignedAffineStore
 
   LogicalResult matchAndRewrite(affine::AffineStoreOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!op->hasAttr("alignment"))
+    if (!op.getAlignment())
       return failure();
     auto indices = expandMap(rewriter, op.getLoc(), op.getAffineMap(),
                              op.getMapOperands());
     auto newStore = memref::StoreOp::create(
         rewriter, op.getLoc(), op.getValueToStore(), op.getMemRef(), indices);
     // See LowerAlignedAffineLoad.
-    for (NamedAttribute attr : op->getDiscardableAttrs()) {
-      if (attr.getName() == "alignment")
-        newStore.setAlignmentAttr(cast<IntegerAttr>(attr.getValue()));
-      else
-        newStore->setAttr(attr.getName(), attr.getValue());
-    }
+    newStore.setAlignmentAttr(op.getAlignmentAttr());
+    for (NamedAttribute attr : op->getDiscardableAttrs())
+      newStore->setAttr(attr.getName(), attr.getValue());
     rewriter.replaceOp(op, newStore);
     return success();
   }

--- a/src/enzyme_ad/jax/Passes/ParallelLower.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLower.cpp
@@ -976,8 +976,11 @@ void ParallelLower::runOnOperation() {
                                                    storeOp.getMapOperands());
         indices.push_back(apply->getResult(0));
       }
-      builder.replaceOpWithNewOp<memref::StoreOp>(storeOp, storeOp.getValue(),
-                                                  storeOp.getMemref(), indices);
+      auto align = storeOp.getAlignment();
+      auto newStore = builder.replaceOpWithNewOp<memref::StoreOp>(
+          storeOp, storeOp.getValue(), storeOp.getMemref(), indices);
+      if (align)
+        newStore.setAlignment(*align);
     });
 
     container.walk([&](affine::AffineLoadOp storeOp) {
@@ -990,8 +993,11 @@ void ParallelLower::runOnOperation() {
                                                    storeOp.getMapOperands());
         indices.push_back(apply->getResult(0));
       }
-      builder.replaceOpWithNewOp<memref::LoadOp>(storeOp, storeOp.getMemref(),
-                                                 indices);
+      auto align = storeOp.getAlignment();
+      auto newLoad = builder.replaceOpWithNewOp<memref::LoadOp>(
+          storeOp, storeOp.getMemref(), indices);
+      if (align)
+        newLoad.setAlignment(*align);
     });
     builder.eraseOp(launchOp);
   }

--- a/src/enzyme_ad/jax/Passes/RemoveAtomics.cpp
+++ b/src/enzyme_ad/jax/Passes/RemoveAtomics.cpp
@@ -508,6 +508,8 @@ void convertRmw(enzyme::AffineAtomicRMWOp rmw) {
   OpBuilder b(rmw);
   auto read = affine::AffineLoadOp::create(b, rmw.getLoc(), rmw.getMemref(),
                                            rmw.getMap(), rmw.getIndices());
+  if (auto align = rmw.getAlignment())
+    read.setAlignment(*align);
 
   mlir::Value modify;
   switch (rmw.getKind()) {
@@ -571,8 +573,10 @@ void convertRmw(enzyme::AffineAtomicRMWOp rmw) {
           iface.getFastMathAttrName(),
           arith::FastMathFlagsAttr::get(rmw.getContext(), rmw.getFastmath()));
 
-  affine::AffineStoreOp::create(b, rmw.getLoc(), modify, rmw.getMemref(),
-                                rmw.getMap(), rmw.getIndices());
+  auto write = affine::AffineStoreOp::create(
+      b, rmw.getLoc(), modify, rmw.getMemref(), rmw.getMap(), rmw.getIndices());
+  if (auto align = rmw.getAlignment())
+    write.setAlignment(*align);
   rmw.getResult().replaceAllUsesWith(read);
   rmw.erase();
 }


### PR DESCRIPTION
**Draft — blocked on the LLVM affine-alignment rebase.** `affine.load`/`affine.store` do not carry an owned `alignment` in our pinned LLVM yet (the upstream affine-alignment interface is merged but not in our pin), so `getAlignment()`/`setAlignment()`/`getAlignmentAttr()`/`setAlignmentAttr()` on affine ops does not compile here. Opened to track the sites; lands after the rebase.

Two parts, same defect/theme as the merged/queued memref/LLVM carries (#2817, #2818, Enzyme #3115/#3116):

**1. New carries** — rewrites that dropped alignment entirely now forward it via the owned API:
- `DelinearizeIndexing.cpp`: the `affine.load`/`store` rebuild carries `getAlignment()`.
- `ParallelLower.cpp`: the affine→memref lowering forwards the affine source's alignment onto the new `memref` op.
- `RemoveAtomics.cpp`: the affine load/store built from an `AffineAtomicRMWOp` carries `rmw.getAlignment()`.

**2. Discardable → owned migration** — with affine ops owning alignment, the discardable `"alignment"` attribute round-trip is replaced by the op's own slot:
- `AffineCFG.cpp`: `copyAccessAttrs` / `MoveLoadToAffine` set the new affine op's owned alignment (`setAlignmentAttr`) instead of a discardable `"alignment"`.
- `LowerAlignedAffineAccesses.cpp`: reads the affine op's owned alignment rather than the discardable attribute; once standard affine lowering carries owned alignment this pass may be removable entirely.

**Latent, not handled** (no site attaches alignment to affine *vector* ops today): the `AffineVectorLoad/Store` fixups in `AffineCFG.cpp` and `LLVMToAffineAccess.cpp`.

Mark ready once the LLVM pin has affine alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
