### PR TITLE
Translate flowing kernel pointers to their registered stubs

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -2450,6 +2450,20 @@ ConvertGPUModuleOp::matchAndRewrite(gpu::GPUModuleOp kernelModule,
             rewriter.setInsertionPointToEnd(stub.addEntryBlock(rewriter));
             LLVM::ReturnOp::create(rewriter, ctorloc, ValueRange());
           }
+          // Remember which host function this kernel was raised from, so
+          // that a kernel pointer flowing into a cuda runtime query can be
+          // translated to this registered stub.
+          {
+            StringRef origName = f.getName();
+            if (origName.starts_with("reactant$"))
+              origName = origName.drop_front(strlen("reactant$"));
+            else if (origName.ends_with("_kernel"))
+              origName = origName.drop_back(strlen("_kernel"));
+            if (moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(origName))
+              stub->setAttr(
+                  "polygeist.host_origin",
+                  FlatSymbolRefAttr::get(rewriter.getContext(), origName));
+          }
           auto aoo = LLVM::AddressOfOp::create(ctorBuilder, ctorloc, stub);
           auto bitcast = LLVM::AddrSpaceCastOp::create(ctorBuilder, ctorloc,
                                                        llvmPointerType, aoo);
@@ -4986,10 +5000,43 @@ struct ConvertPolygeistToLLVMPass
         if (callee.getLeafReference() == GetDeviceFromHostFuncName)
           toHandle.push_back(call);
       });
-      for (auto call : toHandle) {
-        assert(call->getNumResults() == 1 && call.getNumOperands() == 1);
-        call.getResult().replaceAllUsesWith(call.getArgOperands()[0]);
-        call->erase();
+      SmallVector<std::pair<FlatSymbolRefAttr, LLVM::LLVMFuncOp>> hostToStub;
+      m->walk([&](LLVM::LLVMFuncOp f) {
+        if (auto orig =
+                f->getAttrOfType<FlatSymbolRefAttr>("polygeist.host_origin")) {
+          f->removeAttr("polygeist.host_origin");
+          hostToStub.emplace_back(orig, f);
+        }
+      });
+      auto decl = m.lookupSymbol<LLVM::LLVMFuncOp>(GetDeviceFromHostFuncName);
+      if (!toHandle.empty() && !hostToStub.empty() && decl &&
+          decl.getBody().empty()) {
+        // A kernel pointer that reaches a cuda runtime query has to name a
+        // function registered with the runtime. The original registration is
+        // gone; translate each raised kernel's host function to the stub
+        // registered for it, and leave unknown pointers unchanged.
+        OpBuilder b(decl);
+        Block *entry = decl.addEntryBlock(b);
+        b.setInsertionPointToStart(entry);
+        auto loc = decl.getLoc();
+        auto ptrTy = LLVM::LLVMPointerType::get(b.getContext());
+        Value p = entry->getArgument(0);
+        Value res = p;
+        for (auto &[orig, stub] : hostToStub) {
+          Value origAddr = LLVM::AddressOfOp::create(b, loc, ptrTy, orig);
+          Value stubAddr = LLVM::AddressOfOp::create(b, loc, stub);
+          Value eq = LLVM::ICmpOp::create(b, loc, LLVM::ICmpPredicate::eq, p,
+                                          origAddr);
+          res = LLVM::SelectOp::create(b, loc, eq, stubAddr, res);
+        }
+        LLVM::ReturnOp::create(b, loc, res);
+        decl.setLinkage(LLVM::Linkage::Internal);
+      } else {
+        for (auto call : toHandle) {
+          assert(call->getNumResults() == 1 && call.getNumOperands() == 1);
+          call.getResult().replaceAllUsesWith(call.getArgOperands()[0]);
+          call->erase();
+        }
       }
     }
   }

--- a/test/lit_tests/lowering/host-stub-translate.mlir
+++ b/test/lit_tests/lowering/host-stub-translate.mlir
@@ -1,0 +1,45 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=cuda})" | FileCheck %s
+
+// A kernel pointer that flows into a cuda runtime query (occupancy,
+// attributes) as a value cannot be rewritten to the registered stub at
+// compile time; the query receives the original host function whose
+// registration was removed and fails with invalid resource handle. The
+// translation function maps each raised kernel's host function to the stub
+// this pass registers for it, and leaves unknown pointers unchanged.
+
+module attributes {gpu.container_module} {
+  llvm.func @_Z4stepv() {
+    llvm.return
+  }
+  llvm.func @"__reactant$get_device_from_host"(!llvm.ptr) -> !llvm.ptr
+  llvm.func @query(%arg0: !llvm.ptr) -> !llvm.ptr {
+    %0 = llvm.call @"__reactant$get_device_from_host"(%arg0) : (!llvm.ptr) -> !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+  llvm.func @launch(%arg0: i64) {
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %stream = llvm.inttoptr %arg0 : i64 to !llvm.ptr
+    %e = "enzymexla.gpu_error"() ({
+      gpu.launch_func <%stream : !llvm.ptr> @_Z4stepv_kernel_1::@_Z4stepv_kernel blocks in (%c1, %c1, %c1) threads in (%c32, %c1, %c1)
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : () -> index
+    llvm.return
+  }
+  gpu.module @_Z4stepv_kernel_1 [#nvvm.target] {
+    gpu.func @_Z4stepv_kernel() kernel {
+      gpu.return
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func internal @__reactant$get_device_from_host(%arg0: !llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT: %[[ORIG:.+]] = llvm.mlir.addressof @_Z4stepv : !llvm.ptr
+// CHECK-NEXT: %[[STUB:.+]] = llvm.mlir.addressof @__polygeist__Z4stepv_kernel_1__Z4stepv_kernel_device_stub : !llvm.ptr
+// CHECK-NEXT: %[[EQ:.+]] = llvm.icmp "eq" %arg0, %[[ORIG]] : !llvm.ptr
+// CHECK-NEXT: %[[RES:.+]] = llvm.select %[[EQ]], %[[STUB]], %arg0 : i1, !llvm.ptr
+// CHECK-NEXT: llvm.return %[[RES]] : !llvm.ptr
+
+// CHECK-LABEL: llvm.func @query(%arg0: !llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT: %[[V:.+]] = llvm.call @__reactant$get_device_from_host(%arg0) : (!llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT: llvm.return %[[V]] : !llvm.ptr


### PR DESCRIPTION
CUB's device dispatch reads the kernel's occupancy before launching: \`cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(&occ, scan_kernel, ...)\` where \`scan_kernel\` is a function-pointer value selected at runtime from the tuning policy. Reactant's fixup rewrites the kernel-pointer argument of such runtime queries when it is a direct function reference, but a flowing value only gets wrapped in \`__reactant$get_device_from_host\` -- which this pass then lowered as identity. The query therefore received the original host stub, whose cuda-runtime registration the plugin removed, and failed with \`invalid resource handle\` (400); CUB bails before ever launching. This is what killed both Scan suites (Inclusive/Exclusive, SIGABRT) in the MFEM unit tests, reduced to a 25-line \`cub::DeviceScan::InclusiveSum\` reproducer.

The registration this pass emits (one \`__polygeist_*_device_stub\` per raised kernel, registered under the kernel's name) is exactly what the query needs -- the pointer just never reaches it. The fix records, on each registration stub, which host function its kernel was raised from (kernel name minus the \`_kernel\` suffix, or minus the \`reactant$\` prefix, when that symbol exists), and lowers \`__reactant$get_device_from_host\` as a compare/select chain over those pairs instead of identity: a known host stub translates to its registered stub, unknown pointers pass through unchanged. When there are no raised kernels or no callers the old identity erase is kept, so nothing changes for modules that never take a kernel's address.

Verified: the cub reproducer goes from \`invalid resource handle: 0 0 0 0 0 0 0 0\` to matching vanilla (\`1 3 6 10 15 21 28 36\`); both MFEM Scan suites pass end-to-end (40/40 assertions each, previously SIGABRT); full lit suite green with the new \`host-stub-translate.mlir\` covering the emitted chain and pass-through call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD