### PR TITLE
Serialize barrier-carrying parallels by distributing at the barrier

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1914,7 +1914,15 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     }
     rewriter.eraseOp(yieldOp);
 
+    // A barrier nested in a parallel op that remains after mapping
+    // synchronizes that parallel's iterations, not the launch's threads; it
+    // is serialized together with its parallel by distributing the loop at
+    // the barrier, which needs the enzymexla barrier and its operands.
     launchBlock->walk([&](mlir::enzymexla::BarrierOp op) {
+      for (Operation *parent = op->getParentOp(); parent != launchOp;
+           parent = parent->getParentOp())
+        if (isa<scf::ParallelOp>(parent))
+          return;
       rewriter.setInsertionPoint(op);
       rewriter.replaceOpWithNewOp<gpu::BarrierOp>(op);
     });

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -154,7 +154,9 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       if (getenv("REACTANT_OMP")) {
         pass_pipeline += ",convert-scf-to-openmp,";
       } else {
-        pass_pipeline += ",parallel-serialization,";
+        // Serializing a parallel that contains barriers is only correct
+        // once the loop is distributed at each barrier.
+        pass_pipeline += ",cpuify{method=distribute},parallel-serialization,";
       }
       pass_pipeline += "canonicalize-parallel,hoist-allocas,convert-polygeist-to-llvm{backend=";
       pass_pipeline += backend;
@@ -219,7 +221,9 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       if (getenv("REACTANT_OMP")) {
         pass_pipeline += ",convert-scf-to-openmp,";
       } else {
-	      pass_pipeline += ",parallel-serialization,";
+        // Serializing a parallel that contains barriers is only correct
+        // once the loop is distributed at each barrier.
+        pass_pipeline += ",cpuify{method=distribute},parallel-serialization,";
       }
       pass_pipeline += "canonicalize-parallel,hoist-allocas,convert-polygeist-to-llvm{backend=";
       pass_pipeline += backend;

--- a/test/lit_tests/lowering/serialize-inner-barrier.mlir
+++ b/test/lit_tests/lowering/serialize-inner-barrier.mlir
@@ -1,0 +1,59 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1,cpuify{method=distribute},parallel-serialization,canonicalize)" | FileCheck %s -check-prefix=SERIAL
+
+// A parallel op left inside the launch after mapping runs within one thread.
+// A barrier inside it synchronizes that parallel's own iterations, not the
+// launch's threads: it must stay an enzymexla.barrier so that cpuify can
+// distribute the loop at it before it is serialized. Converting it to
+// gpu.barrier both loses that structure -- naive serialization then runs
+// thread-zero-guarded trailing ops on the first iteration, before the other
+// iterations have executed -- and emits a divergent block-wide sync.
+
+module {
+  func.func @f(%in: memref<?xf64, 1>, %out: memref<?xf64, 1>) -> index {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c256 = arith.constant 256 : index
+    %r = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c256, %c1, %c1) ({
+      scf.parallel (%t) = (%c0) to (%c256) step (%c1) {
+        %alloca = memref.alloca() : memref<4xf64>
+        %g = arith.cmpi slt, %t, %c3 : index
+        scf.if %g {
+          scf.parallel (%q) = (%c0) to (%c2) step (%c1) {
+            %v = memref.load %in[%q] : memref<?xf64, 1>
+            memref.store %v, %alloca[%q] : memref<4xf64>
+            scf.reduce
+          }
+          %a = memref.load %alloca[%c0] : memref<4xf64>
+          %b = memref.load %alloca[%c1] : memref<4xf64>
+          %s = arith.addf %a, %b : f64
+          memref.store %s, %out[%t] : memref<?xf64, 1>
+        }
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return %r : index
+  }
+}
+
+// CHECK-LABEL: func.func @f(
+// CHECK: scf.parallel (%[[Q:.+]]) =
+// CHECK: memref.store
+// CHECK-NEXT: "enzymexla.barrier"(%[[Q]])
+// CHECK: scf.if
+// CHECK-NOT: gpu.barrier
+
+// The distributed form runs every iteration's store, then the guarded sum.
+// SERIAL-LABEL: func.func @f(
+// SERIAL: scf.for %[[I:.+]] = %c0 to %c2
+// SERIAL: memref.store
+// SERIAL-NEXT: }
+// SERIAL: scf.for
+// SERIAL: scf.if
+// SERIAL: %[[A:.+]] = memref.load
+// SERIAL: %[[B:.+]] = memref.load
+// SERIAL: arith.addf %[[A]], %[[B]]
+// SERIAL: memref.store


### PR DESCRIPTION
Part 2 of 2 fixing the MFEM Hcurl/Hdiv wrong-values family (with #2883; both are needed).

## The bug

A parallel op left inside a `gpu.launch` after mapping (e.g. the per-element inner loops of a thread-per-element kernel) runs within a single thread. A barrier inside it — placed by the gpu1 normalization that merges sibling parallels — synchronizes that parallel's own iterations, not the launch's threads. But `ParallelToGPULaunch` blanket-converted **every** `enzymexla.barrier` in the launch to `gpu.barrier`, and `parallel-serialization` then turned the parallel into a plain `scf.for` with the `gpu.barrier` left inline. Result:

- thread-zero-guarded ops ran on the first iteration, before the remaining iterations computed the values they read (wrong values), and
- the barrier became a block-wide sync inside divergent control flow (deadlock hazard).

## The fix

1. `ParallelToGPULaunch`: only convert barriers **not** nested in a remaining `scf.parallel`; those belong to their parallel and keep their operands.
2. Pipeline: run `cpuify{method=distribute}` (the existing Polygeist barrier-aware machinery) before `parallel-serialization`, so barrier-carrying loops are distributed at their barriers: every iteration of the segment before the barrier completes before the segment after it starts. Applied to both the native and xla paths.

## Verified

- New lit test `serialize-inner-barrier.mlir`: gpu1 keeps `enzymexla.barrier` inside the unmapped inner parallel (and emits no gpu.barrier); gpu1+cpuify+serialization yields the fissioned loops with the guarded sum after the store loop.
- Full lit suite green (including the existing cpuify suite).
- The standalone `PAHcurlHdivMassApply2D` reproducer, wrong since it first compiled, now matches vanilla exactly (checksum 761.6123046875, all elements). Full MFEM suite re-run in progress; will report on the PR.
