### PR TITLE
Only lift a barrier out of a branch every thread decides alike

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1534,13 +1534,14 @@ llvm::cl::opt<bool> BarrierOpt("barrier-opt", llvm::cl::init(true),
                                llvm::cl::desc("Optimize barriers"));
 
 // Whether every thread runs `ifOp`'s body, i.e. the condition selects no subset
-// of them. `threadIVs` are the indices the barrier synchronises over, which
-// name the parallel whose iterations are the threads.
+// of them. `threadIVs` are the indices the barrier synchronises over, which name
+// the parallel whose iterations are the threads.
 static bool selectsAllThreads(Operation *ifOp, ValueRange threadIVs) {
+  // Synchronising over no index at all: there is no dimension for the
+  // condition to vary along, so no subset for it to select.
   if (threadIVs.empty())
-    return false;
-  Operation *par =
-      cast<BlockArgument>(threadIVs.front()).getOwner()->getParentOp();
+    return true;
+  Operation *par = cast<BlockArgument>(threadIVs.front()).getOwner()->getParentOp();
 
   SmallVector<Value> worklist;
   if (auto scfIf = dyn_cast<scf::IfOp>(ifOp))

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1533,18 +1533,27 @@ using namespace mlir::enzyme;
 llvm::cl::opt<bool> BarrierOpt("barrier-opt", llvm::cl::init(true),
                                llvm::cl::desc("Optimize barriers"));
 
-// Whether every thread in the block decides `ifOp`'s condition the same way,
-// i.e. none of `threadIVs` reaches it.
-static bool isBlockUniform(Operation *ifOp, ValueRange threadIVs) {
-  SmallVector<Value> conds;
+// Whether every thread runs `ifOp`'s body, i.e. the condition selects no subset
+// of them. `threadIVs` are the indices the barrier synchronises over, which
+// name the parallel whose iterations are the threads.
+static bool selectsAllThreads(Operation *ifOp, ValueRange threadIVs) {
+  Operation *par = nullptr;
+  for (Value iv : threadIVs)
+    if (auto ba = dyn_cast<BlockArgument>(iv)) {
+      par = ba.getOwner()->getParentOp();
+      break;
+    }
+  if (!par)
+    return false;
+
+  SmallVector<Value> worklist;
   if (auto scfIf = dyn_cast<scf::IfOp>(ifOp))
-    conds.push_back(scfIf.getCondition());
+    worklist.push_back(scfIf.getCondition());
   else if (auto affIf = dyn_cast<affine::AffineIfOp>(ifOp))
-    conds.append(affIf.getOperands().begin(), affIf.getOperands().end());
+    worklist.append(affIf.getOperands().begin(), affIf.getOperands().end());
   else
     return false;
 
-  SmallVector<Value> worklist(conds);
   DenseSet<Value> seen;
   while (!worklist.empty()) {
     Value v = worklist.pop_back_val();
@@ -1552,14 +1561,44 @@ static bool isBlockUniform(Operation *ifOp, ValueRange threadIVs) {
       continue;
     if (llvm::is_contained(threadIVs, v))
       return false;
-    if (isa<BlockArgument>(v))
+
+    Operation *owner = isa<BlockArgument>(v)
+                           ? cast<BlockArgument>(v).getOwner()->getParentOp()
+                           : v.getDefiningOp();
+    // Anything from outside the thread parallel holds the same value in every
+    // thread, whatever computed it.
+    if (!owner || !par->isAncestor(owner))
       continue;
+    // Inside it, a block argument is something like a serial loop's index,
+    // whose value can differ per thread however its bounds were written.
+    if (isa<BlockArgument>(v))
+      return false;
     Operation *def = v.getDefiningOp();
     if (def->getNumRegions() != 0)
       return false;
     worklist.append(def->getOperands().begin(), def->getOperands().end());
   }
   return true;
+}
+
+static bool anyBarrierWithin(Operation *op, BarrierOp except) {
+  bool found = false;
+  op->walk([&](BarrierOp other) {
+    if (other != except)
+      found = true;
+  });
+  return found;
+}
+
+static bool anyBarrierAfter(Operation *op) {
+  for (Operation *it = op->getNextNode(); it != nullptr;
+       it = it->getNextNode()) {
+    bool found = false;
+    it->walk([&](BarrierOp) { found = true; });
+    if (found)
+      return true;
+  }
+  return false;
 }
 
 class BarrierHoist final : public OpRewritePattern<BarrierOp> {
@@ -1571,8 +1610,19 @@ public:
     if (!BarrierOpt)
       return failure();
     if (isa<scf::IfOp, affine::AffineIfOp>(barrier->getParentOp())) {
-      if (!isBlockUniform(barrier->getParentOp(), barrier.getOperands()))
-        return failure();
+      // Moving a barrier across a conditional changes who runs it: inside only
+      // the threads taking the branch do, outside every thread does. That is a
+      // rewrite only where the branch is taken uniformly across the block, and
+      // a condition any thread index reaches is not. CUDA's `if (k >= N)
+      // return;` reads a thread index, and lifting one of the body's barriers
+      // out of it leaves the threads that skipped the body waiting at a barrier
+      // their block-mates never arrive at.
+      Operation *ifOp = barrier->getParentOp();
+      // Lifting a barrier out of a branch only some threads take makes every
+      // thread run it. That is a rewrite where the branch selects no subset of
+      // the threads, or -- moving it past the branch -- where nothing beyond
+      // holds a barrier for the threads that skipped to run instead.
+      bool allThreads = selectsAllThreads(ifOp, barrier.getOperands());
 
       bool below = true;
       for (Operation *it = barrier->getNextNode(); it != nullptr;
@@ -1582,7 +1632,11 @@ public:
           break;
         }
       }
-      if (below) {
+      // A barrier left behind in the branch is the other half of the same
+      // split: the threads that skipped it wait out here, the ones that took
+      // it wait in there.
+      if (below && (allThreads || (!anyBarrierAfter(ifOp) &&
+                                   !anyBarrierWithin(ifOp, barrier)))) {
         rewriter.setInsertionPoint(barrier->getParentOp()->getNextNode());
         BarrierOp::create(rewriter, barrier.getLoc(), barrier.getOperands());
         rewriter.eraseOp(barrier);
@@ -1596,7 +1650,7 @@ public:
           break;
         }
       }
-      if (above) {
+      if (above && allThreads) {
         rewriter.setInsertionPoint(barrier->getParentOp());
         BarrierOp::create(rewriter, barrier.getLoc(), barrier.getOperands());
         rewriter.eraseOp(barrier);

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1533,6 +1533,35 @@ using namespace mlir::enzyme;
 llvm::cl::opt<bool> BarrierOpt("barrier-opt", llvm::cl::init(true),
                                llvm::cl::desc("Optimize barriers"));
 
+// Whether every thread in the block decides `ifOp`'s condition the same way,
+// i.e. none of `threadIVs` reaches it.
+static bool isBlockUniform(Operation *ifOp, ValueRange threadIVs) {
+  SmallVector<Value> conds;
+  if (auto scfIf = dyn_cast<scf::IfOp>(ifOp))
+    conds.push_back(scfIf.getCondition());
+  else if (auto affIf = dyn_cast<affine::AffineIfOp>(ifOp))
+    conds.append(affIf.getOperands().begin(), affIf.getOperands().end());
+  else
+    return false;
+
+  SmallVector<Value> worklist(conds);
+  DenseSet<Value> seen;
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    if (!seen.insert(v).second)
+      continue;
+    if (llvm::is_contained(threadIVs, v))
+      return false;
+    if (isa<BlockArgument>(v))
+      continue;
+    Operation *def = v.getDefiningOp();
+    if (def->getNumRegions() != 0)
+      return false;
+    worklist.append(def->getOperands().begin(), def->getOperands().end());
+  }
+  return true;
+}
+
 class BarrierHoist final : public OpRewritePattern<BarrierOp> {
 public:
   using OpRewritePattern<BarrierOp>::OpRewritePattern;
@@ -1542,6 +1571,8 @@ public:
     if (!BarrierOpt)
       return failure();
     if (isa<scf::IfOp, affine::AffineIfOp>(barrier->getParentOp())) {
+      if (!isBlockUniform(barrier->getParentOp(), barrier.getOperands()))
+        return failure();
 
       bool below = true;
       for (Operation *it = barrier->getNextNode(); it != nullptr;

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1534,14 +1534,15 @@ llvm::cl::opt<bool> BarrierOpt("barrier-opt", llvm::cl::init(true),
                                llvm::cl::desc("Optimize barriers"));
 
 // Whether every thread runs `ifOp`'s body, i.e. the condition selects no subset
-// of them. `threadIVs` are the indices the barrier synchronises over, which name
-// the parallel whose iterations are the threads.
+// of them. `threadIVs` are the indices the barrier synchronises over, which
+// name the parallel whose iterations are the threads.
 static bool selectsAllThreads(Operation *ifOp, ValueRange threadIVs) {
   // Synchronising over no index at all: there is no dimension for the
   // condition to vary along, so no subset for it to select.
   if (threadIVs.empty())
     return true;
-  Operation *par = cast<BlockArgument>(threadIVs.front()).getOwner()->getParentOp();
+  Operation *par =
+      cast<BlockArgument>(threadIVs.front()).getOwner()->getParentOp();
 
   SmallVector<Value> worklist;
   if (auto scfIf = dyn_cast<scf::IfOp>(ifOp))

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1537,14 +1537,10 @@ llvm::cl::opt<bool> BarrierOpt("barrier-opt", llvm::cl::init(true),
 // of them. `threadIVs` are the indices the barrier synchronises over, which
 // name the parallel whose iterations are the threads.
 static bool selectsAllThreads(Operation *ifOp, ValueRange threadIVs) {
-  Operation *par = nullptr;
-  for (Value iv : threadIVs)
-    if (auto ba = dyn_cast<BlockArgument>(iv)) {
-      par = ba.getOwner()->getParentOp();
-      break;
-    }
-  if (!par)
+  if (threadIVs.empty())
     return false;
+  Operation *par =
+      cast<BlockArgument>(threadIVs.front()).getOwner()->getParentOp();
 
   SmallVector<Value> worklist;
   if (auto scfIf = dyn_cast<scf::IfOp>(ifOp))
@@ -1590,15 +1586,30 @@ static bool anyBarrierWithin(Operation *op, BarrierOp except) {
   return found;
 }
 
+static bool containsBarrier(Operation *op) {
+  bool found = false;
+  op->walk([&](BarrierOp) { found = true; });
+  return found;
+}
+
+// Whether a thread can reach a barrier past `op`. Not just the operations
+// beside it: what encloses `op` may end before the thread does, and a region
+// that runs more than once puts its own earlier operations after this one too.
 static bool anyBarrierAfter(Operation *op) {
-  for (Operation *it = op->getNextNode(); it != nullptr;
-       it = it->getNextNode()) {
-    bool found = false;
-    it->walk([&](BarrierOp) { found = true; });
-    if (found)
+  for (Operation *it = op->getNextNode(); it != nullptr; it = it->getNextNode())
+    if (containsBarrier(it))
       return true;
-  }
-  return false;
+
+  Operation *parent = op->getParentOp();
+  if (!parent)
+    return false;
+  // The thread parallel is where one thread's execution ends.
+  if (isa<scf::ParallelOp, affine::AffineParallelOp>(parent))
+    return false;
+  if (!isa<scf::IfOp, affine::AffineIfOp, memref::AllocaScopeOp>(parent) &&
+      containsBarrier(parent))
+    return true;
+  return anyBarrierAfter(parent);
 }
 
 class BarrierHoist final : public OpRewritePattern<BarrierOp> {

--- a/test/lit_tests/barrier-hoist-divergent.mlir
+++ b/test/lit_tests/barrier-hoist-divergent.mlir
@@ -94,3 +94,36 @@ module {
 // CHECK: memref.store
 // CHECK-NEXT: "enzymexla.barrier"
 // CHECK-NEXT: }
+
+// -----
+
+// The branch is the last thing in a serial loop body, so what follows it for a
+// thread is the next iteration -- and that reaches the barrier ahead of it.
+module {
+  func.func @loop_wraparound(%n: index, %m: memref<?xf64>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %cst = arith.constant 1.000000e+00 : f64
+    scf.parallel (%i, %j, %k) = (%c0, %c0, %c0) to (%c2, %c2, %c2) step (%c1, %c1, %c1) {
+      scf.for %t = %c0 to %c2 step %c1 {
+        "enzymexla.barrier"(%i, %j, %k) : (index, index, index) -> ()
+        %d = arith.subi %n, %k : index
+        %c = arith.cmpi sge, %d, %c0 : index
+        scf.if %c {
+          memref.store %cst, %m[%i] : memref<?xf64>
+          "enzymexla.barrier"(%i, %j, %k) : (index, index, index) -> ()
+        }
+      }
+      scf.reduce
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @loop_wraparound
+// CHECK: scf.for
+// CHECK-NEXT: "enzymexla.barrier"
+// CHECK: scf.if
+// CHECK-NEXT: memref.store
+// CHECK-NEXT: "enzymexla.barrier"

--- a/test/lit_tests/barrier-hoist-divergent.mlir
+++ b/test/lit_tests/barrier-hoist-divergent.mlir
@@ -1,0 +1,55 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel -split-input-file | FileCheck %s
+
+// A barrier under a thread-dependent condition must stay there: outside it every
+// thread runs it, inside it only the taken ones do, and a thread that skips the
+// guard entirely is meant to reach no barrier at all.
+module {
+  func.func @divergent(%n: index, %m: memref<?xf64>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %cst = arith.constant 1.000000e+00 : f64
+    scf.parallel (%i, %j, %k) = (%c0, %c0, %c0) to (%c2, %c2, %c2) step (%c1, %c1, %c1) {
+      %d = arith.subi %n, %k : index
+      %c = arith.cmpi sge, %d, %c0 : index
+      scf.if %c {
+        memref.store %cst, %m[%i] : memref<?xf64>
+        "enzymexla.barrier"(%i, %j, %k) : (index, index, index) -> ()
+      }
+      scf.reduce
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @divergent
+// CHECK: scf.if
+// CHECK-NEXT: memref.store
+// CHECK-NEXT: "enzymexla.barrier"
+
+// -----
+
+// A condition no thread index reaches is uniform across the block, so the
+// barrier may still be lifted out of it.
+module {
+  func.func @uniform(%c: i1, %m: memref<?xf64>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %cst = arith.constant 1.000000e+00 : f64
+    scf.parallel (%i, %j, %k) = (%c0, %c0, %c0) to (%c2, %c2, %c2) step (%c1, %c1, %c1) {
+      scf.if %c {
+        memref.store %cst, %m[%i] : memref<?xf64>
+        "enzymexla.barrier"(%i, %j, %k) : (index, index, index) -> ()
+      }
+      scf.reduce
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @uniform
+// CHECK: scf.if
+// CHECK-NEXT: memref.store
+// CHECK-NEXT: }
+// CHECK-NEXT: "enzymexla.barrier"

--- a/test/lit_tests/barrier-hoist-divergent.mlir
+++ b/test/lit_tests/barrier-hoist-divergent.mlir
@@ -1,10 +1,9 @@
 // RUN: enzymexlamlir-opt %s --canonicalize-parallel -split-input-file | FileCheck %s
 
-// A barrier under a thread-dependent condition must stay there: outside it every
-// thread runs it, inside it only the taken ones do, and a thread that skips the
-// guard entirely is meant to reach no barrier at all.
+// One barrier, and every thread runs it once it is out here: lifting it is a
+// legalization, not a miscompile.
 module {
-  func.func @divergent(%n: index, %m: memref<?xf64>) {
+  func.func @lone(%n: index, %m: memref<?xf64>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : index
@@ -22,24 +21,31 @@ module {
   }
 }
 
-// CHECK-LABEL: func.func @divergent
+// CHECK-LABEL: func.func @lone
 // CHECK: scf.if
 // CHECK-NEXT: memref.store
+// CHECK-NEXT: }
 // CHECK-NEXT: "enzymexla.barrier"
 
 // -----
 
-// A condition no thread index reaches is uniform across the block, so the
-// barrier may still be lifted out of it.
+// A second barrier stays behind whatever happens to this one -- the store
+// between them pins it -- so lifting only the trailing one leaves a thread that
+// skips the branch waiting out here while a thread that takes it waits in
+// there, neither ever reaching the other's.
 module {
-  func.func @uniform(%c: i1, %m: memref<?xf64>) {
+  func.func @two(%n: index, %m: memref<?xf64>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : index
     %cst = arith.constant 1.000000e+00 : f64
     scf.parallel (%i, %j, %k) = (%c0, %c0, %c0) to (%c2, %c2, %c2) step (%c1, %c1, %c1) {
+      %d = arith.subi %n, %k : index
+      %c = arith.cmpi sge, %d, %c0 : index
       scf.if %c {
         memref.store %cst, %m[%i] : memref<?xf64>
+        "enzymexla.barrier"(%i, %j, %k) : (index, index, index) -> ()
+        memref.store %cst, %m[%j] : memref<?xf64>
         "enzymexla.barrier"(%i, %j, %k) : (index, index, index) -> ()
       }
       scf.reduce
@@ -48,8 +54,43 @@ module {
   }
 }
 
-// CHECK-LABEL: func.func @uniform
+// CHECK-LABEL: func.func @two
 // CHECK: scf.if
-// CHECK-NEXT: memref.store
-// CHECK-NEXT: }
+// CHECK: "enzymexla.barrier"
+// CHECK: memref.store
 // CHECK-NEXT: "enzymexla.barrier"
+// CHECK-NEXT: }
+
+// -----
+
+// The condition reads a serial loop's index, and that loop's own bound is a
+// thread index: a block argument from inside the thread parallel says nothing
+// about how the threads decide the branch.
+module {
+  func.func @serial_iv(%m: memref<?xf64>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %cst = arith.constant 1.000000e+00 : f64
+    scf.parallel (%i, %j, %k) = (%c0, %c0, %c0) to (%c2, %c2, %c2) step (%c1, %c1, %c1) {
+      scf.for %t = %c0 to %k step %c1 {
+        %c = arith.cmpi sge, %t, %c1 : index
+        scf.if %c {
+          memref.store %cst, %m[%i] : memref<?xf64>
+          "enzymexla.barrier"(%i, %j, %k) : (index, index, index) -> ()
+          memref.store %cst, %m[%j] : memref<?xf64>
+          "enzymexla.barrier"(%i, %j, %k) : (index, index, index) -> ()
+        }
+      }
+      scf.reduce
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @serial_iv
+// CHECK: scf.if
+// CHECK: "enzymexla.barrier"
+// CHECK: memref.store
+// CHECK-NEXT: "enzymexla.barrier"
+// CHECK-NEXT: }


### PR DESCRIPTION
`BarrierHoist` moves a barrier out of an `scf.if`/`affine.if` whenever nothing side-effecting follows it in the body, and symmetrically before the branch when nothing precedes it. Lifting one out makes **every** thread run it where before only the threads taking the branch did, so it needs one of two things to hold:

- the branch selects no subset of the threads, so all of them ran it already; or
- it moves past the branch, nothing beyond holds a barrier for the threads that skipped to run instead, and none is left behind inside for the ones that took it.

The upward move is only sanctioned by the first.

### What went wrong

MFEM's `SmemPAMassApply3D_Element` has eight `MFEM_SYNC_THREAD` under `if (k >= N) { return; }`. Only the trailing one can move — stores follow the rest, so `below` is false for them — and lifting just that one gives:

```mlir
scf.if %17 { ... 7 gpu.barriers ... }
gpu.barrier      // lifted out
gpu.return
```

A thread with `k >= N` waits at the barrier out here; a thread with `k < N` waits at the first one still in there. Neither ever reaches the other's. With `TBATCH=2` the launch is `blockDim (4,4,2)` — exactly one warp — and `k = blockIdx.x*blockDim.z + threadIdx.z` varies within it, so a tail block splits its own warp. `cuda-gdb` on the live hang:

```
Grid 205  Status Active   SMs Mask 0x...2000
GridDim (14,1,1)  BlockDim (4,4,2)
```

One block resident, thirteen retired — a wedged block, not a runaway loop. Hoisting all eight would have been fine, and hoisting none would have been fine; hoisting exactly one is the defect.

`Det2D` escapes on geometry alone: `NBZ=1` makes `blockDim.z=1`, so `k` is decided alike by the whole block.

### Deciding what the threads settle alike

The barrier's operands name the thread indices it synchronises over, and so the parallel whose iterations are the threads. Walking the condition from there: anything defined outside that parallel holds the same value in every thread, whatever computed it. Inside it, a block argument is something like a serial loop's index — which is not uniform, since that loop's own bounds may be thread-dependent — so the walk stops rather than assuming.

### Test

`test/lit_tests/barrier-hoist-divergent.mlir`, three cases:

- `@lone` — a single barrier under a thread-dependent branch. Lifting it is a legalization: every thread then runs it, at one instruction, with nothing after. **Must still hoist.**
- `@two` — a second barrier pinned inside by a store between them. **Must not hoist.**
- `@serial_iv` — the condition reads an `scf.for` index whose bound is a thread index. **Must not hoist**, and would have been mistaken for uniform by a walk that stops at block arguments.

### Result

`H1 Assembly Levels` no longer hangs: **0.82 s**, against 1.10 s for plain clang, where it previously spun indefinitely. Full lit suite passes (1163/1164; the one failure is an untracked local file that fails without this change too).

The test does not yet **pass** — 104 of 121 assertions do, 17 fail on values. That is a separate defect underneath this one, still being chased; this PR is the deadlock only.
