### PR TITLE
Don't fuse reduce/slice chains through shared intermediates

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -30520,12 +30520,31 @@ private:
       visited.insert(current);
 
       if (auto binaryOp = current.template getDefiningOp<BinaryOpType>()) {
+        // Only fuse through an intermediate that feeds this chain and nothing
+        // else. If it has another user the chain stays live, so the fused
+        // reduce recomputes everything below it rather than reusing it, once
+        // per user. For an accumulator such as
+        //   state_i = state_{i-1} + x[i]; loss += state_i * state_i
+        // every state_i is read by its own multiply, so fusing rewrites each
+        // one into a reduce over a growing prefix and turns O(N) work into
+        // O(N^2). Treat such a value as an opaque leaf instead.
+        if (current != startOp.getResult() && !current.hasOneUse()) {
+          extraValues.push_back(current);
+          continue;
+        }
         worklist.push_back(binaryOp.getLhs());
         worklist.push_back(binaryOp.getRhs());
       } else if (auto reshape =
                      current.template getDefiningOp<stablehlo::ReshapeOp>()) {
         // slice -> reduce -> single insert dim along reduction dim -> ...
         auto [isMatchRRS, infoRRS] = matchReshapeReduceSlice(reshape);
+        // Absorbing a reduce that something else also reads recomputes it, so
+        // only do so when this chain is its sole consumer (see the binary-op
+        // case above).
+        if (isMatchRRS && !current.hasOneUse()) {
+          extraValues.push_back(current);
+          continue;
+        }
         if (isMatchRRS && matchingSourceOperand(slices, infoRRS.sliceOp)) {
           slices.push_back(infoRRS);
         } else {
@@ -30554,6 +30573,14 @@ private:
         }
       } else if (auto reduce =
                      current.template getDefiningOp<stablehlo::ReduceOp>()) {
+        // Same reasoning as above: rolling an existing reduce into a wider one
+        // duplicates its work unless this chain is its only user. This is the
+        // shape a running accumulator takes once earlier iterations have
+        // already been fused.
+        if (!current.hasOneUse()) {
+          extraValues.push_back(current);
+          continue;
+        }
         auto [isMatchRR, infoRR] = matchReduceSlice(reduce);
         if (isMatchRR && matchingSourceOperand(slices, infoRR.sliceOp)) {
           slices.push_back(infoRR);

--- a/test/lit_tests/reduce_slice_fusion_shared_intermediate.mlir
+++ b/test/lit_tests/reduce_slice_fusion_shared_intermediate.mlir
@@ -1,0 +1,58 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// `state_i = state_{i-1} + x[i]` where every `state_i` is also read by its own
+// `multiply`. Fusing the chain into a reduce would rewrite each `state_i` into a
+// reduce over a growing prefix; because the other users keep the chain alive the
+// prefixes are recomputed rather than shared, turning O(N) work into O(N^2).
+// The chain must be left alone.
+
+func.func @shared_intermediate(%x: tensor<4xf32>) -> tensor<f32> {
+  %zero = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+  %s0 = stablehlo.slice %x [0:1] : (tensor<4xf32>) -> tensor<1xf32>
+  %e0 = stablehlo.reshape %s0 : (tensor<1xf32>) -> tensor<f32>
+  %st1 = stablehlo.add %zero, %e0 : tensor<f32>
+  %q1 = stablehlo.multiply %st1, %st1 : tensor<f32>
+  %s1 = stablehlo.slice %x [1:2] : (tensor<4xf32>) -> tensor<1xf32>
+  %e1 = stablehlo.reshape %s1 : (tensor<1xf32>) -> tensor<f32>
+  %st2 = stablehlo.add %st1, %e1 : tensor<f32>
+  %q2 = stablehlo.multiply %st2, %st2 : tensor<f32>
+  %s2 = stablehlo.slice %x [2:3] : (tensor<4xf32>) -> tensor<1xf32>
+  %e2 = stablehlo.reshape %s2 : (tensor<1xf32>) -> tensor<f32>
+  %st3 = stablehlo.add %st2, %e2 : tensor<f32>
+  %q3 = stablehlo.multiply %st3, %st3 : tensor<f32>
+  %s3 = stablehlo.slice %x [3:4] : (tensor<4xf32>) -> tensor<1xf32>
+  %e3 = stablehlo.reshape %s3 : (tensor<1xf32>) -> tensor<f32>
+  %st4 = stablehlo.add %st3, %e3 : tensor<f32>
+  %q4 = stablehlo.multiply %st4, %st4 : tensor<f32>
+  %l1 = stablehlo.add %q1, %q2 : tensor<f32>
+  %l2 = stablehlo.add %l1, %q3 : tensor<f32>
+  %l3 = stablehlo.add %l2, %q4 : tensor<f32>
+  return %l3 : tensor<f32>
+}
+
+// The accumulator chain survives: each step adds one element to the previous
+// state (%8 uses %4, %12 uses %8) rather than re-reducing a growing prefix, so
+// the op count stays linear in the chain length. Fusing the first two elements
+// is fine -- it reads two slices and reduces no existing accumulator.
+
+// CHECK:  func.func @shared_intermediate(%arg0: tensor<4xf32>) -> tensor<f32> {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [0:1] : (tensor<4xf32>) -> tensor<1xf32>
+// CHECK-NEXT:    %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %1 : tensor<f32>
+// CHECK-NEXT:    %3 = stablehlo.slice %arg0 [0:2] : (tensor<4xf32>) -> tensor<2xf32>
+// CHECK-NEXT:    %4 = stablehlo.reduce(%3 init: %cst) applies stablehlo.add across dimensions = [0] : (tensor<2xf32>, tensor<f32>) -> tensor<f32>
+// CHECK-NEXT:    %5 = stablehlo.multiply %4, %4 : tensor<f32>
+// CHECK-NEXT:    %6 = stablehlo.slice %arg0 [2:3] : (tensor<4xf32>) -> tensor<1xf32>
+// CHECK-NEXT:    %7 = stablehlo.reshape %6 : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:    %8 = stablehlo.add %4, %7 : tensor<f32>
+// CHECK-NEXT:    %9 = stablehlo.multiply %8, %8 : tensor<f32>
+// CHECK-NEXT:    %10 = stablehlo.slice %arg0 [3:4] : (tensor<4xf32>) -> tensor<1xf32>
+// CHECK-NEXT:    %11 = stablehlo.reshape %10 : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:    %12 = stablehlo.add %8, %11 : tensor<f32>
+// CHECK-NEXT:    %13 = stablehlo.multiply %12, %12 : tensor<f32>
+// CHECK-NEXT:    %14 = stablehlo.add %2, %5 : tensor<f32>
+// CHECK-NEXT:    %15 = stablehlo.add %14, %9 : tensor<f32>
+// CHECK-NEXT:    %16 = stablehlo.add %15, %13 : tensor<f32>
+// CHECK-NEXT:    return %16 : tensor<f32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Fixes #2830. Also fixes the Reactant-side report, EnzymeAD/Reactant.jl#3166.

### Problem

`ReduceSliceFusionBase` walks a chain of binary ops and folds the slices it finds into a single `reduce`. It descended into nested binary ops and absorbed existing reduces without checking whether those intermediates have other users.

Fusing only pays off when the intermediates die afterwards. When one has an outside user the chain stays live, so the wider reduce recomputes everything below it — once per user. A running accumulator is the worst case:

```
state_i = state_{i-1} + x[i]
loss   += state_i * state_i
```

Every `state_i` is read by its own `multiply`, so each is rewritten into a reduce over a growing prefix instead of reusing the previous state. `O(N)` work becomes `O(N^2)`.

On the 4-element test added here, before this change:

```mlir
%3  = stablehlo.slice %arg0 [0:2] ...
%4  = stablehlo.reduce(%3 init: %cst) applies stablehlo.add ...
%6  = stablehlo.slice %arg0 [0:3] ...
%7  = stablehlo.reduce(%6 init: %cst) applies stablehlo.add ...
%9  = stablehlo.reduce(%arg0 init: %cst) applies stablehlo.add ...
```

`N-1` independent reduces over prefixes, with the original chain still present.

### Fix

Require an intermediate to be single-use before fusing through it. This covers three places in `collectSlicesInChain`:

* the binary-op descent;
* the `ReduceOp` branch;
* the `ReshapeOp` branch when it matches `matchReshapeReduceSlice`.

The reduce cases are the ones that actually bite for this pattern. `state_1 = add(%zero, x[0])` folds away as add-with-zero, so the chain is never add-of-add; what gets absorbed is the reduce produced by the *previous* iteration's fusion. Guarding only the binary-op descent has no effect at all — I tried that first and the output was unchanged.

Plain `slice` leaves are deliberately left unguarded. Re-reading a slice duplicates no computation, so requiring single-use there would only stop the pattern from firing. That is why one reduce legitimately remains in the new test: fusing the first two elements reads two slices and re-reduces nothing.

### Effect

The chain keeps a **single** reduce regardless of length, and later states reuse earlier ones (`%8` uses `%4`, `%12` uses `%8`):

| chain length | reduces before | reduces after |
|---|---|---|
| 4 | 3 | 1 |
| 8 | 7 | 1 |

Chains whose intermediates really are dead still collapse to one reduce — `main_add1` in `elementwise_reduce_slice_fuse.mlir` and `addreduceslicefusion2.mlir` both cover that and still pass, which is the check that this is not just disabling the pattern.

### Testing

New lit test `test/lit_tests/reduce_slice_fusion_shared_intermediate.mlir`, pinning the linear structure rather than merely asserting no reduce appears.

Ran the lit suite with a locally built `enzymexlamlir-opt`: 501 pass, 0 regressions. (Two apparent failures were harness artifacts on my side — one from shell quoting of `--pass-pipeline`, one test needing `stablehlo-translate`, which I had not built; both pass when invoked directly. `while_induction_reduction.mlir` is `XFAIL` upstream.)

End-to-end through Reactant, building its JLL against this branch, on the reproducer from EnzymeAD/Reactant.jl#3166:

| N | reduces | time |
|---|---|---|
| 16 | 1 | 2.74 µs |
| 64 | 1 | 2.75 µs |
| 256 | 1 | 2.88 µs |
| 1024 | 1 | 7.42 µs |
| 2048 | 1 | 36.18 µs |

versus 2.2 / 16.9 / 104.2 / 388.0 / 1070.5 µs reported there, with results unchanged. For reference the issue's control case, a variant of the same loop that never triggered the pattern, was 43.75 µs at N=2048 — so the fixed version is now at parity with code that never hit the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PH4zH9zvavbXWXomJbCq3B
