### PR TITLE
Read an operand before legalizing it, not after

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -669,6 +669,21 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
       return failure();
     SmallVector<Value> preoperands = operands;
 
+    // Legalizing the operands moves the ops that define them, which erases the
+    // ones it clones, so anything to be read off an operand has to be read
+    // before that and not after: what is left afterwards may be a value whose
+    // op is gone.
+    Attribute preConstant;
+    AffineMap preApplyMap;
+    SmallVector<Value> preApplyOperands;
+    if (preoperands.size() == 1) {
+      matchPattern(preoperands[0], m_Constant(&preConstant));
+      if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {
+        preApplyMap = app.getAffineMap();
+        preApplyOperands = llvm::to_vector(app.getMapOperands());
+      }
+    }
+
     AffineExpr exprs[1] = {expr};
     auto map = AffineMap::get(/*dimCount=*/0, /*symbolCount=*/operands.size(),
                               exprs, rewriter.getContext());
@@ -682,15 +697,13 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
     map = mlir::enzyme::recreateExpr(map);
 
     if (preoperands.size() == 1) {
-      Attribute attr;
-      if (matchPattern(preoperands[0], m_Constant(&attr)))
+      if (preConstant)
         return failure();
       if (preoperands == operands)
         return failure();
-      if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {
-        if (app.getAffineMap() == map && app.getMapOperands() == operands)
-          return failure();
-      }
+      if (preApplyMap && preApplyMap == map &&
+          ArrayRef<Value>(preApplyOperands) == ArrayRef<Value>(operands))
+        return failure();
     }
 
     Value app;


### PR DESCRIPTION
`MemrefLoadAffineApply` saves its operands, legalizes them, and then reads three things back off the saved operand:

```cpp
SmallVector<Value> preoperands = operands;
...
fully2ComposeAffineMapAndOperands(rewriter, &map, &operands, DI, scope);
...
if (preoperands.size() == 1) {
  Attribute attr;
  if (matchPattern(preoperands[0], m_Constant(&attr)))        // dereferences it
    return failure();
  if (preoperands == operands)
    return failure();
  if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {   // and again
```

Legalizing moves the ops that define those operands, and moving one clones it and erases the original (`AffineApplyNormalizer::fix` → `rewriter.replaceOp(op, cloned->getResults())`). Two of the three reads dereference the saved value, so whenever an operand's defining op is hoisted, this reads a freed op.

This reads them beforehand and compares the saved answers instead. `preoperands == operands` only compares the values themselves, so it stays where it was.

### How it turned up

Transiently, while #2865 was in an intermediate state. Refusing to read through a truncation made an operand get hoisted where it previously had not, and MFEM's `normal_deriv_restriction` then crashed here:

```
#0  mlir::detail::constant_op_binder<mlir::Attribute>::match(mlir::Operation*)
#1  (anonymous namespace)::MemrefLoadAffineApply::matchAndRewrite(mlir::memref::LoadOp, ...)
```

The final shape of #2865 does not produce that IR, so **this is not reachable today** and there is no test with it. It is a real hazard rather than a hypothetical one — the crash above is what it fixes — but it is latent, and I would rather have it written down than rediscovered the next time an operand becomes hoistable.

Reviewers may reasonably prefer to close this instead; the read-before-legalize ordering is correct either way, and I have no reachable case to defend it with.
