### PR TITLE
Register device globals with the runtime the module is registered with

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -2508,21 +2508,34 @@ ConvertGPUModuleOp::matchAndRewrite(gpu::GPUModuleOp kernelModule,
           // to pass the GPU DL in here
           DataLayout DLI(moduleOp);
           auto size = DLI.getTypeSize(globalTy);
-          rtRegisterVarCallBuilder.create(
-              ctorloc, ctorBuilder,
-              {module.getResult(), bitcast, symbolName, symbolName,
-               /*isExtern*/
-               LLVM::ConstantOp::create(ctorBuilder, ctorloc, llvmInt32Type,
-                                        /* TODO */ 0),
-               /*varSize*/
-               LLVM::ConstantOp::create(ctorBuilder, ctorloc, llvmIntPtrType,
-                                        size),
-               /*isConstant*/
-               LLVM::ConstantOp::create(ctorBuilder, ctorloc, llvmInt32Type,
-                                        /* TODO */ 0),
-               /* just a 0? */
-               LLVM::ConstantOp::create(ctorBuilder, ctorloc, llvmInt32Type,
-                                        0)});
+          Type varTys[] = {llvmPointerType, llvmPointerType, llvmPointerType,
+                           llvmPointerType, llvmInt32Type,   llvmIntPtrType,
+                           llvmInt32Type,   llvmInt32Type};
+
+          auto cudaRegisterVarFn = LLVM::lookupOrCreateFn(
+              rewriter, moduleOp, registerVarFuncName, varTys, llvmVoidType);
+
+          if (failed(cudaRegisterVarFn)) {
+            llvm::errs() << " " << registerVarFuncName
+                         << " already exists with different types\n";
+            return failure();
+          }
+
+          auto isExtern = LLVM::ConstantOp::create(ctorBuilder, ctorloc,
+                                                   llvmInt32Type, /* TODO */ 0);
+          auto varSize = LLVM::ConstantOp::create(ctorBuilder, ctorloc,
+                                                  llvmIntPtrType, size);
+          auto isConstant = LLVM::ConstantOp::create(
+              ctorBuilder, ctorloc, llvmInt32Type, /* TODO */ 0);
+          auto isGlobal =
+              LLVM::ConstantOp::create(ctorBuilder, ctorloc, llvmInt32Type, 0);
+
+          Value varArgs[] = {module.getResult(), bitcast,  symbolName,
+                             symbolName,         isExtern, varSize,
+                             isConstant,         isGlobal};
+
+          LLVM::CallOp::create(rewriter, ctorloc, cudaRegisterVarFn.value(),
+                               varArgs);
         }
       }
       // TODO this has to happen only for some CUDA versions, hip does not need

--- a/test/lit_tests/lowering/register-device-global.mlir
+++ b/test/lit_tests/lowering/register-device-global.mlir
@@ -1,0 +1,34 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=cuda})" | FileCheck %s
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=rocm})" | FileCheck %s --check-prefix=ROCM
+
+module attributes {gpu.container_module} {
+  llvm.mlir.global external @device_var(dense<0.000000e+00> : tensor<4xf32>) {addr_space = 1 : i32} : !llvm.array<4 x f32>
+
+  llvm.func @launch(%arg0: !llvm.ptr) {
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c1_i64 = arith.constant 1 : i64
+    %stream = llvm.inttoptr %c1_i64 : i64 to !llvm.ptr
+    gpu.launch_func <%stream : !llvm.ptr> @test_module::@test_kernel blocks in (%c1, %c1, %c1) threads in (%c32, %c1, %c1) args(%arg0 : !llvm.ptr)
+    llvm.return
+  }
+
+  gpu.module @test_module {
+    llvm.mlir.global external @device_var(dense<0.000000e+00> : tensor<4xf32>) {addr_space = 1 : i32} : !llvm.array<4 x f32>
+
+    gpu.func @test_kernel(%arg0: !llvm.ptr) kernel {
+      gpu.return
+    }
+  }
+}
+
+// A device global is registered with the runtime the rest of the module is
+// registered with, not with the mlir gpu runtime.
+
+// CHECK: llvm.func @__cudaRegisterVar(!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i64, i32, i32)
+// CHECK: llvm.call @__cudaRegisterVar(
+// CHECK-NOT: __mgpurtRegisterVar
+
+// ROCM: llvm.func @__hipRegisterVar(!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i64, i32, i32)
+// ROCM: llvm.call @__hipRegisterVar(
+// ROCM-NOT: __mgpurtRegisterVar


### PR DESCRIPTION
`ConvertGPUModuleOp` picks `__cudaRegisterVar` / `__hipRegisterVar` into `registerVarFuncName` alongside the fat-binary and function names, and then never uses it: the device-global case calls `__mgpurtRegisterVar` instead. Nothing in a cuda or rocm link provides that symbol, so any module holding a device global failed to link with `undefined reference to __mgpurtRegisterVar` -- MFEM's `lor_batched.cpp` is one.

The argument list already matched `__cudaRegisterVar`'s signature, so this is the name and the declaration, not the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD