### PR TITLE
convert-parallel-to-gpu: survive kernels without an exact or recorded shape

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -547,8 +547,9 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       curRegion++;
     };
 
+    enzymexla::AlternativesOp alternativesOp = nullptr;
     if (char *blockSizeStr = getenv("POLYGEIST_GPU_KERNEL_BLOCK_SIZE")) {
-      auto alternativesOp = enzymexla::AlternativesOp::create(rewriter, loc, 1);
+      alternativesOp = enzymexla::AlternativesOp::create(rewriter, loc, 1);
       alternativesOp->setAttr("alternatives.type",
                               rewriter.getStringAttr("gpu_kernel"));
       llvm::errs() << "Emitting kernel with " << atoi(blockSizeStr)
@@ -556,15 +557,28 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       emitAlternative(atoi(blockSizeStr), alternativesOp);
       if (curRegion == 0) {
         llvm::errs() << " Failed to make kernel with exact dimension\n";
-        assert(wrapper.getOperands().size() == 6);
-        assert(pop.getUpperBound().size() == 6 &&
-               pop.getUpperBound() == wrapper.getOperands());
-        exactMatch(alternativesOp);
+        if (pop.getUpperBound().size() == 6 &&
+            pop.getUpperBound() == wrapper.getOperands()) {
+          exactMatch(alternativesOp);
+        } else if (pop->hasAttr("enzymexla.kernel_thread_indices")) {
+          // The exact-shape fallback needs the six grid and block bounds;
+          // a collapsed parallel op does not have them, so reproduce the
+          // recorded original block shape instead.
+          emitAlternative(-1, alternativesOp);
+        } else {
+          // No exact shape and no recorded shape: try the alternative
+          // block sizes until one splits.
+          for (unsigned blockSize : ALTERNATIVE_KERNEL_BLOCK_SIZES) {
+            emitAlternative(blockSize, alternativesOp);
+            if (curRegion != 0)
+              break;
+          }
+        }
       }
       alternativesOp->setAttr("alternatives.descs",
                               rewriter.getArrayAttr(descs));
     } else if (shouldEmitAlternatives(pop)) {
-      auto alternativesOp = enzymexla::AlternativesOp::create(
+      alternativesOp = enzymexla::AlternativesOp::create(
           rewriter, loc,
           ALTERNATIVE_KERNEL_BLOCK_SIZES.size() +
               (pop.getUpperBound().size() == 6 &&
@@ -581,14 +595,27 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       }
       alternativesOp->setAttr("alternatives.descs",
                               rewriter.getArrayAttr(descs));
-      shrinkAlternativesOp(alternativesOp, curRegion, rewriter);
+      if (curRegion != 0)
+        shrinkAlternativesOp(alternativesOp, curRegion, rewriter);
     } else {
-      auto alternativesOp = enzymexla::AlternativesOp::create(rewriter, loc, 1);
+      alternativesOp = enzymexla::AlternativesOp::create(rewriter, loc, 1);
       alternativesOp->setAttr("alternatives.type",
                               rewriter.getStringAttr("gpu_kernel"));
       emitAlternative(-1, alternativesOp);
       alternativesOp->setAttr("alternatives.descs",
                               rewriter.getArrayAttr(descs));
+    }
+
+    if (curRegion == 0) {
+      // Nothing split: every candidate block size failed. The regions hold
+      // only the corpses of the failed attempts; drop them and leave the
+      // launch-out-of-resources error the failed splits already stand for.
+      rewriter.eraseOp(alternativesOp);
+      rewriter.setInsertionPoint(wrapper);
+      auto err = arith::ConstantIndexOp::create(
+          rewriter, loc, CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES);
+      rewriter.replaceOp(wrapper, err->getResults());
+      return success();
     }
 
     rewriter.eraseOp(wrapper);
@@ -667,7 +694,10 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       if (maxThreads == -1) {
         auto dea = pop->getAttrOfType<DenseElementsAttr>(
             "enzymexla.kernel_thread_indices");
-        assert(dea);
+        // Without the recorded thread indices there is no original block
+        // shape to reproduce; the caller falls back to a chosen size.
+        if (!dea)
+          return tmp;
         for (auto index_ : dea.getValues<IntegerAttr>()) {
           auto index = index_.getValue().getLimitedValue();
           tmp.push_back(index);

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
@@ -1,0 +1,78 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --split-input-file --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// The requested block size cannot split a parallel op with more than three
+// dynamic dimensions, and this op offers no fallback: its shape is not the
+// six bounds of the wrapper and no original block shape was recorded. Every
+// alternative size fails the same way; the kernel collapses to the
+// launch-out-of-resources error the failed splits stand for, instead of
+// slicing six bounds out of a four-dimensional op.
+
+module {
+  func.func @allfail(%n: index, %m: index, %p: index, %q: index, %out: memref<?xf64>, %v: f64) -> index {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %w = "enzymexla.gpu_wrapper"(%n, %m, %c1, %c1, %c1, %c1) ({
+      scf.parallel (%i, %j, %k, %l) = (%c0, %c0, %c0, %c0) to (%n, %m, %p, %q) step (%c1, %c1, %c1, %c1) {
+        memref.store %v, %out[%i] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return %w : index
+  }
+}
+
+// CHECK-LABEL: func.func @allfail
+// CHECK: %[[ERR:.+]] = arith.constant 701 : index
+// CHECK-NEXT: return %[[ERR]] : index
+
+// -----
+
+// Six bounds matching the wrapper operands exactly: when the requested size
+// fails, the original grid/block split is reproduced verbatim.
+
+module {
+  func.func @exact(%a: index, %b: index, %c: index, %d: index, %out: memref<?xf64>, %v: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %w = "enzymexla.gpu_wrapper"(%a, %b, %c, %d, %a, %b) ({
+      scf.parallel (%i0, %i1, %i2, %i3, %i4, %i5) = (%c0, %c0, %c0, %c0, %c0, %c0) to (%a, %b, %c, %d, %a, %b) step (%c1, %c1, %c1, %c1, %c1, %c1) {
+        memref.store %v, %out[%i0] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @exact(
+// CHECK-SAME: %[[A:[^ :]+]]: index, %[[B:[^ :]+]]: index, %[[C:[^ :]+]]: index, %[[D:[^ :]+]]: index
+// CHECK: enzymexla.alternatives
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[A]], %{{.+}} = %[[B]], %{{.+}} = %[[C]]) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[D]], %{{.+}} = %[[A]], %{{.+}} = %[[B]])
+// CHECK: alternatives.descs = ["block_size=-1,"]
+
+// -----
+
+// No exact shape, but the original block dimensions were recorded: the
+// original block shape is reproduced from the attribute.
+
+module {
+  func.func @recorded(%n: index, %m: index, %p: index, %q: index, %out: memref<?xf64>, %v: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %w = "enzymexla.gpu_wrapper"(%n, %m, %c1, %c1, %c1, %c1) ({
+      scf.parallel (%i, %j, %k, %l) = (%c0, %c0, %c0, %c0) to (%n, %m, %p, %q) step (%c1, %c1, %c1, %c1) {
+        memref.store %v, %out[%i] : memref<?xf64>
+        scf.reduce
+      } {enzymexla.kernel_thread_indices = dense<[2, 3]> : tensor<2xi64>}
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @recorded(
+// CHECK-SAME: %[[N:[^ :]+]]: index, %[[M:[^ :]+]]: index, %[[P:[^ :]+]]: index, %[[Q:[^ :]+]]: index
+// CHECK: enzymexla.alternatives
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[N]], %{{.+}} = %[[M]], %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[P]], %{{.+}} = %[[Q]], %{{.+}} = %{{.+}})


### PR DESCRIPTION
Split out of #2832 per review.

Two compiled-out asserts in the block-size splitting turned into segfaults on MFEM's derefmat_op.cpp compiled as CUDA:
- With `POLYGEIST_GPU_KERNEL_BLOCK_SIZE` set and the requested split failing, the exact-shape fallback sliced six grid and block bounds out of a parallel op that does not have six dimensions.
- Reproducing the original block shape (`maxThreads == -1`) read the `enzymexla.kernel_thread_indices` attribute through an assert.

Guarded chain: exact shape → recorded shape (attribute) → alternative block sizes → if nothing splits, collapse to the launch-out-of-resources error instead of erasing the wrapper out from under its uses. Lit test covers all three fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD