### PR TITLE
convert-parallel-to-gpu: interchange a guard with the parallel it guards

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1602,6 +1602,72 @@ struct RemovePolygeistGPUWrapperOp : public OpRewritePattern<OpType> {
   }
 };
 
+/// parallel {
+///   ...
+///   if (c) { parallel { A() } }
+/// }
+/// ->
+/// parallel {
+///   ...
+///   parallel { if (c) { A() } }
+/// }
+///
+/// The launch wants the block parallel directly in the grid parallel's body,
+/// but the guard its bounds need is left wrapped around it. The condition is
+/// computed outside the block parallel, so it is the same for every thread:
+/// running the parallel and having each thread skip the body is what the
+/// guard already means.
+struct InterchangeGuardedParallel : public OpRewritePattern<scf::IfOp> {
+  using OpRewritePattern<scf::IfOp>::OpRewritePattern;
+  const char *PATTERN = "interchange-guarded-parallel";
+  LogicalResult matchAndRewrite(scf::IfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    if (!ifOp.getElseRegion().empty() || ifOp->getNumResults() != 0)
+      return failure();
+    auto parent = dyn_cast<scf::ParallelOp>(ifOp->getParentOp());
+    if (!parent || !parent->getParentOfType<enzymexla::GPUWrapperOp>())
+      return failure();
+    auto *thenBlock = ifOp.thenBlock();
+    auto pop =
+        dyn_cast<scf::ParallelOp>(thenBlock->getTerminator()->getPrevNode());
+    if (!pop)
+      return failure();
+    // Whatever the guard computes on the way to the parallel comes with it:
+    // that is only sound for ops that do nothing but compute, which can as
+    // well run unguarded.
+    for (Operation &op : *thenBlock) {
+      if (&op == pop.getOperation() || &op == thenBlock->getTerminator())
+        continue;
+      if (!isPure(&op))
+        return failure();
+    }
+    if (Operation *def = ifOp.getCondition().getDefiningOp())
+      if (pop->isProperAncestor(def))
+        return failure();
+
+    rewriter.setInsertionPoint(ifOp);
+    // The pure prologue moves out of the guard, in order, so the parallel is
+    // all the guard holds.
+    for (Operation &op : llvm::make_early_inc_range(*thenBlock)) {
+      if (&op == pop.getOperation() || &op == thenBlock->getTerminator())
+        continue;
+      rewriter.moveOpBefore(&op, ifOp);
+    }
+    auto newPop =
+        scf::ParallelOp::create(rewriter, pop.getLoc(), pop.getLowerBound(),
+                                pop.getUpperBound(), pop.getStep());
+    rewriter.setInsertionPointToStart(newPop.getBody());
+    auto guard =
+        scf::IfOp::create(rewriter, ifOp.getLoc(), ifOp.getCondition());
+    rewriter.eraseOp(pop.getBody()->getTerminator());
+    rewriter.inlineBlockBefore(pop.getBody(),
+                               guard.thenBlock()->getTerminator(),
+                               newPop.getBody()->getArguments());
+    rewriter.eraseOp(ifOp);
+    return success();
+  }
+};
+
 struct InterchangeIfOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
   using OpRewritePattern<enzymexla::GPUWrapperOp>::OpRewritePattern;
   const char *PATTERN = "interchange-if-op";
@@ -1918,9 +1984,8 @@ struct AsyncGPULaunch : public OpRewritePattern<async::ExecuteOp> {
           dep.getDefiningOp<enzymexla::StreamToTokenOp>().getOperand());
 
     // Both launch ops carry the stream on their asyncObject operand: a
-    // dependency operand without a result token no longer verifies, and
-    // neither launch built here returns one. The operand is a single value,
-    // so more than one stream cannot be said.
+    // dependency operand without a result token no longer verifies. The
+    // operand is a single value, so more than one stream cannot be said.
     if ((!launches.empty() || !launches2.empty()) &&
         (streams.size() != 1 ||
          llvm::any_of(launches,
@@ -2113,6 +2178,7 @@ struct ConvertParallelToGPU1Pass
       patterns.insert<
         //BarrierElim</*TopLevelOnly*/ false>,
         InterchangeIfOp,
+        InterchangeGuardedParallel,
         SplitOffParallel,
         HandleWrapperRootAlloca,
         HandleWrapperRootOps,

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-guarded-parallel.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-guarded-parallel.mlir
@@ -1,0 +1,41 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// Splitting a kernel whose thread count does not divide its work leaves the
+// block parallel inside the guard its bounds need. The launch wants that
+// parallel directly in the grid parallel's body, so without interchanging the
+// two the wrapper is never converted and survives to the LLVM lowering, where
+// it fails as an unhandled unrealized conversion cast. The condition is
+// computed outside the block parallel, so it is the same for every thread:
+// running the parallel and having each thread skip the body is what the guard
+// already means.
+
+module {
+  func.func @guarded(%n: index, %m: index, %out: memref<?xf64>, %v: f64) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c8, %c1, %c1) ({
+      scf.parallel (%i) = (%c0) to (%n) step (%c1) {
+        %in = arith.cmpi slt, %i, %m : index
+        scf.if %in {
+          %off = arith.muli %i, %c8 : index
+          scf.parallel (%j) = (%c0) to (%c8) step (%c1) {
+            %k = arith.addi %off, %j : index
+            memref.store %v, %out[%k] : memref<?xf64>
+            scf.reduce
+          }
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// The guard ends up inside the thread parallel, and the kernel becomes a
+// launch instead of surviving as a wrapper.
+// CHECK-LABEL: func.func @guarded
+// CHECK-NOT: enzymexla.gpu_wrapper
+// CHECK: gpu.launch blocks
+// CHECK: scf.if


### PR DESCRIPTION
Stacked on #2844.

Splitting a kernel whose thread count does not divide its work leaves the block parallel *inside* the guard its bounds need, and the launch wants it directly in the grid parallel's body. So the wrapper is never converted: it survives every kernel pattern, has its parallels serialized away later, and reaches the LLVM lowering as an unhandled unrealized conversion cast — the failure raising MFEM's lor_batched.cpp as CUDA.

Interchanging the two is sound because the condition is computed outside the block parallel and is therefore uniform across threads: running the parallel and having each thread skip the body is exactly what the guard means. A pure prologue inside the guard comes along (it can run unguarded); anything else leaves the guard alone.

**This is half of lor_batched:** it takes that TU's surviving wrappers from 32 to 16 (16 launches created). The remainder hold their thread parallel inside a *grid-stride `scf.for`* within the guard, which needs the loop and the parallel interchanged — a real loop transformation with its own legality conditions, and a design question I would rather raise than answer unilaterally. No regressions: test_mass, tmop 302, mesh.cpp and the multikernel repro all still lower cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD