### PR TITLE
Replace the split wrapper's result instead of erasing it away

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -676,7 +676,9 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       return success();
     }
 
-    rewriter.eraseOp(wrapper);
+    rewriter.setInsertionPoint(wrapper);
+    auto zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    rewriter.replaceOp(wrapper, zero->getResults());
 
     return success();
   }

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-used-result.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-used-result.mlir
@@ -1,0 +1,32 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// The wrapper's result is the launch error code. On the path where the kernel
+// splits successfully the wrapper was erased without replacing that result, so
+// any remaining use was left dangling and the next fold crashed the compiler.
+
+module {
+  func.func @f(%m: memref<?xf64, 1>, %v: f64) -> index {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c256 = arith.constant 256 : index
+    %r = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c256, %c1, %c1) ({
+      scf.parallel (%i) = (%c0) to (%c256) step (%c1) {
+        %g = arith.cmpi sle, %i, %c2 : index
+        scf.if %g {
+          memref.store %v, %m[%i] : memref<?xf64, 1>
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return %r : index
+  }
+}
+
+// CHECK-LABEL: func.func @f(
+// CHECK: %[[Z:.+]] = arith.constant 0 : index
+// CHECK: enzymexla.alternatives
+// CHECK: gpu.launch
+// CHECK: return %[[Z]] : index


### PR DESCRIPTION
## The bug

`SplitParallelOp` ends two ways. When no candidate block size splits the kernel, the wrapper is `replaceOp`'d with a `CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES` constant. On the **success** path, it was simply `rewriter.eraseOp(wrapper)` — but the wrapper has a result (the launch error code), and erasing an op whose result still has uses leaves those uses dangling. The next `Operation::fold` in the same greedy run then reads freed memory:

```
#0 mlir::Value::getDefiningOp()
#1 mlir::Operation::fold(...)
#2 GreedyPatternRewriteDriver::processWorklist()
#4 ConvertParallelToGPU1Pass::runOnOperation()
```

MFEM's translation units never hit this because their wrapper results happen to be dropped by earlier passes; a 19-line CUDA file whose launch error result reaches a use crashes the compiler deterministically, with or without `POLYGEIST_GPU_KERNEL_BLOCK_SIZE`, and on every recent main (pre-#2870 included).

## The fix

Replace the wrapper with a success constant, the same shape the failure path already has. The per-alternative error codes are produced by the `gpu_error` ops inside the alternatives regions and are not plumbed out, so a constant is the only value the surviving uses can receive.

## Test

`convert-parallel-to-gpu1-used-result.mlir`: a `gpu_wrapper` whose result is returned by the function, run both with and without the requested-block-size environment variable. Checks the kernel still splits (alternatives + `gpu.launch`) and the function returns the constant.