### PR TITLE
Give enzymexla.polygeist_yield its region-terminator AD rule

### DIFF
--- a/src/enzyme_ad/jax/Implementations/EnzymeXLADerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/EnzymeXLADerivatives.td
@@ -26,6 +26,8 @@ def : EnzymeXLAControlFlowOp<"GPUWrapperOp", [{
   }
 }]>;
 
+def : EnzymeXLARegionTerminatorOp<"PolygeistYieldOp">;
+
 def : EnzymeXLAReadOnlyIdentityOp<"Pointer2MemrefOp", [0]>;
 def : EnzymeXLAReadOnlyIdentityOp<"Memref2PointerOp", [0]>;
 

--- a/test/lit_tests/diffrules/enzymexla/gpu_wrapper_fwd.mlir
+++ b/test/lit_tests/diffrules/enzymexla/gpu_wrapper_fwd.mlir
@@ -1,0 +1,46 @@
+// RUN: enzymexlamlir-opt %s --enzyme --canonicalize --remove-unnecessary-enzyme-ops --enzyme-simplify-math | FileCheck %s
+
+func.func private @gpu_wrapper(%ptr: !llvm.ptr) {
+  %c1 = arith.constant 1 : index
+  %c120 = arith.constant 120 : index
+  %code = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c120, %c120, %c1) ({
+    affine.for %iv = 0 to 120 {
+      %mem = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr) -> memref<?xf32>
+      %val = affine.load %mem[%iv] : memref<?xf32>
+      %sq = arith.mulf %val, %val : f32
+      affine.store %sq, %mem[%iv] : memref<?xf32>
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+func.func @dgpu_wrapper(%ptr: !llvm.ptr, %dptr: !llvm.ptr) {
+  enzyme.fwddiff @gpu_wrapper(%ptr, %dptr) {
+    activity = [#enzyme<activity enzyme_dup>],
+    ret_activity = []
+  } : (!llvm.ptr, !llvm.ptr) -> ()
+  return
+}
+
+// CHECK-LABEL:   func.func private @fwddiffegpu_wrapper(
+// CHECK-SAME:      %[[ARG0:.*]]: !llvm.ptr, %[[ARG1:.*]]: !llvm.ptr) {
+// CHECK:           %[[C1:.*]] = arith.constant 1 : index
+// CHECK:           %[[C120:.*]] = arith.constant 120 : index
+// CHECK:           %{{.*}} = "enzymexla.gpu_wrapper"(%[[C1]], %[[C1]], %[[C1]], %[[C120]], %[[C120]], %[[C1]]) ({
+// CHECK:             %[[DMEM:.*]] = "enzymexla.pointer2memref"(%[[ARG1]]) : (!llvm.ptr) -> memref<?xf32>
+// CHECK:             %[[MEM:.*]] = "enzymexla.pointer2memref"(%[[ARG0]]) : (!llvm.ptr) -> memref<?xf32>
+// CHECK:             affine.for %[[IV:.*]] = 0 to 120 {
+// CHECK:               %[[DVAL:.*]] = affine.load %[[DMEM]]{{\[}}%[[IV]]] : memref<?xf32>
+// CHECK:               %[[VAL:.*]] = affine.load %[[MEM]]{{\[}}%[[IV]]] : memref<?xf32>
+// CHECK:               %[[L:.*]] = arith.mulf %[[DVAL]], %[[VAL]] fastmath<fast> : f32
+// CHECK:               %[[R:.*]] = arith.mulf %[[DVAL]], %[[VAL]] fastmath<fast> : f32
+// CHECK:               %[[DSQ:.*]] = arith.addf %[[L]], %[[R]] fastmath<fast> : f32
+// CHECK:               %[[SQ:.*]] = arith.mulf %[[VAL]], %[[VAL]] : f32
+// CHECK:               affine.store %[[DSQ]], %[[DMEM]]{{\[}}%[[IV]]] : memref<?xf32>
+// CHECK:               affine.store %[[SQ]], %[[MEM]]{{\[}}%[[IV]]] : memref<?xf32>
+// CHECK:             }
+// CHECK:             "enzymexla.polygeist_yield"() : () -> ()
+// CHECK:           }) : (index, index, index, index, index, index) -> index
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
`enzymexla.gpu_wrapper` has had a control-flow AD rule since it was added, but the terminator of its region never got one, so forward mode over a wrapper stopped at `could not compute the adjoint for this operation "enzymexla.polygeist_yield"()`. Reverse mode reaches the terminator by a different path and did not notice.

`EnzymeXLARegionTerminatorOp` was already declared in the file and unused; this is the one line that uses it.

Together with EnzymeAD/Enzyme#3140 (forward mode for `affine.parallel`) this is what a raised CUDA kernel needs to be differentiated in forward mode. The test here uses an `affine.for` body so it stands on its own without that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD