### PR TITLE
Take a launch's kernel operands by segment, not from the back

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -2160,9 +2160,11 @@ Value ConvertLaunchFuncOpToGpuRuntimeCallPattern::generateParamsArray(
     gpu::LaunchFuncOp launchOp, OpAdaptor adaptor, OpBuilder &builder,
     Block *allocaBlock) const {
   auto loc = launchOp.getLoc();
-  auto numKernelOperands = launchOp.getNumKernelOperands();
-  SmallVector<Value, 4> arguments =
-      adaptor.getOperands().take_back(numKernelOperands);
+  // The kernel operands are not the trailing operands: an async launch carries
+  // its stream after them, so taking from the back picks the stream up as an
+  // argument and drops the first real one, shifting every argument by one.
+  SmallVector<Value, 4> arguments(adaptor.getKernelOperands().begin(),
+                                  adaptor.getKernelOperands().end());
   auto numArguments = arguments.size();
   SmallVector<Type, 4> argumentTypes;
   argumentTypes.reserve(numArguments);

--- a/test/lit_tests/lowering/cuda_async_codegen.mlir
+++ b/test/lit_tests/lowering/cuda_async_codegen.mlir
@@ -31,69 +31,70 @@ module attributes {gpu.container_module} {
 }
 
 
-// CHECK:  llvm.func weak_odr local_unnamed_addr @_ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii(%arg0: i64, %arg1: !llvm.ptr, %arg2: i32, %arg3: i32) -> !llvm.ptr {
-// CHECK-NEXT:      %0 = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %1 = llvm.mlir.constant(32 : i64) : i64
-// CHECK-NEXT:      %2 = llvm.mlir.addressof @__polygeist__ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii_kernel_29__ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii_kernel_device_stub : !llvm.ptr
-// CHECK-NEXT:      %3 = llvm.mlir.constant(1 : index) : i64
-// CHECK-NEXT:      %4 = llvm.mlir.constant(8 : index) : i64
-// CHECK-NEXT:      %5 = llvm.mlir.constant(32 : index) : i64
-// CHECK-NEXT:      %6 = llvm.mlir.constant(5 : i32) : i32
-// CHECK-NEXT:      %7 = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:      %8 = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:      %9 = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:      %10 = llvm.alloca %9 x i32 : (i64) -> !llvm.ptr
-// CHECK-NEXT:      %11 = llvm.alloca %7 x !llvm.ptr : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %12 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %13 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %14 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %15 = llvm.alloca %7 x !llvm.ptr : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %16 = llvm.alloca %6 x !llvm.ptr : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %17 = llvm.inttoptr %9 : i64 to !llvm.ptr
-// CHECK-NEXT:      %18 = llvm.alloca %7 x !llvm.struct<"struct.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::cuda_cub::__uninitialized_fill::functor.189.1", packed (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::device_ptr.56.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::pointer.57.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::iterator_adaptor.58.1", (ptr)>)>)>, i32, array<4 x i8>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK-NEXT:      %19 = llvm.sext %arg3 : i32 to i64
-// CHECK-NEXT:      %20 = llvm.sext %arg3 : i32 to i64
-// CHECK-NEXT:      %21 = llvm.sext %arg3 : i32 to i64
-// CHECK-NEXT:      llvm.br ^bb1
-// CHECK-NEXT:    ^bb1:  // pred: ^bb0
-// CHECK-NEXT:      %22 = llvm.icmp "sge" %arg0, %9 : i64
-// CHECK-NEXT:      llvm.cond_br %22, ^bb2, ^bb3
-// CHECK-NEXT:    ^bb2:  // pred: ^bb1
-// CHECK-NEXT:      llvm.store %18, %15 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %15, %16 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %21, %14 : i64, !llvm.ptr
-// CHECK-NEXT:      %23 = llvm.getelementptr %16[1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %14, %23 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %19, %13 : i64, !llvm.ptr
-// CHECK-NEXT:      %24 = llvm.getelementptr %16[2] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %13, %24 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %20, %12 : i64, !llvm.ptr
-// CHECK-NEXT:      %25 = llvm.getelementptr %16[3] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %12, %25 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %17, %11 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      %26 = llvm.getelementptr %16[4] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      llvm.store %11, %26 : !llvm.ptr, !llvm.ptr
-// CHECK-NEXT:      %27 = llvm.trunc %3 : i64 to i32
-// CHECK-NEXT:      %28 = llvm.trunc %4 : i64 to i32
-// CHECK-NEXT:      %29 = llvm.trunc %3 : i64 to i32
-// CHECK-NEXT:      %30 = llvm.zext %27 : i32 to i64
-// CHECK-NEXT:      %31 = llvm.zext %28 : i32 to i64
-// CHECK-NEXT:      %32 = llvm.shl %31, %1 : i64
-// CHECK-NEXT:      %33 = llvm.or %30, %32 : i64
-// CHECK-NEXT:      %34 = llvm.trunc %5 : i64 to i32
-// CHECK-NEXT:      %35 = llvm.trunc %3 : i64 to i32
-// CHECK-NEXT:      %36 = llvm.trunc %3 : i64 to i32
-// CHECK-NEXT:      %37 = llvm.zext %34 : i32 to i64
-// CHECK-NEXT:      %38 = llvm.zext %35 : i32 to i64
-// CHECK-NEXT:      %39 = llvm.shl %38, %1 : i64
-// CHECK-NEXT:      %40 = llvm.or %37, %39 : i64
-// CHECK-NEXT:      %41 = llvm.call @cudaLaunchKernel(%2, %33, %29, %40, %36, %16, %0, %17) : (!llvm.ptr, i64, i32, i64, i32, !llvm.ptr, i64, !llvm.ptr) -> i32
-// CHECK-NEXT:      llvm.store %41, %10 : i32, !llvm.ptr
-// CHECK-NEXT:      llvm.br ^bb3
-// CHECK-NEXT:    ^bb3:  // 2 preds: ^bb1, ^bb2
-// CHECK-NEXT:      %42 = llvm.load %10 : !llvm.ptr -> i32
-// CHECK-NEXT:      llvm.br ^bb4(%42 : i32)
-// CHECK-NEXT:    ^bb4(%43: i32):  // pred: ^bb3
-// CHECK-NEXT:      llvm.store %8, %10 : i32, !llvm.ptr
-// CHECK-NEXT:      llvm.unreachable
-// CHECK-NEXT:    }
+// CHECK: llvm.func weak_odr local_unnamed_addr @_ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii(%arg0: i64, %arg1: !llvm.ptr, %arg2: i32, %arg3: i32) -> !llvm.ptr {
+// CHECK-NEXT:    %0 = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:    %1 = llvm.mlir.constant(32 : i64) : i64
+// CHECK-NEXT:    %2 = llvm.mlir.addressof @__polygeist__ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii_kernel_29__ZN9AllocatorI8Vector_dIiEE6resizeEPS1_ii_kernel_device_stub : !llvm.ptr
+// CHECK-NEXT:    %3 = llvm.mlir.constant(1 : index) : i64
+// CHECK-NEXT:    %4 = llvm.mlir.constant(8 : index) : i64
+// CHECK-NEXT:    %5 = llvm.mlir.constant(32 : index) : i64
+// CHECK-NEXT:    %6 = llvm.mlir.constant(5 : i32) : i32
+// CHECK-NEXT:    %7 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:    %8 = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:    %9 = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:    %10 = llvm.alloca %9 x i32 : (i64) -> !llvm.ptr
+// CHECK-NEXT:    %11 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %12 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %13 = llvm.alloca %7 x i64 : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %14 = llvm.alloca %7 x !llvm.ptr : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %15 = llvm.alloca %7 x !llvm.ptr : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %16 = llvm.alloca %6 x !llvm.ptr : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %17 = llvm.alloca %9 x !llvm.struct<"struct.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::cuda_cub::__uninitialized_fill::functor.8.1", packed (struct<".2", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::system::cuda_cub::detail::cuda_error_category.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::system::error_category.1", (ptr)>)>)>, i32, array<4 x i8>)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:    %18 = llvm.inttoptr %9 : i64 to !llvm.ptr
+// CHECK-NEXT:    %19 = llvm.alloca %7 x !llvm.struct<"struct.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::cuda_cub::__uninitialized_fill::functor.189.1", packed (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::device_ptr.56.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::pointer.57.1", (struct<"class.thrust::THRUST_200802_SM___CUDA_ARCH_LIST___NS::iterator_adaptor.58.1", (ptr)>)>)>, i32, array<4 x i8>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %20 = llvm.sext %arg3 : i32 to i64
+// CHECK-NEXT:    %21 = llvm.sext %arg3 : i32 to i64
+// CHECK-NEXT:    %22 = llvm.sext %arg3 : i32 to i64
+// CHECK-NEXT:    llvm.br ^bb1
+// CHECK-NEXT:  ^bb1:  // pred: ^bb0
+// CHECK-NEXT:    %23 = llvm.icmp "sge" %arg0, %9 : i64
+// CHECK-NEXT:    llvm.cond_br %23, ^bb2, ^bb3
+// CHECK-NEXT:  ^bb2:  // pred: ^bb1
+// CHECK-NEXT:    llvm.store %17, %15 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %15, %16 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %19, %14 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    %24 = llvm.getelementptr %16[1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %14, %24 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %22, %13 : i64, !llvm.ptr
+// CHECK-NEXT:    %25 = llvm.getelementptr %16[2] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %13, %25 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %20, %12 : i64, !llvm.ptr
+// CHECK-NEXT:    %26 = llvm.getelementptr %16[3] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %12, %26 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %21, %11 : i64, !llvm.ptr
+// CHECK-NEXT:    %27 = llvm.getelementptr %16[4] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    llvm.store %11, %27 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:    %28 = llvm.trunc %3 : i64 to i32
+// CHECK-NEXT:    %29 = llvm.trunc %4 : i64 to i32
+// CHECK-NEXT:    %30 = llvm.trunc %3 : i64 to i32
+// CHECK-NEXT:    %31 = llvm.zext %28 : i32 to i64
+// CHECK-NEXT:    %32 = llvm.zext %29 : i32 to i64
+// CHECK-NEXT:    %33 = llvm.shl %32, %1 : i64
+// CHECK-NEXT:    %34 = llvm.or %31, %33 : i64
+// CHECK-NEXT:    %35 = llvm.trunc %5 : i64 to i32
+// CHECK-NEXT:    %36 = llvm.trunc %3 : i64 to i32
+// CHECK-NEXT:    %37 = llvm.trunc %3 : i64 to i32
+// CHECK-NEXT:    %38 = llvm.zext %35 : i32 to i64
+// CHECK-NEXT:    %39 = llvm.zext %36 : i32 to i64
+// CHECK-NEXT:    %40 = llvm.shl %39, %1 : i64
+// CHECK-NEXT:    %41 = llvm.or %38, %40 : i64
+// CHECK-NEXT:    %42 = llvm.call @cudaLaunchKernel(%2, %34, %30, %41, %37, %16, %0, %18) : (!llvm.ptr, i64, i32, i64, i32, !llvm.ptr, i64, !llvm.ptr) -> i32
+// CHECK-NEXT:    llvm.store %42, %10 : i32, !llvm.ptr
+// CHECK-NEXT:    llvm.br ^bb3
+// CHECK-NEXT:  ^bb3:  // 2 preds: ^bb1, ^bb2
+// CHECK-NEXT:    %43 = llvm.load %10 : !llvm.ptr -> i32
+// CHECK-NEXT:    llvm.br ^bb4(%43 : i32)
+// CHECK-NEXT:  ^bb4(%44: i32):  // pred: ^bb3
+// CHECK-NEXT:    llvm.store %8, %10 : i32, !llvm.ptr
+// CHECK-NEXT:    llvm.unreachable
+// CHECK-NEXT:  }

--- a/test/lit_tests/polygeist-async-launch-operands.mlir
+++ b/test/lit_tests/polygeist-async-launch-operands.mlir
@@ -1,0 +1,22 @@
+// RUN: enzymexlamlir-opt %s --convert-polygeist-to-llvm | FileCheck %s
+
+// An async launch carries its stream after the kernel operands, so the kernel
+// arguments are not the trailing operands. Both arguments have to reach the
+// argument array, and the stream must not be mistaken for one of them.
+module attributes {gpu.container_module} {
+  gpu.module @gpum {
+    gpu.func @kern(%arg0: i32, %arg1: i64) kernel {
+      gpu.return
+    }
+  }
+  func.func @caller(%a: i32, %b: i64, %stream: !llvm.ptr) {
+    %c1 = arith.constant 1 : index
+    %shmem = arith.constant 0 : i32
+    gpu.launch_func <%stream : !llvm.ptr> @gpum::@kern blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) dynamic_shared_memory_size %shmem args(%a : i32, %b : i64)
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @caller
+// CHECK-DAG: llvm.alloca %{{.+}} x i32
+// CHECK-DAG: llvm.alloca %{{.+}} x i64


### PR DESCRIPTION
## Problem

Packing kernel arguments for a launch sliced them off the end of the operand list:

```cpp
auto numKernelOperands = launchOp.getNumKernelOperands();
SmallVector<Value, 4> arguments =
    adaptor.getOperands().take_back(numKernelOperands);
```

`gpu.launch_func` carries its **asyncObject after** the kernel operands, so on an async launch that slice takes the stream as the last argument and drops the first real one. Every argument shifts by one and the kernel reads each parameter from its neighbour's slot.

This is quiet in every way that usually catches such a bug: the operand count is right, and the stream is a pointer, so when the launch's first argument is also a pointer the type sequence still matches. `cub::DeviceScan` ran to completion and returned `cudaSuccess` while writing nothing — its tile state had arrived where its output pointer belonged.

Reproduced by the new test on `main`, a launch with an `i32` and an `i64` argument plus a stream:

```
%6 = llvm.alloca %5 x !llvm.ptr   <- the stream
%7 = llvm.alloca %5 x i64
                                   <- the i32 argument is gone
```

## Fix

Use the segment-aware accessor, `adaptor.getKernelOperands()`.

## Testing

- New lit test, which fails on `main` and packs both arguments with the fix.
- `cuda_async_codegen.mlir` expectations regenerated. They had recorded the buggy output: the packed types were `ptr, i64, i64, i64, ptr` for a launch taking `(ptr, ptr, index, index, index)` — arguments 1-4 with the stream appended. The multiset of types is unchanged by the bug there, which is likely why the golden output looked plausible.
- Full lit suite: 1156/1157, the remaining failure being an untracked local WIP file exercising a different pass.
- End to end: `cub::DeviceScan::InclusiveSum` now returns the correct prefix sums (`0 1 3 6 10 15 21 28 36 45`) through the raising path, matching nvcc. Before this it returned `cudaSuccess` with the input untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD