### PR TITLE
Return the right result when legalizing a multi-result conditional as a symbol

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -550,11 +550,12 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
       assert(isValidSymbolInt(sel, /*recur*/ false, scope));
       return sel;
     }
+    unsigned resultIdx = cast<OpResult>(v).getResultNumber();
     if (!rewriter) {
       // Everything below this point moves the op; without a rewriter it stays
       // where it is, and so is a symbol only where it already was one.
       operationContext.pop_back();
-      Value res = op->getResult(0);
+      Value res = op->getResult(resultIdx);
       return isValidSymbolInt(res, /*recur*/ false, scope) ? res : Value();
     } else {
       PatternRewriter::InsertionGuard B(*rewriter);
@@ -573,13 +574,14 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
       rewriter->replaceOp(op, cloned->getResults());
 
       operationContext.pop_back();
-      if (!isValidSymbolInt(cloned->getResult(0), /*recur*/ false, scope)) {
+      if (!isValidSymbolInt(cloned->getResult(resultIdx), /*recur*/ false,
+                            scope)) {
         llvm::errs() << " clonedParent: "
                      << *cloned->getParentOfType<FunctionOpInterface>() << "\n";
         llvm::errs() << " cloned: " << *cloned << "\n";
         llvm_unreachable("busted");
       }
-      return cloned->getResult(0);
+      return cloned->getResult(resultIdx);
     }
   };
   auto renumberOneSymbol = [&](Value v) {

--- a/test/lit_tests/raising/affine-if-multi-result.mlir
+++ b/test/lit_tests/raising/affine-if-multi-result.mlir
@@ -1,0 +1,53 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access,canonicalize,affine-cfg)" | FileCheck %s
+
+// When a value used in an affine map is a non-first result of a pure
+// multi-result affine.if, symbol legalization hoists the if and must hand
+// back the result the value came from. It handed back result zero for
+// every result, so the second access below read with the first access's
+// offset: in MFEM's PAHdivMassSetup3D (vector-coefficient branch, the
+// (i,j,k)=(2,2,2) term) that meant C(1) was read where C(2) was needed and
+// every 3D Hdiv PA operator with a vector coefficient was wrong.
+
+#set = affine_set<()[s0] : (s0 - 3 == 0)>
+module {
+  func.func @f(%cd: index, %m: !llvm.ptr, %out: memref<?xf64>) {
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c8_i32 = arith.constant 8 : i32
+    affine.parallel (%q) = (0) to (8) {
+      %of:2 = affine.if #set()[%cd] -> (i32, i32) {
+        affine.yield %c1_i32, %c2_i32 : i32, i32
+      } else {
+        affine.yield %c0_i32, %c0_i32 : i32, i32
+      }
+      %qi = arith.index_cast %q : index to i32
+      %e = arith.muli %qi, %c8_i32 : i32
+      %e64 = arith.extsi %e : i32 to i64
+      %base = llvm.getelementptr inbounds %m[%e64] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+      affine.for %r = 0 to 4 {
+        %ri = arith.index_cast %r : index to i32
+        %i1 = arith.addi %ri, %of#0 : i32
+        %i1e = arith.extsi %i1 : i32 to i64
+        %p1 = llvm.getelementptr inbounds %base[%i1e] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+        %m1 = "enzymexla.pointer2memref"(%p1) : (!llvm.ptr) -> memref<?xf64>
+        %c0 = arith.constant 0 : index
+        %v1 = memref.load %m1[%c0] : memref<?xf64>
+        %i2 = arith.addi %ri, %of#1 : i32
+        %i2e = arith.extsi %i2 : i32 to i64
+        %p2 = llvm.getelementptr inbounds %base[%i2e] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+        %m2 = "enzymexla.pointer2memref"(%p2) : (!llvm.ptr) -> memref<?xf64>
+        %v2 = memref.load %m2[%c0] : memref<?xf64>
+        %s = arith.addf %v1, %v2 : f64
+        affine.store %s, %out[%r + %q * 4] : memref<?xf64>
+      }
+    }
+    return
+  }
+}
+
+// CHECK: %[[IF:.+]]:2 = affine.if
+// CHECK: %[[S0:.+]] = arith.index_cast %[[IF]]#0 : i32 to index
+// CHECK: %[[S1:.+]] = arith.index_cast %[[IF]]#1 : i32 to index
+// CHECK: affine.load %{{.+}}[%{{.+}} + symbol(%[[S0]]) + %{{.+}} * 8]
+// CHECK: affine.load %{{.+}}[%{{.+}} + symbol(%[[S1]]) + %{{.+}} * 8]

--- a/test/lit_tests/raising/affinecfg_select_hoist_capture.mlir
+++ b/test/lit_tests/raising/affinecfg_select_hoist_capture.mlir
@@ -68,7 +68,7 @@ module attributes {gpu.container_module} {
 // CHECK-NEXT:      } else {
 // CHECK-NEXT:        scf.yield %[[V]], %[[V]], %[[C0_I32]] : i32, i32, i32
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[IF2IDX:.+]] = arith.index_cast %[[IF2]]#0 : i32 to index
+// CHECK-NEXT:      %[[IF2IDX:.+]] = arith.index_cast %[[IF2]]#2 : i32 to index
 // CHECK-NEXT:      affine.parallel (%[[TID:.+]]) = (0) to (256) {
 // CHECK-NEXT:        %[[PI:.+]] = llvm.ptrtoint %[[PTR]] : !llvm.ptr to i64
 // CHECK-NEXT:        %[[PZ:.+]] = arith.cmpi eq, %[[PI]], %[[C0_I64]] : i64


### PR DESCRIPTION
When affine symbol legalization hoists a pure operation by cloning it to the scope entry, it returned \`cloned->getResult(0)\` no matter which result the value being legalized was. For a multi-result conditional -- e.g. the \`coeffDim == 3 ? (1, 2) : (0, 0)\` pair of k-offsets that clang produces for MFEM's \`C(coeffDim == 3 ? k : 0)\` coefficient indexing -- every result collapsed to result zero after hoisting: the k=2 access composed \`symbol(index_cast %if#0)\` instead of \`#1\` and read \`C(1)\` where \`C(2)\` was needed.

End-to-end this made every 3D Hdiv PA operator with a vector coefficient wrong (the qdata's last diagonal entry \`y(q,5,e)\` summed \`J(k,2)*C(k')*J(k,2)\` with \`k'=(0,1,1)\` instead of \`(0,1,2)\`): the MFEM suites "Hcurl/Hdiv PA Coefficient" (2 failures), "3D Bilinear VectorFE Integrators PartialAssembly" (4 failures, the RT sections), and part of "Hcurl/Hdiv diagonal PA"/"Mixed" trace to this. Found by object-level delta-debugging to \`bilininteg_hdiv_kernels.cpp.o\`, a one-hot coefficient probe that fingerprinted the exact wrong load, and per-pass IR dumps showing \`%48 = index_cast %37#0\` and \`%49 = index_cast %37#0\` where \`%49\` had to cast \`%37#1\`.

The fix returns the result matching the legalized value's result number, in both the rewriter (clone) and no-rewriter paths.

The existing \`affinecfg_select_hoist_capture.mlir\` test had the bug baked into its expectations: the hoisted conditional's guard set uses the conditional's result 2 (\`%253#2 == 0\`), but the CHECK expected the symbol to be \`index_cast %if#0\` -- the same collapse, silently mis-guarding the region. Its expectation is updated to \`#2\`, and the new \`affine-if-multi-result.mlir\` covers the load-offset shape directly (without the fix its two accesses both compose \`symbol(index_cast %if#0)\`).

Verified: a standalone driver calling \`PAHdivMassSetup3D\` against the miscompiled object goes from 2 wrong configurations to none; MFEM's "Hcurl/Hdiv PA Coefficient" (100/100) and "3D Bilinear VectorFE PA" (144/144) pass end-to-end after rebuilding the affected TUs; full lit suite green; the CUDA round-trip reproducers (v1, mwe_hcurl, cub scan) still match vanilla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD