### PR TITLE
convert-parallel-to-gpu: keep block merging out of the greedy drivers

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1982,6 +1982,13 @@ struct ConvertParallelToGPU1Pass
       patterns.insert<InnerParallelSerialization>(&getContext());
       GreedyRewriteConfig config;
       config.enableFolding();
+      // Aggressive region simplification (the greedy default) merges
+      // identical blocks by adding their differing values as block arguments
+      // and appending them to every predecessor's successor operands --
+      // including llvm.invoke's, which cannot carry index- or memref-typed
+      // successor operands. These functions still hold raised llvm CFGs;
+      // keep block merging off.
+      config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         signalPassFailure();
         return;
@@ -2001,6 +2008,13 @@ struct ConvertParallelToGPU1Pass
       // clang-format on
       GreedyRewriteConfig config;
       config.enableFolding();
+      // Aggressive region simplification (the greedy default) merges
+      // identical blocks by adding their differing values as block arguments
+      // and appending them to every predecessor's successor operands --
+      // including llvm.invoke's, which cannot carry index- or memref-typed
+      // successor operands. These functions still hold raised llvm CFGs;
+      // keep block merging off.
+      config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         signalPassFailure();
         return;
@@ -2026,6 +2040,13 @@ struct ConvertParallelToGPU1Pass
       populateNormalizationPatterns(patterns);
       GreedyRewriteConfig config;
       config.enableFolding();
+      // Aggressive region simplification (the greedy default) merges
+      // identical blocks by adding their differing values as block arguments
+      // and appending them to every predecessor's successor operands --
+      // including llvm.invoke's, which cannot carry index- or memref-typed
+      // successor operands. These functions still hold raised llvm CFGs;
+      // keep block merging off.
+      config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         signalPassFailure();
         return;
@@ -2446,6 +2467,13 @@ struct ConvertParallelToGPU1Pass
       // clang-format on
       GreedyRewriteConfig config;
       config.enableFolding();
+      // Aggressive region simplification (the greedy default) merges
+      // identical blocks by adding their differing values as block arguments
+      // and appending them to every predecessor's successor operands --
+      // including llvm.invoke's, which cannot carry index- or memref-typed
+      // successor operands. These functions still hold raised llvm CFGs;
+      // keep block merging off.
+      config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         signalPassFailure();
         return;
@@ -2460,6 +2488,13 @@ struct ConvertParallelToGPU1Pass
       // clang-format on
       GreedyRewriteConfig config;
       config.enableFolding();
+      // Aggressive region simplification (the greedy default) merges
+      // identical blocks by adding their differing values as block arguments
+      // and appending them to every predecessor's successor operands --
+      // including llvm.invoke's, which cannot carry index- or memref-typed
+      // successor operands. These functions still hold raised llvm CFGs;
+      // keep block merging off.
+      config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
       if (failed(applyPatternsGreedily(m, std::move(patterns), config))) {
         signalPassFailure();
         return;
@@ -2534,6 +2569,7 @@ gdgo->erase();
             &getContext());
     GreedyRewriteConfig config;
     config.enableFolding();
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
                                      config))) {
       signalPassFailure();

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-no-block-merge.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-no-block-merge.mlir
@@ -1,0 +1,41 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// Aggressive region simplification (the greedy driver's default) merges
+// identical blocks by adding their differing values as block arguments and
+// appending them to every predecessor's successor operands. One of these
+// predecessors is an llvm.invoke, whose successor operands must be LLVM
+// types: merging the two store blocks would hand it an index, which the op
+// cannot carry. The pass's drivers keep block merging off, so both blocks
+// survive and the invoke keeps zero successor operands.
+
+module {
+  llvm.func @g()
+  llvm.func @pers(i32) -> i32
+  llvm.func @f(%p: !llvm.ptr, %v: f64, %c: i1) attributes {personality = @pers} {
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    llvm.cond_br %c, ^inv, ^direct
+  ^inv:
+    llvm.invoke @g() to ^n unwind ^u : () -> ()
+  ^n:
+    memref.store %v, %m[%c1] : memref<?xf64>
+    llvm.br ^end
+  ^direct:
+    llvm.br ^n2
+  ^n2:
+    memref.store %v, %m[%c2] : memref<?xf64>
+    llvm.br ^end
+  ^end:
+    llvm.return
+  ^u:
+    %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: llvm.func @f
+// CHECK: llvm.invoke @g() to ^[[N:.+]] unwind
+// CHECK: ^[[N]]:
+// CHECK-NEXT: memref.store
+// CHECK: memref.store


### PR DESCRIPTION
Aggressive region simplification (the greedy driver's default) merges
identical blocks by adding their differing values as block arguments
and appending them to every predecessor's successor operands --
including llvm.invoke's, whose successor operands must be LLVM types.
Raising MFEM's mesh.cpp as CUDA, the pass's drivers merged two loop
blocks behind an invoke and handed it seventeen index- and memref-typed
successor operands; only the disabled inter-pass verification let the
invalid invoke travel, surfacing as 'Unhandled unrealized conversion
cast' at lowering. The functions these drivers run over still hold
raised llvm CFGs; pin every driver in the pass to normal simplification,
which (like the canonicalize pass's default) does not merge blocks.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD