### PR TITLE
Barrier before ops moved to after an inner parallel

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1187,9 +1187,15 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
     it++;
 
     // Handle ops after the parallel
-    {
-      auto zeroindex = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    bool anyAfter = false;
+    for (auto probe = it; probe != end; ++probe)
+      if (!pinned.count(&*probe))
+        anyAfter = true;
+    if (anyAfter) {
       rewriter.setInsertionPoint(innerBlock->getTerminator());
+      mlir::enzymexla::BarrierOp::create(rewriter, loc,
+                                         innerBlock->getArguments());
+      auto zeroindex = arith::ConstantIndexOp::create(rewriter, loc, 0);
       auto cmpOp =
           arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq,
                                 zeroindex, innerBlock->getArgument(0));

--- a/test/lit_tests/lowering/parallelize-trailing-barrier.mlir
+++ b/test/lit_tests/lowering/parallelize-trailing-barrier.mlir
@@ -1,0 +1,45 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+
+// Ops that follow an inner parallel read what every lane wrote, so when they
+// are moved into the parallel under a thread-zero if, a barrier must precede
+// the if: without one thread zero races ahead of the other lanes' stores, and
+// when the parallel is later serialized the guarded ops run on the first
+// iteration, before the remaining iterations have stored their values.
+
+module {
+  func.func @f(%in: memref<?xf64, 1>, %out: memref<?xf64, 1>) -> index {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c256 = arith.constant 256 : index
+    %r = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c256, %c1, %c1) ({
+      scf.parallel (%e) = (%c0) to (%c3) step (%c1) {
+        %alloca = memref.alloca() : memref<4xf64>
+        scf.parallel (%q) = (%c0) to (%c2) step (%c1) {
+          %v = memref.load %in[%q] : memref<?xf64, 1>
+          memref.store %v, %alloca[%q] : memref<4xf64>
+          scf.reduce
+        }
+        %a = memref.load %alloca[%c0] : memref<4xf64>
+        %b = memref.load %alloca[%c1] : memref<4xf64>
+        %s = arith.addf %a, %b : f64
+        memref.store %s, %out[%e] : memref<?xf64, 1>
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return %r : index
+  }
+}
+
+// CHECK-LABEL: func.func @f(
+// CHECK: %[[TID:.+]] = gpu.thread_id x
+// CHECK: memref.store
+// CHECK-NEXT: gpu.barrier
+// CHECK-NEXT: %[[COND:.+]] = arith.cmpi eq, %[[TID]]
+// CHECK-NEXT: scf.if %[[COND]]
+// CHECK: memref.load
+// CHECK: memref.load
+// CHECK: arith.addf
+// CHECK: memref.store


### PR DESCRIPTION
Part 1 of 2 fixing the MFEM Hcurl/Hdiv wrong-values family (with #2884; both are needed).

`ParallelizeBlockOps` moves the ops surrounding an inner parallel into it. Ops that *precede* the parallel get `if (tid==0) { ... }; barrier` — correct. Ops that *follow* it were placed in a thread-zero if at the end of the body with **no barrier before it**, though the pattern's own doc comment shows `A'() barrier B() barrier C'()`. The trailing ops read what every lane wrote:

- If the parallel is thread-mapped, thread zero races ahead of the other lanes' stores.
- If the parallel is later serialized, the guarded ops run on the **first iteration** — deterministically before the remaining iterations store the values they read.

The serialized case is how MFEM's `PAHcurlHdivMassApply2D` miscompiled: the reduction-sum + output store ran at `q==0`, so every contribution except lane 0's was dropped (reproduced end-to-end in a 20-line kernel: expected `10`, got `6` = the partial sum at iteration 0).

Also skip creating the trailing if when there are no trailing ops, so no barrier is emitted for nothing.

Test: `parallelize-trailing-barrier.mlir` — fully-mapped kernel; checks `gpu.barrier` directly between the lanes' store and the thread-zero if holding the trailing reduce+store.
