### PR TITLE
Move each write and its feeding slice into one thread-zero if

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1055,6 +1055,12 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
 ///     C'()
 ///   }
 /// }
+static Operation *ancestorOpInBlock(Operation *op, Block *block) {
+  while (op && op->getBlock() != block)
+    op = op->getParentOp();
+  return op;
+}
+
 struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
   using OpRewritePattern<scf::ParallelOp>::OpRewritePattern;
 
@@ -1078,29 +1084,6 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
       return failure();
     }
 
-    // Handle ops before the parallel
-    scf::IfOp ifOp = nullptr;
-    auto getIf = [&]() {
-      if (!ifOp) {
-        auto zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-        Value cond;
-        for (unsigned i = 0; i < innerBlock->getNumArguments(); i++) {
-          auto threadId = innerBlock->getArgument(i);
-          auto threadCond = arith::CmpIOp::create(
-              rewriter, loc, arith::CmpIPredicate::eq, threadId, zero);
-          if (i == 0)
-            cond = threadCond.getResult();
-          else
-            cond = arith::AndIOp::create(rewriter, loc, threadCond, cond)
-                       .getResult();
-        }
-        ifOp = scf::IfOp::create(rewriter, loc, cond);
-        mlir::enzymexla::BarrierOp::create(rewriter, loc,
-                                           innerBlock->getArguments());
-        rewriter.setInsertionPoint(ifOp);
-      }
-    };
-
     // Two things read values of this block from outside the inner parallel's
     // body, where moving their computation inside cannot rewrite them: the
     // parallel's own bounds, and the block's terminator -- which, when the
@@ -1109,6 +1092,26 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
     // Only the uses within the body are replaced, so erasing what those read
     // leaves them pointing at a corpse. They, and everything they are in turn
     // computed from in this block, have to stay where they are.
+    // This application owns the ops between the previous sibling parallel
+    // and pop, and between pop and the next sibling parallel: everything
+    // before that sibling precedes it in program order, so it is that
+    // parallel's application that may move it, and likewise after.
+    auto end = outerBlock->getTerminator()->getIterator();
+    auto walkBegin = outerBlock->begin();
+    for (auto it = pop->getIterator(); it != outerBlock->begin();) {
+      --it;
+      if (isa<scf::ParallelOp>(&*it)) {
+        walkBegin = std::next(it);
+        break;
+      }
+    }
+    auto walkEnd = end;
+    for (auto it = std::next(pop->getIterator()); it != end; ++it)
+      if (isa<scf::ParallelOp>(&*it)) {
+        walkEnd = it;
+        break;
+      }
+
     DenseSet<Operation *> pinned;
     {
       SmallVector<Value> todo(pop->getOperands().begin(),
@@ -1129,66 +1132,142 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
       // leaving everything in place is not: the greedy driver would rescan
       // for ever.
       bool anyWork = false;
-      for (Operation &op : *outerBlock)
-        if (&op != pop.getOperation() && &op != outerBlock->getTerminator() &&
-            !isa<memref::AllocaOp, LLVM::AllocaOp>(&op) && !pinned.count(&op))
+      for (auto it = walkBegin; &*it != pop.getOperation(); ++it)
+        if (!isa<memref::AllocaOp, LLVM::AllocaOp>(&*it) && !pinned.count(&*it))
+          anyWork = true;
+      for (auto it = std::next(pop->getIterator()); it != walkEnd; ++it)
+        if (!isa<memref::AllocaOp, LLVM::AllocaOp>(&*it) && !pinned.count(&*it))
           anyWork = true;
       if (!anyWork)
         return rewriter.notifyMatchFailure(
             pop, "every op beside the parallel computes its bounds");
     }
 
+    // Handle ops before the parallel, in three traversals. First, in block
+    // order: the ops with write effects must run once, in a thread-zero if.
+    llvm::SetVector<Operation *> needsIf;
+    for (auto it = walkBegin; &*it != pop.getOperation(); ++it) {
+      Operation &op = *it;
+      if (pinned.count(&op))
+        continue;
+      if (it == end)
+        llvm_unreachable("Impossible");
+      if (isa<memref::AllocaOp, LLVM::AllocaOp>(&op))
+        continue;
+      SmallVector<MemoryEffects::EffectInstance> effects;
+      collectEffects(&op, effects, /*ignoreBarriers*/ false);
+      if (hasEffect<MemoryEffects::Allocate>(effects))
+        llvm_unreachable("??");
+      if (hasEffect<MemoryEffects::Free>(effects))
+        llvm_unreachable("??");
+      if (hasEffect<MemoryEffects::Write>(effects))
+        needsIf.insert(&op);
+    }
+
+    // Second, in reverse order from the parallel: an op whose value feeds
+    // the if runs in it too, so the guarded ops read what they read at their
+    // original position.
+    llvm::SetVector<Operation *> feedsIf;
+    for (auto it = pop->getIterator(); it != walkBegin;) {
+      --it;
+      Operation &op = *it;
+      if (pinned.count(&op) || isa<memref::AllocaOp, LLVM::AllocaOp>(&op) ||
+          needsIf.contains(&op))
+        continue;
+      for (Value res : op.getResults())
+        for (Operation *user : res.getUsers()) {
+          Operation *anc = ancestorOpInBlock(user, outerBlock);
+          if (anc && (needsIf.contains(anc) || feedsIf.contains(anc))) {
+            feedsIf.insert(&op);
+            break;
+          }
+        }
+    }
+
+    // A moved value used outside the if is recomputed after it, and so is
+    // every moved value such a recomputation reads in turn.
+    llvm::DenseSet<Operation *> needClone;
+    for (auto it = pop->getIterator(); it != walkBegin;) {
+      --it;
+      Operation &op = *it;
+      if (!feedsIf.contains(&op))
+        continue;
+      for (Operation *user : op.getUsers()) {
+        Operation *anc = ancestorOpInBlock(user, outerBlock);
+        if (!anc || (!needsIf.contains(anc) && !feedsIf.contains(anc)) ||
+            needClone.count(anc)) {
+          needClone.insert(&op);
+          break;
+        }
+      }
+    }
+
+    // Third: recompute and forward what the parallel's body reads, then
+    // move the guarded slice into the if, in original order.
     rewriter.setInsertionPointToStart(innerBlock);
-    auto it = outerBlock->begin();
-    auto end = outerBlock->getTerminator()->getIterator();
+    scf::IfOp ifOp = nullptr;
+    if (!needsIf.empty()) {
+      Value cond;
+      for (unsigned i = 0; i < innerBlock->getNumArguments(); i++) {
+        auto threadId = innerBlock->getArgument(i);
+        auto threadCond =
+            arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
+                                  threadId, pop.getLowerBound()[i]);
+        if (i == 0)
+          cond = threadCond.getResult();
+        else
+          cond = arith::AndIOp::create(rewriter, loc, threadCond, cond)
+                     .getResult();
+      }
+      ifOp = scf::IfOp::create(rewriter, loc, cond);
+      mlir::enzymexla::BarrierOp::create(rewriter, loc,
+                                         innerBlock->getArguments());
+    }
     SmallVector<Operation *> toErase;
     IRMapping mapping;
-    for (; &*it != pop.getOperation(); ++it) {
+    for (auto it = walkBegin; &*it != pop.getOperation(); ++it) {
       Operation &op = *it;
-      Operation *newOp;
-      if (pinned.count(&op)) {
+      if (pinned.count(&op) || isa<memref::AllocaOp, LLVM::AllocaOp>(&op))
         continue;
-      } else if (isa<scf::ParallelOp>(&op)) {
-        llvm_unreachable("Unhandled case");
-        break;
-      } else if (it == end) {
-        llvm_unreachable("Impossible");
-        continue;
-      } else if (auto alloca = dyn_cast<memref::AllocaOp>(&op)) {
-        continue;
-      } else if (auto alloca = dyn_cast<LLVM::AllocaOp>(&op)) {
-        continue;
-      } else {
-        mlir::OpBuilder::InsertionGuard guard(rewriter);
-        SmallVector<MemoryEffects::EffectInstance> effects;
-        collectEffects(&op, effects, /*ignoreBarriers*/ false);
-        if (effects.empty()) {
-        } else if (hasEffect<MemoryEffects::Allocate>(effects)) {
-          llvm_unreachable("??");
-        } else if (hasEffect<MemoryEffects::Free>(effects)) {
-          llvm_unreachable("??");
-        } else if (hasEffect<MemoryEffects::Write>(effects)) {
-          getIf();
-          assert(ifOp);
-          rewriter.setInsertionPoint(ifOp.thenBlock()->getTerminator());
-          // TODO currently we assume that ops with write effects will have no
-          // uses - we have to introduce shared mem otherwise
-          if (!op.use_empty()) {
+      if (needsIf.contains(&op)) {
+        // TODO currently we assume that ops with write effects will have no
+        // uses outside the if - we have to introduce shared mem otherwise
+        for (Operation *user : op.getUsers()) {
+          Operation *anc = ancestorOpInBlock(user, outerBlock);
+          if (!anc || (!needsIf.contains(anc) && !feedsIf.contains(anc)) ||
+              needClone.count(anc))
             llvm_unreachable("could not fix parallel fusion");
-          }
-        } else if (hasEffect<MemoryEffects::Read>(effects)) {
-          // Reads-only ops are legal to parallelize
         }
-        newOp = rewriter.clone(op, mapping);
+        continue;
       }
+      if (feedsIf.contains(&op)) {
+        if (!needClone.count(&op))
+          continue;
+        Operation *newOp = rewriter.clone(op, mapping);
+        for (auto [oldRes, newRes] :
+             llvm::zip(op.getResults(), newOp->getResults()))
+          rewriter.replaceUsesWithIf(oldRes, newRes, [&](OpOperand &use) {
+            Operation *anc = ancestorOpInBlock(use.getOwner(), outerBlock);
+            return !anc || (!needsIf.contains(anc) && !feedsIf.contains(anc));
+          });
+        continue;
+      }
+      Operation *newOp = rewriter.clone(op, mapping);
       rewriter.replaceOpUsesWithinBlock(&op, newOp->getResults(), innerBlock);
       toErase.push_back(&op);
     }
-    it++;
+    if (ifOp)
+      for (auto it = walkBegin; &*it != pop.getOperation();) {
+        Operation &op = *it;
+        ++it;
+        if (needsIf.contains(&op) || feedsIf.contains(&op))
+          rewriter.moveOpBefore(&op, ifOp.thenBlock()->getTerminator());
+      }
+    auto it = std::next(pop->getIterator());
 
     // Handle ops after the parallel
     bool anyAfter = false;
-    for (auto probe = it; probe != end; ++probe)
+    for (auto probe = it; probe != walkEnd; ++probe)
       if (!pinned.count(&*probe))
         anyAfter = true;
     if (anyAfter) {
@@ -1209,7 +1288,7 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
       }
       auto ifOp = scf::IfOp::create(rewriter, loc, condition);
       rewriter.setInsertionPointToStart(ifOp.thenBlock());
-      for (; it != end; ++it) {
+      for (; it != walkEnd; ++it) {
         Operation &op = *it;
         if (pinned.count(&op)) {
           continue;

--- a/test/lit_tests/lowering/parallelize-multi-parallel.mlir
+++ b/test/lit_tests/lowering/parallelize-multi-parallel.mlir
@@ -1,0 +1,78 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// With several sibling parallels in one block, each application only owns
+// the ops between the previous sibling parallel and its own, and between
+// its own and the next: the zero store belongs to the first parallel and
+// must precede its body, and the middle load and store belong between the
+// two -- moving either into the wrong parallel would reorder them around
+// the other parallel's body.
+
+module {
+  func.func @f(%in: memref<?xf64, 1>, %out: memref<?xf64, 1>, %out2: memref<?xf64, 1>) -> index {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c256 = arith.constant 256 : index
+    %cst = arith.constant 0.000000e+00 : f64
+    %r = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c256, %c1, %c1) ({
+      scf.parallel (%t) = (%c0) to (%c256) step (%c1) {
+        %alloca = memref.alloca() : memref<4xf64>
+        %g = arith.cmpi slt, %t, %c3 : index
+        scf.if %g {
+          memref.store %cst, %alloca[%c0] : memref<4xf64>
+          scf.parallel (%q) = (%c0) to (%c2) step (%c1) {
+            %v = memref.load %in[%q] : memref<?xf64, 1>
+            memref.store %v, %alloca[%q] : memref<4xf64>
+            scf.reduce
+          }
+          %m = memref.load %alloca[%c0] : memref<4xf64>
+          memref.store %m, %out2[%t] : memref<?xf64, 1>
+          scf.parallel (%q) = (%c0) to (%c2) step (%c1) {
+            %v = memref.load %alloca[%q] : memref<4xf64>
+            %i = arith.muli %t, %c2 : index
+            %j = arith.addi %i, %q : index
+            memref.store %v, %out[%j] : memref<?xf64, 1>
+            scf.reduce
+          }
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return %r : index
+  }
+}
+
+// CHECK-LABEL: func.func @f(
+// CHECK-SAME: %[[IN:[a-z0-9]+]]: memref<?xf64, 1>, %[[OUT:[a-z0-9]+]]: memref<?xf64, 1>, %[[OUT2:[a-z0-9]+]]: memref<?xf64, 1>
+// CHECK: gpu.launch
+// CHECK: %[[BID:[a-z0-9_]+]] = gpu.block_id x
+// CHECK-NEXT: %[[A:[a-z0-9_]+]] = memref.alloca() : memref<4xf64>
+// CHECK-NEXT: %[[G:[a-z0-9_]+]] = arith.cmpi slt, %[[BID]], %[[C3:[a-z0-9_]+]] : index
+// CHECK-NEXT: scf.if %[[G]] {
+// CHECK-NEXT: scf.parallel (%[[Q1:[a-z0-9_]+]]) = (%[[C0:[a-z0-9_]+]]) to (%[[C2:[a-z0-9_]+]]) step (%[[C1:[a-z0-9_]+]]) {
+// CHECK-NEXT: %[[T1:[a-z0-9_]+]] = arith.cmpi eq, %[[Q1]], %[[C0]] : index
+// CHECK-NEXT: scf.if %[[T1]] {
+// CHECK-NEXT: memref.store %[[CST:[a-z0-9_]+]], %[[A]][%[[C0]]] : memref<4xf64>
+// CHECK-NEXT: }
+// CHECK-NEXT: {{(gpu.barrier|"enzymexla.barrier")}}
+// CHECK-NEXT: %[[V1:[a-z0-9_]+]] = memref.load %[[IN]][%[[Q1]]] : memref<?xf64, 1>
+// CHECK-NEXT: memref.store %[[V1]], %[[A]][%[[Q1]]] : memref<4xf64>
+// CHECK-NEXT: scf.reduce
+// CHECK-NEXT: }
+// CHECK-NEXT: scf.parallel (%[[Q2:[a-z0-9_]+]]) = (%[[C0]]) to (%[[C2]]) step (%[[C1]]) {
+// CHECK-NEXT: %[[T2:[a-z0-9_]+]] = arith.cmpi eq, %[[Q2]], %[[C0]] : index
+// CHECK-NEXT: scf.if %[[T2]] {
+// CHECK-NEXT: %[[M:[a-z0-9_]+]] = memref.load %[[A]][%[[C0]]] : memref<4xf64>
+// CHECK-NEXT: memref.store %[[M]], %[[OUT2]][%[[BID]]] : memref<?xf64, 1>
+// CHECK-NEXT: }
+// CHECK-NEXT: {{(gpu.barrier|"enzymexla.barrier")}}
+// CHECK-NEXT: %[[V2:[a-z0-9_]+]] = memref.load %[[A]][%[[Q2]]] : memref<4xf64>
+// CHECK-NEXT: %[[MUL:[a-z0-9_]+]] = arith.muli %[[BID]], %[[C2]] : index
+// CHECK-NEXT: %[[J:[a-z0-9_]+]] = arith.addi %[[MUL]], %[[Q2]] : index
+// CHECK-NEXT: memref.store %[[V2]], %[[OUT]][%[[J]]] : memref<?xf64, 1>
+// CHECK-NEXT: scf.reduce
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: gpu.terminator

--- a/test/lit_tests/lowering/parallelize-store-order.mlir
+++ b/test/lit_tests/lowering/parallelize-store-order.mlir
@@ -1,0 +1,63 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// Write ops moved into the inner parallel land in a thread-zero if, together
+// with everything that feeds them, in original program order. The if used to
+// collect only the writes while their operands were cloned after it, leaving
+// a use above its def when a store's operand was computed between two writes.
+
+module {
+  func.func @f(%in: memref<?xf64, 1>, %out: memref<?xf64, 1>, %s: index) -> index {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c256 = arith.constant 256 : index
+    %cst = arith.constant 0.000000e+00 : f64
+    %r = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c256, %c1, %c1) ({
+      scf.parallel (%e) = (%c0) to (%c3) step (%c1) {
+        %alloca = memref.alloca() : memref<5xf64>
+        memref.store %cst, %alloca[%c0] : memref<5xf64>
+        %sum = scf.for %q = %c0 to %c2 step %c1 iter_args(%acc = %cst) -> (f64) {
+          %v = memref.load %in[%q] : memref<?xf64, 1>
+          %a = arith.addf %acc, %v : f64
+          scf.yield %a : f64
+        }
+        memref.store %sum, %alloca[%c1] : memref<5xf64>
+        scf.parallel (%q) = (%c0) to (%c2) step (%c1) {
+          %v = memref.load %alloca[%q] : memref<5xf64>
+          %i = arith.muli %e, %c2 : index
+          %j = arith.addi %i, %q : index
+          memref.store %v, %out[%j] : memref<?xf64, 1>
+          scf.reduce
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return %r : index
+  }
+}
+
+// CHECK-LABEL: func.func @f(
+// CHECK-SAME: %[[IN:[a-z0-9]+]]: memref<?xf64, 1>, %[[OUT:[a-z0-9]+]]: memref<?xf64, 1>
+// CHECK: gpu.launch
+// CHECK: %[[BID:[a-z0-9_]+]] = gpu.block_id x
+// CHECK-NEXT: %[[ALLOCA:[a-z0-9_]+]] = memref.alloca() : memref<5xf64, 5>
+// CHECK-NEXT: %[[BUF:[a-z0-9_]+]] = memref.memory_space_cast %[[ALLOCA]] : memref<5xf64, 5> to memref<5xf64>
+// CHECK-NEXT: %[[TID:[a-z0-9_]+]] = gpu.thread_id x
+// CHECK-NEXT: %[[COND:[a-z0-9_]+]] = arith.cmpi eq, %[[TID]], %[[C0:[a-z0-9_]+]] : index
+// CHECK-NEXT: scf.if %[[COND]] {
+// CHECK-NEXT: memref.store %[[CST:[a-z0-9_]+]], %[[BUF]][%[[C0]]] : memref<5xf64>
+// CHECK-NEXT: %[[SUM:[a-z0-9_]+]] = scf.for %[[Q:[a-z0-9_]+]] = %[[C0]] to %[[C2:[a-z0-9_]+]] step %[[C1:[a-z0-9_]+]] iter_args(%[[ACC:[a-z0-9_]+]] = %[[CST]]) -> (f64) {
+// CHECK-NEXT: %[[V:[a-z0-9_]+]] = memref.load %[[IN]][%[[Q]]] : memref<?xf64, 1>
+// CHECK-NEXT: %[[ADD:[a-z0-9_]+]] = arith.addf %[[ACC]], %[[V]] : f64
+// CHECK-NEXT: scf.yield %[[ADD]] : f64
+// CHECK-NEXT: }
+// CHECK-NEXT: memref.store %[[SUM]], %[[BUF]][%[[C1]]] : memref<5xf64>
+// CHECK-NEXT: }
+// CHECK-NEXT: gpu.barrier
+// CHECK-NEXT: %[[L:[a-z0-9_]+]] = memref.load %[[BUF]][%[[TID]]] : memref<5xf64>
+// CHECK-NEXT: %[[MUL:[a-z0-9_]+]] = arith.muli %[[BID]], %[[C2]] : index
+// CHECK-NEXT: %[[IDX:[a-z0-9_]+]] = arith.addi %[[MUL]], %[[TID]] : index
+// CHECK-NEXT: memref.store %[[L]], %[[OUT]][%[[IDX]]] : memref<?xf64, 1>
+// CHECK-NEXT: gpu.terminator


### PR DESCRIPTION
Reworked per review: instead of patching the memoized-if placement, rebuild the guarded region in three traversals.

## The bug (unchanged)

`ParallelizeBlockOps` moves the ops beside an inner parallel into it, and write ops land in a thread-zero if. The if was memoized: every later write went into the *first* one, even a write whose operand is computed by ops cloned after it — leaving a use above its definition (`error: operand #0 does not dominate this use`, the crash behind the `PAHcurlHdivMassApply2D` family).

## The new fix

Three traversals, no cloning until the shape is decided:

1. **Forward**, in block order: collect the ops that must run once — those with write effects — into a set vector.
2. **Reverse**: collect every op whose value feeds the first set, directly or transitively, into a second set vector, so the guarded ops read exactly what they read at their original position.
3. **Move** both sets into a **single** thread-zero if, in original program order, followed by one barrier. A moved value used outside the if is recomputed after it — and so is every moved value such a recomputation reads in turn (the recomputables are exactly the non-write members, that's what kept them out of the first set).

Compared to the old interleaved-ifs shape this emits one if and one barrier for the whole prefix instead of one pair per write run.

One more latent ordering bug fixed en route (exposed by the rework, present before it): an application walked from the **block start** to its parallel, so ops belonging to an *earlier* sibling parallel could be moved into a *later* one and run out of order (a zero-initialization ended up executing after the initialization it was supposed to precede). An application now only owns the ops between the previous sibling parallel and its own.

## Verified

- `parallelize-store-order.mlir` updated for the new shape: one `if (tid==0)` holding store → reduction loop → store in order, then the barrier.
- End-to-end reproducers exact vs vanilla (v1, the `PAHcurlHdivMassApply2D` MWE checksum, the 288-config sweep, the separate-TU reproducer).
- Real MFEM `Hcurl/Hdiv PA Coefficient` unchanged at 42/43 with this stacked on the other open fixes; full lit suite green.