### PR TITLE
parallel-lower: repair yields whose inlined callee cannot return

### DIFF
--- a/src/enzyme_ad/jax/Passes/ParallelLower.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLower.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -59,6 +60,37 @@ namespace enzyme {
 #include "RuntimeWrapperUtils.h"
 
 #define DEBUG_TYPE "parallel-lower-opt"
+
+// A call wrapped in an execute_region yields the call's results, but when
+// the inlined callee never returns -- an assert or error path ending in a
+// trap -- the yield is left with nothing to forward. Control cannot reach
+// such a yield; say its operands as poison so the op stays consistent.
+// Inlining a callee with no returning path leaves the call's results with
+// nothing to replace them; the yield built to forward them would be erased
+// out from under. Control cannot reach those uses; say them as poison.
+static void poisonRemainingUses(mlir::CallOpInterface caller) {
+  if (caller->use_empty())
+    return;
+  mlir::OpBuilder b(caller);
+  llvm::SmallVector<mlir::Value> vals;
+  for (mlir::Value r : caller->getResults())
+    vals.push_back(
+        mlir::ub::PoisonOp::create(b, caller->getLoc(), r.getType()));
+  caller->replaceAllUsesWith(vals);
+}
+
+static void repairNonReturningYields(mlir::scf::ExecuteRegionOp exOp) {
+  for (mlir::Block &blk : exOp.getRegion()) {
+    auto yield = llvm::dyn_cast<mlir::scf::YieldOp>(blk.getTerminator());
+    if (!yield || yield.getNumOperands() == exOp.getNumResults())
+      continue;
+    mlir::OpBuilder yb(yield);
+    llvm::SmallVector<mlir::Value> vals;
+    for (mlir::Type t : exOp.getResultTypes())
+      vals.push_back(mlir::ub::PoisonOp::create(yb, yield.getLoc(), t));
+    yield->setOperands(vals);
+  }
+}
 
 using namespace mlir;
 using namespace mlir::arith;
@@ -385,9 +417,11 @@ void ParallelLower::runOnOperation() {
     if (inlineCall(interface, cloneCallback, caller, callableOp, targetRegion,
                    /*shouldCloneInlinedRegion=*/true)
             .succeeded()) {
+      poisonRemainingUses(caller);
       caller.erase();
       replacedCallables.insert(callableOp);
     }
+    repairNonReturningYields(exOp);
     b.setInsertionPointToEnd(&allocScope.getRegion().front());
     memref::AllocaScopeReturnOp::create(b, allocScope.getLoc(),
                                         exOp.getResults());
@@ -447,10 +481,12 @@ void ParallelLower::runOnOperation() {
       if (inlineCall(interface, cloneCallback, caller, callableOp, targetRegion,
                      /*shouldCloneInlinedRegion=*/true)
               .succeeded()) {
+        poisonRemainingUses(caller);
         caller.erase();
         replacedCallables.insert(callableOp);
       }
     }
+    repairNonReturningYields(exOp);
     b.setInsertionPointToEnd(&allocScope.getRegion().front());
     memref::AllocaScopeReturnOp::create(b, allocScope.getLoc(),
                                         exOp.getResults());
@@ -488,6 +524,7 @@ void ParallelLower::runOnOperation() {
     ret.erase();
     b.setInsertionPointToEnd(&exOp.getRegion().back());
     scf::YieldOp::create(b, callerLoc, retVals);
+    repairNonReturningYields(exOp);
     b.setInsertionPointToEnd(&allocScope.getRegion().front());
     memref::AllocaScopeReturnOp::create(b, allocScope.getLoc(),
                                         exOp.getResults());
@@ -1110,6 +1147,7 @@ void FixGPUFunc::runOnOperation() {
     if (inlineCall(interface, cloneCallback, caller, callableOp, targetRegion,
                    /*shouldCloneInlinedRegion=*/true)
             .succeeded()) {
+      poisonRemainingUses(caller);
       caller.erase();
     }
   };

--- a/test/lit_tests/parallel-lower-noreturn.mlir
+++ b/test/lit_tests/parallel-lower-noreturn.mlir
@@ -1,0 +1,27 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(parallel-lower)" | FileCheck %s
+
+// The inlined callee holds device intrinsics, so parallel-lower wraps the
+// call in an execute_region that yields the call's results -- but this
+// callee never returns, so inlining leaves those results with nothing to
+// replace them and the yield with nothing to forward. Control cannot reach
+// the yield; its operands are said as poison instead of erasing the call
+// out from under its uses.
+
+module {
+  llvm.func @abort()
+  func.func private @dies() -> i32 {
+    %t = gpu.thread_id x
+    llvm.call @abort() : () -> ()
+    llvm.unreachable
+  }
+  func.func @main() -> i32 {
+    %v = func.call @dies() : () -> i32
+    return %v : i32
+  }
+}
+
+// CHECK-LABEL: func.func @main
+// CHECK: %[[P:.+]] = ub.poison : i32
+// CHECK: scf.execute_region
+// CHECK: llvm.call @abort()
+// CHECK-NEXT: scf.yield %[[P]] : i32


### PR DESCRIPTION
Follow-up to #2829 (these commits landed on that branch after it merged). Root-causes and fixes the remaining MFEM CUDA compile crash, per-review without any LLVM patch:

**Bug**: `parallel-lower`'s GPU-inline wrapping puts a call in an `scf.execute_region` that yields the call's results — but when the inlined callee never returns (an assert/error path that prints and traps, as MFEM's device bounds checks do), the yield is left with nothing to forward: *"region branch point has 0 operands, but region successor needs 1 inputs"*. With pipeline verification off (#2828 default) the malformed op survived until `scf.execute_region`'s inlining canonicalization walked it into upstream's unimplemented `defaultReplBuilderFn` and segfaulted.

**Fix**: control cannot reach such a yield, so its operands are said as poison (`repairNonReturningYields`, applied at all three wrap sites).

**Sixteen-line reproducer** (crashes before, compiles+runs after):
```cuda
#include <cstdio>
__device__ void check(int i, int n) {
  if (i >= n) { printf("out of bounds %d\n", i); __builtin_trap(); }
}
__global__ void fill(int *a, int n) { int i = threadIdx.x; check(i, n); a[i] = i; }
int main() { int *a; cudaMalloc(&a, 128); fill<<<1,32>>>(a, 32); cudaDeviceSynchronize(); }
```

Validated: the reproducer runs, the `__enzyme_autodiff` CUDA MWE still matches LLVM-Enzyme exactly, and MFEM's `sparsemat.cpp` (the TU that surfaced this) compiles. Also adds `REACTANT_DUMP_IMPORTED` for dumping the pipeline's exact input module, which is how this was localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD