### PR TITLE
Say when a kernel is dropped instead of dropping it silently

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -606,9 +606,14 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     }
 
     if (curRegion == 0) {
-      // Nothing split: every candidate block size failed. The regions hold
-      // only the corpses of the failed attempts; drop them and leave the
-      // launch-out-of-resources error the failed splits already stand for.
+      // Nothing split: every candidate block size failed, and the shape could
+      // not be recovered from the wrapper either. Dropping the kernel here
+      // silently turns the launch into a no-op that leaves its outputs
+      // untouched, so say so rather than miscompiling.
+      wrapper.emitError()
+          << "no block size splits this kernel and its " << pop.getNumLoops()
+          << " parallel dimensions do not match the wrapper's grid and block "
+             "bounds; the kernel would be dropped";
       rewriter.eraseOp(alternativesOp);
       rewriter.setInsertionPoint(wrapper);
       auto err = arith::ConstantIndexOp::create(

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
@@ -1,4 +1,4 @@
-// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --split-input-file --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
 
 // The requested block size cannot split a parallel op with more than three
 // dynamic dimensions, and this op offers no fallback: its shape is not the
@@ -11,6 +11,7 @@ module {
   func.func @allfail(%n: index, %m: index, %p: index, %q: index, %out: memref<?xf64>, %v: f64) -> index {
     %c1 = arith.constant 1 : index
     %c0 = arith.constant 0 : index
+    // expected-error @+1 {{no block size splits this kernel}}
     %w = "enzymexla.gpu_wrapper"(%n, %m, %c1, %c1, %c1, %c1) ({
       scf.parallel (%i, %j, %k, %l) = (%c0, %c0, %c0, %c0) to (%n, %m, %p, %q) step (%c1, %c1, %c1, %c1) {
         memref.store %v, %out[%i] : memref<?xf64>


### PR DESCRIPTION
## The problem

When no candidate block size splits the parallel op and its shape does not match the wrapper's bounds, `SplitParallelOp` erases the wrapper and replaces the launch result with a `CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES` constant.

Nothing observes that constant in practice:

- the kernel is gone from the device module,
- no launch happens, so `cudaGetLastError()` still reports success,
- the output buffer keeps whatever it held.

The program runs to completion and computes the wrong answer, with no indication anywhere that a kernel was lost. That is the worst failure mode available — worse than refusing to compile, and much worse than a launch that fails at runtime.

## The change

Emit an error naming the mismatch before the wrapper is replaced:

```
no block size splits this kernel and its 5 parallel dimensions do not match
the wrapper's grid and block bounds; the kernel would be dropped
```

The diagnostic is deliberately **not** fatal. Builds that depend on this path today keep working and start reporting which kernels they are losing; making it fatal is a one-line change once those are addressed. On MFEM's CUDA build it currently fires for a set of large templated instantiations that are genuinely being dropped right now.

## Test

The existing `@allfail` case in `convert-parallel-to-gpu1-blocksize-fallback.mlir` is the shape that legitimately cannot be matched. It gains an `expected-error`, and the RUN line gains `--verify-diagnostics`, so the diagnostic is covered and the other cases are checked to stay silent.