### PR TITLE
Keep kernels whose grid and block parallels were fused

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -172,6 +172,46 @@ template <int S = 3> SmallVector<Value, S> getUpperBounds(scf::ParallelOp pop) {
   return bounds;
 }
 
+/// Whether `ub` is the launch bound `bound`, possibly narrowed by a min against
+/// the kernel's own trip count -- folding the `k >= N` guard into the loop
+/// makes the bound `min(N, bound)`. The narrowed bound is the real iteration
+/// space, so the launch is built from it, not from `bound`.
+bool boundMatchesLaunch(Value ub, Value bound) {
+  if (ub == bound)
+    return true;
+  if (auto mn = ub.getDefiningOp<arith::MinSIOp>())
+    return mn.getLhs() == bound || mn.getRhs() == bound;
+  if (auto mn = ub.getDefiningOp<arith::MinUIOp>())
+    return mn.getLhs() == bound || mn.getRhs() == bound;
+  return false;
+}
+
+/// Match the dimensions of `pop` against the six grid and block bounds of
+/// `wrapper`, filling `dimOf` with the dimension of `pop` that carries each
+/// bound, or -1 for a bound of extent one that `pop` does not carry. Passes
+/// that fuse the grid and block parallels drop such trivial dimensions, so an
+/// exact-shape match must tolerate their absence.
+bool matchWrapperShape(scf::ParallelOp pop, enzymexla::GPUWrapperOp wrapper,
+                       SmallVectorImpl<int> &dimOf) {
+  auto bounds = wrapper.getOperands();
+  if (bounds.size() != 6)
+    return false;
+  auto ubs = pop.getUpperBound();
+  unsigned next = 0;
+  for (Value bound : bounds) {
+    if (next < ubs.size() && boundMatchesLaunch(ubs[next], bound)) {
+      dimOf.push_back(next++);
+      continue;
+    }
+    if (matchPattern(bound, m_One())) {
+      dimOf.push_back(-1);
+      continue;
+    }
+    return false;
+  }
+  return next == ubs.size();
+}
+
 void insertReturn(PatternRewriter &rewriter, func::FuncOp f) {
   func::ReturnOp::create(rewriter, rewriter.getUnknownLoc());
 }
@@ -505,7 +545,8 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
         curRegion++;
       }
     };
-    auto exactMatch = [&](enzymexla::AlternativesOp alternativesOp) {
+    auto exactMatch = [&](enzymexla::AlternativesOp alternativesOp,
+                          ArrayRef<int> dimOf) {
       auto block = &*alternativesOp->getRegion(curRegion).begin();
       rewriter.setInsertionPointToStart(block);
       // TODO not very efficient...
@@ -515,26 +556,40 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
           getDirectlyNestedSingleParallel(newWrapper.getBody());
       auto loc = pop->getLoc();
 
-      auto upperBounds = getUpperBounds<6>(pop);
-
       mlir::OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(pop);
-      auto gridPop = scf::ParallelOp::create(
-          rewriter, loc, pop.getLowerBound().slice(0, 3),
-          pop.getUpperBound().slice(0, 3), pop.getStep().slice(0, 3));
+      Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+      Value one = arith::ConstantIndexOp::create(rewriter, loc, 1);
+
+      SmallVector<Value, 3> lbs[2], ubs[2], steps[2];
+      for (unsigned i = 0; i < 6; i++) {
+        unsigned half = i / 3;
+        if (dimOf[i] < 0) {
+          lbs[half].push_back(zero);
+          ubs[half].push_back(one);
+          steps[half].push_back(one);
+        } else {
+          lbs[half].push_back(pop.getLowerBound()[dimOf[i]]);
+          ubs[half].push_back(pop.getUpperBound()[dimOf[i]]);
+          steps[half].push_back(pop.getStep()[dimOf[i]]);
+        }
+      }
+
+      auto gridPop =
+          scf::ParallelOp::create(rewriter, loc, lbs[0], ubs[0], steps[0]);
       rewriter.setInsertionPointToStart(gridPop.getBody());
-      auto blockPop = scf::ParallelOp::create(
-          rewriter, loc, pop.getLowerBound().slice(3, 3),
-          pop.getUpperBound().slice(3, 3), pop.getStep().slice(3, 3));
+      auto blockPop =
+          scf::ParallelOp::create(rewriter, loc, lbs[1], ubs[1], steps[1]);
       rewriter.setInsertionPointToStart(blockPop.getBody());
 
       IRMapping mapping;
-      for (unsigned i = 0; i < 3; i++)
-        mapping.map(pop.getBody()->getArgument(i),
-                    gridPop.getBody()->getArgument(i));
-      for (unsigned i = 0; i < 3; i++)
-        mapping.map(pop.getBody()->getArgument(i + 3),
-                    blockPop.getBody()->getArgument(i));
+      for (unsigned i = 0; i < 6; i++) {
+        if (dimOf[i] < 0)
+          continue;
+        auto newPop = i < 3 ? gridPop : blockPop;
+        mapping.map(pop.getBody()->getArgument(dimOf[i]),
+                    newPop.getBody()->getArgument(i % 3));
+      }
 
       rewriter.eraseOp(pop.getBody()->getTerminator());
       for (auto &op : *pop.getBody())
@@ -546,6 +601,9 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       curRegion++;
     };
 
+    SmallVector<int, 6> exactDims;
+    bool hasExactMatch = matchWrapperShape(pop, wrapper, exactDims);
+
     enzymexla::AlternativesOp alternativesOp = nullptr;
     if (char *blockSizeStr = getenv("POLYGEIST_GPU_KERNEL_BLOCK_SIZE")) {
       alternativesOp = enzymexla::AlternativesOp::create(rewriter, loc, 1);
@@ -556,9 +614,8 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       emitAlternative(atoi(blockSizeStr), alternativesOp);
       if (curRegion == 0) {
         llvm::errs() << " Failed to make kernel with exact dimension\n";
-        if (pop.getUpperBound().size() == 6 &&
-            pop.getUpperBound() == wrapper.getOperands()) {
-          exactMatch(alternativesOp);
+        if (hasExactMatch) {
+          exactMatch(alternativesOp, exactDims);
         } else if (pop->hasAttr("enzymexla.kernel_thread_indices")) {
           // The exact-shape fallback needs the six grid and block bounds;
           // a collapsed parallel op does not have them, so reproduce the
@@ -578,19 +635,15 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
                               rewriter.getArrayAttr(descs));
     } else if (shouldEmitAlternatives(pop)) {
       alternativesOp = enzymexla::AlternativesOp::create(
-          rewriter, loc,
-          ALTERNATIVE_KERNEL_BLOCK_SIZES.size() +
-              (pop.getUpperBound().size() == 6 &&
-               pop.getUpperBound() == wrapper.getOperands()));
+          rewriter, loc, ALTERNATIVE_KERNEL_BLOCK_SIZES.size() + hasExactMatch);
       alternativesOp->setAttr("alternatives.type",
                               rewriter.getStringAttr("gpu_kernel"));
       for (unsigned blockSize : ALTERNATIVE_KERNEL_BLOCK_SIZES) {
         emitAlternative(blockSize, alternativesOp);
       }
       assert(wrapper.getOperands().size() == 6);
-      if (pop.getUpperBound().size() == 6 &&
-          pop.getUpperBound() == wrapper.getOperands()) {
-        exactMatch(alternativesOp);
+      if (hasExactMatch) {
+        exactMatch(alternativesOp, exactDims);
       }
       alternativesOp->setAttr("alternatives.descs",
                               rewriter.getArrayAttr(descs));

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-blocksize-fallback.mlir
@@ -115,3 +115,59 @@ module {
 // CHECK: gpu.thread_id y
 // CHECK: gpu.thread_id z
 // CHECK-NOT: gpu.thread_id
+
+// -----
+
+// The grid and block parallels of a barrier-free kernel are fused into one op,
+// and dimensions of extent one are dropped: five bounds carrying the wrapper's
+// six. The exact-shape split still applies, reinstating the dropped grid.z.
+
+module {
+  func.func @fused_unit_dim(%gx: index, %gy: index, %bx: index, %by: index, %bz: index, %out: memref<?xf64>, %v: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %w = "enzymexla.gpu_wrapper"(%gx, %gy, %c1, %bx, %by, %bz) ({
+      scf.parallel (%i0, %i1, %i2, %i3, %i4) = (%c0, %c0, %c0, %c0, %c0) to (%gx, %gy, %bx, %by, %bz) step (%c1, %c1, %c1, %c1, %c1) {
+        memref.store %v, %out[%i0] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @fused_unit_dim(
+// CHECK-SAME: %[[GX:[^ :]+]]: index, %[[GY:[^ :]+]]: index, %[[BX:[^ :]+]]: index, %[[BY:[^ :]+]]: index, %[[BZ:[^ :]+]]: index
+// CHECK: enzymexla.alternatives
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[GX]], %{{.+}} = %[[GY]], %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[BX]], %{{.+}} = %[[BY]], %{{.+}} = %[[BZ]])
+// CHECK: alternatives.descs = ["block_size=-1,"]
+
+// -----
+
+// Folding the `k >= N` guard into the loop narrows a bound to a min against the
+// kernel's own trip count. That is still the wrapper's dimension, and the
+// narrowed bound is the one the launch is built from.
+
+module {
+  func.func @min_narrowed_bound(%gx: index, %gy: index, %bx: index, %by: index, %n: index, %out: memref<?xf64>, %v: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %t = arith.minsi %n, %gx : index
+    %w = "enzymexla.gpu_wrapper"(%gx, %gy, %c1, %bx, %by, %c1) ({
+      scf.parallel (%i0, %i1, %i2, %i3) = (%c0, %c0, %c0, %c0) to (%t, %gy, %bx, %by) step (%c1, %c1, %c1, %c1) {
+        memref.store %v, %out[%i0] : memref<?xf64>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @min_narrowed_bound(
+// CHECK-SAME: %[[GX:[^ :]+]]: index, %[[GY:[^ :]+]]: index, %[[BX:[^ :]+]]: index, %[[BY:[^ :]+]]: index
+// CHECK: %[[T:.+]] = arith.minsi
+// CHECK: enzymexla.alternatives
+// CHECK: gpu.launch blocks(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[T]], %{{.+}} = %[[GY]], %{{.+}} = %{{.+}}) threads(%{{.+}}, %{{.+}}, %{{.+}}) in (%{{.+}} = %[[BX]], %{{.+}} = %[[BY]], %{{.+}} = %{{.+}})
+// CHECK: alternatives.descs = ["block_size=-1,"]


### PR DESCRIPTION
> **Draft: correct as far as it goes, but not mergeable yet — see Blocker below.**

## The bug

The exact-shape fallback in `SplitParallelOp` was gated on

```cpp
pop.getUpperBound().size() == 6 && pop.getUpperBound() == wrapper.getOperands()
```

A kernel **with no barrier** has its grid and block `scf.parallel` ops fused into one by earlier passes, and dimensions of extent one are dropped, so the count is 5 or 4 rather than 6 and the fallback never fires. Every candidate block size then fails too, and the kernel is dropped: it vanishes from the device module, the launch becomes a no-op, `cudaGetLastError()` still reports success, and the output buffer keeps whatever it held.

## The fix

`matchWrapperShape()` maps the parallel's dimensions onto the wrapper's six bounds instead of demanding equality:

- a wrapper bound of extent one may have no corresponding dimension, because it was dropped; `exactMatch()` reinstates it as `0..1 step 1`;
- a bound may be narrowed to `min(N, bound)`, which is what folding the `k >= N` guard into the loop leaves behind. The narrowed bound is the real iteration space, so the launch is built from it rather than from the wrapper operand.

## Tests

- `@fused_unit_dim` — five bounds carrying the wrapper's six; the split applies and reinstates grid.z.
- `@min_narrowed_bound` — a bound behind an `arith.minsi`; matched, and the launch uses the narrowed value.

## Measured

MFEM's CUDA build was dropping all nine `EAMassAssemble1D` instantiations and all three `PADiffusionSetup` kernels. The diffusion ones compute the geometric factors shared by every assembly level, which is why one dropped kernel failed `PARTIAL`, `ELEMENT` and `FULL` alike, and why only meshes whose setup lives in that TU were affected.

Swapping only the affected objects into an otherwise vanilla-clang build of `H1 Assembly Levels`:

| TU | before | after |
|---|---|---|
| `bilininteg_mass_ea.cpp` | 1 failed | **0** |
| `bilininteg_diffusion_kernels.cpp` | 12 failed | **0** |

## Blocker

A full `ninja gpu_unit_tests` with this change **fails to build 33 `fem/tmop/*` translation units**. Bisected to this commit alone, and it reproduces on plain `main` plus this commit.

Kernels that were being dropped now survive, including very large instantiations such as `TMOP_AssembleDiagPA_2D<24, 24, 0, 0>` — a 576-thread block that cannot be split to the requested 128. Those reach a `polygeist_stubs` `gpu.module` whose body only forwards to a host stub:

```
ptxas fatal : Unresolved extern function 'reactant$..._device_stub__CuKernel2D<...>'
```

There is a second, independent defect in front of it: that module is given the **host** target, `#nvvm.target<chip = "x86-64", features = "+cmov,...">`, because the arch is read from the enclosing host function's `target_cpu` (`ConvertParallelToGPU.cpp`, in the `GPUErrorOp` walk). Rejecting a non-`sm_` chip and borrowing the arch from a sibling `gpu.module` fixes that one — I tried it, the chip becomes a valid arch — but it only uncovers the unresolved-stub error underneath. That change is not included here.

So this needs the stub/placeholder path (#2857's territory) to handle these kernels before it can land. Filed as a draft so the analysis and tests are available; happy to rebase on whatever shape that fix takes.