### PR TITLE
convert-parallel-to-gpu: a nested parallel only means split if it is a child

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -475,10 +475,9 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     if (!pop)
       return failure();
     bool child = false;
-    pop->walk([&](scf::ParallelOp p) {
-      if (pop != p)
+    for (Operation &op : *pop.getBody())
+      if (isa<scf::ParallelOp>(&op))
         child = true;
-    });
     if (child) {
       LLVM_DEBUG(DBGS() << "only single parallel ops\n");
       return failure();

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-nested-parallel.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-nested-parallel.mlir
@@ -1,0 +1,30 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+module {
+  func.func @foreach_thread(%n: index, %out: memref<?xf64>, %v: f64) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c288 = arith.constant 288 : index
+    "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c8, %c4, %c1) ({
+      scf.parallel (%b, %tx, %ty) = (%c0, %c0, %c0) to (%n, %c8, %c4) step (%c1, %c1, %c1) {
+        %in = arith.cmpi slt, %b, %n : index
+        scf.if %in {
+          scf.parallel (%i) = (%c0) to (%c288) step (%c1) {
+            memref.store %v, %out[%i] : memref<?xf64>
+            scf.reduce
+          }
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @foreach_thread
+// CHECK-NOT: enzymexla.gpu_wrapper
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %{{.+}}, %{{.+}} = %{{.+}}, %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[TX:.+]], %{{.+}} = %[[TY:.+]], %{{.+}} = %{{.+}})
+// CHECK: scf.parallel


### PR DESCRIPTION
Replaces #2847 with your suggestion, which is both smaller and the one that respects the ordering — this pass now does no serialization at all.

`SplitParallelOp` skips a kernel whose parallel already holds another, because that is a kernel already split into a grid and a block. It asked with a `walk`, so a parallel at *any* depth answered yes — including a loop of the kernel's own that the raising proved parallel (`MFEM_FOREACH_THREAD` is `for (i = threadIdx.x; i < N; i += blockDim.x)`). Those kernels were never split, no launch was built, and the wrapper reached the LLVM lowering, which has no pattern for a `gpu_wrapper` — the `Unhandled unrealized conversion cast` from lor_batched.cpp. Proving the inner loop parallel cost the kernel its launch.

Asking about direct children is what the question meant:

```cpp
bool child = false;
for (Operation &op : *pop.getBody())
  if (isa<scf::ParallelOp>(&op))
    child = true;
```

The kernels then take grid and block dims from the launch geometry the wrapper records, and the loops inside are left to `parallel-serialization` afterwards rather than being serialized here before the launch is decided.

**Result** (identical to #2847, from 9 lines instead of a new pattern): lor_batched.cpp's 32 unconverted kernels all become launches with their real thread shapes — dynamic ×15, 8×8×4, 7×7×4, 6×6×6, 5×5×5 — and its full pipeline passes. test_mass, tmop 302, mesh.cpp and the multikernel repro unchanged; convert-parallel-to-gpu2 and the other kernel lit tests still pass. Lit test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD