### PR TITLE
Fix crash promoting a kernel with no argument attributes

### DIFF
--- a/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
+++ b/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
@@ -688,8 +688,12 @@ enum __device_builtin__ cudaMemcpyKind
         }
         if (launchFuncOp) {
 
+          // A kernel with no argument attributes has no attribute list at
+          // all, and the optional is empty rather than holding an empty array.
           SmallVector<Attribute> newArgAttrs;
-          for (auto [i, argAttrs] : llvm::enumerate(*cur.getArgAttrs())) {
+          ArrayAttr curArgAttrs =
+              cur.getArgAttrs().value_or(ArrayAttr::get(cur->getContext(), {}));
+          for (auto [i, argAttrs] : llvm::enumerate(curArgAttrs)) {
             if (std::optional<NamedAttribute> attr =
                     cast<DictionaryAttr>(argAttrs).getNamed(
                         LLVM::LLVMDialect::getByValAttrName())) {

--- a/test/lit_tests/gpu-launch-recognition-noargattrs.mlir
+++ b/test/lit_tests/gpu-launch-recognition-noargattrs.mlir
@@ -1,0 +1,30 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(gpu-launch-recognition)" | FileCheck %s
+
+// A kernel whose address escapes to a runtime query is captured, so it is
+// promoted with gpu.launch_func rather than lowered to a parallel region. If it
+// also has a launch to rewrite and carries no argument attributes -- taking no
+// arguments at all is the simplest way to get there -- the attribute list is
+// absent rather than empty.
+module attributes {gpu.container_module} {
+  llvm.func @__mlir_cuda_caller_phase3(...)
+  llvm.func @cudaFuncGetAttributes(!llvm.ptr, !llvm.ptr) -> i32
+
+  llvm.func internal @kern() {
+    llvm.return
+  }
+
+  llvm.func @caller(%attrs: !llvm.ptr) {
+    %f = llvm.mlir.addressof @kern : !llvm.ptr
+    %dim = llvm.mlir.constant(1 : i32) : i32
+    %shmem = llvm.mlir.constant(0 : i64) : i64
+    %stream = llvm.mlir.zero : !llvm.ptr
+    llvm.call @__mlir_cuda_caller_phase3(%f, %dim, %dim, %dim, %dim, %dim, %dim, %shmem, %stream) vararg(!llvm.func<void (...)>) : (!llvm.ptr, i32, i32, i32, i32, i32, i32, i64, !llvm.ptr) -> ()
+    %0 = llvm.call @cudaFuncGetAttributes(%attrs, %f) : (!llvm.ptr, !llvm.ptr) -> i32
+    llvm.return
+  }
+}
+
+// CHECK: gpu.func @kern() kernel
+// CHECK: gpu.launch_func
+// CHECK-SAME: @kern
+// CHECK-SAME: reactant.arg_attrs = []


### PR DESCRIPTION
## Problem

`GPULaunchRecognition` dereferences an optional unconditionally when attaching argument attributes to a newly created `gpu.launch_func`:

```cpp
for (auto [i, argAttrs] : llvm::enumerate(*cur.getArgAttrs())) {
```

A function with no argument attributes has no attribute list at all — `getArgAttrs()` returns `nullopt`, not an empty array — so this is undefined behavior, and it segfaults in practice. Taking no arguments is the simplest way to get there.

Reaching the line needs two things at once:

- the kernel is **captured**, which is what selects the `launch_func` path over lowering to a parallel region, and
- it still has a **launch to rewrite**.

Those rarely co-occur today: a kernel captured by a runtime query has usually had its launch optimized away by the time the pass runs (its stub is uncalled and gets deleted), so it promotes with an empty launch list and never reaches this code. The combination shows up once a kernel is promoted whose launch still exists, e.g. in an unoptimized build.

The added test reproduces the crash on `main` directly — a zero-argument kernel with a `caller_phase3` launch plus a `cudaFuncGetAttributes` use to make it captured:

```
$ enzymexlamlir-opt test.mlir --pass-pipeline="builtin.module(gpu-launch-recognition)"
Segmentation fault (core dumped)
```

## Fix

Treat an absent attribute list as empty. With the fix the same input promotes cleanly:

```mlir
gpu.func @kern() kernel { ... }
gpu.launch_func @__mlir_gpu_module::@kern blocks in (...) threads in (...)
    dynamic_shared_memory_size %4 {reactant.arg_attrs = []}
```

## Testing

- New lit test, which segfaults on `main` and passes with the fix.
- Full lit suite: 1156/1157. The single failure is an untracked local WIP file exercising a different pass and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD