### PR TITLE
mem2reg: an array of one wraps a value like a struct of one

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2089,6 +2089,14 @@ Value castToType(Type elType, Value val, Operation *op) {
       return LLVM::InsertValueOp::create(b, val.getLoc(), ud, c0,
                                          b.getDenseI64ArrayAttr({0}));
     }
+  } else if (auto AT = dyn_cast<LLVM::LLVMArrayType>(elType)) {
+    if (AT.getNumElements() == 1) {
+      auto ud = LLVM::UndefOp::create(b, val.getLoc(), elType);
+      auto c0 = castToType(AT.getElementType(), val, op);
+      b.setInsertionPoint(op);
+      return LLVM::InsertValueOp::create(b, val.getLoc(), ud, c0,
+                                         b.getDenseI64ArrayAttr({0}));
+    }
   }
   llvm::errs() << " mismatched load type, needed: " << elType << " found "
                << val << "\n";

--- a/test/lit_tests/mem2reg_array_of_one.mlir
+++ b/test/lit_tests/mem2reg_array_of_one.mlir
@@ -1,0 +1,18 @@
+// RUN: enzymexlamlir-opt --polygeist-mem2reg %s | FileCheck %s
+
+llvm.func @use(!llvm.array<1 x i32>)
+
+llvm.func @wrap(%v : i32) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %slot = llvm.alloca %c1 x !llvm.array<1 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+  llvm.store %v, %slot : i32, !llvm.ptr
+  %agg = llvm.load %slot : !llvm.ptr -> !llvm.array<1 x i32>
+  llvm.call @use(%agg) : (!llvm.array<1 x i32>) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL:   llvm.func @wrap(
+// CHECK-SAME:      %[[v:.*]]: i32) {
+// CHECK-NOT:       llvm.load
+// CHECK:           %[[agg:.*]] = llvm.insertvalue %[[v]], %{{.*}}[0] : !llvm.array<1 x i32>
+// CHECK:           llvm.call @use(%[[agg]])


### PR DESCRIPTION
`castToType` takes a value out of an aggregate of one element -- array or struct alike -- but only knew how to put one back into a struct. Asked for an array of one it fell through to the `llvm_unreachable` at the bottom, which under `NDEBUG` is not an abort but undefined behaviour: the compiler prints ` mismatched load type, needed: !llvm.array<1 x i32> found ... : !llvm.ptr -> i32` and then segfaults.

Putting a value into an array of one is the same question as putting it into a struct of one, and the unwrapping side above already treats them the same way.

### How it turned up

MFEM's `tests/unit/dfem/test_tmop.cpp` reaches it once the wrappers around its `forall` are inlined (mfem/mfem#5450), with `elType` `!llvm.array<1 x i32>` and an `i32` in the slot. That translation unit compiles cleanly without the inlining, which is why this has not been seen before -- the shape only arises once the closure lands in the caller's frame.

### Test

`test/lit_tests/mem2reg_array_of_one.mlir` stores an `i32` into a slot typed `!llvm.array<1 x i32>` and reads the array back. The alloca and the load promote away entirely and the value is wrapped with `llvm.insertvalue`. The other 13 tests touching `polygeist-mem2reg` are unaffected.

Worth noting separately: a `llvm_unreachable` reached after an `llvm::errs()` diagnostic is a segfault in release rather than a clean failure. Every other caller of `castToType` has the same exposure, so a `report_fatal_error` there would turn a crash into an error message. I have not changed that here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
