### PR TITLE
Drop nneg when arith.extui's fold merges extension chains

### DIFF
--- a/test/lit_tests/extui-nneg-merge.mlir
+++ b/test/lit_tests/extui-nneg-merge.mlir
@@ -1,0 +1,29 @@
+// RUN: enzymexlamlir-opt --canonicalize %s | FileCheck %s
+
+// Merging extui(extui(x)) must not keep the outer op's nneg flag: the flag
+// asserts the SOURCE is non-negative as a signed value, and the merge changes
+// the source. extui nneg i8->i32 over extui i1->i8 is satisfied for every
+// bool byte, but the merged extui nneg i1->i32 is poison whenever the bool
+// is true -- LLVM then folds the bool to false wherever the merged value
+// flows, which is how MFEM's trialHcurl=true kernels lost their loop bounds.
+
+func.func @merge(%b: i1) -> i32 {
+  %w = arith.extui %b : i1 to i8
+  %r = arith.extui %w nneg : i8 to i32
+  return %r : i32
+}
+
+// CHECK-LABEL: func.func @merge(
+// CHECK-NOT: nneg
+// CHECK: arith.extui %{{.*}} : i1 to i32
+// CHECK-NOT: nneg
+
+// When the inner extension itself carries nneg, the merged one may keep it.
+func.func @keep(%v: i8) -> i64 {
+  %w = arith.extui %v nneg : i8 to i32
+  %r = arith.extui %w nneg : i32 to i64
+  return %r : i64
+}
+
+// CHECK-LABEL: func.func @keep(
+// CHECK: arith.extui %{{.*}} nneg : i8 to i64

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -202,6 +202,14 @@ sed -i.bak0 "s/cupti_driver_cbid/cupti/g" xla/backends/profiler/gpu/cupti_tracer
 sed -i.bak0 "s/patch_cmds = \\[/patch_cmds = \\[\\\"find . -type f -name config.bzl -exec sed -i.bak0 's\\/HAVE_LINK_H=1\\/HAVE_LINK_H=0\\/g' {} +\\\",/g" third_party/llvm/workspace.bzl
 """,
     """
+# arith.extui's fold merges extui(extui(x)) by swapping the outer op's source
+# while keeping its nneg flag. The flag asserts the source is non-negative as
+# a signed value, about which the outer flag says nothing once the source
+# changes: extui nneg i8->i32 over extui i1->i8 becomes extui nneg i1->i32,
+# poison whenever the bool is true. Keep nneg only if the inner ext had it.
+sed -i.bak0 "s/patch_cmds = \\[/patch_cmds = \\[\\\"sed -i.baknneg 's\\/auto lhs = getIn().getDefiningOp<ExtUIOp>()) {\\/auto lhs = getIn().getDefiningOp<ExtUIOp>()) { setNonNeg(lhs.getNonNeg());\\/' mlir\\/lib\\/Dialect\\/Arith\\/IR\\/ArithOps.cpp\\\",/g" third_party/llvm/workspace.bzl
+""",
+    """
 sed -i.bak0 "s/patch_cmds = \\[/patch_cmds = \\[\\\"find . -type f -name config.bzl -exec sed -i.bak0 's\\/LLVM_ENABLE_THREADS=1\\/LLVM_ENABLE_THREADS=0\\/g' {} +\\\",/g" third_party/llvm/workspace.bzl
 """,
     """


### PR DESCRIPTION
This is the actual root cause of the long-standing MFEM Hcurl/Hdiv wrong-values family (`Hcurl/Hdiv PA Coefficient` et al., always `trialHcurl=true` only): an **upstream MLIR miscompile in `arith::ExtUIOp::fold`**, patched here against the pinned LLVM until it lands upstream.

## The bug

`ExtUIOp::fold` merges `extui(extui(x))` by reassigning the outer op's source — keeping the outer op's `nneg` flag:

```cpp
if (auto lhs = getIn().getDefiningOp<ExtUIOp>()) {
  getInMutable().assign(lhs.getIn());
  return getResult();
}
```

`nneg` asserts the *source* is non-negative **as a signed value**. The merge changes the source, about which the outer flag says nothing. The killer instance, produced naturally when `polygeist-mem2reg` forwards a raised bool-byte store to its load:

```mlir
%w = arith.extui %b : i1 to i8          // bool byte
%r = arith.extui %w nneg : i8 to i32    // valid: the i8 is 0 or 1
```

folds to `arith.extui %b nneg : i1 to i32` — but signed i1 `1` **is −1**, so this is poison whenever the bool is **true**. After translation, LLVM's host -O3 legally folds the bool to false everywhere the merged value flows. In MFEM this hit the kernel-launch argument computations for `PAHcurlHdivMassApply2D`: every `trialHcurl`-derived loop bound and offset passed to the kernel took its `false` arm, scrambling `y` indices (and reading one element past a basis array — the sanitizer OOB that started this hunt). `trialHcurl=false` was correct by construction, which is why only half the family ever failed, and why the failure survived every pipeline-level bisection: the MLIR was correct at every stage; the poison only cashed out in LLVM host codegen.

## The fix

Keep `nneg` on the merged extension only if the **inner** extension carries it (its assertion is about the surviving source). Applied to the pinned LLVM via the existing `patch_cmds` mechanism; needs the same one-line fix upstream (`mlir/lib/Dialect/Arith/IR/ArithOps.cpp`).

## Verified

- New lit test `extui-nneg-merge.mlir`: the i1 chain merges **without** nneg; an all-nneg chain keeps it.
- The 50-line standalone reproducer (separate-TU kernel with two closure-pair selects): 4 wrong configs → 0.
- Real MFEM `Hcurl/Hdiv PA Coefficient` with the fixed TU: **32/43 → 42/43 assertions** (remaining 1 + an exit-time abort under investigation).
- Full lit suite green.

Diagnosis trail (for the curious): suite → single TU → 50-line separate-compilation reproducer (single-TU builds fold the bool and mask the bug) → intermediates instrumented on-device (`wy`, `massX` correct; store indices wrong; loop bounds taking the `th=0` arm) → `LD_PRELOAD` interception of `cudaLaunchKernel` showing a wrong host-computed argument → x86 disassembly showing `zext(th)` compiled to the literal `0` → `zext nneg i1` in the final IR → the fold.