### PR TITLE
ConvertPolygeistToLLVM: keep the stream out of the kernel's parameter array

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -2160,9 +2160,8 @@ Value ConvertLaunchFuncOpToGpuRuntimeCallPattern::generateParamsArray(
     gpu::LaunchFuncOp launchOp, OpAdaptor adaptor, OpBuilder &builder,
     Block *allocaBlock) const {
   auto loc = launchOp.getLoc();
-  auto numKernelOperands = launchOp.getNumKernelOperands();
   SmallVector<Value, 4> arguments =
-      adaptor.getOperands().take_back(numKernelOperands);
+      llvm::to_vector<4>(adaptor.getKernelOperands());
   auto numArguments = arguments.size();
   SmallVector<Type, 4> argumentTypes;
   argumentTypes.reserve(numArguments);

--- a/test/lit_tests/lowering/cuda_async_codegen.mlir
+++ b/test/lit_tests/lowering/cuda_async_codegen.mlir
@@ -31,69 +31,70 @@ module attributes {gpu.container_module} {
 }
 
 
-// CHECK:  llvm.func weak_odr local_unnamed_addr @_ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii(%arg0: i64, %arg1: !llvm.ptr, %arg2: i32, %arg3: i32) -> !llvm.ptr {
-// CHECK-NEXT:      %0 = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %1 = llvm.mlir.constant(32 : i64) : i64
-// CHECK-NEXT:      %2 = llvm.mlir.addressof @__polygeist__ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii_kernel_29__ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii_kernel_device_stub : !llvm.ptr
-// CHECK-NEXT:      %3 = llvm.mlir.constant(1 : index) : i64
-// CHECK-NEXT:      %4 = llvm.mlir.constant(8 : index) : i64
-// CHECK-NEXT:      %5 = llvm.mlir.constant(32 : index) : i64
-// CHECK-NEXT:      %6 = llvm.mlir.constant(5 : i32) : i32
-// CHECK-NEXT:      %7 = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:      %8 = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:      %9 = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:      %10 = llvm.alloca %9 x i32 : (i64) -> !llvm.ptr
-// CHECK-NEXT:      %11 = llvm.alloca %7 x !llvm.ptr : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %12 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %13 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %14 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %15 = llvm.alloca %7 x !llvm.ptr : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %16 = llvm.alloca %6 x !llvm.ptr : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %17 = llvm.inttoptr %9 : i64 to !llvm.ptr
-// CHECK-NEXT:      %18 = llvm.alloca %7 x !llvm.struct<"struct.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::cuda_cub::__uninitialized_fill::functor.189.1", packed (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::device_ptr.56.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::pointer.57.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::iterator_adaptor.58.1", (ptr)>)>)>, i32, array<4 x i8>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %19 = llvm.sext %arg3 : i32 to i64
-// CHECK-NEXT:      %20 = llvm.sext %arg3 : i32 to i64
-// CHECK-NEXT:      %21 = llvm.sext %arg3 : i32 to i64
-// CHECK-NEXT:      llvm.br ^bb1
-// CHECK-NEXT:    ^bb1:  // pred: ^bb0
-// CHECK-NEXT:      %22 = llvm.icmp "sge" %arg0, %9 : i64
-// CHECK-NEXT:      llvm.cond_br %22, ^bb2, ^bb3
-// CHECK-NEXT:    ^bb2:  // pred: ^bb1
-// CHECK-NEXT:      llvm.store %18, %15 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %15, %16 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %21, %14 : i64, !llvm.ptr
-// CHECK-NEXT:      %23 = llvm.getelementptr %16[1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %14, %23 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %19, %13 : i64, !llvm.ptr
-// CHECK-NEXT:      %24 = llvm.getelementptr %16[2] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %13, %24 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %20, %12 : i64, !llvm.ptr
-// CHECK-NEXT:      %25 = llvm.getelementptr %16[3] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %12, %25 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %17, %11 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      %26 = llvm.getelementptr %16[4] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %11, %26 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      %27 = llvm.trunc %3 : i64 to i32
-// CHECK-NEXT:      %28 = llvm.trunc %4 : i64 to i32
-// CHECK-NEXT:      %29 = llvm.trunc %3 : i64 to i32
-// CHECK-NEXT:      %30 = llvm.zext %27 : i32 to i64
-// CHECK-NEXT:      %31 = llvm.zext %28 : i32 to i64
-// CHECK-NEXT:      %32 = llvm.shl %31, %1 : i64
-// CHECK-NEXT:      %33 = llvm.or %30, %32 : i64
-// CHECK-NEXT:      %34 = llvm.trunc %5 : i64 to i32
-// CHECK-NEXT:      %35 = llvm.trunc %3 : i64 to i32
-// CHECK-NEXT:      %36 = llvm.trunc %3 : i64 to i32
-// CHECK-NEXT:      %37 = llvm.zext %34 : i32 to i64
-// CHECK-NEXT:      %38 = llvm.zext %35 : i32 to i64
-// CHECK-NEXT:      %39 = llvm.shl %38, %1 : i64
-// CHECK-NEXT:      %40 = llvm.or %37, %39 : i64
-// CHECK-NEXT:      %41 = llvm.call @cudaLaunchKernel(%2, %33, %29, %40, %36, %16, %0, %17) : (!llvm.ptr, i64, i32, i64, i32, !llvm.ptr, i64, !llvm.ptr) -> i32
-// CHECK-NEXT:      llvm.store %41, %10 : i32, !llvm.ptr
-// CHECK-NEXT:      llvm.br ^bb3
-// CHECK-NEXT:    ^bb3:  // 2 preds: ^bb1, ^bb2
-// CHECK-NEXT:      %42 = llvm.load %10 : !llvm.ptr -> i32
-// CHECK-NEXT:      llvm.br ^bb4(%42 : i32)
-// CHECK-NEXT:    ^bb4(%43: i32):  // pred: ^bb3
-// CHECK-NEXT:      llvm.store %8, %10 : i32, !llvm.ptr
-// CHECK-NEXT:      llvm.unreachable
-// CHECK-NEXT:    }
+// CHECK:    llvm.func weak_odr local_unnamed_addr @_ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii(%arg0: i64, %arg1: !llvm.ptr, %arg2: i32, %arg3: i32) -> !llvm.ptr {
+// CHECK-NEXT:        %0 = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:        %1 = llvm.mlir.constant(32 : i64) : i64
+// CHECK-NEXT:        %2 = llvm.mlir.addressof @__polygeist__ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii_kernel_29__ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii_kernel_device_stub : !llvm.ptr
+// CHECK-NEXT:        %3 = llvm.mlir.constant(1 : index) : i64
+// CHECK-NEXT:        %4 = llvm.mlir.constant(8 : index) : i64
+// CHECK-NEXT:        %5 = llvm.mlir.constant(32 : index) : i64
+// CHECK-NEXT:        %6 = llvm.mlir.constant(5 : i32) : i32
+// CHECK-NEXT:        %7 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:        %8 = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:        %9 = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:        %10 = llvm.alloca %9 x i32 : (i64) -> !llvm.ptr
+// CHECK-NEXT:        %11 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
+// CHECK-NEXT:        %12 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
+// CHECK-NEXT:        %13 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
+// CHECK-NEXT:        %14 = llvm.alloca %7 x !llvm.ptr : (i32) -> !llvm.ptr
+// CHECK-NEXT:        %15 = llvm.alloca %7 x !llvm.ptr : (i32) -> !llvm.ptr
+// CHECK-NEXT:        %16 = llvm.alloca %6 x !llvm.ptr : (i32) -> !llvm.ptr
+// CHECK-NEXT:        %17 = llvm.alloca %9 x !llvm.struct<"struct.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::cuda_cub::__uninitialized_fill::functor.8.1", packed (struct<".2", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::system::cuda_cub::detail::cuda_error_category.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::system::error_category.1", (ptr)>)>)>, i32, array<4 x i8>)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:        %18 = llvm.inttoptr %9 : i64 to !llvm.ptr
+// CHECK-NEXT:        %19 = llvm.alloca %7 x !llvm.struct<"struct.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::cuda_cub::__uninitialized_fill::functor.189.1", packed (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::device_ptr.56.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::pointer.57.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::iterator_adaptor.58.1", (ptr)>)>)>, i32, array<4 x i8>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:        %20 = llvm.sext %arg3 : i32 to i64
+// CHECK-NEXT:        %21 = llvm.sext %arg3 : i32 to i64
+// CHECK-NEXT:        %22 = llvm.sext %arg3 : i32 to i64
+// CHECK-NEXT:        llvm.br ^bb1
+// CHECK-NEXT:      ^bb1:  // pred: ^bb0
+// CHECK-NEXT:        %23 = llvm.icmp "sge" %arg0, %9 : i64
+// CHECK-NEXT:        llvm.cond_br %23, ^bb2, ^bb3
+// CHECK-NEXT:      ^bb2:  // pred: ^bb1
+// CHECK-NEXT:        llvm.store %17, %15 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %15, %16 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %19, %14 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        %24 = llvm.getelementptr %16[1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %14, %24 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %22, %13 : i64, !llvm.ptr
+// CHECK-NEXT:        %25 = llvm.getelementptr %16[2] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %13, %25 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %20, %12 : i64, !llvm.ptr
+// CHECK-NEXT:        %26 = llvm.getelementptr %16[3] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %12, %26 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %21, %11 : i64, !llvm.ptr
+// CHECK-NEXT:        %27 = llvm.getelementptr %16[4] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        llvm.store %11, %27 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        %28 = llvm.trunc %3 : i64 to i32
+// CHECK-NEXT:        %29 = llvm.trunc %4 : i64 to i32
+// CHECK-NEXT:        %30 = llvm.trunc %3 : i64 to i32
+// CHECK-NEXT:        %31 = llvm.zext %28 : i32 to i64
+// CHECK-NEXT:        %32 = llvm.zext %29 : i32 to i64
+// CHECK-NEXT:        %33 = llvm.shl %32, %1 : i64
+// CHECK-NEXT:        %34 = llvm.or %31, %33 : i64
+// CHECK-NEXT:        %35 = llvm.trunc %5 : i64 to i32
+// CHECK-NEXT:        %36 = llvm.trunc %3 : i64 to i32
+// CHECK-NEXT:        %37 = llvm.trunc %3 : i64 to i32
+// CHECK-NEXT:        %38 = llvm.zext %35 : i32 to i64
+// CHECK-NEXT:        %39 = llvm.zext %36 : i32 to i64
+// CHECK-NEXT:        %40 = llvm.shl %39, %1 : i64
+// CHECK-NEXT:        %41 = llvm.or %38, %40 : i64
+// CHECK-NEXT:        %42 = llvm.call @cudaLaunchKernel(%2, %34, %30, %41, %37, %16, %0, %18) : (!llvm.ptr, i64, i32, i64, i32, !llvm.ptr, i64, !llvm.ptr) -> i32
+// CHECK-NEXT:        llvm.store %42, %10 : i32, !llvm.ptr
+// CHECK-NEXT:        llvm.br ^bb3
+// CHECK-NEXT:      ^bb3:  // 2 preds: ^bb1, ^bb2
+// CHECK-NEXT:        %43 = llvm.load %10 : !llvm.ptr -> i32
+// CHECK-NEXT:        llvm.br ^bb4(%43 : i32)
+// CHECK-NEXT:      ^bb4(%44: i32):  // pred: ^bb3
+// CHECK-NEXT:        llvm.store %8, %10 : i32, !llvm.ptr
+// CHECK-NEXT:        llvm.unreachable
+// CHECK-NEXT:      }

--- a/test/lit_tests/lowering/launch-stream-params.mlir
+++ b/test/lit_tests/lowering/launch-stream-params.mlir
@@ -1,0 +1,39 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=cuda})" | FileCheck %s
+
+module attributes {gpu.container_module} {
+  llvm.func @launch(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: i32) {
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c1_i64 = arith.constant 1 : i64
+    %stream = llvm.inttoptr %c1_i64 : i64 to !llvm.ptr
+    gpu.launch_func <%stream : !llvm.ptr> @test_module::@test_kernel blocks in (%c1, %c1, %c1) threads in (%c32, %c1, %c1) args(%arg0 : !llvm.ptr, %arg1 : !llvm.ptr, %arg2 : i32)
+    llvm.return
+  }
+
+  gpu.module @test_module {
+    gpu.func @test_kernel(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: i32) kernel {
+      gpu.return
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @launch
+// CHECK-DAG:     %[[STREAM:.+]] = llvm.inttoptr
+
+// CHECK-DAG:     %[[THREE:.+]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK-DAG:     %[[ONE:.+]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:     %[[SLOT2:.+]] = llvm.alloca %[[ONE]] x i32
+// CHECK-DAG:     %[[SLOT1:.+]] = llvm.alloca %[[ONE]] x !llvm.ptr
+// CHECK-DAG:     %[[SLOT0:.+]] = llvm.alloca %[[ONE]] x !llvm.ptr
+// CHECK-DAG:     %[[ARRAY:.+]] = llvm.alloca %[[THREE]] x !llvm.ptr
+
+// CHECK:         llvm.store %arg0, %[[SLOT0]]
+// CHECK:         llvm.store %[[SLOT0]], %[[ARRAY]]
+// CHECK:         llvm.store %arg1, %[[SLOT1]]
+// CHECK:         %[[GEP1:.+]] = llvm.getelementptr %[[ARRAY]][1]
+// CHECK:         llvm.store %[[SLOT1]], %[[GEP1]]
+// CHECK:         llvm.store %arg2, %[[SLOT2]]
+// CHECK:         %[[GEP2:.+]] = llvm.getelementptr %[[ARRAY]][2]
+// CHECK:         llvm.store %[[SLOT2]], %[[GEP2]]
+
+// CHECK:         llvm.call @cudaLaunchKernel({{.*}}, %[[ARRAY]], {{.*}}, %[[STREAM]])


### PR DESCRIPTION
Partially fix #2854 

After the fix, RSBench and XSBench will not segfault in the runtime.
**The root cause**:
`generateParamsArray` took the launch's arguments with `adaptor.getOperands().take_back(getNumKernelOperands())`, but `gpu.launch_func` declares `asyncObject` after `kernelOperands`. On a launch carrying a stream that window sits one operand too far right: the first kernel argument falls out and the stream lands in the last slot, which the driver dereferences as the address of the last parameter. The array is still the right length, so nothing downstream notices.