### PR TITLE
Fold reading the constant high half of a packed launch dimension

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
@@ -526,6 +526,45 @@ public:
   }
 };
 
+// The high half of a packed pair of launch dimensions is a constant: the
+// import spells dim3(x, 1) as ori(extui(x : i32 to i64), 1 << 32) and reads
+// the second field back as shrui(packed, 32). Every bit the shift keeps
+// comes from the constant, so the read is that constant, but no upstream
+// fold sees through the pack. Leaving it opaque makes the launch bound look
+// like a runtime value.
+class ShrUIOfPackedHigh final : public OpRewritePattern<arith::ShRUIOp> {
+public:
+  using OpRewritePattern<arith::ShRUIOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::ShRUIOp op,
+                                PatternRewriter &rewriter) const override {
+    IntegerAttr shiftAttr;
+    if (!matchPattern(op.getRhs(), m_Constant(&shiftAttr)))
+      return failure();
+    auto ori = op.getLhs().getDefiningOp<arith::OrIOp>();
+    if (!ori)
+      return failure();
+    Value other;
+    IntegerAttr cst;
+    if (matchPattern(ori.getRhs(), m_Constant(&cst)))
+      other = ori.getLhs();
+    else if (matchPattern(ori.getLhs(), m_Constant(&cst)))
+      other = ori.getRhs();
+    else
+      return failure();
+    auto ext = other.getDefiningOp<arith::ExtUIOp>();
+    if (!ext)
+      return failure();
+    unsigned srcWidth = ext.getIn().getType().getIntOrFloatBitWidth();
+    const APInt &shift = shiftAttr.getValue();
+    if (shift.ult(srcWidth) || shift.uge(cst.getValue().getBitWidth()))
+      return failure();
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+        op, rewriter.getIntegerAttr(op.getType(), cst.getValue().lshr(shift)));
+    return success();
+  }
+};
+
 class DivUIOfIndexUI final : public OpRewritePattern<arith::DivUIOp> {
 public:
   using OpRewritePattern<arith::DivUIOp>::OpRewritePattern;
@@ -1346,8 +1385,8 @@ struct CanonicalizeLoopsPass
 
 void mlir::enzyme::addSingleIter(RewritePatternSet &patterns,
                                  MLIRContext *ctx) {
-  patterns
-      .add<RemoveAffineParallelSingleIter, ExtUIOfIndexUI, TruncIOfIndexUI,
-           ShrUIOfIndexUI, DivUIOfIndexUI, DivMul, AddIOfIndexUI, SubIOfIndexUI,
-           MulIOfIndexUI, ShLIOfIndexUI, AddIOfDoubleIndex, ToRem>(ctx);
+  patterns.add<RemoveAffineParallelSingleIter, ExtUIOfIndexUI, TruncIOfIndexUI,
+               ShrUIOfIndexUI, ShrUIOfPackedHigh, DivUIOfIndexUI, DivMul,
+               AddIOfIndexUI, SubIOfIndexUI, MulIOfIndexUI, ShLIOfIndexUI,
+               AddIOfDoubleIndex, ToRem>(ctx);
 }

--- a/test/lit_tests/shrui-packed-high.mlir
+++ b/test/lit_tests/shrui-packed-high.mlir
@@ -1,0 +1,34 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(func.func(canonicalize-loops))" %s | FileCheck %s
+
+// The import spells a dim3(x, 1) launch configuration as
+// ori(extui(x : i32 to i64), 1 << 32) and reads the second field back as
+// shrui(packed, 32). Every bit the shift keeps comes from the constant, so
+// the read is that constant; leaving it opaque makes the launch bound look
+// like a runtime value and kernels lose their static block shape.
+
+func.func @high(%x: i32) -> i64 {
+  %c32 = arith.constant 32 : i64
+  %chigh = arith.constant 4294967296 : i64
+  %e = arith.extui %x : i32 to i64
+  %o = arith.ori %e, %chigh : i64
+  %s = arith.shrui %o, %c32 : i64
+  return %s : i64
+}
+
+// CHECK-LABEL: func.func @high(
+// CHECK: %[[C:.+]] = arith.constant 1 : i64
+// CHECK: return %[[C]]
+
+// The low half keeps its runtime value: a shift below the source width must
+// not fold.
+func.func @low(%x: i32) -> i64 {
+  %c16 = arith.constant 16 : i64
+  %chigh = arith.constant 4294967296 : i64
+  %e = arith.extui %x : i32 to i64
+  %o = arith.ori %e, %chigh : i64
+  %s = arith.shrui %o, %c16 : i64
+  return %s : i64
+}
+
+// CHECK-LABEL: func.func @low(
+// CHECK: arith.shrui


### PR DESCRIPTION
Every MFEM `forall`-launched kernel whose grid size is a runtime value currently loses its static block shape. The import spells the `dim3(GRID, 1)` launch configuration as

```mlir
%packed = arith.ori (arith.extui %grid : i32 to i64), 4294967296  // y = 1 packed in the high half
%gy     = arith.trunci (arith.shrui %packed, 32)                  // read back: provably 1
```

and nothing folds the read, so `grid.y` looks like a runtime value. The launch parallel then keeps a phantom second dimension, `createSplitOp` fails for every block size ("Failed to make kernel with exact dimension"), and the kernel takes the recorded-shape fallback: **one thread per block** (`known_block_size = 1,1,1`, grid = the flattened iteration space). Confirmed on `bilininteg_hcurlhdiv_kernels.cpp`: with the fold, wrappers go from `(gx, %phantom, 1, 256, 1, 1)` to `(gx, 1, 1, 256, 1, 1)` and the failed-split count drops accordingly.

The fold: `shrui(ori(extui(x : iN to iM), C), s) → C >> s` when `s >= N` (the shift discards every bit of `x`) — added to the `addSingleIter` family in CanonicalizeLoops, which runs in both `canonicalize-loops` and `affine-cfg`, well before the GPU mapping.

Test: `shrui-packed-high.mlir` — the high-half read folds to the constant; a shift below the source width does not fold.

Verified: full lit suite green; the Hcurl reproducers still match vanilla exactly.