### PR TITLE
ParallelLower: lower gpu.launch_func by leaf name, guard inliner recursion and re-prepared callees

### DIFF
--- a/src/enzyme_ad/jax/Passes/ParallelLower.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLower.cpp
@@ -697,6 +697,15 @@ void ParallelLower::runOnOperation() {
     if (captured)
       return;
 
+    // A kernel lives in a gpu.module, so the launch names it with a nested
+    // symbol reference. func.call takes a flat callee, and building one from a
+    // nested reference yields an op carrying no callee at all, which faults
+    // when symbol resolution later reads it. Lowering the launch to a call is
+    // not expressible here; leave it for the passes that lower
+    // gpu.launch_func directly.
+    if (!isa<FlatSymbolRefAttr>(launchOp.getKernel()))
+      return;
+
     OpBuilder builder(launchOp);
     auto op = mlir::gpu::LaunchOp::create(
         builder, launchOp.getLoc(), launchOp.getGridSizeX(),

--- a/src/enzyme_ad/jax/Passes/ParallelLower.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLower.cpp
@@ -28,6 +28,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
@@ -369,6 +370,12 @@ void ParallelLower::runOnOperation() {
   std::function<void(enzyme::AutoDiffOp)> autodiffInliner;
   std::function<void(LLVM::CallOp)> LLVMcallInliner;
   SmallPtrSet<Operation *, 1> replacedCallables;
+  // Pre-inlining recurses into the callee's own calls; a (mutually)
+  // recursive callee would recurse forever. A callable already on the
+  // stack keeps its recursive call sites uninlined, and a call site inside
+  // its own callee is never inlined: cloning a region into itself never
+  // ends.
+  SmallPtrSet<Operation *, 8> inliningStack;
   std::function<void(CallOp)> callInliner = [&](CallOp caller) {
     // Build the inliner interface.
     AlwaysInlinerInterface interface(&getContext());
@@ -382,6 +389,11 @@ void ParallelLower::runOnOperation() {
       return;
     if (targetRegion->empty())
       return;
+    if (callableOp->isAncestor(caller) ||
+        !inliningStack.insert(callableOp).second)
+      return;
+    llvm::scope_exit stackGuard(
+        [&, op = callableOp.getOperation()] { inliningStack.erase(op); });
     {
       SmallVector<CallOp> ops;
       callableOp.walk([&](CallOp caller) { ops.push_back(caller); });
@@ -439,6 +451,11 @@ void ParallelLower::runOnOperation() {
       return;
     if (targetRegion->empty())
       return;
+    if (callableOp->isAncestor(caller) ||
+        !inliningStack.insert(callableOp).second)
+      return;
+    llvm::scope_exit stackGuard(
+        [&, op = callableOp.getOperation()] { inliningStack.erase(op); });
     {
       SmallVector<CallOp> ops;
       callableOp.walk([&](CallOp caller) { ops.push_back(caller); });
@@ -501,6 +518,12 @@ void ParallelLower::runOnOperation() {
     assert(gpuWrapper);
     auto [callInGPU, lfn] =
         prepareForGPUInline(caller, gpuWrapper, symbolTable);
+    if (callInGPU == caller) {
+      // Already-prepared callee: the plain inliner consumes the call whole,
+      // and the clone-based tail below would then touch the erased op.
+      LLVMcallInlinerImpl(caller);
+      return;
+    }
     LLVMcallInlinerImpl(callInGPU);
     OpBuilder b(caller);
     auto allocScope = memref::AllocaScopeOp::create(b, caller.getLoc(),
@@ -541,6 +564,11 @@ void ParallelLower::runOnOperation() {
     Region &targetRegion = callableOp.getFunctionBody();
     if (targetRegion.empty())
       return;
+    if (callableOp->isAncestor(caller) ||
+        !inliningStack.insert(callableOp).second)
+      return;
+    llvm::scope_exit stackGuard(
+        [&, op = callableOp.getOperation()] { inliningStack.erase(op); });
     {
       SmallVector<CallOp> ops;
       callableOp.walk([&](CallOp caller) { ops.push_back(caller); });
@@ -598,7 +626,8 @@ void ParallelLower::runOnOperation() {
       auto lop = op->getParentOfType<gpu::LaunchOp>();
       auto fop = op->getParentOfType<FunctionOpInterface>();
       if (!lop || lop->isAncestor(fop)) {
-        toinl.insert(fop);
+        if (!toinl.insert(fop))
+          continue;
         for (Operation *m : symbolUserMap.getUsers(fop)) {
           if (isa<LLVM::CallOp, func::CallOp>(m))
             inlineOps.push_back(m);
@@ -697,15 +726,6 @@ void ParallelLower::runOnOperation() {
     if (captured)
       return;
 
-    // A kernel lives in a gpu.module, so the launch names it with a nested
-    // symbol reference. func.call takes a flat callee, and building one from a
-    // nested reference yields an op carrying no callee at all, which faults
-    // when symbol resolution later reads it. Lowering the launch to a call is
-    // not expressible here; leave it for the passes that lower
-    // gpu.launch_func directly.
-    if (!isa<FlatSymbolRefAttr>(launchOp.getKernel()))
-      return;
-
     OpBuilder builder(launchOp);
     auto op = mlir::gpu::LaunchOp::create(
         builder, launchOp.getLoc(), launchOp.getGridSizeX(),
@@ -720,8 +740,11 @@ void ParallelLower::runOnOperation() {
         launchOp.getClusterSizeY(), launchOp.getClusterSizeZ());
 
     builder.setInsertionPointToStart(&op.getRegion().front());
-    func::CallOp::create(builder, launchOp.getLoc(), launchOp.getKernel(),
-                         TypeRange(), launchOp.getKernelOperands());
+    // func.call cannot carry the nested gpu-module reference; the top-level
+    // original of the kernel launcher shares the leaf name and body.
+    func::CallOp::create(builder, launchOp.getLoc(),
+                         launchOp.getKernelName().getValue(), TypeRange(),
+                         launchOp.getKernelOperands());
     gpu::TerminatorOp::create(builder, launchOp.getLoc());
     for (auto &&[lhs, rhs] :
          llvm::zip_equal(launchOp->getResults(), op->getResults())) {
@@ -766,6 +789,21 @@ void ParallelLower::runOnOperation() {
 
     auto oneindex = ConstantIndexOp::create(builder, loc, 1);
 
+    // launch_func-recognized kernels carry i64 dims; everything below wants
+    // index.
+    auto dimToIndex = [&](Value v) -> Value {
+      if (isa<IndexType>(v.getType()))
+        return v;
+      return arith::IndexCastOp::create(builder, loc, builder.getIndexType(),
+                                        v);
+    };
+    Value dimGridX = dimToIndex(launchOp.getGridSizeX());
+    Value dimGridY = dimToIndex(launchOp.getGridSizeY());
+    Value dimGridZ = dimToIndex(launchOp.getGridSizeZ());
+    Value dimBlockX = dimToIndex(launchOp.getBlockSizeX());
+    Value dimBlockY = dimToIndex(launchOp.getBlockSizeY());
+    Value dimBlockZ = dimToIndex(launchOp.getBlockSizeZ());
+
     async::ExecuteOp asyncOp = nullptr;
     if (!launchOp.getAsyncDependencies().empty()) {
       SmallVector<Value> dependencies;
@@ -785,9 +823,8 @@ void ParallelLower::runOnOperation() {
     if (wrapParallelOps) {
       auto pw = enzymexla::GPUWrapperOp::create(
           builder, loc,
-          ValueRange({launchOp.getGridSizeX(), launchOp.getGridSizeY(),
-                      launchOp.getGridSizeZ(), launchOp.getBlockSizeX(),
-                      launchOp.getBlockSizeY(), launchOp.getBlockSizeZ()}));
+          ValueRange(
+              {dimGridX, dimGridY, dimGridZ, dimBlockX, dimBlockY, dimBlockZ}));
       if (lfn) {
         if (auto passthrough = lfn.getPassthrough()) {
           pw->setAttr("passthrough", *passthrough);
@@ -808,8 +845,7 @@ void ParallelLower::runOnOperation() {
 
     auto block = mlir::scf::ParallelOp::create(
         builder, loc, std::vector<Value>({zindex, zindex, zindex}),
-        std::vector<Value>({launchOp.getGridSizeX(), launchOp.getGridSizeY(),
-                            launchOp.getGridSizeZ()}),
+        std::vector<Value>({dimGridX, dimGridY, dimGridZ}),
         std::vector<Value>({oneindex, oneindex, oneindex}));
     Block *blockB = &block.getRegion().front();
     builder.setInsertionPointToStart(blockB);
@@ -831,8 +867,7 @@ void ParallelLower::runOnOperation() {
 
     auto threadr = mlir::scf::ParallelOp::create(
         builder, loc, std::vector<Value>({zindex, zindex, zindex}),
-        std::vector<Value>({launchOp.getBlockSizeX(), launchOp.getBlockSizeY(),
-                            launchOp.getBlockSizeZ()}),
+        std::vector<Value>({dimBlockX, dimBlockY, dimBlockZ}),
         std::vector<Value>({oneindex, oneindex, oneindex}));
     Block *threadB = &threadr.getRegion().front();
     builder.setInsertionPointToStart(threadB);
@@ -868,12 +903,12 @@ void ParallelLower::runOnOperation() {
     SmallVector<Value> launchArgs;
     llvm::append_range(launchArgs, blockB->getArguments());
     llvm::append_range(launchArgs, threadB->getArguments());
-    launchArgs.push_back(launchOp.getGridSizeX());
-    launchArgs.push_back(launchOp.getGridSizeY());
-    launchArgs.push_back(launchOp.getGridSizeZ());
-    launchArgs.push_back(launchOp.getBlockSizeX());
-    launchArgs.push_back(launchOp.getBlockSizeY());
-    launchArgs.push_back(launchOp.getBlockSizeZ());
+    launchArgs.push_back(dimGridX);
+    launchArgs.push_back(dimGridY);
+    launchArgs.push_back(dimGridZ);
+    launchArgs.push_back(dimBlockX);
+    launchArgs.push_back(dimBlockY);
+    launchArgs.push_back(dimBlockZ);
     builder.inlineBlockBefore(&launchOp.getRegion().front(), mergeLoc,
                               launchArgs);
 
@@ -996,11 +1031,11 @@ void ParallelLower::runOnOperation() {
     container.walk([&](gpu::GridDimOp bidx) {
       Value val = nullptr;
       if (bidx.getDimension() == gpu::Dimension::x)
-        val = launchOp.getGridSizeX();
+        val = dimGridX;
       else if (bidx.getDimension() == gpu::Dimension::y)
-        val = launchOp.getGridSizeY();
+        val = dimGridY;
       else if (bidx.getDimension() == gpu::Dimension::z)
-        val = launchOp.getGridSizeZ();
+        val = dimGridZ;
       else
         llvm_unreachable("illegal dimension");
       builder.replaceOp(bidx, val);
@@ -1009,11 +1044,11 @@ void ParallelLower::runOnOperation() {
     container.walk([&](gpu::BlockDimOp bidx) {
       Value val = nullptr;
       if (bidx.getDimension() == gpu::Dimension::x)
-        val = launchOp.getBlockSizeX();
+        val = dimBlockX;
       else if (bidx.getDimension() == gpu::Dimension::y)
-        val = launchOp.getBlockSizeY();
+        val = dimBlockY;
       else if (bidx.getDimension() == gpu::Dimension::z)
-        val = launchOp.getBlockSizeZ();
+        val = dimBlockZ;
       else
         llvm_unreachable("illegal dimension");
       builder.replaceOp(bidx, val);

--- a/test/lit_tests/parallel-lower-launch-func.mlir
+++ b/test/lit_tests/parallel-lower-launch-func.mlir
@@ -1,0 +1,21 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(parallel-lower{wrapParallelOps=true})" | FileCheck %s
+
+// A kernel lives in a gpu.module, so the launch names it with a nested symbol
+// reference, which cannot be lowered to a func.call here. The launch is left
+// for the passes that lower gpu.launch_func directly.
+module attributes {gpu.container_module} {
+  gpu.module @gpum {
+    gpu.func @kern() kernel {
+      gpu.return
+    }
+  }
+  func.func @caller() {
+    %c1 = arith.constant 1 : index
+    %shmem = arith.constant 0 : i32
+    gpu.launch_func @gpum::@kern blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) dynamic_shared_memory_size %shmem
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @caller
+// CHECK: gpu.launch_func @gpum::@kern

--- a/test/lit_tests/parallel-lower-launch-func.mlir
+++ b/test/lit_tests/parallel-lower-launch-func.mlir
@@ -1,21 +1,40 @@
 // RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(parallel-lower{wrapParallelOps=true})" | FileCheck %s
 
 // A kernel lives in a gpu.module, so the launch names it with a nested symbol
-// reference, which cannot be lowered to a func.call here. The launch is left
-// for the passes that lower gpu.launch_func directly.
+// reference that func.call cannot carry. Launch recognition clones the
+// kernel into the gpu.module under its own name, so the top-level original
+// shares the leaf name and body: lower the launch through a call to that.
+// The launch carries i64 dims, which become index for the parallel loops.
 module attributes {gpu.container_module} {
   gpu.module @gpum {
-    gpu.func @kern() kernel {
+    gpu.func @kern(%arg0: memref<?xf32>) kernel {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 1.0 : f32
+      memref.store %cst, %arg0[%c0] : memref<?xf32>
       gpu.return
     }
   }
-  func.func @caller() {
-    %c1 = arith.constant 1 : index
+  func.func @kern(%arg0: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 1.0 : f32
+    memref.store %cst, %arg0[%c0] : memref<?xf32>
+    return
+  }
+  func.func @caller(%arg0: memref<?xf32>, %n: i64) {
+    %c1 = arith.constant 1 : i64
     %shmem = arith.constant 0 : i32
-    gpu.launch_func @gpum::@kern blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) dynamic_shared_memory_size %shmem
+    gpu.launch_func @gpum::@kern blocks in (%n, %c1, %c1) threads in (%c1, %c1, %c1) : i64 dynamic_shared_memory_size %shmem args(%arg0 : memref<?xf32>)
     return
   }
 }
 
 // CHECK-LABEL: func.func @caller
-// CHECK: gpu.launch_func @gpum::@kern
+// CHECK-SAME: (%[[BUF:.+]]: memref<?xf32>, %[[N:.+]]: i64)
+// CHECK-DAG: %[[NI:.+]] = arith.index_cast %[[N]] : i64 to index
+// CHECK-DAG: %[[ONE:.+]] = arith.constant 1 : index
+// CHECK: "enzymexla.gpu_wrapper"(%[[NI]], %[[ONE]], %[[ONE]], %[[ONE]], %[[ONE]], %[[ONE]])
+// CHECK: scf.parallel (%{{.*}}) = (%{{.*}}) to (%[[NI]], %[[ONE]], %[[ONE]])
+// CHECK: scf.parallel
+// CHECK: memref.store %{{.*}}, %[[BUF]][%{{.*}}] : memref<?xf32>
+// CHECK-NOT: gpu.launch_func
+// CHECK-NOT: func.call

--- a/test/lit_tests/parallel-lower-prepared-callee.mlir
+++ b/test/lit_tests/parallel-lower-prepared-callee.mlir
@@ -1,0 +1,32 @@
+// RUN: enzymexlamlir-opt %s --parallel-lower | FileCheck %s
+
+// A callee already prepared for GPU inlining (a by-value wrapper this pass
+// itself builds, left behind by an earlier run) needs no second wrapper: the
+// call is inlined whole, and nothing may touch it afterwards.
+module {
+  llvm.func private @foo(%p: !llvm.ptr) {
+    %c1 = llvm.mlir.constant(1 : i32) : i32
+    nvvm.barrier
+    llvm.store %c1, %p : i32, !llvm.ptr
+    llvm.return
+  }
+  llvm.func private @"foo$tmp_for_inline"(%p: !llvm.ptr) attributes {enzyme.prepared_for_inline} {
+    llvm.call @foo(%p) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func @launch(%p: !llvm.ptr) {
+    %c1 = arith.constant 1 : index
+    %sh = arith.constant 0 : i32
+    gpu.launch blocks(%bx, %by, %bz) in (%gx = %c1, %gy = %c1, %gz = %c1) threads(%tx, %ty, %tz) in (%sx = %c1, %sy = %c1, %sz = %c1) dynamic_shared_memory_size %sh {
+      llvm.call @"foo$tmp_for_inline"(%p) : (!llvm.ptr) -> ()
+      gpu.terminator
+    }
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: llvm.func @launch
+// CHECK: scf.parallel
+// CHECK: scf.parallel
+// CHECK: llvm.store
+// CHECK-NOT: llvm.call

--- a/test/lit_tests/parallel-lower-recursive.mlir
+++ b/test/lit_tests/parallel-lower-recursive.mlir
@@ -1,0 +1,32 @@
+// RUN: enzymexlamlir-opt %s --parallel-lower --verify-diagnostics
+
+// Pre-inlining descends into the callee's own calls before inlining it, so a
+// recursive callee would recurse forever. A callee already being inlined
+// keeps its recursive call sites as calls, and the pass then reports the
+// call it could not remove instead of never finishing.
+module {
+  llvm.func private @rec(%p: !llvm.ptr, %n: i32) {
+    %c0 = llvm.mlir.constant(0 : i32) : i32
+    %c1 = llvm.mlir.constant(1 : i32) : i32
+    nvvm.barrier
+    %cmp = llvm.icmp "sgt" %n, %c0 : i32
+    llvm.cond_br %cmp, ^bb1, ^bb2
+  ^bb1:
+    %n1 = llvm.sub %n, %c1 : i32
+    llvm.store %n, %p : i32, !llvm.ptr
+    // expected-error @below {{Could not erase function with gpu-specific instruction due to this use}}
+    llvm.call @rec(%p, %n1) : (!llvm.ptr, i32) -> ()
+    llvm.br ^bb2
+  ^bb2:
+    llvm.return
+  }
+  llvm.func @launch(%p: !llvm.ptr, %n: i32) {
+    %c1 = arith.constant 1 : index
+    %sh = arith.constant 0 : i32
+    gpu.launch blocks(%bx, %by, %bz) in (%gx = %c1, %gy = %c1, %gz = %c1) threads(%tx, %ty, %tz) in (%sx = %c1, %sy = %c1, %sz = %c1) dynamic_shared_memory_size %sh {
+      llvm.call @rec(%p, %n) : (!llvm.ptr, i32) -> ()
+      gpu.terminator
+    }
+    llvm.return
+  }
+}

--- a/test/lit_tests/parallel-lower-shared-callee.mlir
+++ b/test/lit_tests/parallel-lower-shared-callee.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --parallel-lower | FileCheck %s
+
+// One device function launched from two sites, each by-value wrapped and
+// inlined on its own.
+module {
+  llvm.func private @foo(%p: !llvm.ptr, %s: !llvm.ptr {llvm.byval = !llvm.struct<(i32)>}) {
+    %v = llvm.load %s : !llvm.ptr -> !llvm.struct<(i32)>
+    %e = llvm.extractvalue %v[0] : !llvm.struct<(i32)>
+    nvvm.barrier
+    llvm.store %e, %p : i32, !llvm.ptr
+    llvm.return
+  }
+  llvm.func @launch(%p: !llvm.ptr, %s: !llvm.ptr) {
+    %c1 = arith.constant 1 : index
+    %sh = arith.constant 0 : i32
+    gpu.launch blocks(%bx, %by, %bz) in (%gx = %c1, %gy = %c1, %gz = %c1) threads(%tx, %ty, %tz) in (%sx = %c1, %sy = %c1, %sz = %c1) dynamic_shared_memory_size %sh {
+      llvm.call @foo(%p, %s) : (!llvm.ptr, !llvm.ptr) -> ()
+      gpu.terminator
+    }
+    gpu.launch blocks(%bx, %by, %bz) in (%gx = %c1, %gy = %c1, %gz = %c1) threads(%tx, %ty, %tz) in (%sx = %c1, %sy = %c1, %sz = %c1) dynamic_shared_memory_size %sh {
+      llvm.call @foo(%p, %s) : (!llvm.ptr, !llvm.ptr) -> ()
+      gpu.terminator
+    }
+    llvm.return
+  }
+}
+
+// CHECK-NOT: llvm.func private @foo
+// CHECK-LABEL: llvm.func @launch
+// CHECK: scf.parallel
+// CHECK: llvm.store
+// CHECK: scf.parallel
+// CHECK: llvm.store
+// CHECK-NOT: llvm.call
+// CHECK-NOT: tmp_for_inline


### PR DESCRIPTION
Four ways `ParallelLower` fails on inputs the CUDA raising path produces, each with a lit test that fails (segfault, hang, or double free) on `main`.

## `gpu.launch_func` lowered to an op with no callee

`ParallelLower` lowers a `gpu.launch_func` into a `gpu.launch` wrapping a call:

```cpp
func::CallOp::create(builder, launchOp.getLoc(), launchOp.getKernel(),
                     TypeRange(), launchOp.getKernelOperands());
```

A kernel lives in a `gpu.module`, so `launchOp.getKernel()` is a **nested** symbol reference (`@gpum::@kern`), while `func.call`'s callee is a **flat** one. Building the call from a nested reference yields `"func.call"() : () -> ()`, and symbol resolution faults on it (`SymbolRefAttr::getRootReference()` via `resolveCallableInTable`) as soon as the pass's call inliner reaches the op. Every `gpu.launch_func` names its kernel this way, so any launch reaching the pass segfaults.

Launch recognition clones the kernel launcher into the `gpu.module` under its own name, so the top-level original shares the leaf name and body. The fix builds the call from `launchOp.getKernelName()`, which is what the launcher inlining path expects, instead of skipping the launch. Such launches also carry `i64` dims; those become `index` through one `arith.index_cast` per dim, so the parallel loops, the `gpu_wrapper`, and the `gpu.grid_dim`/`gpu.block_dim` replacements all see index values.

## Recursive callee: infinite loop

The three inliners pre-inline the callee's own calls before inlining the callee, with no cycle check, so a (mutually) recursive device function never terminates. Two places recurse: the seed collection loop re-pushes the users of a function already in `toinl`, and the inliners re-enter a callee already being inlined. An `inliningStack` keeps a callable's recursive call sites uninlined while it is on the stack, and a call site inside its own callee is never inlined (cloning a region into itself never ends). The pass then terminates and reports the call it could not remove through the existing "Could not erase function with gpu-specific instruction" diagnostic instead of hanging.

## Already-prepared callee: double free

`prepareForGPUInline` returns the call unchanged when the callee is already an `enzyme.prepared_for_inline` by-value wrapper. `LLVMcallInliner` then inlines that call and continues into its clone-based tail, which erases the (already erased) call again. It now returns after the plain inliner in that case.

## Testing

New lit tests: `parallel-lower-launch-func` (segfault on main), `parallel-lower-recursive` (hang on main, now `--verify-diagnostics`), `parallel-lower-prepared-callee` (double free on main), `parallel-lower-shared-callee` (one device function launched from two sites). Existing `parallel-lower-inline` / `parallel-lower-noreturn` pass.

These are the ParallelLower fixes carried by the MFEM raising union (#2968); the union builds all 122 MFEM CUDA TUs with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
