### PR TITLE
llvm-to-affine-access: index access builders by base pointer

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1911,6 +1911,25 @@ convertLLVMToAffineAccess(Operation *op,
   }
 
   IRMapping mapping;
+  // A converted access can be the base pointer of other accesses, whose
+  // builders then need the replacement said to them. Saying it to every
+  // builder for every conversion is quadratic in the number of accesses;
+  // index the builders by base once and tell only the bucket that cares.
+  DenseMap<Value, SmallVector<AffineAccessBuilder *>> buildersByBase;
+  for (auto &aabp : accessBuilders)
+    buildersByBase[aabp->getBase()].push_back(aabp.get());
+  auto replaceBases = [&](Value before, Value after) {
+    auto it = buildersByBase.find(before);
+    if (it == buildersByBase.end())
+      return;
+    SmallVector<AffineAccessBuilder *> moved = std::move(it->second);
+    buildersByBase.erase(it);
+    for (AffineAccessBuilder *a2 : moved)
+      a2->maybeReplaceBase(before, after);
+    auto &dst = buildersByBase[after];
+    dst.append(moved.begin(), moved.end());
+  };
+
   for (auto &aabp : accessBuilders) {
     AffineAccessBuilder &aab = *aabp;
     // TODO add a test where some operations are left illegal
@@ -1972,9 +1991,7 @@ convertLLVMToAffineAccess(Operation *op,
               AffineMap::get(mao.map.getNumDims(), mao.map.getNumSymbols(),
                              expr),
               ic(mao.operands));
-          for (auto &a2 : accessBuilders) {
-            a2->maybeReplaceBase(load, newLoad);
-          }
+          replaceBases(load, newLoad);
           mc.replace(load, newLoad);
           ic.replace(load, newLoad);
           rewriter.replaceOp(load, newLoad);
@@ -1999,9 +2016,7 @@ convertLLVMToAffineAccess(Operation *op,
                                   load.getAddr().getType().getAddressSpace())),
               load.getAddr()),
           idxs);
-      for (auto &a2 : accessBuilders) {
-        a2->maybeReplaceBase(load, newLoad);
-      }
+      replaceBases(load, newLoad);
       mc.replace(load, newLoad);
       ic.replace(load, newLoad);
       rewriter.replaceOp(load, newLoad);


### PR DESCRIPTION
Second fix from the compile-time investigation in #2825 (companion to #2826, independent of it).

A converted access can be the base pointer of other accesses, whose builders need the replacement said to them. The conversion loop said it to **every** builder for **every** conversion — and `maybeReplaceBase` is a single comparison, so this was a full quadratic scan over the access set. `perf` on MFEM's `test_functional_gradient` put **69% of the pass's self time** in this loop: 48s of the 63s pass, the largest pipeline cost left after #2826.

The fix indexes builders by base pointer once and tells only the bucket that cares, moving it under the new base. Same replacements by construction — `maybeReplaceBase` was a no-op for every builder whose base didn't match.

Measured on the same dump: first-run pass time **48s → 6.9s (7×)**. lit suite 1134/1134 (run with this change). Combined with #2826, the full-pipeline replay number will be posted on #2825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD