### PR TITLE
Serialize reduction-carrying parallels nested at any depth

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1065,6 +1065,10 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
       LLVM_DEBUG(DBGS() << "ignoring non nested parallel op\n");
       return failure();
     }
+    if (pop.getNumResults()) {
+      LLVM_DEBUG(DBGS() << "cannot parallelize around a reduction\n");
+      return failure();
+    }
     auto loc = pop->getLoc();
     Block *outerBlock = pop->getBlock();
     Block *innerBlock = pop.getBody();
@@ -2043,8 +2047,13 @@ struct InnerParallelSerialization : public OpRewritePattern<scf::ParallelOp> {
     while ((par = par->getParentOfType<scf::ParallelOp>())) {
       parallelCount++;
     }
-    // is presently one of the three outer parallel loops;
-    if (parallelCount < 2)
+    // is presently one of the three outer parallel loops; a parallel
+    // carrying reductions cannot be one of those -- a launch has no
+    // reduction semantics -- so it is an inner loop wherever it sits,
+    // including directly under the single parallel left when grid and
+    // block were fused
+    if (parallelCount < 2 &&
+        !(parallelCount == 1 && parallelOp.getNumResults()))
       return failure();
 
     // For a parallel loop, we essentially need to create an n-dimensional loop

--- a/test/lit_tests/lowering/serialize-inner-reduction.mlir
+++ b/test/lit_tests/lowering/serialize-inner-reduction.mlir
@@ -1,0 +1,42 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// A runtime-bound accumulation loop raised to a parallel-with-reduction sits
+// directly under the single parallel left when grid and block were fused. It
+// can never be a thread parallel -- a launch has no reduction semantics -- so
+// it must be serialized like any inner loop. Leaving it in place sent it into
+// patterns that only handle resultless parallels and crashed the compiler.
+
+module {
+  func.func @f(%in: memref<?xf64, 1>, %out: memref<?xf64, 1>) -> index {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c256 = arith.constant 256 : index
+    %cst = arith.constant 0.000000e+00 : f64
+    %r = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c256, %c1, %c1) ({
+      scf.parallel (%e) = (%c0) to (%c3) step (%c1) {
+        %sum = scf.parallel (%q) = (%c0) to (%c2) step (%c1) init (%cst) -> f64 {
+          %v = memref.load %in[%q] : memref<?xf64, 1>
+          scf.reduce(%v : f64) {
+          ^bb0(%a: f64, %b: f64):
+            %s = arith.addf %a, %b : f64
+            scf.reduce.return %s : f64
+          }
+        }
+        memref.store %sum, %out[%e] : memref<?xf64, 1>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return %r : index
+  }
+}
+
+// CHECK-LABEL: func.func @f(
+// CHECK: gpu.launch
+// CHECK: %[[ACC:.+]] = scf.for %{{.+}} = %{{.+}} to %{{.+}} step %{{.+}} iter_args(%[[IT:.+]] = %{{.+}}) -> (f64)
+// CHECK: %[[V:.+]] = memref.load
+// CHECK: %[[S:.+]] = arith.addf %[[IT]], %[[V]]
+// CHECK: scf.yield %[[S]]
+// CHECK: memref.store %[[ACC]]


### PR DESCRIPTION
> Stacked on #2877 (its commit is included here; this PR's own change is the top commit). If #2877 merges first this rebases to a single commit.

## The bug

A runtime-bound accumulation loop inside a kernel is raised to an `scf.parallel` with a reduction. `InnerParallelSerialization` — the pattern meant to turn inner parallels back into serial loops — required them to be **at least two parallels deep**, a heuristic for the classic grid×block structure where depth one is the block parallel itself. A kernel *without barriers* has its grid and block parallels fused into one (the shape #2872 handles), so its inner loops sit at depth one and the serializer refused them.

The surviving reduction-parallel then reached `ParallelizeBlockOps`, which predates reduction-carrying parallels: its after-the-parallel path clones the following ops into the parallel's own body, so an op consuming the reduction result was cloned *inside the op that defines its operand*. The invalid IR crashed the compiler a few folds later:

```
#0 mlir::Value::getDefiningOp()
#1 mlir::Operation::fold(...)
#2 GreedyPatternRewriteDriver::processWorklist()
#4 ConvertParallelToGPU1Pass::runOnOperation()
```

This ten-line CUDA kernel crashes every recent main deterministically:

```cuda
K<<<1, 256>>>(NE, [=] __device__ (int e) {
  double acc = 0.0;
  for (int qx = 0; qx < Q1D; ++qx)   // runtime bound
     acc += B[qx];
  y[e] = acc;
});
```

## The fix

A parallel carrying reductions can never be a grid or block parallel — a launch has no reduction semantics — so it is an inner loop wherever it sits: allow the serializer to take depth-one parallels when they carry reductions. Defense in depth: `ParallelizeBlockOps` now refuses reduction-carrying parallels outright instead of producing invalid IR.

## Test

`serialize-inner-reduction.mlir`: the wrapper/parallel/reduction shape above; checks the kernel still becomes a `gpu.launch` and the reduction is serialized to `scf.for ... iter_args` with the accumulated value stored.

## Verified

The ten-line kernel above and several larger reductions of MFEM's `PAHcurlHdivMassApply2D` (with the c-loop, per-component extents, and host wrapper) now compile and run. The full Apply2D kernel still fails later, in `translateModuleToLLVMIR` during serialization — a separate, next-in-line bug.