### PR TITLE
Do not take a grid dimension into an already full block

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -815,7 +815,7 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       // Put a random index, we will override it
       gridArgId.push_back(0);
     } else if (maxThreads != -1 && threadNum <= maxThreads / 2 &&
-               mustBeBlockIVs.empty()) {
+               mustBeBlockIVs.empty() && blockDims.size() < 3) {
       // If we are not getting enough parallelism in the block, use part of the
       // grid dims
 

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
@@ -76,3 +76,41 @@ module {
 // CHECK-SAME: %[[N:[^ :]+]]: index, %[[M:[^ :]+]]: index, %[[P:[^ :]+]]: index, %[[Q:[^ :]+]]: index
 // CHECK: enzymexla.alternatives
 // CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[N]], %{{.+}} = %[[M]], %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[P]], %{{.+}} = %[[Q]], %{{.+}} = %{{.+}})
+
+// -----
+
+// The block already uses all three thread dimensions, so there is no room to
+// take a grid dimension into it however few threads it has. Taking one anyway
+// left a fourth block dimension to alias onto an existing thread id, so two of
+// the parallel op's dimensions advanced together and the rest of the iteration
+// space was never run.
+
+module {
+  func.func @full_block_no_split(%gx: index, %out: memref<?xf64>, %v: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c3 = arith.constant 3 : index
+    %w = "enzymexla.gpu_wrapper"(%gx, %c1, %c1, %c3, %c3, %c3) ({
+      scf.parallel (%i0, %i1, %i2, %i3) = (%c0, %c0, %c0, %c0) to (%gx, %c3, %c3, %c3) step (%c1, %c1, %c1, %c1) {
+        %a = arith.muli %i0, %c3 : index
+        %b = arith.addi %a, %i3 : index
+        %c = arith.muli %b, %c3 : index
+        %d = arith.addi %c, %i2 : index
+        %e = arith.muli %d, %c3 : index
+        %f = arith.addi %e, %i1 : index
+        memref.store %v, %out[%f] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @full_block_no_split(
+// CHECK-SAME: %[[GX:[^ :]+]]: index
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[GX]], %{{.+}} = %{{.+}}, %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %{{.+}}, %{{.+}} = %{{.+}}, %{{.+}} = %{{.+}})
+// CHECK: gpu.thread_id x
+// CHECK: gpu.thread_id y
+// CHECK: gpu.thread_id z
+// CHECK-NOT: gpu.thread_id


### PR DESCRIPTION
## The bug

When the block has fewer threads than the requested size, `createSplitOp` takes a grid dimension into it. The guard for that never checked whether a thread dimension was actually free:

```cpp
} else if (maxThreads != -1 && threadNum <= maxThreads / 2 &&
           mustBeBlockIVs.empty()) {
  ...
  splitDims = 1;
  assert(splitDims <= gridDims.size());
  assert(splitDims + blockDims.size() <= 3);   // <-- 1 + 3 <= 3
```

A block already using x, y and z gained a fourth dimension, which was then aliased onto an existing thread id:

```mlir
%thread_id_z   = gpu.thread_id z
%thread_id_z_3 = gpu.thread_id z     // two parallel dims, one thread id
```

so two of the parallel op's dimensions advanced together and the rest of the iteration space was never run. The assert covers exactly this case and is compiled out of the release builds this ships in, so it miscompiled silently.

## The fix

Only take a grid dimension into the block when a thread dimension is free: `blockDims.size() < 3`. The block then keeps its natural size, which is what the requested size was competing with in the first place.

## Test

`@full_block_no_split` in `convert-parallel-to-gpu1-blocksize-fallback.mlir`: a 3x3x3 block under a requested 128, storing to an index built from all three block dimensions so aliasing is observable. Checks the launch keeps its shape and that each of `gpu.thread_id x`, `y` and `z` is read exactly once.

## Measured

MFEM's `EAConvectionAssemble3D` has a 3x3x3 block, below the requested 128. Filling `ea_data` with a sentinel and assembling with `add = 0` showed **13122 of 19683 entries never written** — exactly 2/3, first miss at the index that is `i2 == 1` — because only the diagonal of the last two dimensions was computed. Compiling that TU with `POLYGEIST_GPU_KERNEL_BLOCK_SIZE=27`, its natural block, also made it pass, confirming the reshape was the trigger.

With this change `H1 Assembly Levels` goes from 4 failing Convection assertions to 0. The previously failing `fem/tmop` translation units still compile.