### PR TITLE
Cast booleans to index unsigned when legalizing affine operands

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -1013,6 +1013,14 @@ bool need(IntegerSet *map, SmallVectorImpl<Value> *operands, Region *scope) {
 // composeAffineMapAndOperands.  A caller passing no builder is asking a
 // question, since without one the normalizer cannot move an operand to make
 // it legal -- and the attribute keeps the answer from being dropped.
+// A boolean is the unsigned value 0 or 1; the signed cast would send true to
+// -1.
+static Value castToIndex(OpBuilder &b, Location loc, Value v) {
+  if (v.getType().isInteger(1))
+    return arith::IndexCastUIOp::create(b, loc, b.getIndexType(), v);
+  return arith::IndexCastOp::create(b, loc, b.getIndexType(), v);
+}
+
 [[nodiscard]] static bool fully2ComposeAffineMapAndOperands(
     PatternRewriter *builder, AffineMap *map, SmallVectorImpl<Value> *operands,
     DominanceInfo *DI, Region *scope,
@@ -1079,16 +1087,13 @@ bool need(IntegerSet *map, SmallVectorImpl<Value> *operands, Region *scope) {
         else {
           if (insertedOps) {
             OpBuilder builder(toInsert);
-            auto inserted = IndexCastOp::create(builder, op.getLoc(),
-                                                builder.getIndexType(), op);
-            op = inserted->getResult(0);
-            insertedOps->push_back(inserted);
+            Value inserted = castToIndex(builder, op.getLoc(), op);
+            op = inserted;
+            insertedOps->push_back(inserted.getDefiningOp());
           } else {
             PatternRewriter::InsertionGuard B(*builder);
             builder->setInsertionPoint(toInsert);
-            auto inserted = IndexCastOp::create(*builder, op.getLoc(),
-                                                builder->getIndexType(), op);
-            op = inserted->getResult(0);
+            op = castToIndex(*builder, op.getLoc(), op);
           }
         }
       }
@@ -1165,16 +1170,13 @@ void fully2ComposeIntegerSetAndOperands(
         if (insertedOps) {
           OpBuilder builder(op.getContext());
           setPoint(builder);
-          auto inserted = IndexCastOp::create(builder, op.getLoc(),
-                                              builder.getIndexType(), op);
-          op = inserted->getResult(0);
-          insertedOps->push_back(inserted);
+          Value inserted = castToIndex(builder, op.getLoc(), op);
+          op = inserted;
+          insertedOps->push_back(inserted.getDefiningOp());
         } else {
           PatternRewriter::InsertionGuard B(builder);
           setPoint(builder);
-          auto inserted = IndexCastOp::create(builder, op.getLoc(),
-                                              builder.getIndexType(), op);
-          op = inserted->getResult(0);
+          op = castToIndex(builder, op.getLoc(), op);
         }
       }
     }
@@ -2323,7 +2325,6 @@ struct MoveIfToAffine : public OpRewritePattern<scf::IfOp> {
         continue;
 
       SmallVector<Value> operands;
-      auto ity = IndexType::get(ifOp.getContext());
       for (auto vori : applies) {
         Value operand = vori.v_val;
         if (!vori.isValue) {
@@ -2331,8 +2332,7 @@ struct MoveIfToAffine : public OpRewritePattern<scf::IfOp> {
                                                    vori.i_val.getSExtValue());
         }
         if (!isa<IndexType>(operand.getType())) {
-          operand =
-              arith::IndexCastOp::create(rewriter, ifOp.getLoc(), ity, operand);
+          operand = castToIndex(rewriter, ifOp.getLoc(), operand);
         }
         operands.push_back(operand);
       }
@@ -2461,7 +2461,6 @@ struct MoveExtToAffine : public OpRewritePattern<arith::ExtUIOp> {
         continue;
 
       SmallVector<Value> operands;
-      auto ity = IndexType::get(ifOp.getContext());
       for (auto vori : applies) {
         Value operand = vori.v_val;
         if (!vori.isValue) {
@@ -2469,8 +2468,7 @@ struct MoveExtToAffine : public OpRewritePattern<arith::ExtUIOp> {
                                                    vori.i_val.getSExtValue());
         }
         if (!isa<IndexType>(operand.getType())) {
-          operand =
-              arith::IndexCastOp::create(rewriter, ifOp.getLoc(), ity, operand);
+          operand = castToIndex(rewriter, ifOp.getLoc(), operand);
         }
         operands.push_back(operand);
       }
@@ -2661,7 +2659,6 @@ struct MoveSelectToAffine : public OpRewritePattern<arith::SelectOp> {
         continue;
 
       SmallVector<Value> operands;
-      auto ity = IndexType::get(ifOp.getContext());
       for (auto vori : applies) {
         Value operand = vori.v_val;
         if (!vori.isValue) {
@@ -2669,8 +2666,7 @@ struct MoveSelectToAffine : public OpRewritePattern<arith::SelectOp> {
                                                    vori.i_val.getSExtValue());
         }
         if (!isa<IndexType>(operand.getType())) {
-          operand =
-              arith::IndexCastOp::create(rewriter, ifOp.getLoc(), ity, operand);
+          operand = castToIndex(rewriter, ifOp.getLoc(), operand);
         }
         operands.push_back(operand);
       }
@@ -2779,7 +2775,6 @@ struct MoveSelectToAffine : public OpRewritePattern<arith::SelectOp> {
             continue;
 
           SmallVector<Value> operands;
-          auto ity = IndexType::get(ifOp.getContext());
           for (auto vori : applies) {
             Value operand = vori.v_val;
             if (!vori.isValue) {
@@ -2787,8 +2782,7 @@ struct MoveSelectToAffine : public OpRewritePattern<arith::SelectOp> {
                   rewriter, ifOp.getLoc(), vori.i_val.getSExtValue());
             }
             if (!isa<IndexType>(operand.getType())) {
-              operand = arith::IndexCastOp::create(rewriter, ifOp.getLoc(), ity,
-                                                   operand);
+              operand = castToIndex(rewriter, ifOp.getLoc(), operand);
             }
             operands.push_back(operand);
           }

--- a/test/lit_tests/raising/affine-i1-symbol-cast.mlir
+++ b/test/lit_tests/raising/affine-i1-symbol-cast.mlir
@@ -1,0 +1,31 @@
+// RUN: enzymexlamlir-opt %s --affine-cfg | FileCheck %s
+
+// When a boolean feeds an affine symbol -- here the guard of an if converted
+// to an affine set -- the legalization strips the zero-extension and casts
+// the raw i1 to index. The signed index_cast sends true to -1, so the set
+// s0 - 1 == 0 evaluated false exactly when the condition held: in MFEM's
+// PAHcurlL2Apply2D the H1 flag selected the L2 basis and stride for H1 test
+// spaces. The cast of an i1 must be unsigned.
+
+module {
+  func.func @f(%a: index, %b: index, %out: memref<?xf64>) {
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant 1.0 : f64
+    %cst2 = arith.constant 2.0 : f64
+    %c = arith.cmpi eq, %a, %b : index
+    %ci = arith.extui %c : i1 to i32
+    affine.parallel (%q) = (0) to (8) {
+      %cond = arith.cmpi eq, %ci, %c1_i32 : i32
+      scf.if %cond {
+        affine.store %cst, %out[%q] : memref<?xf64>
+      } else {
+        affine.store %cst2, %out[%q] : memref<?xf64>
+      }
+    }
+    return
+  }
+}
+
+// CHECK: %[[C:.+]] = arith.cmpi eq, %arg0, %arg1 : index
+// CHECK-NEXT: %[[S:.+]] = arith.index_castui %[[C]] : i1 to index
+// CHECK: affine.if #set{{[0-9]*}}()[%[[S]]]


### PR DESCRIPTION
When affine legalization needs an index-typed symbol from an integer value -- composing map operands in \`fully2ComposeAffineMapAndOperands\`, or materializing the integer-set operands of a converted conditional -- it emitted a signed \`arith.index_cast\`. The operand walker strips zero-extensions to reach the underlying value, so a boolean condition reaches the cast as a raw \`i1\`, and the signed cast sends \`true\` to \`-1\`: an \`affine.if\` built as \`s0 - 1 == 0\` over that symbol evaluates false exactly when the original condition held.

End-to-end this broke MFEM's \`PAHcurlL2Apply2D\` (MixedScalarCurlIntegrator, the "Hcurl/Hdiv Mixed PA Coefficient" HcurlH1_2D case): the kernel's \`H1 = (D1Dtest == D1D)\` flag reached the launch as \`-1\`, so \`select(H1 == 1, Bt, Bot)\` picked the L2 basis and the companion stride select picked \`D1D-1\`, for an H1 test space. Found by delta-debugging to \`bilininteg_hcurl_kernels.cpp.o\`, a one-hot operator-matrix probe showing Bot-scale products where Bt belonged, and an \`LD_PRELOAD\` dump of the 24 launch parameters showing \`a17 = 0xffffffffffffffff\` where the H1 flag (1) was expected.

The fix routes these casts through a helper that uses \`arith.index_castui\` for \`i1\` sources and keeps the signed cast otherwise.

Verified: the standalone kernel driver goes from 4/4 wrong configurations to 0; the "Hcurl/Hdiv Mixed PA Coefficient" suite passes 180/180 end-to-end after rebuilding the TU -- the last failing suite of the MFEM GPU unit-test campaign; full lit suite green with the new \`affine-i1-symbol-cast.mlir\` (without the fix its \`affine.if\` symbol is produced by a signed cast of the compare).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD