### PR TITLE
mem2reg: take apart a load of an aggregate that is only read field by field

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2181,6 +2181,49 @@ std::set<std::string> NoWriteFunctions = {"exit", "__errno_location"};
 // The way into `from` that reaches what lies at `at` bytes into it and is of
 // the size of `want`, as the indices an extractvalue takes. Aggregates are
 // walked into; anything else is only reachable when it is the whole of it.
+// The byte at which the field named by `pos` sits inside `from`, and its type.
+// The mirror of extractPath, which goes the other way: from a byte offset to
+// the indices that reach it.
+static std::optional<std::pair<uint64_t, Type>>
+aggregateFieldOffset(Type from, ArrayRef<int64_t> pos, const DataLayout &dl) {
+  uint64_t at = 0;
+  Type cur = from;
+  for (int64_t want : pos) {
+    if (want < 0)
+      return std::nullopt;
+    if (auto ST = dyn_cast<LLVM::LLVMStructType>(cur)) {
+      if ((size_t)want >= ST.getBody().size())
+        return std::nullopt;
+      uint64_t byte = 0;
+      for (auto &&[i, member] : llvm::enumerate(ST.getBody())) {
+        auto size = typeSize(member, dl);
+        if (!size)
+          return std::nullopt;
+        if (!ST.isPacked())
+          byte = llvm::alignTo(byte, dl.getTypeABIAlignment(member));
+        if ((int64_t)i == want)
+          break;
+        byte += *size;
+      }
+      at += byte;
+      cur = ST.getBody()[want];
+      continue;
+    }
+    if (auto AT = dyn_cast<LLVM::LLVMArrayType>(cur)) {
+      if ((uint64_t)want >= AT.getNumElements())
+        return std::nullopt;
+      auto size = typeSize(AT.getElementType(), dl);
+      if (!size)
+        return std::nullopt;
+      at += (uint64_t)want * *size;
+      cur = AT.getElementType();
+      continue;
+    }
+    return std::nullopt;
+  }
+  return std::make_pair(at, cur);
+}
+
 static bool extractPath(Type from, uint64_t at, Type want, const DataLayout &dl,
                         SmallVectorImpl<int64_t> &path) {
   auto wantSize = typeSize(want, dl), fromSize = typeSize(from, dl);
@@ -2330,8 +2373,43 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           containedLoads[loadOp] = at;
           break;
         }
-        default:
+        default: {
+          // A read this slot has no whole value for still answers the
+          // fields taken out of it: each extract lands at a byte of its own,
+          // and where that byte is inside the slot it is a read of a piece of
+          // the slot like any other. This is how a by-value capture is read --
+          // built one field at a time and loaded whole, so the read spans
+          // every slot and matches none.
+          //
+          // A read that was itself forwarded, on the round some other slot
+          // matched it, already stands for its fields; answering them here
+          // as well would answer them twice.
+          if (llvm::is_contained(loadOpsToErase, loadOp))
+            return;
+          auto slotAt = tree.add(accessed, dl).containsAt(idx, dl);
+          if (!slotAt)
+            return;
+          Type held = elType ? elType : idx.getBase();
+          if (!held)
+            return;
+          for (Operation *user : loadOp->getResult(0).getUsers()) {
+            auto ev = dyn_cast<LLVM::ExtractValueOp>(user);
+            if (!ev)
+              continue;
+            auto field = aggregateFieldOffset(read, ev.getPosition(), dl);
+            if (!field || field->first < *slotAt)
+              continue;
+            uint64_t at = field->first - *slotAt;
+            SmallVector<int64_t> path;
+            if (!extractPath(held, at, field->second, dl, path))
+              continue;
+            containedLoads[ev] = at;
+            loadOps.insert(ev);
+            LLVM_DEBUG(llvm::dbgs() << "Matching Extract: " << *ev << " of "
+                                    << *loadOp << "\n");
+          }
           return;
+        }
         }
         loadOps.insert(loadOp);
         LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << *loadOp << "\n");

--- a/test/lit_tests/mem2reg_aggregate_capture.mlir
+++ b/test/lit_tests/mem2reg_aggregate_capture.mlir
@@ -1,0 +1,53 @@
+// RUN: enzymexlamlir-opt --polygeist-mem2reg --split-input-file %s | FileCheck %s
+
+// A capture built one field at a time and read back whole: the load of the
+// aggregate has no single store to forward from, but each field taken out of
+// it does.
+
+module {
+  llvm.func @use(!llvm.ptr, !llvm.ptr)
+  func.func @affine_capture(%a : !llvm.ptr, %b : !llvm.ptr) {
+    %c1 = arith.constant 1 : i32
+    %alloca = llvm.alloca %c1 x !llvm.struct<"cap", (ptr, ptr)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %f = "enzymexla.pointer2memref"(%alloca) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    affine.store %a, %f[0] : memref<?x!llvm.ptr>
+    affine.store %b, %f[1] : memref<?x!llvm.ptr>
+    %s = "enzymexla.pointer2memref"(%alloca) : (!llvm.ptr) -> memref<?x!llvm.struct<"cap", (ptr, ptr)>>
+    %agg = affine.load %s[0] : memref<?x!llvm.struct<"cap", (ptr, ptr)>>
+    %x = llvm.extractvalue %agg[0] : !llvm.struct<"cap", (ptr, ptr)>
+    %y = llvm.extractvalue %agg[1] : !llvm.struct<"cap", (ptr, ptr)>
+    llvm.call @use(%x, %y) : (!llvm.ptr, !llvm.ptr) -> ()
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @affine_capture(
+// CHECK-SAME:      %[[a:.*]]: !llvm.ptr, %[[b:.*]]: !llvm.ptr) {
+// CHECK-NOT:       llvm.extractvalue
+// CHECK:           llvm.call @use(%[[a]], %[[b]])
+// CHECK:           return
+
+// -----
+
+module {
+  llvm.func @use(!llvm.ptr, !llvm.ptr)
+  func.func @llvm_capture(%a : !llvm.ptr, %b : !llvm.ptr) {
+    %c1 = arith.constant 1 : i32
+    %alloca = llvm.alloca %c1 x !llvm.struct<"cap", (ptr, ptr)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %p0 = llvm.getelementptr %alloca[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"cap", (ptr, ptr)>
+    llvm.store %a, %p0 : !llvm.ptr, !llvm.ptr
+    %p1 = llvm.getelementptr %alloca[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"cap", (ptr, ptr)>
+    llvm.store %b, %p1 : !llvm.ptr, !llvm.ptr
+    %agg = llvm.load %alloca : !llvm.ptr -> !llvm.struct<"cap", (ptr, ptr)>
+    %x = llvm.extractvalue %agg[0] : !llvm.struct<"cap", (ptr, ptr)>
+    %y = llvm.extractvalue %agg[1] : !llvm.struct<"cap", (ptr, ptr)>
+    llvm.call @use(%x, %y) : (!llvm.ptr, !llvm.ptr) -> ()
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @llvm_capture(
+// CHECK-SAME:      %[[a:.*]]: !llvm.ptr, %[[b:.*]]: !llvm.ptr) {
+// CHECK-NOT:       llvm.extractvalue
+// CHECK:           llvm.call @use(%[[a]], %[[b]])
+// CHECK:           return


### PR DESCRIPTION
A by-value capture is built one field at a time and then read whole, so the read of the aggregate spans every slot the fields were stored into and matches none of them: nothing forwards, and the slot stays in memory with every reader going through it.

But a read this slot has no whole value for still answers the fields taken out of it. Each `llvm.extractvalue` lands at a byte offset of its own, and where that byte is inside the slot it is a read of a piece of the slot like any other -- so `matchLoad` registers it in `containedLoads` at the shifted offset and the forwarding already in place answers it, through the same `extractPath` it uses for every other partial read. No narrowed loads are created and no new IR is built; the extract is answered with the stored value directly.

Registering it as a contained read rather than requiring the field to land exactly on the slot is what makes it general: an extract that yields an inner struct of a nested capture is a partial read the slot value covers, and is answered the same way.

Two things it must not do:

- forward a field out of the read it was taken from, which would leave it standing for itself (load-to-load forwarding);
- take fields out of a read that was itself forwarded on the round some other slot matched it, which would answer them twice.

`extractPath` already went from a byte offset to the indices that reach it; `aggregateFieldOffset` is the other direction, and is what says which byte a field lands on.

The emptied read is left to DCE.

### Why it matters beyond a smaller slot

That shape is what a lambda-taking kernel launcher emits. Leaving the capture in memory makes the pointers reach differentiation through a struct, where activity is a property of the whole value:

- an `enzyme_const` pointer sitting beside an active one cannot be told apart, so its shadow falls back to the primal pointer and the tangent reads the primal data instead of zero, adding a spurious term;
- the dataflow activity analysis loses the active pointers entirely and produces a null shadow (EnzymeAD/Enzyme#3142).

With the capture taken apart, each pointer carries its own activity and both go away. On a reproducer differentiating `y = coef * x^3` through a scratch buffer across three launches, the tangent goes from wrong (default analysis) or zero (`--enzyme=dataflow`) to correct under both.

Scope worth stating: this reaches a capture that is *local* to the differentiated function. Where the functor is handed to a launcher by pointer and that launcher is not inlined -- which is what MFEM's `forall`/`CuWrap1DStruct::Call` does -- there is no slot in the launcher to promote, and this cannot help; that case needs field-sensitive activity or inlining, and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD