### PR TITLE
[AffineCFG] take a loop's induction variable by argument number

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -261,9 +261,11 @@ static bool legalCondition(Value en, bool dim, Region *scope) {
   //}
   if (!dim)
     if (auto BA = dyn_cast<BlockArgument>(en)) {
-      if (isa<affine::AffineForOp, affine::AffineParallelOp>(
-              BA.getOwner()->getParentOp()))
-        return true;
+      Operation *parent = BA.getOwner()->getParentOp();
+      if (isa<affine::AffineForOp>(parent))
+        return BA.getArgNumber() == 0;
+      if (auto par = dyn_cast<affine::AffineParallelOp>(parent))
+        return BA.getArgNumber() < par.getNumDims();
     }
   return false;
 }

--- a/test/lit_tests/affinecfg_iter_args_not_iv.mlir
+++ b/test/lit_tests/affinecfg_iter_args_not_iv.mlir
@@ -1,0 +1,37 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+module {
+  func.func @iter_args_symbol(%n: index, %ny: index, %buf: memref<?xi64>,
+                              %val: i64) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %r = affine.for %i = 0 to 12 iter_args(%acc = %c0_i32) -> (i32) {
+      %sym = arith.index_cast %acc : i32 to index
+      %w = "enzymexla.gpu_wrapper"(%n, %ny, %c1, %c32, %c1, %c1) ({
+        %flat = arith.muli %n, %c32 overflow<nsw> : index
+        scf.parallel (%a5, %a6) = (%c0, %c0) to (%ny, %flat) step (%c1, %c1) {
+          %idx = arith.addi %sym, %a6 : index
+          memref.store %val, %buf[%idx] : memref<?xi64>
+          scf.reduce
+        }
+        "enzymexla.polygeist_yield"() : () -> ()
+      }) : (index, index, index, index, index, index) -> index
+      %next = arith.addi %acc, %c1_i32 : i32
+      affine.yield %next : i32
+    }
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @iter_args_symbol(
+// CHECK-SAME:      %[[n:.*]]: index, %[[ny:.*]]: index, %[[buf:.*]]: memref<?xi64>,
+// CHECK-SAME:      %[[val:.*]]: i64) {
+// CHECK:           affine.for %{{.*}} = 0 to 12 iter_args(%[[acc:.*]] = %{{.*}}) -> (i32) {
+// CHECK:             %[[sym:.*]] = arith.index_cast %[[acc]] : i32 to index
+// CHECK:             "enzymexla.gpu_wrapper"
+// CHECK:               affine.parallel (%{{.*}}, %[[iv:.*]]) = (0, 0) to (symbol(%[[ny]]), symbol(%[[n]]) * 32) {
+// The induction variable is the dim and the loop-carried value stays a symbol.
+// CHECK:                 affine.store %[[val]], %[[buf]]{{\[}}%[[iv]] + symbol(%[[sym]])] : memref<?xi64>


### PR DESCRIPTION
`--affine-cfg` does not terminate with `-reactant-remove-atomics=1` on RSBench for CUDA backend

`legalCondition` asks whether a loop induction variable is sitting in a symbol slot, since an induction variable belongs among the dims. It answers by looking at the block argument's parent:
https://github.com/EnzymeAD/Enzyme-JAX/blob/da79ee67b0638683cc7eb4823927d7c473200d70/src/enzyme_ad/jax/Passes/AffineCFG.cpp#L265

An `affine.for` numbers its induction variable 0 and its `iter_args` from 1, so a loop-carried value passes that test. It is not an index and never belonged among the dims, so the move being asked for does not exist. 
`fully2ComposeAffineMapAndOperands` then cannot converge:
```
while (need(map, operands, scope)) {
  if (!composeAffineMapAndOperands(map, operands, builder, DI, scope))
    return false;
}
```
`need()` keeps saying the operands are unfinished. `composeAffineMapAndOperands` finds nothing to move and returns success on an unchanged map. 

**Fix**:
Ask which argument it is rather than its parent op.