### PR TITLE
Decline ParallelizeBlockOps for parallels serialized in a thread

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1075,6 +1075,11 @@ struct ParallelizeBlockOps : public OpRewritePattern<scf::ParallelOp> {
       LLVM_DEBUG(DBGS() << "cannot parallelize around a reduction\n");
       return failure();
     }
+    auto parentPar = dyn_cast<scf::ParallelOp>(pop->getParentOp());
+    if (!parentPar || !isa<enzymexla::GPUWrapperOp>(parentPar->getParentOp())) {
+      LLVM_DEBUG(DBGS() << "parallel is serialized in a thread\n");
+      return failure();
+    }
     auto loc = pop->getLoc();
     Block *outerBlock = pop->getBlock();
     Block *innerBlock = pop.getBody();

--- a/test/lit_tests/lowering/parallelize-multi-parallel.mlir
+++ b/test/lit_tests/lowering/parallelize-multi-parallel.mlir
@@ -1,11 +1,12 @@
 // RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=128 enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu1)" | FileCheck %s
 
-// With several sibling parallels in one block, each application only owns
-// the ops between the previous sibling parallel and its own, and between
-// its own and the next: the zero store belongs to the first parallel and
-// must precede its body, and the middle load and store belong between the
-// two -- moving either into the wrong parallel would reorder them around
-// the other parallel's body.
+// Parallels nested deeper than the grid and block levels -- here inside an
+// if inside the thread parallel -- never map onto the launch: they run,
+// serialized, inside a single thread. ParallelizeBlockOps must decline
+// them: the ops beside them already run in the right order there, and
+// moving them in behind a first-iteration guard both reorders code around
+// the sibling parallel's body and manufactures barriers that the
+// serialized loop would have to be distributed around.
 
 module {
   func.func @f(%in: memref<?xf64, 1>, %out: memref<?xf64, 1>, %out2: memref<?xf64, 1>) -> index {
@@ -47,32 +48,25 @@ module {
 // CHECK-LABEL: func.func @f(
 // CHECK-SAME: %[[IN:[a-z0-9]+]]: memref<?xf64, 1>, %[[OUT:[a-z0-9]+]]: memref<?xf64, 1>, %[[OUT2:[a-z0-9]+]]: memref<?xf64, 1>
 // CHECK: gpu.launch
-// CHECK: %[[BID:[a-z0-9_]+]] = gpu.block_id x
-// CHECK-NEXT: %[[A:[a-z0-9_]+]] = memref.alloca() : memref<4xf64>
-// CHECK-NEXT: %[[G:[a-z0-9_]+]] = arith.cmpi slt, %[[BID]], %[[C3:[a-z0-9_]+]] : index
+// CHECK-NOT: gpu.barrier
+// CHECK-NOT: enzymexla.barrier
+// CHECK: %[[A:[a-z0-9_]+]] = memref.alloca() : memref<4xf64>
+// CHECK-NEXT: %[[G:[a-z0-9_]+]] = arith.cmpi slt, %[[T:[a-z0-9_]+]], %{{.+}} : index
 // CHECK-NEXT: scf.if %[[G]] {
-// CHECK-NEXT: scf.parallel (%[[Q1:[a-z0-9_]+]]) = (%[[C0:[a-z0-9_]+]]) to (%[[C2:[a-z0-9_]+]]) step (%[[C1:[a-z0-9_]+]]) {
-// CHECK-NEXT: %[[T1:[a-z0-9_]+]] = arith.cmpi eq, %[[Q1]], %[[C0]] : index
-// CHECK-NEXT: scf.if %[[T1]] {
-// CHECK-NEXT: memref.store %[[CST:[a-z0-9_]+]], %[[A]][%[[C0]]] : memref<4xf64>
-// CHECK-NEXT: }
-// CHECK-NEXT: {{(gpu.barrier|"enzymexla.barrier")}}
+// CHECK-NEXT: memref.store %[[CST:[a-z0-9_]+]], %[[A]][%[[C0:[a-z0-9_]+]]] : memref<4xf64>
+// CHECK-NEXT: scf.parallel (%[[Q1:[a-z0-9_]+]]) = (%[[C0]]) to (%[[C2:[a-z0-9_]+]]) step (%[[C1:[a-z0-9_]+]]) {
 // CHECK-NEXT: %[[V1:[a-z0-9_]+]] = memref.load %[[IN]][%[[Q1]]] : memref<?xf64, 1>
 // CHECK-NEXT: memref.store %[[V1]], %[[A]][%[[Q1]]] : memref<4xf64>
 // CHECK-NEXT: scf.reduce
 // CHECK-NEXT: }
-// CHECK-NEXT: scf.parallel (%[[Q2:[a-z0-9_]+]]) = (%[[C0]]) to (%[[C2]]) step (%[[C1]]) {
-// CHECK-NEXT: %[[T2:[a-z0-9_]+]] = arith.cmpi eq, %[[Q2]], %[[C0]] : index
-// CHECK-NEXT: scf.if %[[T2]] {
 // CHECK-NEXT: %[[M:[a-z0-9_]+]] = memref.load %[[A]][%[[C0]]] : memref<4xf64>
-// CHECK-NEXT: memref.store %[[M]], %[[OUT2]][%[[BID]]] : memref<?xf64, 1>
-// CHECK-NEXT: }
-// CHECK-NEXT: {{(gpu.barrier|"enzymexla.barrier")}}
+// CHECK-NEXT: memref.store %[[M]], %[[OUT2]][%[[T]]] : memref<?xf64, 1>
+// CHECK-NEXT: scf.parallel (%[[Q2:[a-z0-9_]+]]) = (%[[C0]]) to (%[[C2]]) step (%[[C1]]) {
 // CHECK-NEXT: %[[V2:[a-z0-9_]+]] = memref.load %[[A]][%[[Q2]]] : memref<4xf64>
-// CHECK-NEXT: %[[MUL:[a-z0-9_]+]] = arith.muli %[[BID]], %[[C2]] : index
+// CHECK-NEXT: %[[MUL:[a-z0-9_]+]] = arith.muli %[[T]], %[[C2]] : index
 // CHECK-NEXT: %[[J:[a-z0-9_]+]] = arith.addi %[[MUL]], %[[Q2]] : index
 // CHECK-NEXT: memref.store %[[V2]], %[[OUT]][%[[J]]] : memref<?xf64, 1>
 // CHECK-NEXT: scf.reduce
 // CHECK-NEXT: }
-// CHECK-NEXT: }
-// CHECK-NEXT: gpu.terminator
+// CHECK-NOT: gpu.barrier
+// CHECK-NOT: enzymexla.barrier


### PR DESCRIPTION
Only the grid parallel (directly in the wrapper) and the block parallel (directly in the grid parallel) map onto the gpu launch. A parallel nested any deeper -- under an if, a loop, or a third parallel level -- runs serialized inside a single thread. These arise when the raiser auto-deduces per-thread loops with runtime trip counts as parallel (the MFEM Apply kernels' local-array loops under the divergent \`if (k >= N) return\` guard are all of this shape).

ParallelizeBlockOps used to fire on them too, moving the neighbouring sequential code into the parallel behind a first-iteration guard and a barrier. That is pure churn for a parallel that is about to be serialized -- the surrounding code already runs in the right order there -- and it is what manufactured the barrier-inside-a-serialized-loop shapes that #2884 has to distribute around (and, before #2883/#2884, the Hcurl value-bug family, e.g. the v1.cu reproducer printing 6 7 8 instead of 10 11 12).

With the pattern declined at those depths:
- the end-to-end reproducers (v1, mwe_hcurl, m_cut5) pass even with #2884's cpuify{method=distribute} removed; #2884 remains useful only as defense-in-depth for wrappers that fail conversion entirely,
- kernels whose bodies contain such inner parallels no longer fall back to \`block_size=1\` launches: the multi-parallel test now gets a proper 2x128 split instead of grid=256/block=1, since no barrier lands inside the residual parallels,
- the parallelize-multi-parallel test is updated from "each application owns its segment" to "nested siblings are declined and keep their original order".

Stacked on #2880 (base pb/parallelize-store-order) since the test it updates lives there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD