### PR TITLE
Add enzymexla.math.fmuladd: keep fmuladd's fuse-if-profitable contract through the round trip

### DIFF
--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -1298,6 +1298,31 @@ def ReluOp: EnzymeXLA_Op<"math.relu", [Pure, SameOperandsAndResultType, Elementw
   }];
 }
 
+def FMulAddOp: EnzymeXLA_Op<"math.fmuladd", [Pure, SameOperandsAndResultType, Elementwise]> {
+  let summary = "Multiply-add that may, but need not, be fused";
+
+  let description = [{
+    Carries the semantics of the `llvm.fmuladd` intrinsic through the round
+    trip: compute `a * b + c`, fused into a single rounding only when the
+    target can do so profitably, otherwise as an ordinary multiply and add.
+    This is a *permission* to fuse, unlike `math.fma`, whose single rounding
+    is required and whose honest lowering on a target without FMA units is a
+    libm call. Raised from `llvm.intr.fmuladd`; lowered back to the same.
+  }];
+
+  let arguments = (ins
+    FloatLike:$a,
+    FloatLike:$b,
+    FloatLike:$c
+  );
+
+  let results = (outs FloatLike:$result);
+
+  let assemblyFormat = [{
+    $a `,` $b `,` $c attr-dict `:` type($result)
+  }];
+}
+
 def TGammaOp: EnzymeXLA_Op<"math.tgamma", [Pure, SameOperandsAndResultType, Elementwise]> {
   let summary = "Computes the true gamma function";
 

--- a/src/enzyme_ad/jax/Implementations/EnzymeXLADerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLADerivatives.td
@@ -229,6 +229,16 @@ def : EnzymeXLADerivative<"SincOp", (Op $x),
   (Sinc (Shadow $x))
 >;
 
+// Scalar op from the raised-LLVM path (FloatLike, not tensors), so its
+// adjoints are arith ops -- the same rule as math.fma, whose value it shares.
+def : EnzymeXLADerivative<"FMulAddOp", (Op $x, $y, $z),
+  [
+    (CheckedMulF (DiffeRet), $y),
+    (CheckedMulF (DiffeRet), $x),
+    (DiffeRet)
+  ]
+>;
+
 def CoscDerivTerm : SubRoutine<(Op $diffret, $x),
   (
     Select 

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3103,7 +3103,7 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
   }
 
   // ternary ops
-  if (isa<arith::SelectOp, math::FmaOp>(op)) {
+  if (isa<arith::SelectOp, math::FmaOp, enzymexla::FMulAddOp>(op)) {
     assert(op->getNumOperands() == 3 && op->getNumResults() == 1);
 
     Value a = mapping.lookup(op->getOperand(0)),

--- a/src/enzyme_ad/jax/Passes/ArithRaising.cpp
+++ b/src/enzyme_ad/jax/Passes/ArithRaising.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "src/enzyme_ad/jax/Dialect/Ops.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "src/enzyme_ad/jax/Utils.h"
 #include "xla/mlir_hlo/mhlo/IR/hlo_ops.h"
@@ -287,6 +288,23 @@ struct ArithRaisingPass
       truncOp.erase();
     });
     op->walk([=](math::FmaOp fma) {
+      auto ty = dyn_cast<RankedTensorType>(fma.getResult().getType());
+      if (!use_stablehlo || !ty)
+        return;
+
+      OpBuilder builder(fma);
+      auto res = stablehlo::MulOp::create(builder, fma.getLoc(),
+                                          fma.getOperand(0), fma.getOperand(1));
+      auto res2 = stablehlo::AddOp::create(builder, fma.getLoc(), res,
+                                           fma.getOperand(2));
+      fma.replaceAllUsesWith(res2.getResult());
+      fma.erase();
+    });
+
+    // Same shape as math.fma above. stablehlo has no fused form, so the
+    // separate mul+add is the required lowering for strict fma and the
+    // permitted one for fmuladd alike.
+    op->walk([=](enzymexla::FMulAddOp fma) {
       auto ty = dyn_cast<RankedTensorType>(fma.getResult().getType());
       if (!use_stablehlo || !ty)
         return;

--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -295,6 +295,21 @@ struct Memref2PointerOpLowering
   }
 };
 
+// Back to the intrinsic it was raised from. Not llvm.intr.fma: fmuladd only
+// permits fusing, while fma requires the single rounding, which a target
+// without FMA units honors with a libm call per multiply-add.
+struct FMulAddOpLowering : public ConvertOpToLLVMPattern<enzymexla::FMulAddOp> {
+  using ConvertOpToLLVMPattern<enzymexla::FMulAddOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(enzymexla::FMulAddOp op, OpAdaptor transformed,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<LLVM::FMulAddOp>(
+        op, transformed.getA(), transformed.getB(), transformed.getC());
+    return success();
+  }
+};
+
 struct Pointer2MemrefOpLowering
     : public ConvertOpToLLVMPattern<Pointer2MemrefOp> {
   using ConvertOpToLLVMPattern<Pointer2MemrefOp>::ConvertOpToLLVMPattern;
@@ -368,6 +383,7 @@ void populatePolygeistToLLVMConversionPatterns(LLVMTypeConverter &converter,
   patterns.add<Stream2TokenOpLowering>(converter);
   patterns.add<Memref2PointerOpLowering>(converter);
   patterns.add<Pointer2MemrefOpLowering>(converter);
+  patterns.add<FMulAddOpLowering>(converter);
   // clang-format on
 }
 

--- a/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
+++ b/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/enzyme_ad/jax/Dialect/Dialect.h"
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "src/enzyme_ad/jax/Passes/SelectPatterns.h"
@@ -1254,8 +1255,11 @@ public:
     Value b = op->getOperand(1);
     Value c = op->getOperand(2);
 
-    rewriter.replaceOpWithNewOp<math::FmaOp>(op, op->getResultTypes()[0], a, b,
-                                             c);
+    // Not math.fma: fmuladd only permits fusing, while math.fma requires the
+    // single rounding, which a target without FMA units honors with a libm
+    // call. The strict form still comes from llvm.intr.fma / libm fma().
+    rewriter.replaceOpWithNewOp<enzymexla::FMulAddOp>(
+        op, op->getResultTypes()[0], a, b, c);
     return success();
   }
 };

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -458,6 +458,7 @@ def LibDeviceFuncsRaisingPass : Pass<"libdevice-funcs-raise"> {
   let dependentDialects = [
     "arith::ArithDialect",
     "enzyme::EnzymeDialect",
+    "enzymexla::EnzymeXLADialect",
     "math::MathDialect",
     "gpu::GPUDialect",
   ];

--- a/test/lit_tests/diffrules/enzymexla/fmuladd.mlir
+++ b/test/lit_tests/diffrules/enzymexla/fmuladd.mlir
@@ -1,0 +1,25 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=f outfn= argTys=enzyme_dup,enzyme_dup,enzyme_dup retTys=enzyme_dup mode=ForwardMode" | FileCheck %s --check-prefix=FORWARD
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=f outfn= argTys=enzyme_active,enzyme_active,enzyme_active retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math --canonicalize --cse | FileCheck %s --check-prefix=REVERSE
+
+// d(fmuladd(x, y, z)) = dx*y + x*dy + dz -- the same rule as math.fma, whose
+// value the op shares; only the lowering contract differs.
+
+func.func @f(%x: f64, %y: f64, %z: f64) -> f64 {
+  %r = enzymexla.math.fmuladd %x, %y, %z : f64
+  return %r : f64
+}
+
+// FORWARD:  func.func @f(%arg0: f64, %arg1: f64, %arg2: f64, %arg3: f64, %arg4: f64, %arg5: f64) -> (f64, f64) {
+// FORWARD-NEXT:    %0 = arith.mulf %arg1, %arg2 fastmath<fast> : f64
+// FORWARD-NEXT:    %1 = arith.mulf %arg3, %arg0 fastmath<fast> : f64
+// FORWARD-NEXT:    %2 = arith.addf %0, %1 fastmath<fast> : f64
+// FORWARD-NEXT:    %3 = arith.addf %2, %arg5 fastmath<fast> : f64
+// FORWARD-NEXT:    %4 = enzymexla.math.fmuladd %arg0, %arg2, %arg4 : f64
+// FORWARD-NEXT:    return %4, %3 : f64, f64
+// FORWARD-NEXT:  }
+
+// REVERSE:  func.func @f(%arg0: f64, %arg1: f64, %arg2: f64, %arg3: f64) -> (f64, f64, f64) {
+// REVERSE-NEXT:    %0 = arith.mulf %arg3, %arg1 fastmath<fast> : f64
+// REVERSE-NEXT:    %1 = arith.mulf %arg3, %arg0 fastmath<fast> : f64
+// REVERSE-NEXT:    return %0, %1, %arg3 : f64, f64, f64
+// REVERSE-NEXT:  }

--- a/test/lit_tests/lower_fmuladd.mlir
+++ b/test/lit_tests/lower_fmuladd.mlir
@@ -1,0 +1,27 @@
+// RUN: enzymexlamlir-opt %s --convert-polygeist-to-llvm='backend=cpu' --split-input-file | FileCheck %s
+
+// enzymexla.math.fmuladd lowers back to the intrinsic it was raised from:
+// llvm.intr.fmuladd, which only permits fusing. It must not become
+// llvm.intr.fma, whose required single rounding a target without FMA units
+// honors with a libm call per multiply-add.
+
+// CHECK-LABEL: @permission
+func.func @permission(%a: f64, %b: f64, %c: f64) -> f64 {
+  %r = enzymexla.math.fmuladd %a, %b, %c : f64
+  return %r : f64
+}
+
+// CHECK: llvm.intr.fmuladd(%arg0, %arg1, %arg2) : (f64, f64, f64) -> f64
+// CHECK-NOT: llvm.intr.fma(
+
+// -----
+
+// The strict form stays strict: math.fma still lowers to llvm.intr.fma.
+
+// CHECK-LABEL: @requirement
+func.func @requirement(%a: f64, %b: f64, %c: f64) -> f64 {
+  %r = math.fma %a, %b, %c : f64
+  return %r : f64
+}
+
+// CHECK: llvm.intr.fma(%arg0, %arg1, %arg2) : (f64, f64, f64) -> f64

--- a/test/lit_tests/raising/affine_to_stablehlo_fmuladd.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_fmuladd.mlir
@@ -1,0 +1,25 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --canonicalize --arith-raise --enzyme-hlo-opt=max_constant_expansion=0 | FileCheck %s
+
+// enzymexla.math.fmuladd rides the same route as math.fma: tensorized by the
+// affine raising, then split into multiply+add by arith-raise -- stablehlo has
+// no fused form, which is the required lowering for strict fma and the
+// permitted one for fmuladd alike.
+
+module {
+  func.func @fmuladd(%out: memref<8xf64>, %a: memref<8xf64>, %b: memref<8xf64>, %c: memref<8xf64>) {
+    affine.parallel (%i) = (0) to (8) {
+      %va = affine.load %a[%i] : memref<8xf64>
+      %vb = affine.load %b[%i] : memref<8xf64>
+      %vc = affine.load %c[%i] : memref<8xf64>
+      %r = enzymexla.math.fmuladd %va, %vb, %vc : f64
+      affine.store %r, %out[%i] : memref<8xf64>
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @fmuladd_raised(%arg0: tensor<8xf64>, %arg1: tensor<8xf64>, %arg2: tensor<8xf64>, %arg3: tensor<8xf64>) -> (tensor<8xf64>, tensor<8xf64>, tensor<8xf64>, tensor<8xf64>) {
+// CHECK-NEXT:    %0 = stablehlo.multiply %arg1, %arg2 : tensor<8xf64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %arg3 : tensor<8xf64>
+// CHECK-NEXT:    return %1, %arg1, %arg2, %arg3 : tensor<8xf64>, tensor<8xf64>, tensor<8xf64>, tensor<8xf64>
+// CHECK-NEXT:  }

--- a/test/lit_tests/raising/libdevice_raise.mlir
+++ b/test/lit_tests/raising/libdevice_raise.mlir
@@ -1079,7 +1079,9 @@ module {
   gpu.module @test_module_fmuladd {
     // CHECK-LABEL: @llvm_fmuladd
     llvm.func @llvm_fmuladd(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {
-      // CHECK: math.fma
+      // fmuladd only permits fusing; it must not become the strict math.fma.
+      // CHECK: enzymexla.math.fmuladd
+      // CHECK-NOT: math.fma
       %0 = "llvm.intr.fmuladd"(%arg0, %arg1, %arg2) : (f32, f32, f32) -> f32
       llvm.return %0 : f32
     }


### PR DESCRIPTION
Fixes #2821.

The round trip raised `llvm.intr.fmuladd` to `math.fma` (`libdevice-funcs-raise`) and lowered `math.fma` to `llvm.intr.fma` (upstream `MathToLLVM` via `convert-polygeist-to-llvm`) — a silent semantic **strengthening**. `fmuladd` only *permits* fusing (else an ordinary mul+add); `math.fma`/`llvm.fma` *require* the single rounding, which a target without FMA units honors with a **libm `fma()` call per multiply-add**. On MFEM's dFEM diffusion benchmark (plain `-O3`, no `-mfma`) that put 30–55% of runtime into `__fma_fma3`, blocked SLP vectorization around the 32 calls per quadrature point, and spilled caller-saved xmm registers around each — the ~3× plain-codegen slowdown of #2821.

The math dialect has no permission-form op (`math.fma` documents its lowering is *guaranteed* to produce `llvm.fma`), so this adds one:

- **`enzymexla.math.fmuladd`** (`FloatLike ×3 → FloatLike`, `Pure/SameOperandsAndResultType/Elementwise`), documented as the `fmuladd` contract carried through the round trip.
- **Raise**: `libdevice-funcs-raise` raises `llvm.intr.fmuladd` to it (+ declares the dialect dependency). `llvm.intr.fma` and libm `fma()` still raise to the strict `math.fma` — the previously-conflated distinction is restored.
- **Lower**: `convert-polygeist-to-llvm` lowers it back to `llvm.intr.fmuladd`; `math.fma → llvm.intr.fma` unchanged.
- **Derivative rule** (`EnzymeXLADerivatives.td`): mirrors `math.fma`'s — adjoints `(g·y, g·x, g)` as arith ops; forward from summed reverse. Verified fwd (`ẋy + xẏ + ż`, primal stays fmuladd) and rev.
- **StableHLO paths**: `affine-to-stablehlo` tensorizes it like the other ternary elementwise ops; `arith-raise` splits it into `stablehlo.multiply + add` (stablehlo has no fused form — required for strict fma, permitted for fmuladd alike).

**Results** on the reduced diffusion kernel (`inv`/`transpose`/`det` of a 3×3, plain loop), `objdump` of `kern`:

| | insns | libm fma calls | `mulpd` | stack mem-ops |
|---|---|---|---|---|
| stock `clang -O3` | 167 | 0 | 16 | 2 |
| round trip, before | 260 | **32** | 0 | **133** |
| round trip, **after** | **168** | **0** | **16** | **2** |

Plain codegen returns to parity with stock clang.

Tests: `diffrules/enzymexla/fmuladd.mlir` (fwd+rev), `lower_fmuladd.mlir` (permission → `llvm.intr.fmuladd`, strict `math.fma` → `llvm.intr.fma`), `raising/affine_to_stablehlo_fmuladd.mlir`, and the `libdevice_raise.mlir` expectation updated. Full lit suite 1137/1137. MFEM end-to-end (punit_tests + `bench_dfem_linearized_simple`) rebuild in progress; results to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD