### PR TITLE
Use inttoptr/ptrtoint to coerce launch arguments

### DIFF
--- a/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
+++ b/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
@@ -616,6 +616,12 @@ enum __device_builtin__ cudaMemcpyKind
                        arg.getType().getIntOrFloatBitWidth() ==
                            expectedTy.getIntOrFloatBitWidth()) {
               arg = LLVM::BitcastOp::create(builder, loc, expectedTy, arg);
+            } else if (arg.getType().isIntOrIndex() &&
+                       isa<LLVM::LLVMPointerType>(expectedTy)) {
+              arg = LLVM::IntToPtrOp::create(builder, loc, expectedTy, arg);
+            } else if (isa<LLVM::LLVMPointerType>(arg.getType()) &&
+                       expectedTy.isIntOrIndex()) {
+              arg = LLVM::PtrToIntOp::create(builder, loc, expectedTy, arg);
             } else {
               arg = LLVM::BitcastOp::create(builder, loc, expectedTy,
                                             arg); // Fallback

--- a/test/lit_tests/gpu-launch-recognition-inttoptr.mlir
+++ b/test/lit_tests/gpu-launch-recognition-inttoptr.mlir
@@ -1,0 +1,24 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(gpu-launch-recognition)" | FileCheck %s
+
+// A launch operand whose type does not match the kernel parameter is coerced.
+// An integer and a pointer are not bitcastable, so the integer-to-pointer and
+// pointer-to-integer directions need inttoptr and ptrtoint.
+module attributes {gpu.container_module} {
+  llvm.func @__mlir_cuda_caller_phase3(...)
+
+  llvm.func internal @"reactant$kern"(%arg0: !llvm.ptr) {
+    llvm.return
+  }
+
+  llvm.func @caller(%int_arg: i64) {
+    %f = llvm.mlir.addressof @"reactant$kern" : !llvm.ptr
+    %dim = llvm.mlir.constant(1 : i32) : i32
+    %shmem = llvm.mlir.constant(0 : i64) : i64
+    %stream = llvm.mlir.zero : !llvm.ptr
+    llvm.call @__mlir_cuda_caller_phase3(%f, %dim, %dim, %dim, %dim, %dim, %dim, %shmem, %stream, %int_arg) vararg(!llvm.func<void (...)>) : (!llvm.ptr, i32, i32, i32, i32, i32, i32, i64, !llvm.ptr, i64) -> ()
+    llvm.return
+  }
+}
+
+// CHECK-NOT: llvm.bitcast %{{.*}} : i64 to !llvm.ptr
+// CHECK: llvm.inttoptr


### PR DESCRIPTION
## Problem

`GPULaunchRecognition` coerces each launch operand to the type of the corresponding kernel parameter, ending in a catch-all:

```cpp
} else {
  arg = LLVM::BitcastOp::create(builder, loc, expectedTy, arg); // Fallback
}
```

`bitcast` cannot convert between an integer and a pointer, so an integer operand feeding a pointer parameter builds an op that fails to verify:

```
error: 'llvm.bitcast' op can only cast pointers from and to pointers
note: see current operation: %5 = "llvm.bitcast"(%arg0) : (i64) -> !llvm.ptr
```

The added test reproduces this on `main` — a kernel taking `!llvm.ptr` launched with an `i64` operand.

## Fix

Select `inttoptr` and `ptrtoint` for the integer/pointer directions, leaving `bitcast` for the same-width scalar case and `addrspacecast` for pointers, both of which are already handled above.

## Testing

- New lit test, which errors on `main` and emits `llvm.inttoptr` with the fix.
- Full lit suite: 1156/1157. The single failure is an untracked local WIP file exercising a different pass, unrelated to this change.

## Note for reviewers

This makes the emitted IR valid, but an integer arriving where a kernel expects a pointer is usually a sign that the operand/parameter correspondence itself is off. I hit one such case: for `cub::DeviceScanKernel`, `reactant.arg_attrs` is indexed against the launch operands and the `byval` attribute lands on an `i32` (the empty-struct parameters `plus<void>` and `NullType` appear to shift the correspondence). Converting that integer to a pointer there turns the verifier error into a host segfault when `cudaLaunchKernel` dereferences it, so I deliberately did **not** apply the same change to the `byval` packing in `ConvertPolygeistToLLVM`. That site needs the correspondence fixed, not the cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD