### PR TITLE
Drop kernels that were never resolved to a device body

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -526,6 +526,24 @@ struct SplitParallelOp : public OpRewritePattern<enzymexla::GPUWrapperOp> {
 
     auto loc = pop->getLoc();
 
+    // A wrapper still carrying a host target holds a kernel that was never
+    // resolved to a device body: its content is a call to an external device
+    // stub, and the outlined module would inherit the host chip. No block
+    // size makes that compilable, including an exact shape match.
+    if (auto arch =
+            dyn_cast_or_null<StringAttr>(wrapper->getAttr("target_cpu")))
+      if (!arch.getValue().starts_with("sm_") &&
+          !arch.getValue().starts_with("gfx")) {
+        wrapper.emitError()
+            << "kernel with host target '" << arch.getValue()
+            << "' was not resolved to a device body; the kernel is dropped";
+        rewriter.setInsertionPoint(wrapper);
+        auto err = arith::ConstantIndexOp::create(
+            rewriter, loc, CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES);
+        rewriter.replaceOp(wrapper, err->getResults());
+        return success();
+      }
+
     int curRegion = 0;
     llvm::SmallSet<int, 6> emittedBlockSizes;
     std::vector<Attribute> descs;

--- a/test/lit_tests/lowering/drop-unresolved-kernel.mlir
+++ b/test/lit_tests/lowering/drop-unresolved-kernel.mlir
@@ -1,0 +1,34 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" --verify-diagnostics | FileCheck %s
+
+// A wrapper still carrying a host target holds a kernel that was never
+// resolved to a device body: its content is a call to an external device
+// stub, and an outlined module would inherit the host chip and fail ptxas.
+// Even when the parallel's shape matches the wrapper's launch bounds -- it
+// always does, both were built from the same launch configuration -- the
+// kernel must be dropped, with an error, not emitted.
+
+module {
+  llvm.func @"reactant$stub"(i32)
+  func.func @f() -> index {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c3 = arith.constant 3 : index
+    %c24 = arith.constant 24 : index
+    // expected-error@below {{kernel with host target 'x86-64' was not resolved to a device body; the kernel is dropped}}
+    %r = "enzymexla.gpu_wrapper"(%c3, %c1, %c1, %c24, %c24, %c1) ({
+      scf.parallel (%bx, %tx, %ty) = (%c0, %c0, %c0) to (%c3, %c24, %c24) step (%c1, %c1, %c1) {
+        %i = arith.index_cast %tx : index to i32
+        llvm.call @"reactant$stub"(%i) : (i32) -> ()
+        scf.reduce
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) {target_cpu = "x86-64"} : (index, index, index, index, index, index) -> index
+    return %r : index
+  }
+}
+
+// CHECK-LABEL: func.func @f(
+// CHECK: %[[ERR:.+]] = arith.constant 701
+// CHECK-NOT: gpu.launch
+// CHECK-NOT: enzymexla.gpu_wrapper
+// CHECK: return %[[ERR]]


### PR DESCRIPTION
Fixes a compile regression from #2872 on 33 MFEM tmop TUs (e.g. `fem/tmop/metrics/302.cpp`).

## The regression

A `gpu_wrapper` whose kernel launch was never resolved to a device body (the device instantiation is absent from the `.re_export`) holds only a call to an external `reactant$__device_stub__*` declaration, and carries the **host** function's target attributes (`target_cpu = "x86-64"`).

Before #2872 these wrappers failed every block-size split *and* the 6-bound equality, so they took the loud-error drop path and the TU compiled (the kernel is a genuinely never-launched instantiation). #2872's shape matching now succeeds on them — trivially so: the parallel's bounds and the wrapper's launch bounds were built from the same launch configuration, so they always match. The "kernel" is then emitted, the outlined `gpu.module` inherits the host chip, and compilation dies with:

```
ptxas fatal   : Value 'x86-64' is not defined for option 'gpu-name'
fatal error: error in backend: 64-bit code requested on a subtarget that doesn't support it!
```

Bisected across saved libRaise builds: main-before-#2872 compiles `302.cpp`, main+#2872 fails, all later changes irrelevant.

## The fix

In `SplitParallelOp`, before looking for any split: if the wrapper's `target_cpu` is neither `sm_*` nor `gfx*`, the kernel cannot be compiled for the GPU under any block size — emit the error and take the existing drop path (`CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES` at the launch site), same as the pre-#2872 outcome but with a diagnostic naming the real cause.

## Verified

- New lit test `drop-unresolved-kernel.mlir` (exact-shape-matching wrapper with host target and external stub call → error + constant, no launch).
- `302.cpp` compiles again (rc=0, three "not resolved to a device body" diagnostics); resolved-kernel path unaffected (Hcurl reproducer still exact-matches vanilla).
- Full lit suite green.