### PR TITLE
__enzyme_autodiff raising: the return is activenoneed, not active

### DIFF
--- a/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
+++ b/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
@@ -435,6 +435,16 @@ public:
     parseEnzymeCall(funcToDiff, operands, arguments, argActivities,
                     retActivities, flags);
 
+    // The call returns the gradients and nothing else: __enzyme_autodiff
+    // never hands back the primal value. An enzyme_active return would claim
+    // a primal among the op's results that the call's result types do not
+    // carry -- everything downstream that walks outputs by activity would
+    // read past the end. The seeded-but-not-returned spelling is
+    // enzyme_activenoneed.
+    for (enzyme::Activity &activity : retActivities)
+      if (activity == enzyme::Activity::enzyme_active)
+        activity = enzyme::Activity::enzyme_activenoneed;
+
     // An active return is differentiated from a seed, and enzyme.autodiff
     // takes one operand for each. __enzyme_autodiff does not name them: the C
     // interface seeds every active return with one, which is what makes its

--- a/test/lit_tests/raising/enzyme_call_raising.mlir
+++ b/test/lit_tests/raising/enzyme_call_raising.mlir
@@ -4,7 +4,11 @@
 // operand for each. __enzyme_autodiff does not name them -- the C interface
 // seeds every active return with one, which is what makes its result the
 // gradient rather than a directional derivative -- so the raising has to say
-// the one itself.
+// the one itself. The call also returns the gradient and nothing else, so the
+// return is enzyme_activenoneed: an enzyme_active return would claim a primal
+// among the op's results that the call's result types do not carry, and
+// everything downstream that walks outputs by activity would read past the
+// end.
 
 module {
   llvm.mlir.global external constant @enzyme_const() : i8
@@ -27,7 +31,7 @@ module {
 // CHECK:         %[[one:.+]] = arith.constant 1.000000e+00 : f64
 // CHECK:         enzyme.autodiff @sq(%arg0, %[[one]])
 // CHECK-SAME:      activity = [#enzyme<activity enzyme_active>]
-// CHECK-SAME:      ret_activity = [#enzyme<activity enzyme_active>]
+// CHECK-SAME:      ret_activity = [#enzyme<activity enzyme_activenoneed>]
 
 // -----
 


### PR DESCRIPTION
The C call returns the gradients and nothing else — `__enzyme_autodiff` never hands back the primal value. Raising its float return as `enzyme_active` claimed a primal among the op's results that the call's result types do not carry, so everything downstream that walks outputs by activity read past the end: `ReverseRetOpt` **segfaulted** in the first canonicalize after raising, on as little as

```c
double square(double x) { return x * x; }
double dsquare(double x) { return __enzyme_autodiff((void*)square, x); }
```

The seeded-but-not-returned spelling is `enzyme_activenoneed`; rewrite the parsed activities the same way the fwddiff raising already rewrites its returns (`active → dup` there). The existing lit test had CHECKed the inconsistent form in.

Verified end to end: the sample compiles at `-O2` through the plugin and prints `dsquare(x) == 2x` exactly. Full lit suite 1137/1137. (The `-g` variant of the same sample additionally needs Enzyme#3117, which teaches AD to step over debug intrinsics.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD