### PR TITLE
convert-polygeist-to-llvm: say which unrealized cast is unhandled

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -4942,7 +4942,12 @@ struct ConvertPolygeistToLLVMPass
     }
 
     if (m->walk([](UnrealizedConversionCastOp op) {
-           op->emitError() << "Unhandled unrealized conversion cast\n";
+           InFlightDiagnostic diag =
+               op->emitError() << "Unhandled unrealized conversion cast " << op;
+           if (auto fn = op->getParentOfType<FunctionOpInterface>())
+             diag.attachNote(fn->getLoc()) << "in " << fn.getName();
+           for (Operation *user : op->getUsers())
+             diag.attachNote(user->getLoc()) << "used by " << user->getName();
            return WalkResult::interrupt();
          }).wasInterrupted()) {
       signalPassFailure();

--- a/test/lit_tests/lowering/unhandled-conversion-cast-diagnostic.mlir
+++ b/test/lit_tests/lowering/unhandled-conversion-cast-diagnostic.mlir
@@ -1,0 +1,22 @@
+// RUN: not enzymexlamlir-opt %s --convert-polygeist-to-llvm 2>&1 | FileCheck %s
+
+// A gpu_wrapper no pattern converted reaches the lowering, which converts its
+// index operands and leaves the materialized casts behind. Saying only that
+// an unhandled cast exists leaves nothing to work from; name the cast, the
+// function holding it, and who reads it.
+
+module {
+  func.func @unconverted(%n: index, %m: memref<?xf64>, %v: f64) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %w = "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c1, %c1, %c1) ({
+      memref.store %v, %m[%c0] : memref<?xf64>
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK: error: Unhandled unrealized conversion cast %{{.+}} = "builtin.unrealized_conversion_cast"
+// CHECK: note: in unconverted
+// CHECK: note: used by


### PR DESCRIPTION
Split out of #2840 per review (1 of 3).

The lowering converts the operands of an op it has no pattern for, leaves the materialized casts behind, then reports only that an unhandled cast exists — no value, no types, no enclosing function. That message is how a `gpu_wrapper` that no kernel pattern converted announces itself, and it was the hardest part of diagnosing MFEM's lor_batched.cpp. Now it names the cast, the function, and the users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD