### PR TITLE
Treat an address-taken host stub as capturing its kernel

### DIFF
--- a/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
+++ b/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
@@ -477,6 +477,39 @@ enum __device_builtin__ cudaMemcpyKind
           }
         }
       }
+      // The scan above only sees uses of the device-side function. An address
+      // user code takes is that of clang's host stub, and when it escapes --
+      // handed to a call rather than straight to a runtime query -- nothing
+      // rewrites it to the device symbol, so the kernel would never reach a
+      // gpu.module and never be registered. An address-taken host stub is a
+      // capture of its kernel.
+      if (!captured) {
+        StringRef hostStubName;
+        if (auto attr = dyn_cast_or_null<ArrayAttr>(
+                launch.first.getPassthroughAttr())) {
+          for (auto a : attr) {
+            auto ar = dyn_cast<ArrayAttr>(a);
+            if (!ar || ar.size() != 2)
+              continue;
+            auto s0 = dyn_cast<StringAttr>(ar[0]);
+            auto s1 = dyn_cast<StringAttr>(ar[1]);
+            if (s0 && s1 && s0.getValue() == "polygeist.host_symbol")
+              hostStubName = s1.getValue();
+          }
+        }
+        if (!hostStubName.empty()) {
+          if (auto hostStub = symbolTable.getSymbolTable(getOperation())
+                                  .lookup<LLVM::LLVMFuncOp>(hostStubName)) {
+            if (auto hostStubUses = hostStub.getSymbolUses(getOperation()))
+              for (auto use : *hostStubUses)
+                if (isa<LLVM::AddressOfOp>(use.getUser())) {
+                  captured = true;
+                  break;
+                }
+          }
+        }
+      }
+
       auto cur = launch.first;
       if (cur.isExternal())
         continue;

--- a/test/lit_tests/gpu-launch-recognition-escaped-stub.mlir
+++ b/test/lit_tests/gpu-launch-recognition-escaped-stub.mlir
@@ -1,0 +1,31 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(gpu-launch-recognition)" | FileCheck %s
+
+// The kernel address user code holds is that of clang's host stub. Here it
+// escapes into a call rather than reaching a runtime query directly, so
+// nothing rewrites it to the device symbol. The kernel is still captured and
+// has to reach a gpu.module, or it is never emitted and never registered.
+module attributes {gpu.container_module} {
+  llvm.func @__mlir_cuda_caller_phase3(...)
+  llvm.func @escape(!llvm.ptr)
+
+  llvm.func internal @"reactant$_Z16__device_stub__kPi"(%arg0: !llvm.ptr {llvm.nonnull}) attributes {passthrough = [["polygeist.host_symbol", "_Z16__device_stub__kPi"]]} {
+    llvm.return
+  }
+
+  llvm.func internal @_Z16__device_stub__kPi(%p: !llvm.ptr) {
+    %f = llvm.mlir.addressof @"reactant$_Z16__device_stub__kPi" : !llvm.ptr
+    %dim = llvm.mlir.constant(1 : i32) : i32
+    %shmem = llvm.mlir.constant(0 : i64) : i64
+    %stream = llvm.mlir.zero : !llvm.ptr
+    llvm.call @__mlir_cuda_caller_phase3(%f, %dim, %dim, %dim, %dim, %dim, %dim, %shmem, %stream, %p) vararg(!llvm.func<void (...)>) : (!llvm.ptr, i32, i32, i32, i32, i32, i32, i64, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+
+  llvm.func @user() {
+    %h = llvm.mlir.addressof @_Z16__device_stub__kPi : !llvm.ptr
+    llvm.call @escape(%h) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+}
+
+// CHECK: gpu.func @reactant$_Z16__device_stub__kPi(%{{.+}}: !llvm.ptr {{.*}}) kernel


### PR DESCRIPTION
## Problem

The capture scan in `GPULaunchRecognition` only walks uses of the **device-side** function. But the address user code takes is that of clang's **host stub**, and when it escapes — handed to a call rather than reaching a runtime query directly — there is no call site at which to rewrite it to the device symbol.

The kernel then looks like an ordinary launch: it is lowered to a parallel region inside a stub nothing calls, never reaches a `gpu.module`, and so no device code is emitted for it and nothing registers it. A later `cudaFuncGetAttributes` on that address returns 400 (invalid resource handle).

Optimized builds hide this, since inlining brings the address back to a call site where the existing rewrite fires. It shows up at `-O0`, and in CUB's `PtxVersion()`, which queries `EmptyKernel<void>` through a helper.

## Fix

Also treat an address-taken host stub as a capture of its kernel, using the same `reactant$` naming relation the registration path relies on.

## Testing

- New lit test: a kernel whose host stub's address escapes into a call is promoted to a `gpu.func`. Nothing is promoted without the change.
- Full lit suite: 1156/1157, the remaining failure being an untracked local WIP file exercising a different pass.
- End to end at `-O0`, queries that returned 400 now return the same attributes as vanilla clang, for a plain kernel, a captured-only kernel, and a `linkonce_odr` template kernel.

## Draft, because of the ordering

Promoting kernels that were previously never promoted exercises code that nothing reached before, and it uncovered three latent bugs. This wants to land **after** all of them:

- #2858 — promoting a kernel with no argument attributes dereferences an empty optional. Hit directly by this change; the test here gives its kernel an attributed argument to stay independent, but real `-O0` input does not.
- #2861 — a scalarised `byval` argument is read as an address.
- #2863 — kernel operands sliced from the back pick up the stream.

Landing this first would turn a quiet mis-registration into build failures on CUB-using code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD