### PR TITLE
Store a by-value launch argument instead of reading it as an address

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -2188,9 +2188,16 @@ Value ConvertLaunchFuncOpToGpuRuntimeCallPattern::generateParamsArray(
   auto argAttrss =
       dyn_cast_or_null<ArrayAttr>(launchOp->getAttr("reactant.arg_attrs"));
   for (const auto &en : llvm::enumerate(arguments)) {
-    bool isByVal =
-        argAttrss && cast<DictionaryAttr>(argAttrss[en.index()])
-                         .getNamed(LLVM::LLVMDialect::getByValAttrName());
+    // A byval argument reaches the kernel argument array as a pointer to the
+    // argument's copy, which is exactly what the array slot must hold. When
+    // the parameter has been scalarised the attribute outlives it and the
+    // argument arrives by value; a value needs the same temporary and store as
+    // any other, since reinterpreting it would hand the launch an address made
+    // out of the argument's own bits.
+    bool isByVal = argAttrss &&
+                   cast<DictionaryAttr>(argAttrss[en.index()])
+                       .getNamed(LLVM::LLVMDialect::getByValAttrName()) &&
+                   isa<LLVM::LLVMPointerType>(en.value().getType());
     Value fieldPtr;
     if (isByVal) {
       fieldPtr = en.value();

--- a/test/lit_tests/polygeist-byval-value-operand.mlir
+++ b/test/lit_tests/polygeist-byval-value-operand.mlir
@@ -1,0 +1,24 @@
+// RUN: enzymexlamlir-opt %s --convert-polygeist-to-llvm | FileCheck %s
+
+// A byval kernel argument normally arrives as a pointer to the argument's
+// copy, which is what the kernel argument array holds. Here the parameter has
+// been scalarised and the byval attribute left behind, so the argument arrives
+// by value: it needs a temporary and a store like any other argument, rather
+// than having its own bits reinterpreted as an address.
+module attributes {gpu.container_module} {
+  gpu.module @gpum {
+    gpu.func @kern(%arg0: i32) kernel {
+      gpu.return
+    }
+  }
+  func.func @caller(%v: i32) {
+    %c1 = arith.constant 1 : index
+    %shmem = arith.constant 0 : i32
+    gpu.launch_func @gpum::@kern blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) dynamic_shared_memory_size %shmem args(%v : i32) {reactant.arg_attrs = [{llvm.byval = !llvm.struct<"S", (i8)>}]}
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @caller
+// CHECK: %[[SLOT:.+]] = llvm.alloca %{{.+}} x i32
+// CHECK: llvm.store %{{.+}}, %[[SLOT]]


### PR DESCRIPTION
## Problem

Packing kernel arguments for a launch, a `byval` argument is taken to be a pointer to the argument's copy and put into the argument array as-is:

```cpp
bool isByVal = argAttrss && cast<DictionaryAttr>(argAttrss[en.index()])
                               .getNamed(LLVM::LLVMDialect::getByValAttrName());
if (isByVal) fieldPtr = en.value();
```

That holds while the parameter really is a pointer. When the parameter has been scalarised, the `byval` attribute outlives it and the argument arrives **by value** — and the operand's own bits get used as an address. The cast that follows does not even verify:

```
error: 'llvm.bitcast' op can only cast pointers from and to pointers
note: see current operation: %7 = "llvm.bitcast"(%arg0) : (i32) -> !llvm.ptr
```

The added test reproduces it on `main` in 18 lines. Note the kernel parameter is `i32` there and not a pointer: `gpu.launch_func` verifies operand types against the kernel signature, so the stale part is the attribute, not the operand.

## Fix

Key the decision on the operand rather than the attribute alone. A value operand takes the same temporary-and-store path as any other argument, which is what `byval` means in the first place — the slot ends up pointing at the argument's bytes either way.

## Why this matters beyond the verifier error

Found while chasing a CUB `DeviceScan` failure. With the attribute trusted blindly, three of the launch's `byval` slots were block arguments of type `i32`, so the launch received addresses fabricated from argument values. Fixing the cast alone (`inttoptr`) makes the IR valid and the program segfault instead, when `cudaLaunchKernel` dereferences the fabricated pointer. With this change the same case launches cleanly.

## Testing

- New lit test, which errors on `main` and emits `llvm.alloca` + `llvm.store` with the fix.
- Full lit suite: 1156/1157. The single failure is an untracked local WIP file exercising a different pass, unrelated.
- End to end on the CUB reproducer: the illegal memory access and the segfault are both gone and the scan launches with `err=0`. Its results are still wrong, which is a separate defect I am still chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD