### PR TITLE
convert-parallel-to-gpu: launch what the kernel gives, serialize the rest

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1712,10 +1712,14 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
         getDirectlyNestedSingleParallel(wrapper.getBody());
     if (!gridPop)
       return failure();
+    // A kernel whose thread-level work is not a parallel directly under the
+    // grid parallel -- MFEM's CuKernel3D walks its grid-stride loop and does
+    // its work in loops within it -- still has to become a launch. Decide the
+    // launch's shape here and let what is left inside be serialized: leaving
+    // the wrapper unconverted only means it reaches the LLVM lowering, which
+    // has no pattern for it.
     scf::ParallelOp blockPop = getDirectlyNestedSingleParallel(
         gridPop.getBody(), /* allowAllocas */ true);
-    if (!blockPop)
-      return failure();
 
     // Only mutate once the match is certain: an op created before a bail
     // marks the IR changed on every scan, so a wrapper this pattern cannot
@@ -1749,7 +1753,8 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
         gridBounds[i] = oneindex;
     }
     Value blockBounds[3];
-    auto popBlockBounds = getUpperBounds(blockPop);
+    auto popBlockBounds =
+        blockPop ? getUpperBounds(blockPop) : SmallVector<Value, 3>();
     for (unsigned int i = 0; i < 3; i++) {
       if (i < popBlockBounds.size())
         blockBounds[i] = popBlockBounds[i];
@@ -1799,6 +1804,33 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     auto launchBlock = &launchOp.getRegion().front();
     rewriter.setInsertionPointToStart(launchBlock);
     SmallVector<Value, 3> argReplacements;
+    if (!blockPop) {
+      // One thread per block: the work inside stays as it is written and is
+      // serialized later, which is what happens to a loop in a kernel
+      // regardless.
+      SmallVector<Value, 3> gridReplacements;
+      for (auto en : llvm::enumerate(gridPop.getBody()->getArguments())) {
+        gpu::Dimension dim = getDim(en.index());
+        auto gridIdx = gpu::BlockIdOp::create(
+            rewriter, loc, mlir::IndexType::get(rewriter.getContext()), dim);
+        gridReplacements.push_back(gridIdx);
+      }
+      rewriter.mergeBlocks(gridPop.getBody(), launchBlock, gridReplacements);
+      rewriter.setInsertionPointToEnd(launchBlock);
+      gpu::TerminatorOp::create(rewriter, loc);
+      rewriter.eraseOp(gridPop);
+      Operation *reduce = nullptr;
+      for (auto &op : *launchBlock)
+        if (auto r = dyn_cast<scf::ReduceOp>(&op))
+          reduce = r;
+      if (reduce)
+        rewriter.eraseOp(reduce);
+      launchBlock->walk([&](mlir::enzymexla::BarrierOp op) {
+        rewriter.setInsertionPoint(op);
+        rewriter.replaceOpWithNewOp<gpu::BarrierOp>(op);
+      });
+      return success();
+    }
     for (auto en : llvm::enumerate(blockPop.getBody()->getArguments())) {
       gpu::Dimension dim = getDim(en.index());
       auto blockIdx = gpu::ThreadIdOp::create(

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-no-block-parallel.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-no-block-parallel.mlir
@@ -1,0 +1,44 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// MFEM's CuKernel3D walks a grid-stride loop and does its work in loops
+// within it: 'for (k = blockIdx.x; k < N; k += gridDim.x) { body(k); }'. The
+// thread-level parallelism the raising finds inside that loop is not a
+// parallel directly under the grid parallel, which is all the launch used to
+// accept -- and a wrapper it declines does not stay a wrapper, it reaches the
+// LLVM lowering, which has no pattern for it at all.
+//
+// Decide the launch from what there is, and leave what is inside to the
+// serialization every loop in a kernel gets anyway.
+
+module {
+  func.func @grid_stride(%n: index, %stride: index, %out: memref<?xf64>, %v: f64) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c288 = arith.constant 288 : index
+    "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c288, %c1, %c1) ({
+      scf.parallel (%b) = (%c0) to (%n) step (%c1) {
+        %in = arith.cmpi slt, %b, %n : index
+        scf.if %in {
+          scf.for %k = %b to %n step %stride {
+            scf.parallel (%i) = (%c0) to (%c288) step (%c1) {
+              memref.store %v, %out[%i] : memref<?xf64>
+              scf.reduce
+            }
+          }
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// The kernel becomes a launch rather than surviving as a wrapper, the guard
+// still wraps the whole loop, and the work inside is left to be serialized.
+// CHECK-LABEL: func.func @grid_stride
+// CHECK-NOT: enzymexla.gpu_wrapper
+// CHECK: gpu.launch blocks
+// CHECK: scf.if
+// CHECK: scf.for
+// CHECK: scf.parallel

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-pin-bounds.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-pin-bounds.mlir
@@ -28,12 +28,16 @@ module {
   }
 }
 
-// The bound stays beside the inner parallel, which still reads it; the load,
-// whose only reader is inside the body, moves in as before.
+// The bound stays beside the inner parallel, which still reads it. That
+// parallel cannot give the launch its thread shape -- a trip count computed
+// from the grid index is not a block dimension -- so the launch takes one
+// thread per block and the parallel is left inside it to be serialized, with
+// its bound computation still in front of it.
 
 // CHECK-LABEL: func.func @pin
-// CHECK: scf.parallel (%[[I:.+]]) =
-// CHECK-NEXT: %[[B:.+]] = arith.muli %[[I]], %{{.+}} : index
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %{{.+}}, %{{.+}} = %[[ONE:.+]], %{{.+}} = %[[ONE]]) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[ONE]], %{{.+}} = %[[ONE]], %{{.+}} = %[[ONE]])
+// CHECK: %[[BID:.+]] = gpu.block_id x
+// CHECK-NEXT: %[[B:.+]] = arith.muli %[[BID]], %{{.+}} : index
 // CHECK-NEXT: scf.parallel (%{{.+}}) = (%{{.+}}) to (%[[B]])
 // CHECK-NEXT: %[[R:.+]] = memref.load
 // CHECK-NEXT: memref.store %[[R]]


### PR DESCRIPTION
The launch decider required a parallel directly under the grid parallel for its thread shape and declined the kernel otherwise. Declining is not neutral: a wrapper no pattern converts keeps its wrapper, has its parallels serialized away by later passes, and reaches the LLVM lowering — which has no pattern for a `gpu_wrapper` at all. That is the `Unhandled unrealized conversion cast` raising MFEM's lor_batched.cpp as CUDA.

Per review, the ordering should be: decide and create the launch parameters first, free to take bounds from the outer parallel axes, and serialize what is left afterwards. So the decider now takes grid axes from the outer parallel, thread axes from a parallel directly beneath it when there is one, and one thread per block when there is not. Nothing is moved to manufacture a block parallel — in particular the guard still wraps the whole loop, which is cheaper than re-testing it per thread and is what the kernel already said.

MFEM's `CuKernel3D` is the shape that needs it:

```cuda
for (int k = blockIdx.x; k < N; k += gridDim.x) { body(k); }   // forall.hpp
```

the parallelism the raising finds (from `MFEM_FOREACH_THREAD`) sits under that loop, not under the grid parallel.

**Result:** lor_batched.cpp's surviving wrappers go 16 → 0 and the file's full pipeline passes. test_mass, tmop 302, mesh.cpp and the multikernel repro are unchanged. Two lit tests: the CuKernel3D shape, and the existing pin-bounds test updated — it used to assert the wrapper was left alone, which is precisely the behaviour this replaces.

**Known follow-up:** these kernels launch one thread per block for now. Choosing their thread axes from the parallels inside (288 and 144 wide in lor_batched) is the next step; one thread is slow, where failing to compile was not an option at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD