### PR TITLE
[ConvertParallelToGPU1] Give gridDim.x to a dimension that needs it

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1925,6 +1925,11 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     if (!blockPop)
       return failure();
 
+    SmallVector<Value, 2> cappedByOriginalLaunch;
+    if (wrapper->getNumOperands() == 6)
+      cappedByOriginalLaunch.append(
+          {wrapper->getOperand(1), wrapper->getOperand(2)});
+
     // Only mutate once the match is certain: an op created before a bail
     // marks the IR changed on every scan, so a wrapper this pattern cannot
     // convert -- such as one whose bounds have to stay beside the parallel,
@@ -1964,11 +1969,42 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
 
     // TODO make sure we start at zero or else convert the parallel ops to start
     // at 0
-    Value gridBounds[3];
     auto popGridBounds = getUpperBounds(gridPop);
+
+    constexpr uint64_t MAX_GRID_DIM_Y_Z = 65535;
+    auto fitsOutsideGridX = [&](Value bound) {
+      APInt cst;
+      if (matchPattern(bound, m_ConstantInt(&cst)))
+        return cst.ule(MAX_GRID_DIM_Y_Z);
+      return llvm::is_contained(cappedByOriginalLaunch, bound);
+    };
+
+    SmallVector<unsigned, 3> gridOrder;
+    for (unsigned i = 0; i < popGridBounds.size(); i++)
+      if (!fitsOutsideGridX(popGridBounds[i]))
+        gridOrder.push_back(i);
+    unsigned unprovable = gridOrder.size();
+    for (unsigned i = 0; i < popGridBounds.size(); i++)
+      if (fitsOutsideGridX(popGridBounds[i]))
+        gridOrder.push_back(i);
+
+    SmallVector<unsigned, 3> gridDimOfArg(popGridBounds.size());
+    for (unsigned i = 0; i < gridOrder.size(); i++)
+      gridDimOfArg[gridOrder[i]] = i;
+
+    if (unprovable > 1)
+      gridPop->emitWarning()
+          << "grid has " << unprovable
+          << " dimensions whose size is not known here; only gridDim.x holds "
+             "more than "
+          << MAX_GRID_DIM_Y_Z
+          << " blocks, so this kernel does not launch if more than one of them "
+             "exceeds that";
+
+    Value gridBounds[3];
     for (unsigned int i = 0; i < 3; i++) {
       if (i < popGridBounds.size())
-        gridBounds[i] = popGridBounds[i];
+        gridBounds[i] = popGridBounds[gridOrder[i]];
       else
         gridBounds[i] = oneindex;
     }
@@ -2053,7 +2089,7 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     rewriter.setInsertionPointToStart(launchBlock);
 
     for (auto en : llvm::enumerate(gridPop.getBody()->getArguments())) {
-      gpu::Dimension dim = getDim(en.index());
+      gpu::Dimension dim = getDim(gridDimOfArg[en.index()]);
       auto gridIdx = gpu::BlockIdOp::create(
           rewriter, loc, mlir::IndexType::get(rewriter.getContext()), dim);
       en.value().replaceAllUsesWith(gridIdx);

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1976,14 +1976,16 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       APInt cst;
       if (matchPattern(bound, m_ConstantInt(&cst)))
         return cst.ule(MAX_GRID_DIM_Y_Z);
-      return llvm::any_of(cappedByOriginalLaunch, [&](Value originalBound){return boundMatchesLaunch(bound,originalBound);});
+      return llvm::any_of(cappedByOriginalLaunch, [&](Value originalBound) {
+        return boundMatchesLaunch(bound, originalBound);
+      });
     };
 
     SmallVector<unsigned, 3> gridOrder;
     for (unsigned i = 0; i < popGridBounds.size(); i++)
       if (!fitsOutsideGridX(popGridBounds[i]))
         gridOrder.push_back(i);
-    unsigned unprovable = gridOrder.size();
+    unsigned overflowing_blocks = gridOrder.size();
     for (unsigned i = 0; i < popGridBounds.size(); i++)
       if (fitsOutsideGridX(popGridBounds[i]))
         gridOrder.push_back(i);
@@ -1992,14 +1994,11 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     for (unsigned i = 0; i < gridOrder.size(); i++)
       gridDimOfArg[gridOrder[i]] = i;
 
-    if (unprovable > 1)
-      gridPop->emitWarning()
-          << "grid has " << unprovable
-          << " dimensions whose size is not known here; only gridDim.x holds "
-             "more than "
-          << MAX_GRID_DIM_Y_Z
-          << " blocks, so this kernel does not launch if more than one of them "
-             "exceeds that";
+    if (overflowing_blocks > 1) {
+      LLVM_DEBUG({
+        DBGS() << "more than one grid dimension may exceed the y/z limit\n";
+      });
+    }
 
     Value gridBounds[3];
     for (unsigned int i = 0; i < 3; i++) {

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1976,7 +1976,7 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       APInt cst;
       if (matchPattern(bound, m_ConstantInt(&cst)))
         return cst.ule(MAX_GRID_DIM_Y_Z);
-      return llvm::is_contained(cappedByOriginalLaunch, bound);
+      return llvm::any_of(cappedByOriginalLaunch, [&](Value originalBound){return boundMatchesLaunch(bound,originalBound);});
     };
 
     SmallVector<unsigned, 3> gridOrder;

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1985,7 +1985,7 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     for (unsigned i = 0; i < popGridBounds.size(); i++)
       if (!fitsOutsideGridX(popGridBounds[i]))
         gridOrder.push_back(i);
-    unsigned overflowing_blocks = gridOrder.size();
+    unsigned potentiallyOversizedDims = gridOrder.size();
     for (unsigned i = 0; i < popGridBounds.size(); i++)
       if (fitsOutsideGridX(popGridBounds[i]))
         gridOrder.push_back(i);
@@ -1994,11 +1994,9 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     for (unsigned i = 0; i < gridOrder.size(); i++)
       gridDimOfArg[gridOrder[i]] = i;
 
-    if (overflowing_blocks > 1) {
-      LLVM_DEBUG({
-        DBGS() << "more than one grid dimension may exceed the y/z limit\n";
-      });
-    }
+    if (potentiallyOversizedDims > 1)
+      LLVM_DEBUG(
+          DBGS() << "more than one grid dimension may exceed the y/z limit\n");
 
     Value gridBounds[3];
     for (unsigned int i = 0; i < 3; i++) {

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-grid-dim-x.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-grid-dim-x.mlir
@@ -23,6 +23,37 @@ func.func @degenerate_leading_dim(%gridx: index, %gridy: index, %out: memref<?xf
 
 // -----
 
+// A bound narrowed by a min against the original grid-y dimension is still
+// safe outside x. The derived bound is a different SSA value, so this also
+// checks that launch-bound matching is not limited to value identity.
+
+func.func @min_narrowed_y_bound(%gridx: index, %gridy: index, %n: index, %out: memref<?xf64, 1>, %v: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  %safe_y = arith.minsi %n, %gridy : index
+  "enzymexla.gpu_wrapper"(%gridx, %gridy, %c1, %c32, %c1, %c1) ({
+    %fused = arith.muli %gridx, %c32 : index
+    scf.parallel (%i, %j) = (%c0, %c0) to (%safe_y, %fused) step (%c1, %c1) {
+      %idx = arith.addi %i, %j : index
+      memref.store %v, %out[%idx] : memref<?xf64, 1>
+      scf.reduce
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK-LABEL: func.func @min_narrowed_y_bound(
+// CHECK-SAME: %{{[^ :]+}}: index, %[[GRIDY:[^ :]+]]: index, %[[N:[^ :]+]]: index
+// CHECK: %[[SAFE_Y:.+]] = arith.minsi %[[N]], %[[GRIDY]]
+// CHECK: %[[BLOCKS:.+]] = arith.addi
+// CHECK: gpu.launch blocks({{.*}}) in (%{{[^ ]+}} = %[[BLOCKS]], %{{[^ ]+}} = %[[SAFE_Y]], %{{[^ ]+}} = %c1)
+// CHECK-DAG: gpu.block_id y
+// CHECK-DAG: gpu.block_id x
+
+// -----
+
 // The constant half of the same test, both ways at once: 1000 fits and sinks
 // to y, and 2^32 + 1000 does not and takes x. Read as an int rather than an
 // APInt the wide one looks like 1000, and the two come out the other way up.
@@ -51,14 +82,14 @@ func.func @constant_bounds(%out: memref<?xf64, 1>, %v: f64) {
 // -----
 
 // Only one dimension can be given x, and which of two unknown ones carries the
-// work is not something the loop order says. Keep the order and say so.
+// work is not something the loop order says. Preserve their order; their
+// runtime values determine whether the launch is valid.
 
 func.func @two_unbounded(%n: index, %m: index, %out: memref<?xf64, 1>, %v: f64) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c32 = arith.constant 32 : index
   "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c32, %c1, %c1) ({
-    // expected-warning @below {{grid has 2 dimensions whose size is not known here}}
     scf.parallel (%i, %j, %k) = (%c0, %c0, %c0) to (%n, %m, %c32) step (%c1, %c1, %c1) {
       memref.store %v, %out[%i] : memref<?xf64, 1>
       scf.reduce

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-grid-dim-x.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-grid-dim-x.mlir
@@ -1,0 +1,73 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=32 enzymexlamlir-opt %s --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+func.func @degenerate_leading_dim(%gridx: index, %gridy: index, %out: memref<?xf64, 1>, %v: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  "enzymexla.gpu_wrapper"(%gridx, %gridy, %c1, %c32, %c1, %c1) ({
+    %fused = arith.muli %gridx, %c32 : index
+    scf.parallel (%i, %j) = (%c0, %c0) to (%gridy, %fused) step (%c1, %c1) {
+      memref.store %v, %out[%j] : memref<?xf64, 1>
+      scf.reduce
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK-LABEL: func.func @degenerate_leading_dim(
+// CHECK-SAME: %{{[^ :]+}}: index, %[[GRIDY:[^ :]+]]: index
+// CHECK: %[[BLOCKS:.+]] = arith.addi
+// CHECK: gpu.launch blocks({{.*}}) in (%{{[^ ]+}} = %[[BLOCKS]], %{{[^ ]+}} = %[[GRIDY]], %{{[^ ]+}} = %c1)
+// CHECK: gpu.block_id x
+
+// -----
+
+// The constant half of the same test, both ways at once: 1000 fits and sinks
+// to y, and 2^32 + 1000 does not and takes x. Read as an int rather than an
+// APInt the wide one looks like 1000, and the two come out the other way up.
+
+func.func @constant_bounds(%out: memref<?xf64, 1>, %v: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  %c1000 = arith.constant 1000 : index
+  %big = arith.constant 4294968296 : index
+  "enzymexla.gpu_wrapper"(%c1000, %c1, %c1, %c32, %c1, %c1) ({
+    scf.parallel (%i, %j, %k) = (%c0, %c0, %c0) to (%c1000, %big, %c32) step (%c1, %c1, %c1) {
+      memref.store %v, %out[%j] : memref<?xf64, 1>
+      scf.reduce
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK-LABEL: func.func @constant_bounds(
+// CHECK-DAG: %[[C1000:.+]] = arith.constant 1000 : index
+// CHECK-DAG: %[[BIG:.+]] = arith.constant 4294968296 : index
+// CHECK: gpu.launch blocks({{.*}}) in (%{{[^ ]+}} = %[[BIG]], %{{[^ ]+}} = %[[C1000]], %{{[^ ]+}} = %c1)
+
+// -----
+
+// Only one dimension can be given x, and which of two unknown ones carries the
+// work is not something the loop order says. Keep the order and say so.
+
+func.func @two_unbounded(%n: index, %m: index, %out: memref<?xf64, 1>, %v: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c32, %c1, %c1) ({
+    // expected-warning @below {{grid has 2 dimensions whose size is not known here}}
+    scf.parallel (%i, %j, %k) = (%c0, %c0, %c0) to (%n, %m, %c32) step (%c1, %c1, %c1) {
+      memref.store %v, %out[%i] : memref<?xf64, 1>
+      scf.reduce
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK-LABEL: func.func @two_unbounded(
+// CHECK-SAME: %[[N:[^ :]+]]: index, %[[M:[^ :]+]]: index
+// CHECK: gpu.launch blocks({{.*}}) in (%{{[^ ]+}} = %[[N]], %{{[^ ]+}} = %[[M]], %{{[^ ]+}} = %c1)


### PR DESCRIPTION
Fix #2789 

`gridDim.x` holds 2^31-1 blocks, `gridDim.y` and `gridDim.z` holds 65535 on every CUDA architecture. `MergeParallelInductions` (`AffineCFG.cpp`), which fuses `gridDim.x` with `blockDim.x`, writes the fused
extent into the slot of whichever induction variable was the additive one, and a degenerate grid dimension is not folded away when the launch configuration reaching it is not a constant. 

RSBench launches `<<<318750, 32>>>` at `simulation.cu:33`. Its `gridDim.y` of one survives raising as a dimension of its own, leads the parallel op and takes x, and 318750 blocks which was split into `gridDim.y`

**Fix**
Give x to a dimension whose size is not known here. A dimension which is known to fit y or z when it is a constant that under the bounds or one of the grid dimensions the wrapper records.
