### PR TITLE
Keep kernels whose grid and block parallels were fused

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -172,6 +172,46 @@ template <int S = 3> SmallVector<Value, S> getUpperBounds(scf::ParallelOp pop) {
   return bounds;
 }
 
+/// Whether `ub` is the launch bound `bound`, possibly narrowed by a min against
+/// the kernel's own trip count -- folding the `k >= N` guard into the loop
+/// makes the bound `min(N, bound)`. The narrowed bound is the real iteration
+/// space, so the launch is built from it, not from `bound`.
+bool boundMatchesLaunch(Value ub, Value bound) {
+  if (ub == bound)
+    return true;
+  if (auto mn = ub.getDefiningOp<arith::MinSIOp>())
+    return mn.getLhs() == bound || mn.getRhs() == bound;
+  if (auto mn = ub.getDefiningOp<arith::MinUIOp>())
+    return mn.getLhs() == bound || mn.getRhs() == bound;
+  return false;
+}
+
+/// Match the dimensions of `pop` against the six grid and block bounds of
+/// `wrapper`, filling `dimOf` with the dimension of `pop` that carries each
+/// bound, or -1 for a bound of extent one that `pop` does not carry. Passes
+/// that fuse the grid and block parallels drop such trivial dimensions, so an
+/// exact-shape match must tolerate their absence.
+bool matchWrapperShape(scf::ParallelOp pop, enzymexla::GPUWrapperOp wrapper,
+                       SmallVectorImpl<int> &dimOf) {
+  auto bounds = wrapper.getOperands();
+  if (bounds.size() != 6)
+    return false;
+  auto ubs = pop.getUpperBound();
+  unsigned next = 0;
+  for (Value bound : bounds) {
+    if (next < ubs.size() && boundMatchesLaunch(ubs[next], bound)) {
+      dimOf.push_back(next++);
+      continue;
+    }
+    if (matchPattern(bound, m_One())) {
+      dimOf.push_back(-1);
+      continue;
+    }
+    return false;
+  }
+  return next == ubs.size();
+}
+
 void insertReturn(PatternRewriter &rewriter, func::FuncOp f) {
   func::ReturnOp::create(rewriter, rewriter.getUnknownLoc());
 }
@@ -505,7 +545,8 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
         curRegion++;
       }
     };
-    auto exactMatch = [&](enzymexla::AlternativesOp alternativesOp) {
+    auto exactMatch = [&](enzymexla::AlternativesOp alternativesOp,
+                          ArrayRef<int> dimOf) {
       auto block = &*alternativesOp->getRegion(curRegion).begin();
       rewriter.setInsertionPointToStart(block);
       // TODO not very efficient...
@@ -515,26 +556,40 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
           getDirectlyNestedSingleParallel(newWrapper.getBody());
       auto loc = pop->getLoc();
 
-      auto upperBounds = getUpperBounds<6>(pop);
-
       mlir::OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(pop);
-      auto gridPop = scf::ParallelOp::create(
-          rewriter, loc, pop.getLowerBound().slice(0, 3),
-          pop.getUpperBound().slice(0, 3), pop.getStep().slice(0, 3));
+      Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+      Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
+
+      SmallVector<Value, 3> lbs[2], ubs[2], steps[2];
+      for (unsigned i = 0; i < 6; i++) {
+        unsigned half = i / 3;
+        if (dimOf[i] < 0) {
+          lbs[half].push_back(zero);
+          ubs[half].push_back(one);
+          steps[half].push_back(one);
+        } else {
+          lbs[half].push_back(pop.getLowerBound()[dimOf[i]]);
+          ubs[half].push_back(pop.getUpperBound()[dimOf[i]]);
+          steps[half].push_back(pop.getStep()[dimOf[i]]);
+        }
+      }
+
+      auto gridPop =
+          scf::ParallelOp::create(rewriter, loc, lbs[0], ubs[0], steps[0]);
       rewriter.setInsertionPointToStart(gridPop.getBody());
-      auto blockPop = scf::ParallelOp::create(
-          rewriter, loc, pop.getLowerBound().slice(3, 3),
-          pop.getUpperBound().slice(3, 3), pop.getStep().slice(3, 3));
+      auto blockPop =
+          scf::ParallelOp::create(rewriter, loc, lbs[1], ubs[1], steps[1]);
       rewriter.setInsertionPointToStart(blockPop.getBody());
 
       IRMapping mapping;
-      for (unsigned i = 0; i < 3; i++)
-        mapping.map(pop.getBody()->getArgument(i),
-                    gridPop.getBody()->getArgument(i));
-      for (unsigned i = 0; i < 3; i++)
-        mapping.map(pop.getBody()->getArgument(i + 3),
-                    blockPop.getBody()->getArgument(i));
+      for (unsigned i = 0; i < 6; i++) {
+        if (dimOf[i] < 0)
+          continue;
+        auto newPop = i < 3 ? gridPop : blockPop;
+        mapping.map(pop.getBody()->getArgument(dimOf[i]),
+                    newPop.getBody()->getArgument(i % 3));
+      }
 
       rewriter.eraseOp(pop.getBody()->getTerminator());
       for (auto &op : *pop.getBody())
@@ -546,6 +601,9 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       curRegion++;
     };
 
+    SmallVector<int, 6> exactDims;
+    bool hasExactMatch = matchWrapperShape(pop, wrapper, exactDims);
+
     enzymexla::AlternativesOp alternativesOp = nullptr;
     if (char *blockSizeStr = getenv("POLYGEIST_GPU_KERNEL_BLOCK_SIZE")) {
       alternativesOp = enzymexla::AlternativesOp::create(rewriter, loc, 1);
@@ -556,9 +614,8 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       emitAlternative(atoi(blockSizeStr), alternativesOp);
       if (curRegion == 0) {
         llvm::errs() << " Failed to make kernel with exact dimension\n";
-        if (pop.getUpperBound().size() == 6 &&
-            pop.getUpperBound() == wrapper.getOperands()) {
-          exactMatch(alternativesOp);
+        if (hasExactMatch) {
+          exactMatch(alternativesOp, exactDims);
         } else if (pop->hasAttr("enzymexla.kernel_thread_indices")) {
           // The exact-shape fallback needs the six grid and block bounds;
           // a collapsed parallel op does not have them, so reproduce the
@@ -578,19 +635,15 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
                               rewriter.getArrayAttr(descs));
     } else if (shouldEmitAlternatives(pop)) {
       alternativesOp = enzymexla::AlternativesOp::create(
-          rewriter, loc,
-          ALTERNATIVE_KERNEL_BLOCK_SIZES.size() +
-              (pop.getUpperBound().size() == 6 &&
-               pop.getUpperBound() == wrapper.getOperands()));
+          rewriter, loc, ALTERNATIVE_KERNEL_BLOCK_SIZES.size() + hasExactMatch);
       alternativesOp->setAttr("alternatives.type",
                               rewriter.getStringAttr("gpu_kernel"));
       for (unsigned blockSize : ALTERNATIVE_KERNEL_BLOCK_SIZES) {
         emitAlternative(blockSize, alternativesOp);
       }
       assert(wrapper.getOperands().size() == 6);
-      if (pop.getUpperBound().size() == 6 &&
-          pop.getUpperBound() == wrapper.getOperands()) {
-        exactMatch(alternativesOp);
+      if (hasExactMatch) {
+        exactMatch(alternativesOp, exactDims);
       }
       alternativesOp->setAttr("alternatives.descs",
                               rewriter.getArrayAttr(descs));
@@ -606,9 +659,14 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     }
 
     if (curRegion == 0) {
-      // Nothing split: every candidate block size failed. The regions hold
-      // only the corpses of the failed attempts; drop them and leave the
-      // launch-out-of-resources error the failed splits already stand for.
+      // Nothing split: every candidate block size failed, and the shape could
+      // not be recovered from the wrapper either. Dropping the kernel here
+      // silently turns the launch into a no-op that leaves its outputs
+      // untouched, so say so rather than miscompiling.
+      wrapper.emitError()
+          << "no block size splits this kernel and its " << pop.getNumLoops()
+          << " parallel dimensions do not match the wrapper's grid and block "
+             "bounds; the kernel would be dropped";
       rewriter.eraseOp(alternativesOp);
       rewriter.setInsertionPoint(wrapper);
       auto err = arith::ConstantIndexOp::create(

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -873,7 +873,7 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       // Put a random index, we will override it
       gridArgId.push_back(0);
     } else if (maxThreads != -1 && threadNum <= maxThreads / 2 &&
-               mustBeBlockIVs.empty()) {
+               mustBeBlockIVs.empty() && blockDims.size() < 3) {
       // If we are not getting enough parallelism in the block, use part of the
       // grid dims
 

--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -2428,14 +2428,6 @@ ConvertGPUModuleOp::matchAndRewrite(gpu::GPUModuleOp kernelModule,
 
           auto nullPtr =
               LLVM::ZeroOp::create(ctorBuilder, ctorloc, llvmPointerType);
-          // TODO second param should be ptr to the the original function stub
-          // here like clang does it: e.g. kernel_name_device_stub
-          //
-          // TODO We should probably always generate the original kernel as
-          // well and register it too (in addition to the lowered to parallel
-          // and re-outlined version that we generate) in case the pointer to
-          // the stub is captured somewhere and it is called through
-          // cudaLaunchKernel
           LLVM::LLVMFuncOp stub;
           {
             PatternRewriter::InsertionGuard B(rewriter);
@@ -2450,10 +2442,6 @@ ConvertGPUModuleOp::matchAndRewrite(gpu::GPUModuleOp kernelModule,
             rewriter.setInsertionPointToEnd(stub.addEntryBlock(rewriter));
             LLVM::ReturnOp::create(rewriter, ctorloc, ValueRange());
           }
-          auto aoo = LLVM::AddressOfOp::create(ctorBuilder, ctorloc, stub);
-          auto bitcast = LLVM::AddrSpaceCastOp::create(ctorBuilder, ctorloc,
-                                                       llvmPointerType, aoo);
-
           Type tys[] = {llvmPointerType, llvmPointerType, llvmPointerType,
                         llvmPointerType, llvmInt32Type,   llvmPointerType,
                         llvmPointerType, llvmPointerType, llvmPointerType,
@@ -2467,19 +2455,42 @@ ConvertGPUModuleOp::matchAndRewrite(gpu::GPUModuleOp kernelModule,
             return failure();
           }
 
-          Value args[] = {
-              module.getResult(),
-              bitcast,
-              kernelName,
-              kernelName,
-              LLVM::ConstantOp::create(ctorBuilder, ctorloc, llvmInt32Type, -1),
-              nullPtr,
-              nullPtr,
-              nullPtr,
-              nullPtr,
-              nullPtr};
+          auto registerHostStub = [&](LLVM::LLVMFuncOp hostStub) {
+            auto aoo =
+                LLVM::AddressOfOp::create(ctorBuilder, ctorloc, hostStub);
+            auto bitcast = LLVM::AddrSpaceCastOp::create(ctorBuilder, ctorloc,
+                                                         llvmPointerType, aoo);
+            Value args[] = {module.getResult(),
+                            bitcast,
+                            kernelName,
+                            kernelName,
+                            LLVM::ConstantOp::create(ctorBuilder, ctorloc,
+                                                     llvmInt32Type, -1),
+                            nullPtr,
+                            nullPtr,
+                            nullPtr,
+                            nullPtr,
+                            nullPtr};
+            LLVM::CallOp::create(rewriter, ctorloc, cudaRegisterFn.value(),
+                                 args);
+          };
 
-          LLVM::CallOp::create(rewriter, ctorloc, cudaRegisterFn.value(), args);
+          registerHostStub(stub);
+
+          // Uses of the kernel address that we could not rewrite statically
+          // reach the runtime as the original, un-prefixed host stub, so
+          // register that symbol against the same device function too.
+          // Only the host-side device stubs clang emits are addresses that
+          // user code can hand to the runtime; an outlined parallel region
+          // such as `main_kernel` must not bind its enclosing function.
+          StringRef origName = f.getName();
+          origName.consume_front("reactant$");
+          origName.consume_back("_kernel");
+          if (origName != f.getName() && origName.contains("__device_stub__")) {
+            if (auto origStub =
+                    moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(origName))
+              registerHostStub(origStub);
+          }
         } else if (LLVM::GlobalOp g = dyn_cast<LLVM::GlobalOp>(op)) {
           int addrSpace = g.getAddrSpace();
           if (addrSpace != 1 /* device */ && addrSpace != 4 /* constant */)

--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -1636,6 +1636,25 @@ static std::string getFuncStubName(StringRef moduleName, StringRef name) {
       llvm::formatv("__polygeist_{0}_{1}_device_stub", moduleName, name));
 };
 
+// The host-side pointer a kernel is registered under, and which every symbolic
+// reference to that kernel must lower to. Clang emits a device stub for each
+// __global__ function and that stub is the address user code can take, so bind
+// it when it exists; kernels outlined from parallel regions have no stub of
+// their own and fall back to a synthetic one.
+static std::string getHostStubName(Operation *symbolTableOp,
+                                   StringRef moduleName, StringRef kernelName) {
+  StringRef orig = kernelName;
+  orig.consume_front("reactant$");
+  orig.consume_back("_kernel");
+  if (orig != kernelName && orig.contains("__device_stub__")) {
+    Operation *sym = SymbolTable::lookupSymbolIn(
+        symbolTableOp, StringAttr::get(symbolTableOp->getContext(), orig));
+    if (isa_and_nonnull<FunctionOpInterface>(sym))
+      return orig.str();
+  }
+  return getFuncStubName(moduleName, kernelName);
+}
+
 class ConvertLaunchFuncOpToGpuRuntimeCallPattern
     : public ConvertOpToGpuRuntimeCallPattern<gpu::LaunchFuncOp> {
 public:
@@ -2428,19 +2447,24 @@ ConvertGPUModuleOp::matchAndRewrite(gpu::GPUModuleOp kernelModule,
 
           auto nullPtr =
               LLVM::ZeroOp::create(ctorBuilder, ctorloc, llvmPointerType);
-          LLVM::LLVMFuncOp stub;
-          {
-            PatternRewriter::InsertionGuard B(rewriter);
-            rewriter.setInsertionPointToEnd(moduleOp.getBody());
-            stub = LLVM::LLVMFuncOp::create(
-                rewriter, ctorloc, getFuncStubName(moduleName, f.getName()),
-                LLVM::LLVMFunctionType::get(llvmVoidType, {}),
-                LLVM::Linkage::Internal);
-          }
-          {
-            OpBuilder::InsertionGuard guard(rewriter);
-            rewriter.setInsertionPointToEnd(stub.addEntryBlock(rewriter));
-            LLVM::ReturnOp::create(rewriter, ctorloc, ValueRange());
+          std::string synthStubName = getFuncStubName(moduleName, f.getName());
+          std::string hostStubName =
+              getHostStubName(moduleOp, moduleName, f.getName());
+          if (hostStubName == synthStubName) {
+            LLVM::LLVMFuncOp stub;
+            {
+              PatternRewriter::InsertionGuard B(rewriter);
+              rewriter.setInsertionPointToEnd(moduleOp.getBody());
+              stub = LLVM::LLVMFuncOp::create(
+                  rewriter, ctorloc, synthStubName,
+                  LLVM::LLVMFunctionType::get(llvmVoidType, {}),
+                  LLVM::Linkage::Internal);
+            }
+            {
+              OpBuilder::InsertionGuard guard(rewriter);
+              rewriter.setInsertionPointToEnd(stub.addEntryBlock(rewriter));
+              LLVM::ReturnOp::create(rewriter, ctorloc, ValueRange());
+            }
           }
           Type tys[] = {llvmPointerType, llvmPointerType, llvmPointerType,
                         llvmPointerType, llvmInt32Type,   llvmPointerType,
@@ -2455,42 +2479,24 @@ ConvertGPUModuleOp::matchAndRewrite(gpu::GPUModuleOp kernelModule,
             return failure();
           }
 
-          auto registerHostStub = [&](LLVM::LLVMFuncOp hostStub) {
-            auto aoo =
-                LLVM::AddressOfOp::create(ctorBuilder, ctorloc, hostStub);
-            auto bitcast = LLVM::AddrSpaceCastOp::create(ctorBuilder, ctorloc,
-                                                         llvmPointerType, aoo);
-            Value args[] = {module.getResult(),
-                            bitcast,
-                            kernelName,
-                            kernelName,
-                            LLVM::ConstantOp::create(ctorBuilder, ctorloc,
-                                                     llvmInt32Type, -1),
-                            nullPtr,
-                            nullPtr,
-                            nullPtr,
-                            nullPtr,
-                            nullPtr};
-            LLVM::CallOp::create(rewriter, ctorloc, cudaRegisterFn.value(),
-                                 args);
-          };
+          auto aoo = LLVM::AddressOfOp::create(ctorBuilder, ctorloc,
+                                               llvmPointerType, hostStubName);
+          auto bitcast = LLVM::AddrSpaceCastOp::create(ctorBuilder, ctorloc,
+                                                       llvmPointerType, aoo);
 
-          registerHostStub(stub);
+          Value args[] = {
+              module.getResult(),
+              bitcast,
+              kernelName,
+              kernelName,
+              LLVM::ConstantOp::create(ctorBuilder, ctorloc, llvmInt32Type, -1),
+              nullPtr,
+              nullPtr,
+              nullPtr,
+              nullPtr,
+              nullPtr};
 
-          // Uses of the kernel address that we could not rewrite statically
-          // reach the runtime as the original, un-prefixed host stub, so
-          // register that symbol against the same device function too.
-          // Only the host-side device stubs clang emits are addresses that
-          // user code can hand to the runtime; an outlined parallel region
-          // such as `main_kernel` must not bind its enclosing function.
-          StringRef origName = f.getName();
-          origName.consume_front("reactant$");
-          origName.consume_back("_kernel");
-          if (origName != f.getName() && origName.contains("__device_stub__")) {
-            if (auto origStub =
-                    moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(origName))
-              registerHostStub(origStub);
-          }
+          LLVM::CallOp::create(rewriter, ctorloc, cudaRegisterFn.value(), args);
         } else if (LLVM::GlobalOp g = dyn_cast<LLVM::GlobalOp>(op)) {
           int addrSpace = g.getAddrSpace();
           if (addrSpace != 1 /* device */ && addrSpace != 4 /* constant */)
@@ -2656,7 +2662,8 @@ LogicalResult ConvertLaunchFuncOpToGpuRuntimeCallPattern::matchAndRewrite(
 
   // Build module constructor and destructor
   std::string funcStubName =
-      getFuncStubName(launchOp.getKernelModuleName().getValue(),
+      getHostStubName(launchOp->getParentOfType<ModuleOp>(),
+                      launchOp.getKernelModuleName().getValue(),
                       launchOp.getKernelName().getValue());
 
   auto bitcast =
@@ -3224,7 +3231,8 @@ private:
     }
 
     std::string funcStubName =
-        getFuncStubName(op.getFn().getRootReference().getValue(),
+        getHostStubName(op->getParentOfType<ModuleOp>(),
+                        op.getFn().getRootReference().getValue(),
                         op.getFn().getLeafReference().getValue());
     auto addr = LLVM::AddressOfOp::create(rewriter, loc, ptrty, funcStubName);
     Value args[] = {ptr, addr, adaptor.getBlockSize(),
@@ -3257,7 +3265,8 @@ private:
           op, "KernelAddress lowering only supported for CUDA and ROCM");
 
     std::string funcStubName =
-        getFuncStubName(op.getFn().getRootReference().getValue(),
+        getHostStubName(op->getParentOfType<ModuleOp>(),
+                        op.getFn().getRootReference().getValue(),
                         op.getFn().getLeafReference().getValue());
 
     rewriter.replaceOpWithNewOp<LLVM::AddressOfOp>(op, op.getType(),

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -669,6 +669,21 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
       return failure();
     SmallVector<Value> preoperands = operands;
 
+    // Legalizing the operands moves the ops that define them, which erases the
+    // ones it clones, so anything to be read off an operand has to be read
+    // before that and not after: what is left afterwards may be a value whose
+    // op is gone.
+    Attribute preConstant;
+    AffineMap preApplyMap;
+    SmallVector<Value> preApplyOperands;
+    if (preoperands.size() == 1) {
+      matchPattern(preoperands[0], m_Constant(&preConstant));
+      if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {
+        preApplyMap = app.getAffineMap();
+        preApplyOperands = llvm::to_vector(app.getMapOperands());
+      }
+    }
+
     AffineExpr exprs[1] = {expr};
     auto map = AffineMap::get(/*dimCount=*/0, /*symbolCount=*/operands.size(),
                               exprs, rewriter.getContext());
@@ -682,15 +697,13 @@ struct MemrefLoadAffineApply : public OpRewritePattern<memref::LoadOp> {
     map = mlir::enzyme::recreateExpr(map);
 
     if (preoperands.size() == 1) {
-      Attribute attr;
-      if (matchPattern(preoperands[0], m_Constant(&attr)))
+      if (preConstant)
         return failure();
       if (preoperands == operands)
         return failure();
-      if (auto app = preoperands[0].getDefiningOp<affine::AffineApplyOp>()) {
-        if (app.getAffineMap() == map && app.getMapOperands() == operands)
-          return failure();
-      }
+      if (preApplyMap && preApplyMap == map &&
+          ArrayRef<Value>(preApplyOperands) == ArrayRef<Value>(operands))
+        return failure();
     }
 
     Value app;

--- a/src/enzyme_ad/jax/Passes/ParallelLower.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLower.cpp
@@ -697,6 +697,15 @@ void ParallelLower::runOnOperation() {
     if (captured)
       return;
 
+    // A kernel lives in a gpu.module, so the launch names it with a nested
+    // symbol reference. func.call takes a flat callee, and building one from a
+    // nested reference yields an op carrying no callee at all, which faults
+    // when symbol resolution later reads it. Lowering the launch to a call is
+    // not expressible here; leave it for the passes that lower
+    // gpu.launch_func directly.
+    if (!isa<FlatSymbolRefAttr>(launchOp.getKernel()))
+      return;
+
     OpBuilder builder(launchOp);
     auto op = mlir::gpu::LaunchOp::create(
         builder, launchOp.getLoc(), launchOp.getGridSizeX(),

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
@@ -133,3 +133,40 @@ module {
 // CHECK: enzymexla.alternatives
 // CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[T]], %{{.+}} = %[[GY]], %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[BX]], %{{.+}} = %[[BY]], %{{.+}} = %{{.+}})
 // CHECK: alternatives.descs = ["block_size=-1,"]
+
+// -----
+
+// The block already uses all three thread dimensions, so there is no room to
+// take a grid dimension into it however few threads it has. Taking one anyway
+// left a fourth block dimension to alias onto an existing thread id, so part of
+// the iteration space was never run.
+
+module {
+  func.func @full_block_no_split(%gx: index, %out: memref<?xf64>, %v: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c3 = arith.constant 3 : index
+    %w = "enzymexla.gpu_wrapper"(%gx, %c1, %c1, %c3, %c3, %c3) ({
+      scf.parallel (%i0, %i1, %i2, %i3) = (%c0, %c0, %c0, %c0) to (%gx, %c3, %c3, %c3) step (%c1, %c1, %c1, %c1) {
+        %a = arith.muli %i0, %c3 : index
+        %b = arith.addi %a, %i3 : index
+        %c = arith.muli %b, %c3 : index
+        %d = arith.addi %c, %i2 : index
+        %e = arith.muli %d, %c3 : index
+        %f = arith.addi %e, %i1 : index
+        memref.store %v, %out[%f] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @full_block_no_split(
+// CHECK-SAME: %[[GX:[^ :]+]]: index
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[GX]], %{{.+}} = %{{.+}}, %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %{{.+}}, %{{.+}} = %{{.+}}, %{{.+}} = %{{.+}})
+// CHECK: gpu.thread_id x
+// CHECK: gpu.thread_id y
+// CHECK: gpu.thread_id z
+// CHECK-NOT: gpu.thread_id

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
@@ -1,4 +1,4 @@
-// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --split-input-file --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
 
 // The requested block size cannot split a parallel op with more than three
 // dynamic dimensions, and this op offers no fallback: its shape is not the
@@ -11,6 +11,7 @@ module {
   func.func @allfail(%n: index, %m: index, %p: index, %q: index, %out: memref<?xf64>, %v: f64) -> index {
     %c1 = arith.constant 1 : index
     %c0 = arith.constant 0 : index
+    // expected-error @+1 {{no block size splits this kernel}}
     %w = "enzymexla.gpu_wrapper"(%n, %m, %c1, %c1, %c1, %c1) ({
       scf.parallel (%i, %j, %k, %l) = (%c0, %c0, %c0, %c0) to (%n, %m, %p, %q) step (%c1, %c1, %c1, %c1) {
         memref.store %v, %out[%i] : memref<?xf64>
@@ -76,3 +77,59 @@ module {
 // CHECK-SAME: %[[N:[^ :]+]]: index, %[[M:[^ :]+]]: index, %[[P:[^ :]+]]: index, %[[Q:[^ :]+]]: index
 // CHECK: enzymexla.alternatives
 // CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[N]], %{{.+}} = %[[M]], %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[P]], %{{.+}} = %[[Q]], %{{.+}} = %{{.+}})
+
+// -----
+
+// The grid and block parallels of a barrier-free kernel are fused into one op,
+// and dimensions of extent one are dropped: five bounds carrying the wrapper's
+// six. The exact-shape split still applies, reinstating the dropped grid.z.
+
+module {
+  func.func @fused_unit_dim(%gx: index, %gy: index, %bx: index, %by: index, %bz: index, %out: memref<?xf64>, %v: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %w = "enzymexla.gpu_wrapper"(%gx, %gy, %c1, %bx, %by, %bz) ({
+      scf.parallel (%i0, %i1, %i2, %i3, %i4) = (%c0, %c0, %c0, %c0, %c0) to (%gx, %gy, %bx, %by, %bz) step (%c1, %c1, %c1, %c1, %c1) {
+        memref.store %v, %out[%i0] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @fused_unit_dim(
+// CHECK-SAME: %[[GX:[^ :]+]]: index, %[[GY:[^ :]+]]: index, %[[BX:[^ :]+]]: index, %[[BY:[^ :]+]]: index, %[[BZ:[^ :]+]]: index
+// CHECK: enzymexla.alternatives
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[GX]], %{{.+}} = %[[GY]], %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[BX]], %{{.+}} = %[[BY]], %{{.+}} = %[[BZ]])
+// CHECK: alternatives.descs = ["block_size=-1,"]
+
+// -----
+
+// Folding the `k >= N` guard into the loop narrows a bound to a min against the
+// kernel's own trip count. That is still the wrapper's dimension, and the
+// narrowed bound is the one the launch is built from.
+
+module {
+  func.func @min_narrowed_bound(%gx: index, %gy: index, %bx: index, %by: index, %n: index, %out: memref<?xf64>, %v: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %t = arith.minsi %n, %gx : index
+    %w = "enzymexla.gpu_wrapper"(%gx, %gy, %c1, %bx, %by, %c1) ({
+      scf.parallel (%i0, %i1, %i2, %i3) = (%c0, %c0, %c0, %c0) to (%t, %gy, %bx, %by) step (%c1, %c1, %c1, %c1) {
+        memref.store %v, %out[%i0] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @min_narrowed_bound(
+// CHECK-SAME: %[[GX:[^ :]+]]: index, %[[GY:[^ :]+]]: index, %[[BX:[^ :]+]]: index, %[[BY:[^ :]+]]: index
+// CHECK: %[[T:.+]] = arith.minsi
+// CHECK: enzymexla.alternatives
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[T]], %{{.+}} = %[[GY]], %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[BX]], %{{.+}} = %[[BY]], %{{.+}} = %{{.+}})
+// CHECK: alternatives.descs = ["block_size=-1,"]

--- a/test/lit_tests/parallel-lower-launch-func.mlir
+++ b/test/lit_tests/parallel-lower-launch-func.mlir
@@ -1,0 +1,21 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(parallel-lower{wrapParallelOps=true})" | FileCheck %s
+
+// A kernel lives in a gpu.module, so the launch names it with a nested symbol
+// reference, which cannot be lowered to a func.call here. The launch is left
+// for the passes that lower gpu.launch_func directly.
+module attributes {gpu.container_module} {
+  gpu.module @gpum {
+    gpu.func @kern() kernel {
+      gpu.return
+    }
+  }
+  func.func @caller() {
+    %c1 = arith.constant 1 : index
+    %shmem = arith.constant 0 : i32
+    gpu.launch_func @gpum::@kern blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) dynamic_shared_memory_size %shmem
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @caller
+// CHECK: gpu.launch_func @gpum::@kern

--- a/test/lit_tests/polygeist-register-host-stub.mlir
+++ b/test/lit_tests/polygeist-register-host-stub.mlir
@@ -1,0 +1,41 @@
+// RUN: enzymexlamlir-opt %s --convert-polygeist-to-llvm -split-input-file | FileCheck %s
+
+// Kernel addresses that could not be rewritten statically reach the runtime as
+// the original, un-prefixed host stub, so it is registered against the same
+// device function alongside the synthetic stub.
+module attributes {gpu.container_module} {
+  gpu.module @gpum {
+    gpu.func @"reactant$_Z16__device_stub__kPi"() kernel {
+      gpu.return
+    }
+  }
+  llvm.func @_Z16__device_stub__kPi() {
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: llvm.func private @gpum_gpubin_ctor()
+// CHECK-DAG: %[[ORIG:.+]] = llvm.mlir.addressof @_Z16__device_stub__kPi : !llvm.ptr
+// CHECK-DAG: %[[SYNTH:.+]] = llvm.mlir.addressof @__polygeist_gpum_reactant$_Z16__device_stub__kPi_device_stub : !llvm.ptr
+// CHECK: RegisterFunction(%{{.+}}, %[[SYNTH]],
+// CHECK: RegisterFunction(%{{.+}}, %[[ORIG]],
+
+// -----
+
+// An outlined parallel region is not a device stub and must not bind its
+// enclosing function.
+module attributes {gpu.container_module} {
+  gpu.module @gpum {
+    gpu.func @main_kernel() kernel {
+      gpu.return
+    }
+  }
+  llvm.func @main() {
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: llvm.func private @gpum_gpubin_ctor()
+// CHECK-NOT: llvm.mlir.addressof @main :
+// CHECK: RegisterFunction
+// CHECK-NOT: RegisterFunction

--- a/test/lit_tests/polygeist-register-host-stub.mlir
+++ b/test/lit_tests/polygeist-register-host-stub.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s --convert-polygeist-to-llvm -split-input-file | FileCheck %s
 
-// Kernel addresses that could not be rewritten statically reach the runtime as
-// the original, un-prefixed host stub, so it is registered against the same
-// device function alongside the synthetic stub.
+// A kernel lowered from one of clang's device stubs is registered under that
+// stub, which is the address user code can take, rather than under a synthetic
+// one that nothing else refers to.
 module attributes {gpu.container_module} {
   gpu.module @gpum {
     gpu.func @"reactant$_Z16__device_stub__kPi"() kernel {
@@ -14,16 +14,16 @@ module attributes {gpu.container_module} {
   }
 }
 
+// CHECK-NOT: llvm.func internal @__polygeist_gpum_reactant$_Z16__device_stub__kPi_device_stub
 // CHECK-LABEL: llvm.func private @gpum_gpubin_ctor()
-// CHECK-DAG: %[[ORIG:.+]] = llvm.mlir.addressof @_Z16__device_stub__kPi : !llvm.ptr
-// CHECK-DAG: %[[SYNTH:.+]] = llvm.mlir.addressof @__polygeist_gpum_reactant$_Z16__device_stub__kPi_device_stub : !llvm.ptr
-// CHECK: RegisterFunction(%{{.+}}, %[[SYNTH]],
+// CHECK: %[[ORIG:.+]] = llvm.mlir.addressof @_Z16__device_stub__kPi : !llvm.ptr
 // CHECK: RegisterFunction(%{{.+}}, %[[ORIG]],
+// CHECK-NOT: RegisterFunction(%
 
 // -----
 
-// An outlined parallel region is not a device stub and must not bind its
-// enclosing function.
+// A kernel outlined from a parallel region has no device stub of its own, so a
+// synthetic one is registered. It must not bind its enclosing function.
 module attributes {gpu.container_module} {
   gpu.module @gpum {
     gpu.func @main_kernel() kernel {
@@ -37,5 +37,7 @@ module attributes {gpu.container_module} {
 
 // CHECK-LABEL: llvm.func private @gpum_gpubin_ctor()
 // CHECK-NOT: llvm.mlir.addressof @main :
-// CHECK: RegisterFunction
-// CHECK-NOT: RegisterFunction
+// CHECK: %[[SYNTH:.+]] = llvm.mlir.addressof @__polygeist_gpum_main_kernel_device_stub : !llvm.ptr
+// CHECK: RegisterFunction(%{{.+}}, %[[SYNTH]],
+// CHECK-NOT: RegisterFunction(%
+// CHECK: llvm.func internal @__polygeist_gpum_main_kernel_device_stub()


### PR DESCRIPTION
## The bug

`SplitParallelOp` (`ConvertParallelToGPU.cpp`) gated its exact-shape fallback on

```cpp
pop.getUpperBound().size() == 6 && pop.getUpperBound() == wrapper.getOperands()
```

A kernel **with no barrier** has its grid and block `scf.parallel` ops fused into one by earlier passes, and dimensions of extent one are dropped, so the count is 5 or 4 rather than 6 and the fallback never fires. Every candidate block size then fails too, and the `curRegion == 0` path erased the wrapper and replaced the launch result with a `CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES` constant.

The consequence is a silent miscompile, not a diagnosed failure:

- the kernel disappears from the device module entirely,
- the launch becomes a no-op, so `cudaGetLastError()` still reports success,
- the output buffer keeps whatever it held before.

MFEM's CUDA build hit this on every kernel without a `MFEM_SYNC_THREAD`: all nine `EAMassAssemble1D<*>` instantiations, all three `PADiffusionSetup{2D<2>,2D<3>,3D}`, and two convection assembly kernels. The diffusion ones compute the geometric factors shared by every assembly level, which is why one dropped kernel failed `PARTIAL`, `ELEMENT` and `FULL` alike. 13 of the 17 failing `H1 Assembly Levels` assertions come from this.

## The fix

`matchWrapperShape()` maps the parallel's dimensions onto the wrapper's six bounds instead of demanding equality:

- a wrapper bound of extent one may have no corresponding dimension (it was dropped), and `exactMatch()` reinstates it as `0..1 step 1`;
- a bound may be narrowed to `min(N, bound)`, which is what folding the `k >= N` guard into the loop leaves behind. The narrowed bound is the real iteration space, so the launch is built from it, not from the wrapper operand.

When nothing matches even then, the pass now emits an error saying the kernel would be dropped, instead of quietly producing a program that computes the wrong answer.

## Tests

Three cases added to `test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir`:

- `@fused_unit_dim` — five bounds carrying the wrapper's six; the split still applies and reinstates grid.z.
- `@min_narrowed_bound` — a bound behind an `arith.minsi`; matched, and the launch uses the narrowed value.
- `@allfail` (existing) — still drops, now with `expected-error`, so the diagnostic is covered.

## Measured

MFEM `H1 Assembly Levels`, swapping only the affected objects into an otherwise vanilla-clang build:

| TU | before | after |
|---|---|---|
| `bilininteg_mass_ea.cpp` | 1 failed | **0** |
| `bilininteg_diffusion_kernels.cpp` | 12 failed | **0** |
| `bilininteg_convection_ea.cpp` | 4 failed | 4 failed |

Convection no longer drops any kernel, so its remaining 4 failures are a separate defect; I am still chasing it and it is not addressed here.