### PR TITLE
Only drop an if constraint subsumed by a parent that implies it

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -3218,10 +3218,16 @@ struct AffineIfSimplification : public OpRewritePattern<affine::AffineIfOp> {
         bool canRemove = false;
         for (auto paren = op->getParentOfType<affine::AffineIfOp>(); paren;
              paren = paren->getParentOfType<affine::AffineIfOp>()) {
-          for (auto cst2 : paren.getIntegerSet().getConstraints()) {
+          for (auto cst2 :
+               llvm::enumerate(paren.getIntegerSet().getConstraints())) {
             if (paren.getElseRegion().isAncestor(op->getParentRegion()))
               continue;
-            if (cst2 == cst.value() &&
+            // The parent constraint only subsumes this one if it implies it:
+            // an equality implies both forms, an inequality only implies the
+            // same inequality.
+            if (cst2.value() == cst.value() &&
+                (paren.getIntegerSet().isEq(cst2.index()) ||
+                 !op.getIntegerSet().isEq(cst.index())) &&
                 paren.getIntegerSet().getNumDims() ==
                     op.getIntegerSet().getNumDims() &&
                 paren.getIntegerSet().getNumSymbols() ==

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -3215,6 +3215,24 @@ struct AffineIfSimplification : public OpRewritePattern<affine::AffineIfOp> {
           }
         }
 
+        // Within this set an inequality is subsumed by the same expression
+        // appearing as an equality: a >= 0 && a == 0 is a == 0.
+        if (!op.getIntegerSet().isEq(cst.index())) {
+          bool subsumedByEq = false;
+          for (auto cst2 :
+               llvm::enumerate(op.getIntegerSet().getConstraints())) {
+            if (cst2.index() != cst.index() && cst2.value() == cst.value() &&
+                op.getIntegerSet().isEq(cst2.index())) {
+              subsumedByEq = true;
+              break;
+            }
+          }
+          if (subsumedByEq) {
+            removed = true;
+            continue;
+          }
+        }
+
         bool canRemove = false;
         for (auto paren = op->getParentOfType<affine::AffineIfOp>(); paren;
              paren = paren->getParentOfType<affine::AffineIfOp>()) {

--- a/test/lit_tests/raising/affine-if-eq-in-ineq.mlir
+++ b/test/lit_tests/raising/affine-if-eq-in-ineq.mlir
@@ -9,6 +9,7 @@
 
 #ge = affine_set<()[s0] : (s0 - 1 >= 0)>
 #eq = affine_set<()[s0] : (s0 - 1 == 0)>
+#both = affine_set<()[s0] : (s0 - 1 >= 0, s0 - 1 == 0)>
 module {
   func.func @f(%m: index, %out: memref<?xf64>) {
     %cst = arith.constant 1.0 : f64
@@ -23,9 +24,26 @@ module {
     }
     return
   }
+
+  // The reverse direction within a single set does simplify: an inequality
+  // conjoined with the same expression as an equality is the equality,
+  // s0 - 1 >= 0 && s0 - 1 == 0 is s0 - 1 == 0.
+  func.func @g(%m: index, %out: memref<?xf64>) {
+    %cst2 = arith.constant 2.0 : f64
+    affine.if #both()[%m] {
+      affine.store %cst2, %out[0] : memref<?xf64>
+    }
+    return
+  }
 }
 
-// CHECK: affine.if #set{{[0-9]*}}()[%{{.+}}] {
-// CHECK: affine.if #set{{[0-9]*}}()[%{{.+}}] {
+// CHECK-DAG: #[[GE:set[0-9]*]] = affine_set<()[s0] : (s0 - 1 >= 0)>
+// CHECK-DAG: #[[EQ:set[0-9]*]] = affine_set<()[s0] : (s0 - 1 == 0)>
+// CHECK-LABEL: func.func @f
+// CHECK: affine.if #[[GE]]()[%{{.+}}] {
+// CHECK: affine.if #[[EQ]]()[%{{.+}}] {
 // CHECK-NEXT: } else {
+// CHECK-NEXT: affine.store
+// CHECK-LABEL: func.func @g
+// CHECK: affine.if #[[EQ]]()[%{{.+}}] {
 // CHECK-NEXT: affine.store

--- a/test/lit_tests/raising/affine-if-eq-in-ineq.mlir
+++ b/test/lit_tests/raising/affine-if-eq-in-ineq.mlir
@@ -1,0 +1,31 @@
+// RUN: enzymexlamlir-opt %s --affine-cfg | FileCheck %s
+
+// An equality constraint is not implied by the same expression appearing as
+// an inequality in an enclosing affine.if: s0 - 1 >= 0 admits every s0 >= 1,
+// not only s0 == 1. Dropping it as redundant made the inner set vacuously
+// true and replaced the conditional with its empty then-region -- in MFEM's
+// batched LUSolve that deleted the whole back-substitution remainder (every
+// solve returned its right-hand side unchanged).
+
+#ge = affine_set<()[s0] : (s0 - 1 >= 0)>
+#eq = affine_set<()[s0] : (s0 - 1 == 0)>
+module {
+  func.func @f(%m: index, %out: memref<?xf64>) {
+    %cst = arith.constant 1.0 : f64
+    %cst2 = arith.constant 2.0 : f64
+    affine.parallel (%q) = (0) to (8) {
+      affine.if #ge()[%m] {
+        affine.if #eq()[%m] {
+        } else {
+          affine.store %cst2, %out[%q] : memref<?xf64>
+        }
+      }
+    }
+    return
+  }
+}
+
+// CHECK: affine.if #set{{[0-9]*}}()[%{{.+}}] {
+// CHECK: affine.if #set{{[0-9]*}}()[%{{.+}}] {
+// CHECK-NEXT: } else {
+// CHECK-NEXT: affine.store


### PR DESCRIPTION
AffineIfSimplification removes a constraint from an \`affine.if\`'s set when the same constraint appears in an enclosing \`affine.if\` with the same operands. The comparison only looked at the constraint expression, not whether each side is an equality or an inequality: nested inside a guard with \`s0 - 1 >= 0\`, an inner \`affine.if\` on \`s0 - 1 == 0\` had its only constraint dropped as redundant, the set became vacuously true, and the conditional was replaced by its (empty) then-region.

End-to-end this deleted the entire back-substitution remainder of MFEM's batched \`LUSolve\` device kernel (clang rotates the \`for (j = m-1; j >= 0; j--)\` loop into a peeled first iteration guarded by \`m >= 1\` plus an \`if (m != 1)\` remainder -- exactly the eq-inside-ineq nesting): every batched solve returned its right-hand side unchanged. The "Batched Linear Algebra" suite failure, and one "Hcurl/Hdiv diagonal PA" failure with the same shape in the curl-curl kernels, trace here; found by object-level delta-debugging to \`linalg/batched/native.cpp.o\`, a standalone LUFactor/LUSolve driver (factors bit-identical, solve a no-op), and instrumenting the pass to log which constraint removal fired (\`CANREMOVE cst=s0 - 1 myEq=1 parent: ()[s0] : (s0 - 1 >= 0)\`).

The fix requires implication: an equality parent subsumes either form; an inequality parent only subsumes the same inequality.

Verified: the LUSolve driver goes from solution == RHS to matching the host reference to 5.6e-17; "Batched Linear Algebra" passes 216/216 and "Hcurl/Hdiv diagonal PA" 152/152 end-to-end after rebuilding the affected TUs; full lit suite green with the new \`affine-if-eq-in-ineq.mlir\` covering the nesting directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD