### PR TITLE
affine-cfg: settle on one shape for a recreated bound

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2190,6 +2190,14 @@ struct CanonicalieForBounds : public OpRewritePattern<affine::AffineForOp> {
     ubMap = removeDuplicateExprs(ubMap);
     ubMap = recreateExpr(ubMap);
 
+    // recreateExpr rebuilds each sum, and the tree it builds need not be the
+    // one the canonicalizer left: `(-d0 + s0) - 1` and `-d0 + (s0 - 1)` are
+    // the same map, print the same, and are not the same object. Comparing
+    // those to decide progress had the two of them handing the loop back and
+    // forth forever. Simplifying settles on one shape.
+    lbMap = simplifyAffineMap(lbMap);
+    ubMap = simplifyAffineMap(ubMap);
+
     // ubMap.dump();
     // forOp.dump();
 

--- a/test/lit_tests/affinecfg_recreated_bound.mlir
+++ b/test/lit_tests/affinecfg_recreated_bound.mlir
@@ -1,0 +1,33 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+// The inner bound composes to n - i - 1. recreateExpr rebuilds that sum, and
+// the tree it builds need not be the one the canonicalizer left: (-d0 + s0) - 1
+// and -d0 + (s0 - 1) are the same map, print the same, and are not the same
+// object. Comparing those to decide whether the bound changed left the pattern
+// and the canonicalizer handing the loop back and forth, so the greedy driver
+// never reached a fixpoint and the pass failed -- silently, since its only
+// failure path is applyPatternsGreedily.
+
+func.func @triangular(%n : index, %A : memref<?xf64>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.000000e+00 : f64
+  scf.for %i = %c0 to %n step %c1 {
+    %rest = arith.subi %n, %i : index
+    %ub = arith.subi %rest, %c1 : index
+    scf.for %j = %c0 to %ub step %c1 {
+      memref.store %cst, %A[%j] : memref<?xf64>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:   func.func @triangular(
+// CHECK-SAME:      %[[n:.*]]: index, %[[A:.*]]: memref<?xf64>) {
+// CHECK:           %[[cst:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK:           affine.for %[[i:.*]] = 0 to %[[n]] {
+// CHECK:             affine.parallel (%[[j:.*]]) = (0) to (-%[[i]] + symbol(%[[n]]) - 1) {
+// CHECK:               affine.store %[[cst]], %[[A]]{{\[}}%[[j]]] : memref<?xf64>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return


### PR DESCRIPTION
`CanonicalieForBounds` composes a loop's bounds and then decides whether that changed anything. `recreateExpr` rebuilds each sum on the way, and the tree it builds need not be the one the canonicalizer left: `(-d0 + s0) - 1` and `-d0 + (s0 - 1)` are the same map, print as the same string, and are not the same object. Comparing those to decide progress had the pattern and the canonicalizer handing the loop back and forth, so `applyPatternsGreedily` never reached a fixpoint.

Simplifying the composed maps settles on one shape.

The failure is silent, which is most of what made it expensive to find: `applyPatternsGreedily` returning failure is the pass's only failure path, and it calls `signalPassFailure()` with no diagnostic, so all a caller sees is that the pipeline failed. Three of MFEM's CUDA translation units -- `fem/hybridization_ext.cpp`, `linalg/batched/native.cpp`, `fem/integ/bilininteg_transpose_ea.cpp` -- did not compile because of it.

Two details worth recording for anyone who meets this class again:

- With the iteration limit removed the pass *hangs*, which is how to tell a genuine cycle from a budget that is merely too small.
- The maps involved print identically, so a trace of them looks like a pattern reporting success having changed nothing. Printing `getNumDims()`/`getNumSymbols()` and the `==` result beside them is what showed the difference was association rather than content.

### Test

`test/lit_tests/affinecfg_recreated_bound.mlir` -- an `scf.for` nest whose inner bound composes to `n - i - 1`, the shape that looped. It fails on `main` (the pass returns non-zero and FileCheck does not match) and passes with this change; I checked both directions rather than only that it passes now. The other 68 tests mentioning `affine-cfg` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
