### PR TITLE
AffineCFG: do not lift a read out of the guard that bounds it

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -5905,6 +5905,10 @@ public:
           BlockRange(), regions);
       conditional = conditional2;
     } else {
+      if (loadOp->getBlock() != conditional->getBlock())
+        return rewriter.notifyMatchFailure(
+            loadOp, "load runs under a condition the conditional does not");
+
       for (auto i = 0; i < conditional->getNumResults(); i++)
         resultsNeeded.insert(i);
 

--- a/test/lit_tests/raising/lift-read-past-guard.mlir
+++ b/test/lit_tests/raising/lift-read-past-guard.mlir
@@ -1,0 +1,37 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(affine-cfg)" | FileCheck %s
+
+#setblk = affine_set<(d0) : (d0 == 0)>
+#set256 = affine_set<(d0) : (255 - d0 >= 0)>
+
+module {
+  func.func @red(%blk: index) {
+    %c0 = arith.constant 0 : index
+    %c256 = arith.constant 256 : index
+    %alloca = memref.alloca() : memref<1024xf64>
+    affine.parallel (%tid) = (0) to (1024) {
+      %t64 = arith.index_castui %tid : index to i64
+      %sel = affine.if #setblk(%blk) -> i64 {
+        affine.yield %t64 : i64
+      } else {
+        affine.yield %t64 : i64
+      }
+      "enzymexla.barrier"(%tid, %c0, %c0) : (index, index, index) -> ()
+      affine.if #set256(%tid) {
+        %j = arith.index_cast %sel : i64 to index
+        %k = arith.addi %j, %c256 : index
+        %b = memref.load %alloca[%k] : memref<1024xf64>
+        memref.store %b, %alloca[%j] : memref<1024xf64>
+      }
+      affine.yield
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @red
+// CHECK:         affine.parallel (%[[TID:.+]]) = (0) to (1024) {
+// CHECK:           "enzymexla.barrier"
+// CHECK:           affine.if
+// CHECK-NEXT:        %[[V:.+]] = affine.load %{{.+}}[%[[TID]] + 256]
+// CHECK-NEXT:        affine.store %[[V]], %{{.+}}[%[[TID]]]
+// CHECK-NEXT:      }


### PR DESCRIPTION
Fix for LULESH which denotes in #2854

`LiftMemrefRead` moves a load into the branches of the `if` that computes its index. When the load sits inside another `if`, that inner guard is left behind.

LULESH `Inner_CalcMinDtOneBlock` reduces a 1024-element `__shared__` buffer with 1024 threads:
```cuda
if (tid < 512) { s_data[tid] = min(s_data[tid], s_data[tid + 512]); }
```
`tid < 512` is the only thing keeping `s_data[tid + 512]` inside the buffer. The index reaches that read through the branch on `blockIdx` picking which array to reduce, so the read was moved there and ran for all 1024 threads:
```
Invalid __shared__ read of size 8 bytes
  by thread (800,0,0) in block (0,0,0)
  Access at 0x2d00 is out of bounds
```
The pattern has two ways to fix:
- **move the load up** to the `if`, cloning it into both branches. The `if`stays put; the load ends up running under the `if`'s condition.
- **move the `if` down** to the load, rebuilding it there.

The better fix may to change what picks between the paths: send a guarded load to the rebuilding path rather than declining it. It was not done here because the choice is currently spread through the pattern rather than made in one place. While I am not sure if they have big performance differences.

How much these two methods' cost has not been measured: both GPUs on hydra are shared and one sat at 98% during the runs.