### PR TITLE
affine-cfg: never insert index casts after a terminator

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -1146,26 +1146,34 @@ void fully2ComposeIntegerSetAndOperands(
                          map.getResults(), set->getEqFlags());
   for (auto &op : *operands) {
     if (!op.getType().isIndex()) {
-      Operation *toInsert;
-      if (auto *o = op.getDefiningOp())
-        toInsert = o->getNextNode();
-      else {
-        auto BA = cast<BlockArgument>(op);
-        toInsert = &BA.getOwner()->front();
-      }
+      // Insert right after the defining op -- which may be the last in its
+      // block, where getNextNode is null -- or at the top of the block for
+      // an argument. A value defined by a terminator (e.g. llvm.invoke) is
+      // only usable in its successors; inserting after it would place an op
+      // past the terminator and hide its successors from CFG walks.
+      auto setPoint = [&](OpBuilder &b) {
+        if (auto *o = op.getDefiningOp()) {
+          if (o->getNumSuccessors() > 0)
+            b.setInsertionPointToStart(o->getSuccessor(0));
+          else
+            b.setInsertionPointAfter(o);
+        } else
+          b.setInsertionPointToStart(cast<BlockArgument>(op).getOwner());
+      };
 
       if (auto v = indexMap.lookupOrNull(op))
         op = v;
       else {
         if (insertedOps) {
-          OpBuilder builder(toInsert);
+          OpBuilder builder(op.getContext());
+          setPoint(builder);
           auto inserted = IndexCastOp::create(builder, op.getLoc(),
                                               builder.getIndexType(), op);
           op = inserted->getResult(0);
           insertedOps->push_back(inserted);
         } else {
           PatternRewriter::InsertionGuard B(builder);
-          builder.setInsertionPoint(toInsert);
+          setPoint(builder);
           auto inserted = IndexCastOp::create(builder, op.getLoc(),
                                               builder.getIndexType(), op);
           op = inserted->getResult(0);

--- a/test/lit_tests/affinecfg_invoke_operand.mlir
+++ b/test/lit_tests/affinecfg_invoke_operand.mlir
@@ -1,0 +1,34 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+// Raising the scf.if to affine.if composes an integer set over %v, whose
+// non-index type needs an index cast inserted "after its defining op". That
+// op is an llvm.invoke: a terminator. Inserting after it would place the cast
+// past the end of the block, hiding the invoke's successors from CFG walks;
+// region simplification then erased the (live) normal destination and left
+// the invoke with a null successor. The cast belongs at the start of the
+// normal destination instead.
+
+llvm.func @get() -> i64
+llvm.func @pers(i32) -> i32
+
+llvm.func @invoke_operand(%p: !llvm.ptr, %x: f64) attributes {personality = @pers} {
+  %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<16xf64>
+  %v = llvm.invoke @get() to ^bb1 unwind ^bb2 : () -> i64
+^bb1:
+  %c4 = arith.constant 4 : i64
+  %cond = arith.cmpi slt, %v, %c4 : i64
+  scf.if %cond {
+    %i = arith.index_cast %v : i64 to index
+    memref.store %x, %m[%i] : memref<16xf64>
+  }
+  llvm.return
+^bb2:
+  %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @invoke_operand
+// CHECK: %[[V:.+]] = llvm.invoke @get() to ^[[NORMAL:.+]] unwind
+// CHECK: ^[[NORMAL]]:
+// CHECK-NEXT: %[[IDX:.+]] = arith.index_cast %[[V]] : i64 to index
+// CHECK: affine.store %{{.+}}, %{{.+}}[symbol(%[[IDX]])] : memref<16xf64>


### PR DESCRIPTION
Split out of #2832 per review.

`fully2ComposeIntegerSetAndOperands` placed the index cast of a non-index operand directly after its defining op, in two broken ways:
- defining op ends its block → `getNextNode()` is null → `setInsertionPoint(nullptr)` segfault;
- defining op is a result-producing terminator (`llvm.invoke`) → the cast lands past the end of the block, CFG walks stop seeing the invoke's successors, region simplification erases the live normal destination, and the next reachability walk crashes on the null successor.

Insert at the start of the terminator's first successor (the only place an invoke result is usable), or after ordinary defining ops. Found raising MFEM's hybridization_ext.cpp as CUDA; lit test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD