### PR TITLE
Add a ROCm backend to lower-kernel/lower-jit

### DIFF
--- a/src/enzyme_ad/jax/Passes/LowerJIT.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerJIT.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/Pipelines/Passes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/PassManager.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -55,6 +56,7 @@
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
 #include "mlir/Conversion/GPUCommon/GPUCommonPass.h"
 #include "mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h"
+#include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
 #include "mlir/Conversion/IndexToLLVM/IndexToLLVM.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
@@ -193,6 +195,61 @@ void buildLowerToNVVMPassPipeline(
   pm.addPass(createArithToLLVMConversionPass());
 
   // Host post-GPUModule-specific stuff
+  buildHostPostPipeline(pm, options, toolkitPath, linkFiles);
+}
+
+// ROCm analogue of buildCommonPassPipeline. The options struct is reused for
+// its target strings: cubinTriple/cubinChip/cubinFeatures carry the amdgcn
+// triple, gfx chip, and LLVM target features respectively.
+void buildCommonPassPipelineROCDL(
+    OpPassManager &pm, const mlir::gpu::GPUToNVVMPipelineOptions &options) {
+  pm.addPass(createGpuKernelOutliningPass());
+  pm.addPass(createConvertVectorToSCFPass());
+  pm.addPass(createSCFToControlFlowPass());
+  pm.addPass(createConvertFuncToLLVMPass());
+  pm.addPass(memref::createExpandStridedMetadataPass());
+
+  GpuROCDLAttachTargetOptions rocdlTargetOptions;
+  rocdlTargetOptions.triple = options.cubinTriple;
+  rocdlTargetOptions.chip = options.cubinChip;
+  rocdlTargetOptions.features = options.cubinFeatures;
+  rocdlTargetOptions.optLevel = options.optLevel;
+  pm.addPass(createGpuROCDLAttachTarget(rocdlTargetOptions));
+  pm.addPass(createLowerAffinePass());
+  ConvertIndexToLLVMPassOptions convertIndexToLLVMPassOpt;
+  convertIndexToLLVMPassOpt.indexBitwidth = options.indexBitWidth;
+  pm.addPass(createConvertIndexToLLVMPass(convertIndexToLLVMPassOpt));
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+}
+
+// ROCm analogue of buildGpuPassPipeline.
+void buildGpuPassPipelineROCDL(
+    OpPassManager &pm, const mlir::gpu::GPUToNVVMPipelineOptions &options) {
+  pm.addNestedPass<gpu::GPUModuleOp>(createStripDebugInfoPass());
+  pm.addNestedPass<gpu::GPUModuleOp>(createSCFToControlFlowPass());
+  ConvertGpuOpsToROCDLOpsOptions opt;
+  opt.chipset = options.cubinChip;
+  opt.useBarePtrCallConv = options.kernelUseBarePtrCallConv;
+  opt.indexBitwidth = options.indexBitWidth;
+  opt.runtime = gpu::amd::Runtime::HIP;
+  pm.addNestedPass<gpu::GPUModuleOp>(createConvertGpuOpsToROCDLOps(opt));
+  pm.addNestedPass<gpu::GPUModuleOp>(createCanonicalizerPass());
+  pm.addNestedPass<gpu::GPUModuleOp>(createCSEPass());
+  pm.addNestedPass<gpu::GPUModuleOp>(createReconcileUnrealizedCastsPass());
+}
+
+// ROCm analogue of buildLowerToNVVMPassPipeline. The host-post pipeline is
+// shared: gpu-module-to-binary picks the serialization backend from the
+// #rocdl.target attribute attached above (toolkitPath must point at ROCm for
+// the device-library link).
+void buildLowerToROCDLPassPipeline(
+    OpPassManager &pm, const GPUToNVVMPipelineOptions &options,
+    std::string toolkitPath,
+    const llvm::SmallVectorImpl<std::string> &linkFiles) {
+  buildCommonPassPipelineROCDL(pm, options);
+  buildGpuPassPipelineROCDL(pm, options);
+  pm.addPass(createArithToLLVMConversionPass());
   buildHostPostPipeline(pm, options, toolkitPath, linkFiles);
 }
 
@@ -433,7 +490,13 @@ void rewriteKernelCallABI(
     const std::string &cubinTriple, const std::string &cubinChip,
     const std::string &cubinFeatures, const std::string &cubinFormat,
     int cuOptLevel, const std::string &toolkitPath,
-    const llvm::SmallVectorImpl<std::string> &linkFiles) {
+    const llvm::SmallVectorImpl<std::string> &linkFiles, bool useRocm) {
+  // The HIP module API mirrors the CUDA driver API symbol-for-symbol with
+  // identical argument layouts, so the generated calls differ only by name.
+  const char *modLoadName = useRocm ? "hipModuleLoadData" : "cuModuleLoadData";
+  const char *launchName = useRocm ? "hipModuleLaunchKernel" : "cuLaunchKernel";
+  const char *funcLoadName =
+      useRocm ? "hipModuleGetFunction" : "cuModuleGetFunction";
   OpBuilder builder(submod);
 
   builder.setInsertionPointToStart(&submod.getBodyRegion().front());
@@ -446,7 +509,7 @@ void rewriteKernelCallABI(
   mlir::Type cumodtys[] = {ptrty, ptrty};
   auto modload_ty = LLVM::LLVMFunctionType::get(i32, cumodtys);
   LLVM::LLVMFuncOp modload =
-      LLVM::LLVMFuncOp::create(builder, loc, "cuModuleLoadData", modload_ty);
+      LLVM::LLVMFuncOp::create(builder, loc, modLoadName, modload_ty);
 
   mlir::Type cutys[] = {ptrty, idx, idx,   idx,   idx,  idx,
                         idx,   i32, ptrty, ptrty, ptrty};
@@ -455,13 +518,13 @@ void rewriteKernelCallABI(
   mlir::Type curesulttys[] = {i32};
   auto curesult_handler_ty = LLVM::LLVMFunctionType::get(voidty, curesulttys);
   LLVM::LLVMFuncOp launch =
-      LLVM::LLVMFuncOp::create(builder, loc, "cuLaunchKernel", launch_ty);
+      LLVM::LLVMFuncOp::create(builder, loc, launchName, launch_ty);
   auto cusync_ty = LLVM::LLVMFunctionType::get(i32, {ptrty});
 
   mlir::Type cufunctys[] = {ptrty, ptrty, ptrty};
   auto funcload_ty = LLVM::LLVMFunctionType::get(i32, cufunctys);
-  LLVM::LLVMFuncOp funcload = LLVM::LLVMFuncOp::create(
-      builder, loc, "cuModuleGetFunction", funcload_ty);
+  LLVM::LLVMFuncOp funcload =
+      LLVM::LLVMFuncOp::create(builder, loc, funcLoadName, funcload_ty);
 
   LLVM::GlobalOp kernStr;
   {
@@ -729,17 +792,16 @@ void rewriteKernelCallABI(
   });
 }
 
-CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
-                     FunctionOpInterface op, bool jit,
-                     enzymexla::JITCallOp jcall, bool openmp,
-                     size_t cuResultHandlerPtr, size_t cuStreamSynchronizePtr,
-                     int indexBitWidth, const std::string &cubinTriple,
-                     const std::string &cubinChip,
-                     const std::string &cubinFeatures,
-                     const std::string &cubinFormat, int cuOptLevel,
-                     const std::string &toolkitPath,
-                     const llvm::SmallVectorImpl<std::string> &linkFiles,
-                     bool debug, bool returnPtr, bool dump_final_module) {
+CallInfo
+CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
+            FunctionOpInterface op, bool jit, enzymexla::JITCallOp jcall,
+            bool openmp, const std::string &backend, size_t cuResultHandlerPtr,
+            size_t cuStreamSynchronizePtr, int indexBitWidth,
+            const std::string &cubinTriple, const std::string &cubinChip,
+            const std::string &cubinFeatures, const std::string &cubinFormat,
+            int cuOptLevel, const std::string &toolkitPath,
+            const llvm::SmallVectorImpl<std::string> &linkFiles, bool debug,
+            bool returnPtr, bool dump_final_module) {
 
   OpBuilder builder(op);
 
@@ -962,16 +1024,31 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
               StringAttr::get(gmod.getContext(), str.substr(0, 200)),
               gmod.getKernel().getNestedReferences()));
       });
+      bool useRocm = backend == "rocm";
       mlir::gpu::GPUToNVVMPipelineOptions options;
       options.indexBitWidth = indexBitWidth;
       options.cubinTriple = cubinTriple;
       options.cubinChip = cubinChip;
       options.cubinFeatures = cubinFeatures;
+      // The pass options default to CUDA values; when targeting ROCm,
+      // substitute amdgcn equivalents for any the caller left at those
+      // defaults.
+      if (useRocm) {
+        if (StringRef(cubinTriple).starts_with("nvptx"))
+          options.cubinTriple = "amdgcn-amd-amdhsa";
+        if (StringRef(cubinChip).starts_with("sm_"))
+          options.cubinChip = "gfx90a";
+        if (StringRef(cubinFeatures).starts_with("+ptx"))
+          options.cubinFeatures = "";
+      }
       options.cubinFormat = cubinFormat;
       options.optLevel = cuOptLevel;
       options.kernelUseBarePtrCallConv = false;
       options.hostUseBarePtrCallConv = false;
-      buildLowerToNVVMPassPipeline(pm, options, toolkitPath, linkFiles);
+      if (useRocm)
+        buildLowerToROCDLPassPipeline(pm, options, toolkitPath, linkFiles);
+      else
+        buildLowerToNVVMPassPipeline(pm, options, toolkitPath, linkFiles);
       if (numGPUModule != 1) {
         llvm::errs() << " only single gpu module calls supported atm\n";
         submod.erase();
@@ -985,7 +1062,8 @@ CallInfo CompileCall(SymbolTableCollection &symbolTable, mlir::Location loc,
       rewriteKernelCallABI(submod, loc, legalName, debug, jcall, modstr,
                            cuResultHandlerPtr, cuStreamSynchronizePtr,
                            indexBitWidth, cubinTriple, cubinChip, cubinFeatures,
-                           cubinFormat, cuOptLevel, toolkitPath, linkFiles);
+                           cubinFormat, cuOptLevel, toolkitPath, linkFiles,
+                           useRocm);
     }
 
     auto ptr = CompileHostModule(ss.str(), submod, numGPUModule != 0,
@@ -1019,6 +1097,17 @@ struct LowerJITPass
       std::string toolkitPath = "";
       SmallVector<std::string> linkFiles;
       buildLowerToNVVMPassPipeline(pm, options, toolkitPath, linkFiles);
+
+      mlir::gpu::GPUToNVVMPipelineOptions rocdlOptions;
+      rocdlOptions.indexBitWidth = 64;
+      rocdlOptions.cubinTriple = "amdgcn-amd-amdhsa";
+      rocdlOptions.cubinChip = "gfx90a";
+      rocdlOptions.cubinFeatures = "";
+      rocdlOptions.cubinFormat = "bin";
+      rocdlOptions.optLevel = 2;
+      rocdlOptions.kernelUseBarePtrCallConv = false;
+      rocdlOptions.hostUseBarePtrCallConv = false;
+      buildLowerToROCDLPassPipeline(pm, rocdlOptions, toolkitPath, linkFiles);
       /*
       mlir::gpu::GPUToNVVMPipelineOptions options;
       options.indexBitWidth = indexBitWidth;
@@ -1039,7 +1128,8 @@ struct LowerJITPass
                     mlir::math::MathDialect, mlir::memref::MemRefDialect,
                     mlir::scf::SCFDialect, mlir::vector::VectorDialect,
                     mlir::gpu::GPUDialect, mlir::nvgpu::NVGPUDialect,
-                    mlir::NVVM::NVVMDialect, mlir::LLVM::LLVMDialect>();
+                    mlir::NVVM::NVVMDialect, mlir::ROCDL::ROCDLDialect,
+                    mlir::LLVM::LLVMDialect>();
   }
 
   SmallVector<std::string> parseLinkFilesString(StringRef inp) {
@@ -1091,10 +1181,10 @@ struct LowerJITPass
       }
 
       CallInfo cdata = CompileCall(
-          symbolTable, op.getLoc(), fn, jit, op, openmp, cuResultHandlerPtr,
-          cuStreamSynchronizePtr, indexBitWidth, cubinTriple, cubinChip,
-          cubinFeatures, cubinFormat, cuOptLevel, toolkitPath, linkFilesArray,
-          debug, hasReturn, dump_final_module);
+          symbolTable, op.getLoc(), fn, jit, op, openmp, backend,
+          cuResultHandlerPtr, cuStreamSynchronizePtr, indexBitWidth,
+          cubinTriple, cubinChip, cubinFeatures, cubinFormat, cuOptLevel,
+          toolkitPath, linkFilesArray, debug, hasReturn, dump_final_module);
 
       std::string backendinfo((char *)&cdata, sizeof(CallInfo));
       if (jit) {
@@ -1119,7 +1209,7 @@ struct LowerJITPass
       }
 
       Operation *replacement;
-      if (backend == "cuda")
+      if (backend == "cuda" || backend == "rocm")
         replacement = stablehlo::CustomCallOp::create(
             rewriter, op.getLoc(), op.getResultTypes(), op.getInputs(),
             hasReturn

--- a/src/enzyme_ad/jax/Passes/LowerKernel.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerKernel.cpp
@@ -22,6 +22,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -370,6 +371,13 @@ bool CompileCPUKernel(SymbolTableCollection &symbolTable, mlir::Location loc,
     idxOp.replaceAllUsesWith(rep.getResult());
     idxOp.erase();
   });
+  executeRegion->walk([&](ROCDL::BlockIdXOp idxOp) {
+    OpBuilder rewriter(idxOp);
+    auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
+                                            idxOp.getType(), par.getIVs()[0]);
+    idxOp.replaceAllUsesWith(rep.getResult());
+    idxOp.erase();
+  });
   executeRegion->walk([&](NVVM::BlockIdYOp idxOp) {
     OpBuilder rewriter(idxOp);
     auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
@@ -377,7 +385,21 @@ bool CompileCPUKernel(SymbolTableCollection &symbolTable, mlir::Location loc,
     idxOp.replaceAllUsesWith(rep.getResult());
     idxOp.erase();
   });
+  executeRegion->walk([&](ROCDL::BlockIdYOp idxOp) {
+    OpBuilder rewriter(idxOp);
+    auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
+                                            idxOp.getType(), par.getIVs()[1]);
+    idxOp.replaceAllUsesWith(rep.getResult());
+    idxOp.erase();
+  });
   executeRegion->walk([&](NVVM::BlockIdZOp idxOp) {
+    OpBuilder rewriter(idxOp);
+    auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
+                                            idxOp.getType(), par.getIVs()[2]);
+    idxOp.replaceAllUsesWith(rep.getResult());
+    idxOp.erase();
+  });
+  executeRegion->walk([&](ROCDL::BlockIdZOp idxOp) {
     OpBuilder rewriter(idxOp);
     auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
                                             idxOp.getType(), par.getIVs()[2]);
@@ -406,6 +428,13 @@ bool CompileCPUKernel(SymbolTableCollection &symbolTable, mlir::Location loc,
     idxOp.replaceAllUsesWith(rep.getResult());
     idxOp.erase();
   });
+  executeRegion->walk([&](ROCDL::ThreadIdXOp idxOp) {
+    OpBuilder rewriter(idxOp);
+    auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
+                                            idxOp.getType(), par.getIVs()[3]);
+    idxOp.replaceAllUsesWith(rep.getResult());
+    idxOp.erase();
+  });
   executeRegion->walk([&](NVVM::ThreadIdYOp idxOp) {
     OpBuilder rewriter(idxOp);
     auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
@@ -413,7 +442,21 @@ bool CompileCPUKernel(SymbolTableCollection &symbolTable, mlir::Location loc,
     idxOp.replaceAllUsesWith(rep.getResult());
     idxOp.erase();
   });
+  executeRegion->walk([&](ROCDL::ThreadIdYOp idxOp) {
+    OpBuilder rewriter(idxOp);
+    auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
+                                            idxOp.getType(), par.getIVs()[4]);
+    idxOp.replaceAllUsesWith(rep.getResult());
+    idxOp.erase();
+  });
   executeRegion->walk([&](NVVM::ThreadIdZOp idxOp) {
+    OpBuilder rewriter(idxOp);
+    auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
+                                            idxOp.getType(), par.getIVs()[5]);
+    idxOp.replaceAllUsesWith(rep.getResult());
+    idxOp.erase();
+  });
+  executeRegion->walk([&](ROCDL::ThreadIdZOp idxOp) {
     OpBuilder rewriter(idxOp);
     auto rep = arith::IndexCastUIOp::create(rewriter, op.getLoc(),
                                             idxOp.getType(), par.getIVs()[5]);
@@ -490,7 +533,10 @@ struct LowerKernelPass
       }
 
       // Compiled kernel goes here once ready
-      if (backend == "cuda") {
+      // The GPU wrapper built here is target-neutral: it only wraps the
+      // kernel in a gpu.module and a gpu.launch_func for lower-jit to
+      // compile, so ROCm shares the path.
+      if (backend == "cuda" || backend == "rocm") {
         CompileGPUKernel(symbolTable, op.getLoc(), fn, data[1], data[2],
                          data[3], data[4], data[5], data[6], data[7], data[8],
                          data[9], data[10], op);

--- a/src/enzyme_ad/jax/gpu.cc
+++ b/src/enzyme_ad/jax/gpu.cc
@@ -170,4 +170,14 @@ extern "C" MLIR_CAPI_EXPORTED void RegisterEnzymeXLAGPUHandler() {
   xla::ffi::Ffi::RegisterStaticHandler(
       xla::ffi::GetXlaFfiApi(), "enzymexla_compile_gpu_with_error", "CUDA",
       bundle_with_error, /*XLA_FFI_Handler_Traits traits = */ 0);
+
+  // The handler is platform-agnostic (the stream and function handles are
+  // opaque pointers), so the same bundles serve ROCm.
+  xla::ffi::Ffi::RegisterStaticHandler(xla::ffi::GetXlaFfiApi(),
+                                       "enzymexla_compile_gpu", "ROCM", bundle,
+                                       /*XLA_FFI_Handler_Traits traits = */ 0);
+
+  xla::ffi::Ffi::RegisterStaticHandler(
+      xla::ffi::GetXlaFfiApi(), "enzymexla_compile_gpu_with_error", "ROCM",
+      bundle_with_error, /*XLA_FFI_Handler_Traits traits = */ 0);
 }

--- a/test/lit_tests/lowering/rocmjit.mlir
+++ b/test/lit_tests/lowering/rocmjit.mlir
@@ -1,0 +1,43 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(lower-jit{jit=false backend=rocm})" | FileCheck %s
+
+module attributes {gpu.container_module} {
+  gpu.module @gpumod_kern {
+    llvm.func internal unnamed_addr fastcc @throw_boundserror_2676() attributes {dso_local, no_inline, sym_visibility = "private"} {
+      llvm.unreachable
+    }
+    gpu.func @kern(%arg0: !llvm.ptr<1>) kernel {
+      %0 = llvm.mlir.constant(63 : i32) : i32
+      %1 = rocdl.workitem.id.x : i32
+      %2 = llvm.icmp "ugt" %1, %0 : i32
+      llvm.cond_br %2, ^bb2, ^bb1
+    ^bb1:  // pred: ^bb0
+      %3 = llvm.zext %1 : i32 to i64
+      %4 = llvm.getelementptr inbounds %arg0[%3] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i64
+      %5 = llvm.load %4 {alignment = 1 : i64} : !llvm.ptr<1> -> i64
+      %6 = llvm.mul %5, %5 : i64
+      llvm.store %6, %4 {alignment = 1 : i64} : i64, !llvm.ptr<1>
+      gpu.return
+    ^bb2:  // pred: ^bb0
+      llvm.call fastcc @throw_boundserror_2676() : () -> ()
+      gpu.return
+    }
+  }
+  func.func private @kern$call$1(%arg0: !llvm.ptr<1>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c40_i64 = arith.constant 40 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %0 = "enzymexla.get_stream"() : () -> !gpu.async.token
+    %1 = gpu.launch_func async [%0] @gpumod_kern::@kern blocks in (%c1_i64, %c1_i64, %c1_i64) threads in (%c1_i64, %c1_i64, %c40_i64) : i64 dynamic_shared_memory_size %c0_i32 args(%arg0 : !llvm.ptr<1>)
+    return
+  }
+  func.func @main(%arg0: tensor<64xi64>) -> tensor<64xi64> {
+    %0 = enzymexla.jit_call @kern$call$1 (%arg0) {output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 0, operand_tuple_indices = []>], xla_side_effect_free} : (tensor<64xi64>) -> tensor<64xi64>
+    return %0 : tensor<64xi64>
+  }
+}
+
+// CHECK: func.func @main(%arg0: tensor<64xi64>) -> tensor<64xi64> {
+// CHECK-NEXT:    %0 = stablehlo.custom_call @enzymexla_compile_gpu(%arg0) {api_version = 4 : i32, backend_config = {attr = "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"}, output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 0, operand_tuple_indices = []>]} : (tensor<64xi64>) -> tensor<64xi64>
+// CHECK-NEXT:    return %0 : tensor<64xi64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:}


### PR DESCRIPTION
Companion to EnzymeAD/Reactant.jl#3174: that PR makes Reactant hand `lower-jit` a real gfx chip and LLVM target features on ROCm (`cubinChip=gfx950 cubinFeatures=+sramecc,-xnack backend=rocm`); this PR makes enzymexla able to consume them. Until now the native kernel path was NVVM/PTX-only (`GPUToNVVMPipeline` + `GpuNVVMAttachTarget`), so eager kernels on AMD GPUs died deep inside codegen no matter what chip string arrived. Context: [ftynse's gfx950 findings](https://gist.github.com/ftynse/5c3816a1cea5daa7dc189b937b62f9ca), issue 3.

## What's added

- **`buildLowerToROCDLPassPipeline`** — the ROCDL twin of the NVVM pipeline: `GpuROCDLAttachTarget` (triple `amdgcn-amd-amdhsa`) + `convert-gpu-to-rocdl` (`runtime=HIP`). The host-post pipeline is shared; `gpu-module-to-binary` picks the serializer from the attached `#rocdl.target`, with `toolkitPath` pointing at ROCm for the device-library link.
- **`rewriteKernelCallABI`** emits `hipModuleLoadData` / `hipModuleGetFunction` / `hipModuleLaunchKernel` when targeting ROCm. The HIP module API mirrors the CUDA driver API argument-for-argument, so only the symbol names change — grid/block/shmem/stream/params layout is identical.
- **`lower-kernel` accepts `backend=rocm`** (the `gpu.module` wrapper it builds is target-neutral), and `lower-jit`'s custom-call emission treats rocm like cuda, reusing `enzymexla_compile_gpu`. The **XLA FFI handler is registered for the `ROCM` platform** alongside `CUDA` — it only forwards opaque stream/function handles, so the bundles are shared.
- **`CompileCPUKernel`** rewrites the ROCDL workitem/workgroup-id ops next to their NVVM twins, so raised ROCm kernels lower through the CPU path too.
- CUDA-flavored **pass-option defaults** (`nvptx64-nvidia-cuda`, `sm_50`, `+ptx60`) are substituted with amdgcn equivalents when left at their defaults under `backend=rocm`, instead of leaking into the ROCDL target.

## Verification (no AMD GPU available — see caveat)

On a CUDA-only machine, `lower-jit{jit=true backend=rocm cubinFormat=isa}` now runs the **full pipeline**: ROCDL conversion succeeds, `gpu-module-to-binary` serializes real amdgcn ISA (gfx90a) through the in-tree AMDGPU backend, the launch ABI rewrite emits the hip calls, and the host module JITs — failing only at final symbol resolution with

```
JIT session error: Symbols not found: [ hipModuleGetFunction, hipModuleLaunchKernel, hipModuleLoadData ]
```

which is exactly right where no HIP runtime exists. All 34 `test/lit_tests/lowering` tests pass, including the new `rocmjit.mlir` (backend=rocm produces the `enzymexla_compile_gpu` custom call) and the unchanged CUDA/CPU ones.

**Caveat:** the `cubinFormat=bin` HSACO link (device libraries + lld via `toolkitPath`) and an actual launch need real ROCm hardware — cc @ftynse. The Reactant side maps the `hip*` symbols via `EnzymeJaXMapSymbol` in EnzymeAD/Reactant.jl#3174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015drPT8jCwS74HnX6vEBCxz