### PR TITLE
convert-parallel-to-gpu: give gpu.launch its stream the way launch_func takes it

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1917,34 +1917,28 @@ struct AsyncGPULaunch : public OpRewritePattern<async::ExecuteOp> {
       streams.push_back(
           dep.getDefiningOp<enzymexla::StreamToTokenOp>().getOperand());
 
-    // gpu.launch_func carries the stream on its asyncObject operand: a
-    // dependency operand without a result token no longer verifies. The
-    // operand is a single value, so more than one stream cannot be said.
-    if (!launches.empty() &&
+    // Both launch ops carry the stream on their asyncObject operand: a
+    // dependency operand without a result token no longer verifies, and
+    // neither launch built here returns one. The operand is a single value,
+    // so more than one stream cannot be said.
+    if ((!launches.empty() || !launches2.empty()) &&
         (streams.size() != 1 ||
-         llvm::any_of(launches, [](gpu::LaunchFuncOp launch) {
+         llvm::any_of(launches,
+                      [](gpu::LaunchFuncOp launch) {
+                        return launch.getAsyncObject() != nullptr;
+                      }) ||
+         llvm::any_of(launches2, [](gpu::LaunchOp launch) {
            return launch.getAsyncObject() != nullptr;
          })))
       return failure();
 
-    for (auto launch : launches) {
+    for (auto launch : launches)
       rewriter.modifyOpInPlace(
           launch, [&]() { launch.getAsyncObjectMutable().assign(streams[0]); });
-    }
 
-    SmallVector<Value> gpudeps;
-    if (!launches2.empty())
-      for (auto [dep, stream] :
-           llvm::zip_equal(async.getDependencies(), streams))
-        gpudeps.push_back(enzymexla::StreamToTokenOp::create(
-            rewriter, dep.getLoc(), rewriter.getType<gpu::AsyncTokenType>(),
-            stream));
-
-    for (auto launch : launches2) {
-      rewriter.modifyOpInPlace(launch, [&]() {
-        launch.getAsyncDependenciesMutable().append(gpudeps);
-      });
-    }
+    for (auto launch : launches2)
+      rewriter.modifyOpInPlace(
+          launch, [&]() { launch.getAsyncObjectMutable().assign(streams[0]); });
 
     rewriter.eraseOp(async.getBody()->getTerminator());
     rewriter.inlineBlockBefore(async.getBody(), async);

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-async-launch.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-async-launch.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// The stream an async.execute waits on is given to the launch it contains.
+// gpu.launch takes it the same way gpu.launch_func does, on its asyncObject
+// operand: a dependency operand with no result token does not verify, and the
+// launch built here returns no token.
+
+module {
+  func.func @async_launch(%stream: !llvm.ptr, %n: index, %out: memref<?xf64>, %v: f64) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %tok = "enzymexla.stream2token"(%stream) : (!llvm.ptr) -> !async.token
+    %done = async.execute [%tok] {
+      "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c8, %c1, %c1) ({
+        scf.parallel (%i) = (%c0) to (%n) step (%c1) {
+          scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+            memref.store %v, %out[%j] : memref<?xf64>
+            scf.reduce
+          }
+          scf.reduce
+        }
+        "enzymexla.polygeist_yield"() : () -> ()
+      }) : (index, index, index, index, index, index) -> index
+      async.yield
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @async_launch(
+// CHECK-SAME: %[[stream:[^ :]+]]: !llvm.ptr
+// The stream is the launch's asyncObject, and no async token is asked for.
+// CHECK: gpu.launch <%[[stream]] : !llvm.ptr> blocks
+// CHECK-NOT: gpu.launch async


### PR DESCRIPTION
`gpu.launch` and `gpu.launch_func` both carry the stream a surrounding `async.execute` waits on, and both grew an `asyncObject` operand for it — but only `launch_func` was migrated. `gpu.launch` was still handed dependency tokens, which only verify on a launch that *returns* a token, and the launches built here return nothing.

That is the `'gpu.launch' op dependency operands require the dependency-based async model i.e. returning a token` failure raising MFEM's dfem test_mass.cpp and lor_batched.cpp as CUDA — test_mass fails this way on current main. With the fix both get through convert-parallel-to-gpu1, and mesh.cpp, tmop 302 and the multikernel repro are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD