### PR TITLE
convert-parallel-to-gpu: serialize the parallels found inside a kernel

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1602,6 +1602,48 @@ struct RemovePolygeistGPUWrapperOp : public OpRewritePattern<OpType> {
   }
 };
 
+/// A parallel the raising found inside the kernel's own parallel -- what
+/// MFEM_FOREACH_THREAD's 'for (i = threadIdx.x; i < N; i += blockDim.x)'
+/// becomes when it is proven parallel -- is not where the launch gets its
+/// thread shape from: that comes from the launch geometry the wrapper
+/// records. Worse, split-parallel refuses to split a kernel that still
+/// holds one, so proving the inner loop parallel costs the kernel its grid
+/// and block dimensions entirely. Serialize them, which is where a loop
+/// inside a kernel ends up regardless, and let the split proceed.
+///
+/// The parallel a split has just created lives directly in its grid
+/// parallel's body; these sit deeper, under the guards and loops the kernel
+/// was written with. Only the deeper ones are serialized.
+struct SerializeNestedParallel : public OpRewritePattern<scf::ParallelOp> {
+  using OpRewritePattern<scf::ParallelOp>::OpRewritePattern;
+  const char *PATTERN = "serialize-nested-parallel";
+  LogicalResult matchAndRewrite(scf::ParallelOp pop,
+                                PatternRewriter &rewriter) const override {
+    if (pop->getNumResults() != 0 || !pop.getInitVals().empty())
+      return failure();
+    if (!pop->getParentOfType<enzymexla::GPUWrapperOp>())
+      return failure();
+    auto outer = pop->getParentOfType<scf::ParallelOp>();
+    if (!outer || pop->getBlock() == outer.getBody())
+      return failure();
+
+    Location loc = pop.getLoc();
+    rewriter.setInsertionPoint(pop);
+    SmallVector<Value> ivs;
+    for (auto [lb, ub, step] :
+         llvm::zip(pop.getLowerBound(), pop.getUpperBound(), pop.getStep())) {
+      auto forOp = scf::ForOp::create(rewriter, loc, lb, ub, step);
+      ivs.push_back(forOp.getInductionVar());
+      rewriter.setInsertionPointToStart(forOp.getBody());
+    }
+    Block *innermost = rewriter.getInsertionBlock();
+    rewriter.eraseOp(pop.getBody()->getTerminator());
+    rewriter.inlineBlockBefore(pop.getBody(), innermost->getTerminator(), ivs);
+    rewriter.eraseOp(pop);
+    return success();
+  }
+};
+
 struct InterchangeIfOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
   using OpRewritePattern<enzymexla::GPUWrapperOp>::OpRewritePattern;
   const char *PATTERN = "interchange-if-op";
@@ -2113,6 +2155,7 @@ struct ConvertParallelToGPU1Pass
       patterns.insert<
         //BarrierElim</*TopLevelOnly*/ false>,
         InterchangeIfOp,
+        SerializeNestedParallel,
         SplitOffParallel,
         HandleWrapperRootAlloca,
         HandleWrapperRootOps,

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-serialize-nested.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-serialize-nested.mlir
@@ -1,0 +1,44 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// The raising proves MFEM_FOREACH_THREAD's 'for (i = threadIdx.x; i < N;
+// i += blockDim.x)' parallel, which leaves a parallel inside the kernel's own
+// parallel. split-parallel refuses to split a kernel that still holds one, so
+// the kernel loses its grid and block dimensions entirely and the launch is
+// never built: the wrapper reaches the LLVM lowering, which has no pattern for
+// it. Proving the inner loop parallel must not cost the kernel its launch.
+//
+// The thread shape comes from the launch geometry the wrapper records -- 8x4
+// here -- not from the loops inside, which are serialized as any loop in a
+// kernel is.
+
+module {
+  func.func @foreach_thread(%n: index, %out: memref<?xf64>, %v: f64) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c288 = arith.constant 288 : index
+    "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c8, %c4, %c1) ({
+      scf.parallel (%b, %tx, %ty) = (%c0, %c0, %c0) to (%n, %c8, %c4) step (%c1, %c1, %c1) {
+        %in = arith.cmpi slt, %b, %n : index
+        scf.if %in {
+          scf.parallel (%i) = (%c0) to (%c288) step (%c1) {
+            memref.store %v, %out[%i] : memref<?xf64>
+            scf.reduce
+          }
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @foreach_thread
+// CHECK-NOT: enzymexla.gpu_wrapper
+// The launch keeps the kernel's own thread shape ...
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %{{.+}}, %{{.+}} = %{{.+}}, %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[TX:.+]], %{{.+}} = %[[TY:.+]], %{{.+}} = %{{.+}})
+// ... and the loop the raising proved parallel is a loop again.
+// CHECK: scf.for
+// CHECK-NOT: scf.parallel


### PR DESCRIPTION
Replaces #2846, which treated the symptom — thank you for pushing on where the nested parallels were supposed to come from.

`SplitParallelOp` refuses to split a kernel whose parallel still contains another parallel:

```cpp
bool child = false;
pop->walk([&](scf::ParallelOp p) { if (pop != p) child = true; });
if (child) { LLVM_DEBUG(DBGS() << "only single parallel ops\n"); return failure(); }
```

which is precisely the kernel the raising did best on: `MFEM_FOREACH_THREAD` is `for (i = threadIdx.x; i < N; i += blockDim.x)`, so proving it parallel leaves a parallel inside the kernel's own. The kernel then never gets its grid/block split, the launch is never built, and the wrapper reaches the LLVM lowering — the `Unhandled unrealized conversion cast` from lor_batched.cpp. Proving the inner loop parallel cost the kernel its launch.

Serialize those parallels before the split (where a kernel-internal loop ends up regardless) and the split takes grid and block dims from the launch geometry the wrapper records. The safety line: a split's own block parallel sits *directly* in its grid parallel's body, while the raising's sit deeper under the kernel's guards and loops — only the deeper ones are serialized.

**Result:** lor_batched.cpp's 32 unconverted kernels all become launches, and with the thread shapes they were launched with:

| threads | count |
|---|---|
| dynamic (`%91 × %92 × %10`) | 15 |
| 8×8×4 | 2 |
| 7×7×4 | 2 |
| 6×6×6 | 2 |
| 5×5×5 | 2 |

versus 1×1×1 for all of them under #2846. lor_batched.cpp's full pipeline passes; test_mass, tmop 302, mesh.cpp and the multikernel repro are unchanged; lit test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD