### PR TITLE
strip-gpu-info: sweep host-side device residue

### DIFF
--- a/src/enzyme_ad/jax/Passes/ParallelLower.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLower.cpp
@@ -1326,6 +1326,49 @@ void StripGPUInfo::runOnOperation() {
       }
     });
   });
+
+  // Extracting device code into gpu modules can leave renamed host-side
+  // residue behind: internal-linkage clones of device functions, held only
+  // by equally dead device vtable globals. LLVM internal linkage is not
+  // MLIR private visibility, so symbol-dce keeps them, and the host backend
+  // then fatals on their sm_* subtargets. Erase the residue: any host-level
+  // function whose target cpu names a device, together with the internal
+  // globals whose initializers are the only things holding its address.
+  auto m = dyn_cast<ModuleOp>(getOperation());
+  if (!m)
+    return;
+  SmallVector<LLVM::LLVMFuncOp> residue;
+  for (auto fn : m.getBody()->getOps<LLVM::LLVMFuncOp>()) {
+    auto cpu = fn->getAttrOfType<StringAttr>("target_cpu");
+    if (cpu && (cpu.getValue().starts_with("sm_") ||
+                cpu.getValue().starts_with("gfx")))
+      residue.push_back(fn);
+  }
+  if (residue.empty())
+    return;
+  DenseSet<Operation *> residueSyms;
+  for (auto fn : residue)
+    residueSyms.insert(fn);
+  SmallVector<LLVM::GlobalOp> deadGlobals;
+  for (auto glob : m.getBody()->getOps<LLVM::GlobalOp>()) {
+    if (glob.getLinkage() != LLVM::Linkage::Internal &&
+        glob.getLinkage() != LLVM::Linkage::Private)
+      continue;
+    bool holdsResidue = false;
+    glob.walk([&](LLVM::AddressOfOp addr) {
+      if (auto *sym = SymbolTable::lookupNearestSymbolFrom(
+              addr, addr.getGlobalNameAttr()))
+        if (residueSyms.count(sym))
+          holdsResidue = true;
+    });
+    if (holdsResidue && SymbolTable::symbolKnownUseEmpty(glob, m))
+      deadGlobals.push_back(glob);
+  }
+  for (auto glob : deadGlobals)
+    glob.erase();
+  for (auto fn : residue)
+    if (SymbolTable::symbolKnownUseEmpty(fn, m))
+      fn.erase();
 }
 
 // Returns a list of all symbols provided by cudart (obtained from

--- a/test/lit_tests/strip-gpu-info-device-residue.mlir
+++ b/test/lit_tests/strip-gpu-info-device-residue.mlir
@@ -1,0 +1,48 @@
+// RUN: enzymexlamlir-opt %s --strip-gpu-info --split-input-file | FileCheck %s
+
+// Extracting device code into gpu modules can leave renamed host-side residue
+// behind: internal-linkage clones of device functions, held only by equally
+// dead device vtable globals. LLVM internal linkage is not MLIR private
+// visibility, so symbol-dce keeps them, and the host backend fatals on their
+// sm_* subtargets. strip-gpu-info erases the residue.
+
+module {
+  llvm.func internal @_ZNK4mfem6metricEvalW.53(%arg0: !llvm.ptr) -> f64 attributes {dso_local, target_cpu = "sm_120"} {
+    %0 = llvm.mlir.constant(0.0 : f64) : f64
+    llvm.return %0 : f64
+  }
+  llvm.mlir.global internal unnamed_addr constant @_ZTVN4mfem6metricE.51() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<(array<1 x ptr>)> {
+    %0 = llvm.mlir.undef : !llvm.struct<(array<1 x ptr>)>
+    %1 = llvm.mlir.addressof @_ZNK4mfem6metricEvalW.53 : !llvm.ptr
+    %2 = llvm.mlir.undef : !llvm.array<1 x ptr>
+    %3 = llvm.insertvalue %1, %2[0] : !llvm.array<1 x ptr>
+    %4 = llvm.insertvalue %3, %0[0] : !llvm.struct<(array<1 x ptr>)>
+    llvm.return %4 : !llvm.struct<(array<1 x ptr>)>
+  }
+  llvm.func @host(%p: !llvm.ptr) -> f64 attributes {target_cpu = "x86-64"} {
+    %0 = llvm.mlir.constant(1.0 : f64) : f64
+    llvm.return %0 : f64
+  }
+}
+
+// CHECK-NOT: EvalW
+// CHECK-NOT: _ZTVN4mfem6metricE
+// CHECK: llvm.func @host
+
+// -----
+
+// A device function something still holds beyond the dead vtable stays.
+
+module {
+  llvm.func internal @kept.1(%arg0: !llvm.ptr) -> f64 attributes {target_cpu = "sm_120"} {
+    %0 = llvm.mlir.constant(0.0 : f64) : f64
+    llvm.return %0 : f64
+  }
+  llvm.func @host2() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @kept.1 : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+}
+
+// CHECK: llvm.func internal @kept.1
+// CHECK: llvm.func @host2


### PR DESCRIPTION
Extracting device code into gpu modules can leave renamed host-side
residue behind: internal-linkage clones of device functions, held only
by equally dead device vtable globals. LLVM internal linkage is not
MLIR private visibility, so symbol-dce keeps them, and the host backend
then fatals with '64-bit code requested on a subtarget that doesn't
support it' on their sm_* target cpus, as MFEM's tmop metric kernels do
(device-side virtual methods held by the device vtable). Erase any
host-level function whose target cpu names a device, together with the
internal globals whose initializers are the only things holding its
address; anything else still referencing it keeps it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD