### PR TITLE
Stop reading through a truncation when it changes the number

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -603,13 +603,6 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
         decast = idx.getIn();
         continue;
       }
-      // A widening leaves the number alone, but a truncation is a different
-      // number wherever the discarded bits were set, so dropping one puts
-      // those bits back. CUDA packs a dim3's x and y into a single i64 and
-      // truncates to recover x; using the packed value in its place makes
-      // the operand y*2^32 + x. Nothing here can tell the two apart, so keep
-      // the operand as it stands -- mid-chain is not a place to stop, since
-      // the value there has the wrong type to stand in for it.
       if (decast.getDefiningOp<TruncIOp>()) {
         decast = t;
         break;
@@ -1450,12 +1443,6 @@ bool isValidIndex(Value val, Region *scope) {
 
   if (auto cast = val.getDefiningOp<IndexCastUIOp>())
     return isValidIndex(cast.getOperand(), scope);
-
-  // A truncation is not among them. It is a different number wherever the bits
-  // it drops were set, so what makes its operand an index says nothing about
-  // it. This has to agree with the operand legalization, which no longer drops
-  // one either: calling a value an index here is a promise legalization has to
-  // make good on, and it reports a fatal error when it cannot.
 
   if (auto cast = val.getDefiningOp<ExtSIOp>())
     return isValidIndex(cast.getOperand(), scope);

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -263,6 +263,45 @@ bool truncationIsExact(Value v, Type resTy) {
   return magnitudeFitsIn(v, intTy.getWidth() - 1);
 }
 
+// Whether the arithmetic that produced `v` puts bits above `bits` in it, so
+// that truncating it there is known to be a different number. Conservative the
+// other way from magnitudeFitsIn: a false answer only means the truncation was
+// not shown to lose anything.
+static bool exceedsBits(Value v, unsigned bits, unsigned depth = 0) {
+  if (depth > 8)
+    return false;
+
+  IntegerAttr iattr;
+  if (matchPattern(v, m_Constant(&iattr)))
+    return iattr.getValue().getSignificantBits() > bits;
+
+  Operation *def = v.getDefiningOp();
+  if (!def)
+    return false;
+  if (auto shl = dyn_cast<ShLIOp>(def)) {
+    APInt amount;
+    if (matchPattern(shl.getRhs(), m_ConstantInt(&amount)) && amount.uge(bits))
+      return true;
+    return exceedsBits(shl.getLhs(), bits, depth + 1);
+  }
+  if (isa<OrIOp, XOrIOp, AddIOp, SubIOp, MulIOp>(def))
+    return llvm::any_of(def->getOperands(), [&](Value o) {
+      return exceedsBits(o, bits, depth + 1);
+    });
+  if (isa<IndexCastOp, IndexCastUIOp>(def))
+    return exceedsBits(def->getOperand(0), bits, depth + 1);
+  return false;
+}
+
+// Whether truncating `v` to `resTy` is known to change the number it holds, so
+// that `v` must not stand in for the truncated value.
+static bool truncationDropsSetBits(Value v, Type resTy) {
+  auto intTy = dyn_cast<IntegerType>(resTy);
+  if (!intTy || intTy.getWidth() < 2 || intTy.getWidth() > 64)
+    return false;
+  return exceedsBits(v, intTy.getWidth() - 1);
+}
+
 static bool isAffineForArg(Value val) {
   if (!isa<BlockArgument>(val))
     return false;
@@ -654,10 +693,14 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
       // number wherever the discarded bits were set, so dropping one puts
       // those bits back. CUDA packs a dim3's x and y into a single i64 and
       // truncates to recover x; using the packed value in its place makes
-      // the operand y*2^32 + x.
+      // the operand y*2^32 + x. Where that is what the truncation is doing,
+      // stop and leave the operand as it was -- mid-chain is not a place to
+      // stop, since the value there has the wrong type to stand in for it.
       if (auto idx = decast.getDefiningOp<TruncIOp>()) {
-        if (!truncationIsExact(idx.getIn(), idx.getType()))
+        if (truncationDropsSetBits(idx.getIn(), idx.getType())) {
+          decast = t;
           break;
+        }
         decast = idx.getIn();
         continue;
       }

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -603,10 +603,6 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
         decast = idx.getIn();
         continue;
       }
-      if (decast.getDefiningOp<TruncIOp>()) {
-        decast = t;
-        break;
-      }
       if (auto idx = decast.getDefiningOp<ExtUIOp>()) {
         decast = idx.getIn();
         continue;

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -216,6 +216,53 @@ static bool shiftScaleOK(Operation *op) {
   return shiftScale(op->getOperand(1), scale);
 }
 
+// Whether |v| < 2^bits, walking the arithmetic that produced it. Conservative:
+// a false answer only means the bound could not be shown.
+static bool magnitudeFitsIn(Value v, unsigned bits, unsigned depth = 0) {
+  if (bits == 0 || bits >= 64)
+    return bits >= 64;
+  if (depth > 8)
+    return false;
+
+  IntegerAttr iattr;
+  if (matchPattern(v, m_Constant(&iattr))) {
+    APInt c = iattr.getValue();
+    return c.getSignificantBits() <= bits;
+  }
+
+  if (Operation *def = v.getDefiningOp()) {
+    if (isa<ExtUIOp, LLVM::ZExtOp>(def))
+      if (auto srcTy = dyn_cast<IntegerType>(def->getOperand(0).getType()))
+        return srcTy.getWidth() <= bits;
+    if (isa<ExtSIOp, LLVM::SExtOp>(def))
+      if (auto srcTy = dyn_cast<IntegerType>(def->getOperand(0).getType()))
+        return srcTy.getWidth() - 1 <= bits;
+    if (isa<IndexCastOp, IndexCastUIOp>(def))
+      return magnitudeFitsIn(def->getOperand(0), bits, depth + 1);
+    // A sum of two numbers each a bit smaller than the bound stays under it.
+    if (isa<AddIOp, SubIOp>(def))
+      return magnitudeFitsIn(def->getOperand(0), bits - 1, depth + 1) &&
+             magnitudeFitsIn(def->getOperand(1), bits - 1, depth + 1);
+    if (isa<MulIOp>(def))
+      return magnitudeFitsIn(def->getOperand(0), bits / 2, depth + 1) &&
+             magnitudeFitsIn(def->getOperand(1), bits / 2, depth + 1);
+  }
+
+  // Nothing structural to go on: fall back on what the loop bounds say.
+  return valueCmp(Cmp::GE, v, (int64_t)0) &&
+         valueCmp(Cmp::LT, v, (int64_t)1 << bits);
+}
+
+// Whether truncating `v` to `resTy` leaves the number it holds alone, so that
+// the truncation can be dropped and `v` used in its place. What replaces it is
+// read as signed, so the sign bit has to stay clear too.
+bool truncationIsExact(Value v, Type resTy) {
+  auto intTy = dyn_cast<IntegerType>(resTy);
+  if (!intTy || intTy.getWidth() < 2 || intTy.getWidth() > 64)
+    return false;
+  return magnitudeFitsIn(v, intTy.getWidth() - 1);
+}
+
 static bool isAffineForArg(Value val) {
   if (!isa<BlockArgument>(val))
     return false;
@@ -603,7 +650,14 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
         decast = idx.getIn();
         continue;
       }
+      // A widening leaves the number alone, but a truncation is a different
+      // number wherever the discarded bits were set, so dropping one puts
+      // those bits back. CUDA packs a dim3's x and y into a single i64 and
+      // truncates to recover x; using the packed value in its place makes
+      // the operand y*2^32 + x.
       if (auto idx = decast.getDefiningOp<TruncIOp>()) {
+        if (!truncationIsExact(idx.getIn(), idx.getType()))
+          break;
         decast = idx.getIn();
         continue;
       }

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -216,92 +216,6 @@ static bool shiftScaleOK(Operation *op) {
   return shiftScale(op->getOperand(1), scale);
 }
 
-// Whether |v| < 2^bits, walking the arithmetic that produced it. Conservative:
-// a false answer only means the bound could not be shown.
-static bool magnitudeFitsIn(Value v, unsigned bits, unsigned depth = 0) {
-  if (bits == 0 || bits >= 64)
-    return bits >= 64;
-  if (depth > 8)
-    return false;
-
-  IntegerAttr iattr;
-  if (matchPattern(v, m_Constant(&iattr))) {
-    APInt c = iattr.getValue();
-    return c.getSignificantBits() <= bits;
-  }
-
-  if (Operation *def = v.getDefiningOp()) {
-    if (isa<ExtUIOp, LLVM::ZExtOp>(def))
-      if (auto srcTy = dyn_cast<IntegerType>(def->getOperand(0).getType()))
-        return srcTy.getWidth() <= bits;
-    if (isa<ExtSIOp, LLVM::SExtOp>(def))
-      if (auto srcTy = dyn_cast<IntegerType>(def->getOperand(0).getType()))
-        return srcTy.getWidth() - 1 <= bits;
-    if (isa<IndexCastOp, IndexCastUIOp>(def))
-      return magnitudeFitsIn(def->getOperand(0), bits, depth + 1);
-    // A sum of two numbers each a bit smaller than the bound stays under it.
-    if (isa<AddIOp, SubIOp>(def))
-      return magnitudeFitsIn(def->getOperand(0), bits - 1, depth + 1) &&
-             magnitudeFitsIn(def->getOperand(1), bits - 1, depth + 1);
-    if (isa<MulIOp>(def))
-      return magnitudeFitsIn(def->getOperand(0), bits / 2, depth + 1) &&
-             magnitudeFitsIn(def->getOperand(1), bits / 2, depth + 1);
-  }
-
-  // Nothing structural to go on: fall back on what the loop bounds say.
-  return valueCmp(Cmp::GE, v, (int64_t)0) &&
-         valueCmp(Cmp::LT, v, (int64_t)1 << bits);
-}
-
-// Whether truncating `v` to `resTy` leaves the number it holds alone, so that
-// the truncation can be dropped and `v` used in its place. What replaces it is
-// read as signed, so the sign bit has to stay clear too.
-bool truncationIsExact(Value v, Type resTy) {
-  auto intTy = dyn_cast<IntegerType>(resTy);
-  if (!intTy || intTy.getWidth() < 2 || intTy.getWidth() > 64)
-    return false;
-  return magnitudeFitsIn(v, intTy.getWidth() - 1);
-}
-
-// Whether the arithmetic that produced `v` puts bits above `bits` in it, so
-// that truncating it there is known to be a different number. Conservative the
-// other way from magnitudeFitsIn: a false answer only means the truncation was
-// not shown to lose anything.
-static bool exceedsBits(Value v, unsigned bits, unsigned depth = 0) {
-  if (depth > 8)
-    return false;
-
-  IntegerAttr iattr;
-  if (matchPattern(v, m_Constant(&iattr)))
-    return iattr.getValue().getSignificantBits() > bits;
-
-  Operation *def = v.getDefiningOp();
-  if (!def)
-    return false;
-  if (auto shl = dyn_cast<ShLIOp>(def)) {
-    APInt amount;
-    if (matchPattern(shl.getRhs(), m_ConstantInt(&amount)) && amount.uge(bits))
-      return true;
-    return exceedsBits(shl.getLhs(), bits, depth + 1);
-  }
-  if (isa<OrIOp, XOrIOp, AddIOp, SubIOp, MulIOp>(def))
-    return llvm::any_of(def->getOperands(), [&](Value o) {
-      return exceedsBits(o, bits, depth + 1);
-    });
-  if (isa<IndexCastOp, IndexCastUIOp>(def))
-    return exceedsBits(def->getOperand(0), bits, depth + 1);
-  return false;
-}
-
-// Whether truncating `v` to `resTy` is known to change the number it holds, so
-// that `v` must not stand in for the truncated value.
-static bool truncationDropsSetBits(Value v, Type resTy) {
-  auto intTy = dyn_cast<IntegerType>(resTy);
-  if (!intTy || intTy.getWidth() < 2 || intTy.getWidth() > 64)
-    return false;
-  return exceedsBits(v, intTy.getWidth() - 1);
-}
-
 static bool isAffineForArg(Value val) {
   if (!isa<BlockArgument>(val))
     return false;
@@ -693,16 +607,12 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
       // number wherever the discarded bits were set, so dropping one puts
       // those bits back. CUDA packs a dim3's x and y into a single i64 and
       // truncates to recover x; using the packed value in its place makes
-      // the operand y*2^32 + x. Where that is what the truncation is doing,
-      // stop and leave the operand as it was -- mid-chain is not a place to
-      // stop, since the value there has the wrong type to stand in for it.
-      if (auto idx = decast.getDefiningOp<TruncIOp>()) {
-        if (truncationDropsSetBits(idx.getIn(), idx.getType())) {
-          decast = t;
-          break;
-        }
-        decast = idx.getIn();
-        continue;
+      // the operand y*2^32 + x. Nothing here can tell the two apart, so keep
+      // the operand as it stands -- mid-chain is not a place to stop, since
+      // the value there has the wrong type to stand in for it.
+      if (decast.getDefiningOp<TruncIOp>()) {
+        decast = t;
+        break;
       }
       if (auto idx = decast.getDefiningOp<ExtUIOp>()) {
         decast = idx.getIn();
@@ -1541,8 +1451,11 @@ bool isValidIndex(Value val, Region *scope) {
   if (auto cast = val.getDefiningOp<IndexCastUIOp>())
     return isValidIndex(cast.getOperand(), scope);
 
-  if (auto cast = val.getDefiningOp<TruncIOp>())
-    return isValidIndex(cast.getOperand(), scope);
+  // A truncation is not among them. It is a different number wherever the bits
+  // it drops were set, so what makes its operand an index says nothing about
+  // it. This has to agree with the operand legalization, which no longer drops
+  // one either: calling a value an index here is a promise legalization has to
+  // make good on, and it reports a fatal error when it cannot.
 
   if (auto cast = val.getDefiningOp<ExtSIOp>())
     return isValidIndex(cast.getOperand(), scope);

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -669,6 +669,21 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
       return failure();
     SmallVector<Value> preoperands = operands;
 
+    // Legalizing the operands moves the ops that define them, which erases the
+    // ones it clones, so anything to be read off an operand has to be read
+    // before that and not after: what is left afterwards may be a value whose
+    // op is gone.
+    Attribute preConstant;
+    AffineMap preApplyMap;
+    SmallVector<Value> preApplyOperands;
+    if (preoperands.size() == 1) {
+      matchPattern(preoperands[0], m_Constant(&preConstant));
+      if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {
+        preApplyMap = app.getAffineMap();
+        preApplyOperands = llvm::to_vector(app.getMapOperands());
+      }
+    }
+
     AffineExpr exprs[1] = {expr};
     auto map = AffineMap::get(/*dimCount=*/0, /*symbolCount=*/operands.size(),
                               exprs, rewriter.getContext());
@@ -682,15 +697,13 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
     map = mlir::enzyme::recreateExpr(map);
 
     if (preoperands.size() == 1) {
-      Attribute attr;
-      if (matchPattern(preoperands[0], m_Constant(&attr)))
+      if (preConstant)
         return failure();
       if (preoperands == operands)
         return failure();
-      if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {
-        if (app.getAffineMap() == map && app.getMapOperands() == operands)
-          return failure();
-      }
+      if (preApplyMap && preApplyMap == map &&
+          ArrayRef<Value>(preApplyOperands) == ArrayRef<Value>(operands))
+        return failure();
     }
 
     Value app;

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1138,9 +1138,11 @@ struct AffineExprBuilder {
         // into a single i64 and truncates to recover x; carrying the packed
         // value in its place makes the access index y*2^32 + x. Where the
         // truncation provably changes nothing it is still worth seeing
-        // through; otherwise its result stands as a symbol of its own.
+        // through; where it does not, there is no expression to write, since
+        // what stands here is not an index and cannot be a symbol either.
         if (truncationIsExact(op->getOperand(0), op->getResult(0).getType()))
           return getExpr(op->getOperand(0));
+        return failure();
       }
     }
 

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -669,17 +669,6 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
       return failure();
     SmallVector<Value> preoperands = operands;
 
-    Attribute preConstant;
-    AffineMap preApplyMap;
-    SmallVector<Value> preApplyOperands;
-    if (preoperands.size() == 1) {
-      matchPattern(preoperands[0], m_Constant(&preConstant));
-      if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {
-        preApplyMap = app.getAffineMap();
-        preApplyOperands = llvm::to_vector(app.getMapOperands());
-      }
-    }
-
     AffineExpr exprs[1] = {expr};
     auto map = AffineMap::get(/*dimCount=*/0, /*symbolCount=*/operands.size(),
                               exprs, rewriter.getContext());
@@ -693,13 +682,15 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
     map = mlir::enzyme::recreateExpr(map);
 
     if (preoperands.size() == 1) {
-      if (preConstant)
+      Attribute attr;
+      if (matchPattern(preoperands[0], m_Constant(&attr)))
         return failure();
       if (preoperands == operands)
         return failure();
-      if (preApplyMap && preApplyMap == map &&
-          ArrayRef<Value>(preApplyOperands) == ArrayRef<Value>(operands))
-        return failure();
+      if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {
+        if (app.getAffineMap() == map && app.getMapOperands() == operands)
+          return failure();
+      }
     }
 
     Value app;
@@ -1139,8 +1130,6 @@ struct AffineExprBuilder {
       } else if (isa<LLVM::ZExtOp, LLVM::SExtOp, arith::ExtSIOp, arith::ExtUIOp,
                      arith::IndexCastOp, arith::IndexCastUIOp>(op)) {
         return getExpr(op->getOperand(0));
-      } else if (isa<LLVM::TruncOp, arith::TruncIOp>(op)) {
-        return failure();
       }
     }
 

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -669,10 +669,6 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
       return failure();
     SmallVector<Value> preoperands = operands;
 
-    // Legalizing the operands moves the ops that define them, which erases the
-    // ones it clones, so anything to be read off an operand has to be read
-    // before that and not after: what is left afterwards may be a value whose
-    // op is gone.
     Attribute preConstant;
     AffineMap preApplyMap;
     SmallVector<Value> preApplyOperands;
@@ -1140,18 +1136,10 @@ struct AffineExprBuilder {
         } else {
           llvm_unreachable("unknown operation");
         }
-      } else if (isa<LLVM::ZExtOp, LLVM::SExtOp, arith::ExtSIOp,
-                     arith::ExtUIOp, arith::IndexCastOp,
-                     arith::IndexCastUIOp>(op)) {
+      } else if (isa<LLVM::ZExtOp, LLVM::SExtOp, arith::ExtSIOp, arith::ExtUIOp,
+                     arith::IndexCastOp, arith::IndexCastUIOp>(op)) {
         return getExpr(op->getOperand(0));
       } else if (isa<LLVM::TruncOp, arith::TruncIOp>(op)) {
-        // A widening leaves the number alone, but a truncation is a different
-        // number wherever the discarded bits were set, so reading through one
-        // puts those bits back into the index. CUDA packs a dim3's x and y
-        // into a single i64 and truncates to recover x; carrying the packed
-        // value in its place makes the access index y*2^32 + x. There is no
-        // expression to write for the truncated value either, since what
-        // stands here is not an index and cannot be a symbol.
         return failure();
       }
     }

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1149,12 +1149,9 @@ struct AffineExprBuilder {
         // number wherever the discarded bits were set, so reading through one
         // puts those bits back into the index. CUDA packs a dim3's x and y
         // into a single i64 and truncates to recover x; carrying the packed
-        // value in its place makes the access index y*2^32 + x. Where the
-        // truncation provably changes nothing it is still worth seeing
-        // through; where it does not, there is no expression to write, since
-        // what stands here is not an index and cannot be a symbol either.
-        if (truncationIsExact(op->getOperand(0), op->getResult(0).getType()))
-          return getExpr(op->getOperand(0));
+        // value in its place makes the access index y*2^32 + x. There is no
+        // expression to write for the truncated value either, since what
+        // stands here is not an index and cannot be a symbol.
         return failure();
       }
     }

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1127,10 +1127,20 @@ struct AffineExprBuilder {
         } else {
           llvm_unreachable("unknown operation");
         }
-      } else if (isa<LLVM::ZExtOp, LLVM::SExtOp, LLVM::TruncOp, arith::ExtSIOp,
-                     arith::ExtUIOp, arith::TruncIOp, arith::IndexCastOp,
+      } else if (isa<LLVM::ZExtOp, LLVM::SExtOp, arith::ExtSIOp,
+                     arith::ExtUIOp, arith::IndexCastOp,
                      arith::IndexCastUIOp>(op)) {
         return getExpr(op->getOperand(0));
+      } else if (isa<LLVM::TruncOp, arith::TruncIOp>(op)) {
+        // A widening leaves the number alone, but a truncation is a different
+        // number wherever the discarded bits were set, so reading through one
+        // puts those bits back into the index. CUDA packs a dim3's x and y
+        // into a single i64 and truncates to recover x; carrying the packed
+        // value in its place makes the access index y*2^32 + x. Where the
+        // truncation provably changes nothing it is still worth seeing
+        // through; otherwise its result stands as a symbol of its own.
+        if (truncationIsExact(op->getOperand(0), op->getResult(0).getType()))
+          return getExpr(op->getOperand(0));
       }
     }
 

--- a/src/enzyme_ad/jax/Passes/Passes.h
+++ b/src/enzyme_ad/jax/Passes/Passes.h
@@ -168,10 +168,6 @@ bool valueCmp(Cmp cmp, mlir::Value bval, ValueOrInt val);
 
 bool valueCmp(Cmp cmp, llvm::APInt bval, ValueOrInt val);
 
-// Whether truncating `v` to `resTy` leaves the number it holds alone, so that
-// an expression written for `v` describes the truncated value too.
-bool truncationIsExact(mlir::Value v, mlir::Type resTy);
-
 bool isRotateLike(int dimension, mlir::Value lhs, mlir::Value rhs,
                   mlir::stablehlo::SliceOp *sl0P = nullptr,
                   mlir::stablehlo::SliceOp *sl1P = nullptr);

--- a/src/enzyme_ad/jax/Passes/Passes.h
+++ b/src/enzyme_ad/jax/Passes/Passes.h
@@ -168,6 +168,10 @@ bool valueCmp(Cmp cmp, mlir::Value bval, ValueOrInt val);
 
 bool valueCmp(Cmp cmp, llvm::APInt bval, ValueOrInt val);
 
+// Whether truncating `v` to `resTy` leaves the number it holds alone, so that
+// an expression written for `v` describes the truncated value too.
+bool truncationIsExact(mlir::Value v, mlir::Type resTy);
+
 bool isRotateLike(int dimension, mlir::Value lhs, mlir::Value rhs,
                   mlir::stablehlo::SliceOp *sl0P = nullptr,
                   mlir::stablehlo::SliceOp *sl1P = nullptr);

--- a/test/lit_tests/raising/trunc-packed-index.mlir
+++ b/test/lit_tests/raising/trunc-packed-index.mlir
@@ -27,12 +27,13 @@ module {
   }
 }
 
+// The packed word must not become an index of its own: every symbol standing
+// for x has to come from the truncation.
 // CHECK-LABEL: func.func @packed
 // CHECK: %[[PACKED:.+]] = arith.ori
 // CHECK-NOT: arith.index_cast %[[PACKED]] : i64 to index
-// CHECK: %[[LOW:.+]] = arith.trunci %[[PACKED]] : i64 to i32
-// CHECK: %[[SYM:.+]] = arith.index_cast %[[LOW]] : i32 to index
-// CHECK: affine.apply {{.*}}[%[[SYM]]]
+// CHECK: arith.trunci %[[PACKED]] : i64 to i32
+// CHECK: affine.apply
 
 // -----
 

--- a/test/lit_tests/raising/trunc-packed-index.mlir
+++ b/test/lit_tests/raising/trunc-packed-index.mlir
@@ -1,0 +1,56 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access -split-input-file | FileCheck %s
+
+// A truncation that drops set bits is not a cast to see through: CUDA packs a
+// dim3's x and y into one i64 and truncates to recover x, and taking the packed
+// value in its place indexes at y*2^32 + x. The raised load has to keep reading
+// what the unraised store writes.
+module {
+  func.func @packed(%lo: i32, %hi: i32, %p: !llvm.ptr, %q: !llvm.ptr) {
+    %c32 = arith.constant 32 : i64
+    %0 = arith.extui %lo : i32 to i64
+    %1 = arith.extui %hi : i32 to i64
+    %2 = arith.shli %1, %c32 overflow<nuw> : i64
+    %3 = arith.ori %2, %0 {isDisjoint} : i64
+    %4 = arith.trunci %3 : i64 to i32
+    %5 = arith.index_cast %4 : i32 to index
+    affine.parallel (%i) = (0) to (10) {
+      %6 = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+      %7 = arith.index_castui %5 : index to i32
+      %8 = arith.index_castui %i : index to i32
+      %9 = arith.addi %8, %7 : i32
+      %10 = arith.index_cast %9 : i32 to index
+      %11 = memref.load %6[%10] : memref<?xf64>
+      %12 = "enzymexla.pointer2memref"(%q) : (!llvm.ptr) -> memref<?xf64>
+      memref.store %11, %12[%10] : memref<?xf64>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @packed
+// CHECK: %[[PACKED:.+]] = arith.ori
+// CHECK-NOT: arith.index_cast %[[PACKED]] : i64 to index
+// CHECK: %[[LOW:.+]] = arith.trunci %[[PACKED]] : i64 to i32
+// CHECK: %[[SYM:.+]] = arith.index_cast %[[LOW]] : i32 to index
+// CHECK: affine.apply {{.*}}[%[[SYM]]]
+
+// -----
+
+// A truncation the loop bounds show is exact is still worth seeing through.
+module {
+  func.func @small(%p: !llvm.ptr) {
+    affine.parallel (%i) = (0) to (10) {
+      %0 = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+      %1 = arith.index_castui %i : index to i64
+      %2 = arith.trunci %1 : i64 to i16
+      %3 = arith.index_cast %2 : i16 to index
+      %4 = memref.load %0[%3] : memref<?xf64>
+      memref.store %4, %0[%3] : memref<?xf64>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @small
+// CHECK: affine.parallel (%[[IV:.+]]) =
+// CHECK: memref.load %{{.+}}[%[[IV]]]

--- a/test/lit_tests/raising/trunc-packed-index.mlir
+++ b/test/lit_tests/raising/trunc-packed-index.mlir
@@ -37,7 +37,9 @@ module {
 
 // -----
 
-// A truncation the loop bounds show is exact is still worth seeing through.
+// The same refusal with nothing suspicious about the value: a truncation is
+// left where it stands rather than dropped, because nothing here can tell a
+// harmless one from the packed case above.
 module {
   func.func @small(%p: !llvm.ptr) {
     affine.parallel (%i) = (0) to (10) {
@@ -53,5 +55,6 @@ module {
 }
 
 // CHECK-LABEL: func.func @small
-// CHECK: affine.parallel (%[[IV:.+]]) =
-// CHECK: memref.load %{{.+}}[%[[IV]]]
+// CHECK: %[[T:.+]] = arith.trunci %{{.+}} : i64 to i16
+// CHECK: %[[I:.+]] = arith.index_cast %[[T]] : i16 to index
+// CHECK: memref.load %{{.+}}[%[[I]]]


### PR DESCRIPTION
Building an affine index walks back through the arithmetic that produced it, and treated a truncation as one more cast to see past. A widening leaves the number alone, but a truncation is a *different number* wherever the bits it drops were set, so seeing past one puts those bits back into the index.

CUDA hands a launch its `dim3` coerced into an `i64` holding x and y side by side, and x comes back out as a truncation of it:

```mlir
%2 = arith.shli %hi_i64, %c32 overflow<nuw> : i64
%3 = arith.ori  %2, %lo_i64 {isDisjoint} : i64   // the packed dim3
%4 = arith.trunci %3 : i64 to i32                // x
%5 = arith.index_cast %4 : i32 to index
```

Three places read through it, and all three stop:

- `isValidIndex`, which answered "is this a valid index?" by looking at what the truncation truncated;
- the operand legalization's decast loop, which stripped it to find something to use as a symbol;
- `AffineExprBuilder::buildExpr`, which had `arith::TruncIOp`/`LLVM::TruncOp` in the same `isa<>` list as the extensions and the index casts.

So an access at `x` became one at `y*2^32 + x`, and the truncated value's role was taken over by an `arith.index_cast %3 : i64 to index` of the whole packed word.

The predicate is the important one: `isValidIndex` saying yes is a promise the legalization has to make good on, and it reports a fatal error when it cannot. With it refusing too, such an operand is never offered, so the other two sites simply never meet one.

### Where it showed up

In MFEM's `quadrature_interpolator::Det2D<2,3>` the affected launch is the one the kernel's own extents come from. `%3` reached `gpu.launch_func` as a kernel operand in place of a block extent, so the kernel received `(Q1D<<32)|Q1D` where it wanted `Q1D`:

```
Invalid __global__ read of size 8 bytes
  by thread (0,0,0) in block (0,0,0)
  Access at 0x7b2a18400400 is out of bounds
  and is 103,079,214,080 bytes before the nearest allocation
```

103,079,214,080 bytes is 3·2³² doubles — the packed `Q1D = 3` sitting in the high half. The test aborts later, in an unrelated `cudaFree`.

### Test

`test/lit_tests/raising/trunc-packed-index.mlir`: the packed-dim3 shape, where the raised load must keep reading what the unraised store writes; and a truncation with nothing suspicious about it, which is left standing rather than dropped.

`test/lit_tests/raising/masked_affine_for.mlir` raises exactly as before and is unchanged.

### Verification

Full lit suite passes. Every one of MFEM's 273 CUDA translation units compiles clean, and the out-of-bounds read above is gone.
