### PR TITLE
[AffineCFG] clone a select above the conditional its operands sit in

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -151,6 +151,14 @@ bool isValidSymbolInt(Value value, bool recur, Region *scope) {
   return false;
 }
 
+// Whether `value` sits inside a region nested in `scope`, rather than at its
+// top level or above it: the ancestry test isValidSymbolInt opens with, asked
+// on its own.
+bool isNestedInScope(Value value, Region *scope) {
+  assert(scope);
+  return !value.getParentRegion()->isAncestor(scope);
+}
+
 struct AffineApplyNormalizer {
   /// Builds a normalizer for `map` over `operands`, or std::nullopt where
   /// none exists.  Making an operand a valid affine dim or symbol can mean
@@ -362,12 +370,17 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
   };
 
   SmallVector<Operation **> operationContext;
-  std::function<Value(Value, bool)> fix = [&](Value v,
-                                              bool index) -> Value /*legal*/ {
+
+  std::function<Value(Value, bool, bool)> fix =
+      [&](Value v, bool index, bool needTopLevel) -> Value /*legal*/ {
     bool ntop = isNonTopLevelPureSymbol(v);
+
+    if (needTopLevel && isNestedInScope(v, scope))
+      ntop = true;
     if (!ntop && isValidSymbolInt(v, /*recur*/ false, scope)) {
       return v;
     }
+
     if (index && isAffineForArg(v)) {
       return v;
     }
@@ -410,6 +423,8 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
       if (!speculatableOutOf(selTrue, op) || !speculatableOutOf(selFalse, op))
         return nullptr;
     }
+
+    bool needTop = !affine::isValidSymbol(v, scope);
     Operation *front = nullptr;
     operationContext.push_back(&front);
     if (front)
@@ -456,7 +471,7 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
         assert(op->getBlock());
         if (front)
           assert(front->getBlock());
-        if (Value nv = fix(o, index)) {
+        if (Value nv = fix(o, index, needTop)) {
           op = nv.getDefiningOp();
         } else {
           operationContext.pop_back();
@@ -499,6 +514,12 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
     if (!front)
       op->dump();
     assert(front);
+
+    if (!front->getParentRegion()->isAncestor(scope) &&
+        !affine::isValidSymbol(v, scope)) {
+      operationContext.pop_back();
+      return nullptr;
+    }
     if (condIf) {
       // ops now holds the legalized condition and arms: replaceOp rewrote the
       // entries as their defining ops were hoisted.
@@ -631,16 +652,16 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
              (isValidIndex(t.getDefiningOp()->getOperand(1), scope) &&
               isValidSymbolInt(t.getDefiningOp()->getOperand(0), /*recur*/ true,
                                scope))) &&
-            !(fix(t.getDefiningOp()->getOperand(0), false) &&
-              fix(t.getDefiningOp()->getOperand(1), false))
+            !(fix(t.getDefiningOp()->getOperand(0), false, false) &&
+              fix(t.getDefiningOp()->getOperand(1), false, false))
 
                 ) ||
            ((t.getDefiningOp<DivUIOp>() || t.getDefiningOp<DivSIOp>()) &&
             (isValidIndex(t.getDefiningOp()->getOperand(0), scope) &&
              isValidSymbolInt(t.getDefiningOp()->getOperand(1), /*recur*/ true,
                               scope)) &&
-            (!(fix(t.getDefiningOp()->getOperand(0), false) &&
-               fix(t.getDefiningOp()->getOperand(1), false)))) ||
+            (!(fix(t.getDefiningOp()->getOperand(0), false, false) &&
+               fix(t.getDefiningOp()->getOperand(1), false, false)))) ||
            (t.getDefiningOp<DivSIOp>() &&
             (isValidIndex(t.getDefiningOp()->getOperand(0), scope) &&
              isValidSymbolInt(t.getDefiningOp()->getOperand(1), /*recur*/ true,
@@ -878,7 +899,7 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
       if (!isValidSymbolInt(t, /*recur*/ false, scope)) {
         Value orig = t;
         if (t.getDefiningOp()) {
-          if ((t = fix(t, false))) {
+          if ((t = fix(t, false, false))) {
             if (!isValidSymbolInt(t, /*recur*/ false, scope)) {
               llvm::errs()
                   << " op: "

--- a/test/lit_tests/affinecfg_top_level_symbol.mlir
+++ b/test/lit_tests/affinecfg_top_level_symbol.mlir
@@ -1,0 +1,27 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+module {
+  gpu.module @kernels {
+    gpu.func @select_index(%buffer: memref<?xi64>, %index: index,
+                           %enter: i1, %choose_doubled: i1,
+                           %value: i64) kernel {
+      scf.if %enter {
+        %doubled = arith.addi %index, %index : index
+        %selected = arith.select %choose_doubled, %doubled, %index : index
+        memref.store %value, %buffer[%selected] : memref<?xi64>
+      }
+
+      gpu.return
+    }
+  }
+}
+
+// CHECK-LABEL:   gpu.func @select_index(
+// CHECK-SAME:      %[[buffer:.*]]: memref<?xi64>, %[[index:.*]]: index,
+// CHECK-SAME:      %[[enter:.*]]: i1, %[[choose:.*]]: i1, %[[value:.*]]: i64) kernel {
+// CHECK:           %[[doubled:.*]] = arith.addi %[[index]], %[[index]] : index
+// CHECK:           %[[selected:.*]] = arith.select %[[choose]], %[[doubled]], %[[index]] : index
+// CHECK:           scf.if %[[enter]] {
+// CHECK:             affine.store %[[value]], %[[buffer]]{{\[}}symbol(%[[selected]])] : memref<?xi64>
+// CHECK:           }
+// CHECK:           gpu.return


### PR DESCRIPTION
Fix #2795 

`AffineApplyNormalizer::fix` turns a value into an affine symbol by cloning it next to its operands. It now carries a `needTopLevel` down the operand walk, set from `!affine::isValidSymbol(v, scope)`. A value that only the top level of the scope can hold, such as an `arith.select` on an `i1` condition or an `index_cast` off an integer, hoists its operands out with it instead of being cloned next to one still sitting inside a nested region.