### PR TITLE
Add reverse-mode autodiff rule for `stablehlo.custom_call`

### DIFF
--- a/custom_call_from_reactant.mlir
+++ b/custom_call_from_reactant.mlir
@@ -1,0 +1,23 @@
+module @"reactant_#3" attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
+  func.func private @"##_fwd_reverse#281"(%arg0: tensor<1x1x2x2x2xf32>, %arg1: tensor<1x1x2x2x2xf32>, %arg2: tensor<1x1x2x2x2xf32>, %arg3: tensor<1x1x2x2xf32>, %arg4: tensor<1x1x2x2xi1>, %arg5: tensor<1x1x2x2x2xf32>, %arg6: tensor<1x1x2x2xf32>, %arg7: tensor<1x1x2x2x2xf32>, %arg8: tensor<1x1x2x2xf32>) -> (tensor<1x1x2x2x2xf32>, tensor<1x1x2x2x2xf32>, tensor<1x1x2x2x2xf32>, tensor<1x1x2x2xf32>) {
+    %0 = stablehlo.multiply %arg7, %arg7 : tensor<1x1x2x2x2xf32>
+    %1 = stablehlo.add %arg7, %arg5 : tensor<1x1x2x2x2xf32>
+    %2 = stablehlo.add %arg7, %arg7 : tensor<1x1x2x2x2xf32>
+    %3 = stablehlo.multiply %arg6, %arg6 : tensor<1x1x2x2xf32>
+    return %0, %1, %2, %3 : tensor<1x1x2x2x2xf32>, tensor<1x1x2x2x2xf32>, tensor<1x1x2x2x2xf32>, tensor<1x1x2x2xf32>
+  }
+  func.func @main(%arg0: tensor<2x2x2x1x1xf32>, %arg1: tensor<2x2x2x1x1xf32>, %arg2: tensor<2x2x2x1x1xf32>, %arg3: tensor<2x2x1x1xf32>) -> (tensor<2x2x2x1x1xf32>, tensor<2x2x2x1x1xf32>, tensor<2x2x2x1x1xf32>, tensor<2x2x2x1x1xf32>, tensor<2x2x1x1xf32>) {
+    %0 = stablehlo.transpose %arg0, dims = [4, 3, 2, 1, 0] : (tensor<2x2x2x1x1xf32>) -> tensor<1x1x2x2x2xf32>
+    %1 = stablehlo.transpose %arg1, dims = [4, 3, 2, 1, 0] : (tensor<2x2x2x1x1xf32>) -> tensor<1x1x2x2x2xf32>
+    %2 = stablehlo.transpose %arg2, dims = [4, 3, 2, 1, 0] : (tensor<2x2x2x1x1xf32>) -> tensor<1x1x2x2x2xf32>
+    %3 = stablehlo.transpose %arg3, dims = [3, 2, 1, 0] : (tensor<2x2x1x1xf32>) -> tensor<1x1x2x2xf32>
+    %c = stablehlo.constant dense<false> : tensor<1x1x2x2xi1>
+    %4:2 = stablehlo.custom_call @mps.metal_kernel_lib(%0, %1, %2, %3, %c) {backend_config = "{\22name\22:\22_fwd\22,\22metallib_path\22:\22/tmp/none.metallib\22,\22grid\22:[1,1,1],\22threadgroup\22:[1024,1,1],\22dispatch\22:\22threadgroups\22,\22buffers\22:[{\22slot\22:0,\22kind\22:\22output\22,\22arg\22:0},{\22slot\22:1,\22kind\22:\22output\22,\22arg\22:1},{\22slot\22:2,\22kind\22:\22input\22,\22arg\22:0},{\22slot\22:3,\22kind\22:\22input\22,\22arg\22:1},{\22slot\22:4,\22kind\22:\22input\22,\22arg\22:2},{\22slot\22:5,\22kind\22:\22input\22,\22arg\22:3},{\22slot\22:6,\22kind\22:\22input\22,\22arg\22:4}]}", enzyme.active_operands = array<i64: 0, 1, 2, 3>, enzyme.reverse = @"##_fwd_reverse#281"} : (tensor<1x1x2x2x2xf32>, tensor<1x1x2x2x2xf32>, tensor<1x1x2x2x2xf32>, tensor<1x1x2x2xf32>, tensor<1x1x2x2xi1>) -> (tensor<1x1x2x2x2xf32>, tensor<1x1x2x2xf32>)
+    %5 = stablehlo.transpose %4#0, dims = [4, 3, 2, 1, 0] : (tensor<1x1x2x2x2xf32>) -> tensor<2x2x2x1x1xf32>
+    %6 = stablehlo.transpose %0, dims = [4, 3, 2, 1, 0] : (tensor<1x1x2x2x2xf32>) -> tensor<2x2x2x1x1xf32>
+    %7 = stablehlo.transpose %1, dims = [4, 3, 2, 1, 0] : (tensor<1x1x2x2x2xf32>) -> tensor<2x2x2x1x1xf32>
+    %8 = stablehlo.transpose %2, dims = [4, 3, 2, 1, 0] : (tensor<1x1x2x2x2xf32>) -> tensor<2x2x2x1x1xf32>
+    %9 = stablehlo.transpose %3, dims = [3, 2, 1, 0] : (tensor<1x1x2x2xf32>) -> tensor<2x2x1x1xf32>
+    return %5, %6, %7, %8, %9 : tensor<2x2x2x1x1xf32>, tensor<2x2x2x1x1xf32>, tensor<2x2x2x1x1xf32>, tensor<2x2x2x1x1xf32>, tensor<2x2x1x1xf32>
+  }
+}

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -20,6 +20,8 @@
 #include "src/enzyme_ad/jax/Implementations/SHLOGenericBatchOpInterface.h"
 
 #include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Support/DebugStringHelper.h"
 
 #include "llvm/ADT/PointerUnion.h"
 
@@ -37,6 +39,7 @@
 #include "src/enzyme_ad/jax/Implementations/XLADerivatives.h"
 #include "src/enzyme_ad/jax/Utils.h"
 #include <cstdint>
+#include <optional>
 
 using namespace mlir;
 using namespace mlir::enzyme;
@@ -1642,6 +1645,327 @@ public:
   SmallVector<Value> cacheValues(Operation *orig,
                                  MGradientUtilsReverse *gutils) const {
     return {};
+  }
+
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// stablehlo.custom_call
+//
+// A custom call is opaque, so its adjoint has to come from whoever built the
+// call. The rule lives on the call site rather than in a registry keyed on
+// call_target_name: one target name routinely dispatches many different
+// kernels through its backend_config, so the target name is the wrong
+// granularity to key an adjoint on.
+//
+//   %o, %lse = stablehlo.custom_call @foo(%q, %k, %v, %mask) {
+//       enzyme.reverse         = @foo_reverse,
+//       enzyme.active_operands = array<i64: 0, 1, 2>
+//   } : (tensor<...>, tensor<...>, tensor<...>, tensor<...xi1>)
+//    -> (tensor<...>, tensor<...>)
+//
+//   func.func @foo_reverse(%q, %k, %v, %mask,      // primal operands
+//                          %o, %lse,               // primal results
+//                          %do, %dlse)             // result cotangents
+//       -> (tensor<...>, tensor<...>, tensor<...>) // one per active operand
+//
+// * `enzyme.reverse` is a symbol reference to a func.func implementing the
+//   VJP, taking every primal operand, then every primal result, then the
+//   cotangent of every result, and returning one cotangent per entry of
+//   `enzyme.active_operands`, in that order. The signature is checked here:
+//   getting the convention wrong otherwise yields a silently wrong gradient.
+// * `enzyme.active_operands` lists the operand indices that can carry a
+//   gradient; operands left out are treated as constants, which is what an
+//   i1 mask operand needs. When absent it defaults to every float- or
+//   complex-typed operand.
+// * `enzyme.nondiff` marks the call as a gradient stop.
+// * Without any of these attributes the call is refused with the same error
+//   as before this rule existed, rather than silently producing zeros.
+//
+// The rule caches every primal operand and result, because the convention
+// hands all of them to the reverse function. `has_side_effect` is fine: the
+// primal is cloned as-is and the cached values are pushed around it.
+// `output_operand_aliasing` is refused, since a result that aliases an
+// operand may have been overwritten by the time the cotangent runs, making
+// the cached primal result meaningless.
+//===----------------------------------------------------------------------===//
+
+constexpr llvm::StringLiteral kCustomCallReverseAttr = "enzyme.reverse";
+constexpr llvm::StringLiteral kCustomCallActiveOperandsAttr =
+    "enzyme.active_operands";
+constexpr llvm::StringLiteral kCustomCallNonDiffAttr = "enzyme.nondiff";
+
+static bool isDifferentiableTensorType(Type ty) {
+  auto tensorTy = dyn_cast<TensorType>(ty);
+  if (!tensorTy)
+    return false;
+  Type elemTy = tensorTy.getElementType();
+  return isa<FloatType>(elemTy) || isa<ComplexType>(elemTy);
+}
+
+/// Everything the custom call's reverse rule needs, derived once so that
+/// cacheValues and createReverseModeAdjoint cannot disagree about whether the
+/// rule applies.
+struct CustomCallReverseRule {
+  func::FuncOp reverseFn;
+  SmallVector<int64_t> activeOperands;
+};
+
+/// Matches the reverse rule attached to `op`. `emitErrors` is off while
+/// caching so that a call this rule cannot handle is diagnosed exactly once,
+/// from the adjoint.
+static std::optional<CustomCallReverseRule>
+matchCustomCallReverseRule(CustomCallOp op, MGradientUtilsReverse *gutils,
+                           bool emitErrors) {
+  auto diag =
+      [&](const llvm::Twine &msg) -> std::optional<CustomCallReverseRule> {
+    if (emitErrors)
+      op->emitError() << msg;
+    return std::nullopt;
+  };
+
+  auto symbol = op->getAttrOfType<FlatSymbolRefAttr>(kCustomCallReverseAttr);
+  if (!symbol) {
+    if (op->hasAttr(kCustomCallReverseAttr))
+      return diag("'" + kCustomCallReverseAttr +
+                  "' must be a symbol reference to a func.func");
+    // No rule attached: refuse the same way an op with no reverse rule at all
+    // is refused.
+    if (emitErrors)
+      op->emitError() << "could not compute the adjoint for this operation "
+                      << *op;
+    return std::nullopt;
+  }
+
+  if (auto aliases = op.getOutputOperandAliases())
+    if (!aliases.empty())
+      return diag("cannot differentiate a custom call with "
+                  "output_operand_aliasing: an aliased result may no longer "
+                  "hold the value its cotangent is computed from");
+
+  if (gutils->width != 1)
+    return diag("cannot apply '" + kCustomCallReverseAttr +
+                "' in vector reverse mode (width " +
+                llvm::Twine(gutils->width) +
+                "): the rule's signature is "
+                "defined for a single cotangent "
+                "per result");
+
+  auto reverseFn = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+      gutils->newFunc.getOperation(), symbol.getAttr());
+  if (!reverseFn)
+    return diag("'" + kCustomCallReverseAttr + "' refers to '" +
+                symbol.getValue() +
+                "', which is not a func.func in this module");
+
+  SmallVector<int64_t> activeOperands;
+  size_t numOperands = op->getNumOperands();
+  if (auto activeAttr =
+          op->getAttrOfType<DenseI64ArrayAttr>(kCustomCallActiveOperandsAttr)) {
+    for (int64_t idx : activeAttr.asArrayRef()) {
+      if (idx < 0 || (size_t)idx >= numOperands)
+        return diag("'" + kCustomCallActiveOperandsAttr + "' index " +
+                    llvm::Twine(idx) +
+                    " is out of range for a custom call with " +
+                    llvm::Twine(numOperands) + " operands");
+      if (llvm::is_contained(activeOperands, idx))
+        return diag("'" + kCustomCallActiveOperandsAttr + "' lists operand " +
+                    llvm::Twine(idx) + " more than once");
+      // An integer operand would accumulate through arith.addi rather than
+      // fail, so an i1 mask listed here by mistake would quietly produce
+      // integer arithmetic in place of a gradient. Refuse instead.
+      if (!isDifferentiableTensorType(op->getOperand(idx).getType()))
+        return diag("'" + kCustomCallActiveOperandsAttr + "' lists operand " +
+                    llvm::Twine(idx) + " of type " +
+                    debugString(op->getOperand(idx).getType()) +
+                    ", which cannot carry a cotangent; only float- and "
+                    "complex-typed operands may be active");
+      activeOperands.push_back(idx);
+    }
+  } else if (op->hasAttr(kCustomCallActiveOperandsAttr)) {
+    return diag("'" + kCustomCallActiveOperandsAttr +
+                "' must be a dense i64 array attribute, e.g. array<i64: 0, 1>");
+  } else {
+    for (auto &&[idx, operand] : llvm::enumerate(op->getOperands()))
+      if (isDifferentiableTensorType(operand.getType()))
+        activeOperands.push_back(idx);
+  }
+
+  // Check the signature: a mismatch here is the difference between a correct
+  // gradient and a plausible-looking wrong one.
+  size_t numResults = op->getNumResults();
+  auto fnTy = reverseFn.getFunctionType();
+  auto describeConvention = [&]() -> std::string {
+    return (llvm::Twine(" ('") + kCustomCallReverseAttr + "' takes the " +
+            llvm::Twine(numOperands) + " primal operand(s), then the " +
+            llvm::Twine(numResults) + " primal result(s), then the " +
+            llvm::Twine(numResults) +
+            " result cotangent(s), and returns one cotangent per entry of '" +
+            kCustomCallActiveOperandsAttr + "')")
+        .str();
+  };
+
+  if (fnTy.getNumInputs() != numOperands + 2 * numResults)
+    return diag("'" + symbol.getValue() + "' takes " +
+                llvm::Twine(fnTy.getNumInputs()) + " argument(s), expected " +
+                llvm::Twine(numOperands + 2 * numResults) +
+                describeConvention());
+
+  for (auto &&[idx, operand] : llvm::enumerate(op->getOperands()))
+    if (fnTy.getInput(idx) != operand.getType())
+      return diag("'" + symbol.getValue() + "' argument " + llvm::Twine(idx) +
+                  " has type " + llvm::Twine(debugString(fnTy.getInput(idx))) +
+                  ", expected the primal operand type " +
+                  debugString(operand.getType()) + describeConvention());
+
+  for (auto &&[idx, result] : llvm::enumerate(op->getResults())) {
+    Type primalTy = result.getType();
+    Type shadowTy = gutils->getShadowType(primalTy);
+    if (fnTy.getInput(numOperands + idx) != primalTy)
+      return diag("'" + symbol.getValue() + "' argument " +
+                  llvm::Twine(numOperands + idx) + " has type " +
+                  debugString(fnTy.getInput(numOperands + idx)) +
+                  ", expected the primal result type " + debugString(primalTy) +
+                  describeConvention());
+    if (fnTy.getInput(numOperands + numResults + idx) != shadowTy)
+      return diag("'" + symbol.getValue() + "' argument " +
+                  llvm::Twine(numOperands + numResults + idx) + " has type " +
+                  debugString(fnTy.getInput(numOperands + numResults + idx)) +
+                  ", expected the cotangent type " + debugString(shadowTy) +
+                  describeConvention());
+  }
+
+  if (fnTy.getNumResults() != activeOperands.size())
+    return diag("'" + symbol.getValue() + "' returns " +
+                llvm::Twine(fnTy.getNumResults()) +
+                " value(s), expected one cotangent per active operand, i.e. " +
+                llvm::Twine(activeOperands.size()) + describeConvention());
+
+  for (auto &&[idx, operandIdx] : llvm::enumerate(activeOperands)) {
+    Type shadowTy = gutils->getShadowType(op->getOperand(operandIdx).getType());
+    if (fnTy.getResult(idx) != shadowTy)
+      return diag("'" + symbol.getValue() + "' result " + llvm::Twine(idx) +
+                  " has type " + debugString(fnTy.getResult(idx)) +
+                  ", expected the cotangent type " + debugString(shadowTy) +
+                  " of operand " + llvm::Twine(operandIdx) +
+                  describeConvention());
+  }
+
+  return CustomCallReverseRule{reverseFn, std::move(activeOperands)};
+}
+
+/// Whether calling the reverse function can contribute anything: Enzyme may
+/// already know every operand the rule covers is inactive.
+static bool customCallNeedsAdjoint(CustomCallOp op,
+                                   MGradientUtilsReverse *gutils,
+                                   ArrayRef<int64_t> activeOperands) {
+  return llvm::any_of(activeOperands, [&](int64_t idx) {
+    return !gutils->isConstantValue(op->getOperand(idx));
+  });
+}
+
+/// Clears the incoming cotangents of the call's results, so that a later
+/// iteration of an enclosing loop does not read a stale value back.
+static void zeroCustomCallResultDiffes(CustomCallOp op, OpBuilder &builder,
+                                       MGradientUtilsReverse *gutils) {
+  for (auto res : op->getResults())
+    if (!gutils->isConstantValue(res))
+      gutils->zeroDiffe(res, builder);
+}
+
+class AutoDiffCustomCallRev
+    : public ReverseAutoDiffOpInterface::ExternalModel<AutoDiffCustomCallRev,
+                                                       CustomCallOp> {
+public:
+  LogicalResult createReverseModeAdjoint(Operation *orig, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    auto op = cast<CustomCallOp>(orig);
+
+    if (op->hasAttr(kCustomCallNonDiffAttr)) {
+      zeroCustomCallResultDiffes(op, builder, gutils);
+      return success();
+    }
+
+    auto rule = matchCustomCallReverseRule(op, gutils, /*emitErrors=*/true);
+    if (!rule)
+      return failure();
+
+    if (!customCallNeedsAdjoint(op, gutils, rule->activeOperands)) {
+      zeroCustomCallResultDiffes(op, builder, gutils);
+      return success();
+    }
+
+    size_t numOperands = op->getNumOperands(), numResults = op->getNumResults();
+    if (caches.size() != numOperands + numResults) {
+      orig->emitError() << "expected " << (numOperands + numResults)
+                        << " cached values for the reverse of this custom "
+                           "call, got "
+                        << caches.size();
+      return failure();
+    }
+
+    SmallVector<Value> args;
+    args.reserve(caches.size() + numResults);
+    for (Value cache : caches)
+      args.push_back(gutils->popCache(cache, builder));
+
+    for (auto res : op->getResults()) {
+      // A result may be a residual whose cotangent is genuinely zero (an lse
+      // returned alongside an attention output, say). The reverse function
+      // still takes it, so materialize a zero rather than dropping it.
+      if (gutils->isConstantValue(res)) {
+        args.push_back(
+            cast<AutoDiffTypeInterface>(gutils->getShadowType(res.getType()))
+                .createNullValue(builder, op.getLoc()));
+        continue;
+      }
+      args.push_back(gutils->diffe(res, builder));
+      gutils->zeroDiffe(res, builder);
+    }
+
+    auto call =
+        func::CallOp::create(builder, op.getLoc(), rule->reverseFn, args);
+
+    for (auto &&[idx, operandIdx] : llvm::enumerate(rule->activeOperands)) {
+      Value operand = op->getOperand(operandIdx);
+      if (gutils->isConstantValue(operand))
+        continue;
+      gutils->addToDiffe(operand, call.getResult(idx), builder);
+    }
+
+    return success();
+  }
+
+  SmallVector<Value> cacheValues(Operation *orig,
+                                 MGradientUtilsReverse *gutils) const {
+    auto op = cast<CustomCallOp>(orig);
+    if (op->hasAttr(kCustomCallNonDiffAttr))
+      return {};
+
+    auto rule = matchCustomCallReverseRule(op, gutils, /*emitErrors=*/false);
+    if (!rule || !customCallNeedsAdjoint(op, gutils, rule->activeOperands))
+      return {};
+
+    Operation *newOp = gutils->getNewFromOriginal(orig);
+    OpBuilder cacheBuilder(newOp);
+
+    SmallVector<Value> caches;
+    caches.reserve(op->getNumOperands() + op->getNumResults());
+    for (auto operand : op->getOperands())
+      caches.push_back(gutils->initAndPushCache(
+          gutils->getNewFromOriginal(operand), cacheBuilder));
+
+    cacheBuilder.setInsertionPointAfter(newOp);
+    for (auto res : op->getResults())
+      caches.push_back(gutils->initAndPushCache(gutils->getNewFromOriginal(res),
+                                                cacheBuilder));
+
+    return caches;
   }
 
   LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
@@ -4779,6 +5103,7 @@ void mlir::enzyme::registerStableHLODialectAutoDiffInterface(
         SHLODynamicUpdateSliceOpBatchInterface>(*context);
     CustomCallOp::attachInterface<SHLOGenericBatchOpInterface<CustomCallOp>>(
         *context);
+    CustomCallOp::attachInterface<AutoDiffCustomCallRev>(*context);
     RngBitGeneratorOp::attachInterface<SHLORngBitGeneratorOpBatchInterface>(
         *context);
     IotaOp::attachInterface<SHLOIotaOpBatchInterface>(*context);

--- a/test/lit_tests/diffrules/stablehlo/custom_call.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_const mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_const mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=KEEP
+
+// A custom call whose adjoint is supplied by the call site: `@scale` multiplies
+// by 3 and also returns a residual, so its VJP is a single multiply of the
+// output cotangent by 3. The i1 mask operand is excluded from
+// enzyme.active_operands, and the residual's cotangent is never used.
+
+func.func @scale_rev(%x: tensor<4xf32>, %mask: tensor<4xi1>,
+                     %y: tensor<4xf32>, %sum: tensor<f32>,
+                     %dy: tensor<4xf32>, %dsum: tensor<f32>) -> tensor<4xf32> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
+  %res = stablehlo.multiply %dy, %three : tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y:2 = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>, tensor<4xi1>) -> (tensor<4xf32>, tensor<f32>)
+  func.return %y#0 : tensor<4xf32>
+}
+
+// The reverse function is only referenced from an attribute, and survives.
+// KEEP-DAG: func.func @scale_rev(
+// KEEP-DAG: func.func @main(
+
+// REVERSE: func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xi1>, %arg2: tensor<4xf32>) -> tensor<4xf32> {
+// The primal call is still there, and the cotangent goes through @scale_rev,
+// which takes (primal operands..., primal results..., result cotangents...)
+// and returns exactly one cotangent -- for operand 0, the only active one.
+// REVERSE:   %{{.+}}:2 = stablehlo.custom_call @scale(%arg0, %arg1)
+// REVERSE:   call @scale_rev(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}) : (tensor<4xf32>, tensor<4xi1>, tensor<4xf32>, tensor<f32>, tensor<4xf32>, tensor<f32>) -> tensor<4xf32>
+// REVERSE:   return

--- a/test/lit_tests/diffrules/stablehlo/custom_call_accumulate.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_accumulate.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+
+// The custom call's result feeds two consumers and its operand feeds a third,
+// so cotangents have to accumulate on both sides rather than overwrite: the
+// cotangent handed to @scale_rev is the sum of the two uses of %y, and the
+// cotangent @scale_rev returns is added onto the one %x already has.
+
+func.func @scale_rev(%x: tensor<4xf32>,
+                     %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
+  %res = stablehlo.multiply %dy, %three : tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  %a = stablehlo.sine %y : tensor<4xf32>
+  %b = stablehlo.cosine %y : tensor<4xf32>
+  %c = stablehlo.add %a, %b : tensor<4xf32>
+  %d = stablehlo.add %c, %x : tensor<4xf32>
+  func.return %d : tensor<4xf32>
+}
+
+// REVERSE: func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+// REVERSE:   stablehlo.custom_call @scale(%arg0)
+// The two uses of %y are summed into a single cotangent before the call...
+// REVERSE:   arith.addf
+// REVERSE:   call @scale_rev(%{{.+}}, %{{.+}}, %{{.+}}) : (tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+// ... and what it returns is added onto the cotangent %x already has.
+// REVERSE:   arith.addf
+// REVERSE:   return

--- a/test/lit_tests/diffrules/stablehlo/custom_call_aliasing.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_aliasing.mlir
@@ -1,0 +1,27 @@
+// RUN: not enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" 2>&1 | FileCheck %s
+
+// A result that aliases an operand may have been overwritten in place by the
+// time the reverse pass runs, which would make the cached primal result -- and
+// therefore the gradient -- meaningless. Refuse rather than cache it.
+
+func.func @scale_rev(%x: tensor<4xf32>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
+  %res = stablehlo.multiply %dy, %three : tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>,
+    output_operand_aliases = [
+      #stablehlo.output_operand_alias<output_tuple_indices = [],
+                                      operand_index = 0,
+                                      operand_tuple_indices = []>
+    ]
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: cannot differentiate a custom call with output_operand_aliasing

--- a/test/lit_tests/diffrules/stablehlo/custom_call_bad_signature.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_bad_signature.mlir
@@ -1,0 +1,40 @@
+// RUN: not enzymexlamlir-opt %s --split-input-file --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" 2>&1 | FileCheck %s
+
+// The convention is checked before it is used: getting it wrong would produce a
+// silently wrong gradient rather than a failure.
+
+// @scale_rev forgets the primal result, so it takes one argument too few.
+func.func @scale_rev(%x: tensor<4xf32>, %dy: tensor<4xf32>) -> tensor<4xf32> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
+  %res = stablehlo.multiply %dy, %three : tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'scale_rev' takes 2 argument(s), expected 3
+
+// -----
+
+// @scale_rev returns a cotangent of the wrong shape for operand 0.
+func.func @scale_rev(%x: tensor<4xf32>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<8xf32> {
+  %res = stablehlo.constant dense<0.000000e+00> : tensor<8xf32>
+  func.return %res : tensor<8xf32>
+}
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'scale_rev' result 0 has type tensor<8xf32>, expected the cotangent type tensor<4xf32> of operand 0

--- a/test/lit_tests/diffrules/stablehlo/custom_call_default_active.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_default_active.mlir
@@ -1,0 +1,25 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_active,enzyme_const mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+
+// Without enzyme.active_operands the active operands default to the
+// float-typed ones, so the mask is skipped and @axpy_rev returns two
+// cotangents, for operands 0 and 1 in that order.
+
+func.func @axpy_rev(%a: tensor<4xf32>, %b: tensor<4xf32>, %mask: tensor<4xi1>,
+                    %y: tensor<4xf32>,
+                    %dy: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+  %two = stablehlo.constant dense<2.000000e+00> : tensor<4xf32>
+  %da = stablehlo.multiply %dy, %two : tensor<4xf32>
+  func.return %da, %dy : tensor<4xf32>, tensor<4xf32>
+}
+
+func.func @main(%a : tensor<4xf32>, %b : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @axpy(%a, %b, %mask) {
+    enzyme.reverse = @axpy_rev
+  } : (tensor<4xf32>, tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// REVERSE: func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>, %arg2: tensor<4xi1>, %arg3: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+// REVERSE:   stablehlo.custom_call @axpy(%arg0, %arg1, %arg2)
+// REVERSE:   call @axpy_rev(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}) : (tensor<4xf32>, tensor<4xf32>, tensor<4xi1>, tensor<4xf32>, tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>)
+// REVERSE:   return

--- a/test/lit_tests/diffrules/stablehlo/custom_call_forward.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_forward.mlir
@@ -1,0 +1,23 @@
+// RUN: not enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup mode=ForwardMode" 2>&1 | FileCheck %s
+
+// enzyme.reverse is reverse-mode only. Forward mode has no rule for a custom
+// call and must keep refusing, rather than quietly using the reverse function
+// or producing a zero tangent.
+
+func.func @scale_rev(%x: tensor<4xf32>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
+  %res = stablehlo.multiply %dy, %three : tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: could not compute the adjoint for this operation
+// CHECK-SAME: stablehlo.custom_call

--- a/test/lit_tests/diffrules/stablehlo/custom_call_if.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_if.mlir
@@ -1,0 +1,36 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_const mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+
+// The call sits in one branch of a `stablehlo.if`, so its adjoint is built inside a region whose
+// reverse block is only reached when the predicate selected that branch. Together with
+// custom_call_while.mlir this covers the two control-flow shapes where the caches cannot simply
+// fold away into the enclosing block.
+
+func.func @scale_rev(%x: tensor<10xf32>, %y: tensor<10xf32>,
+                     %dy: tensor<10xf32>) -> tensor<10xf32> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<10xf32>
+  %res = stablehlo.multiply %dy, %three : tensor<10xf32>
+  func.return %res : tensor<10xf32>
+}
+
+// Both functions have to sit in the same module: `enzyme.reverse` is a flat symbol reference, so
+// the rule is looked up in the symbol table enclosing the call.
+func.func @main(%arg0: tensor<10xf32>, %pred: tensor<i1>) -> tensor<10xf32> {
+  %cst = stablehlo.constant dense<1.0> : tensor<10xf32>
+
+  %0 = "stablehlo.if"(%pred) ({
+    %1 = stablehlo.custom_call @scale(%arg0) {
+      enzyme.reverse = @scale_rev,
+      enzyme.active_operands = array<i64: 0>
+    } : (tensor<10xf32>) -> tensor<10xf32>
+    "stablehlo.return"(%1) : (tensor<10xf32>) -> ()
+  }, {
+    "stablehlo.return"(%cst) : (tensor<10xf32>) -> ()
+  }) : (tensor<i1>) -> tensor<10xf32>
+
+  return %0 : tensor<10xf32>
+}
+
+// REVERSE: func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<i1>, %arg2: tensor<10xf32>) -> tensor<10xf32> {
+// REVERSE:   stablehlo.custom_call @scale(
+// REVERSE:   call @scale_rev(
+// REVERSE:   return

--- a/test/lit_tests/diffrules/stablehlo/custom_call_invalid.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_invalid.mlir
@@ -1,0 +1,175 @@
+// RUN: not enzymexlamlir-opt %s --split-input-file --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_const mode=ReverseModeCombined" 2>&1 | FileCheck %s
+
+// Every way of getting the attributes or the reverse signature wrong, each of
+// which would otherwise be a silently wrong gradient.
+
+// enzyme.reverse naming a symbol that is not in the module.
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @nowhere,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'enzyme.reverse' refers to 'nowhere', which is not a func.func in this module
+
+// -----
+
+// An operand index past the end of the operand list.
+func.func @scale_rev(%x: tensor<4xf32>, %m: tensor<4xi1>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  func.return %dy : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 7>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'enzyme.active_operands' index 7 is out of range for a custom call with 2 operands
+
+// -----
+
+// The same operand listed twice.
+func.func @scale_rev(%x: tensor<4xf32>, %m: tensor<4xi1>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+  func.return %dy, %dy : tensor<4xf32>, tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0, 0>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'enzyme.active_operands' lists operand 0 more than once
+
+// -----
+
+// A boolean operand explicitly marked active. Integers accumulate through
+// arith.addi rather than failing, so this has to be refused, not tolerated.
+func.func @scale_rev(%x: tensor<4xf32>, %m: tensor<4xi1>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xi1> {
+  %c = stablehlo.constant dense<false> : tensor<4xi1>
+  func.return %c : tensor<4xi1>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 1>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'enzyme.active_operands' lists operand 1 of type tensor<4xi1>, which cannot carry a cotangent
+
+// -----
+
+// enzyme.active_operands given as something other than a dense i64 array.
+func.func @scale_rev(%x: tensor<4xf32>, %m: tensor<4xi1>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  func.return %dy : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = 0 : i64
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'enzyme.active_operands' must be a dense i64 array attribute
+
+// -----
+
+// enzyme.reverse given as a string rather than a symbol reference.
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = "scale_rev",
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'enzyme.reverse' must be a symbol reference to a func.func
+
+// -----
+
+// Argument 0 does not have the primal operand's type.
+func.func @scale_rev(%x: tensor<8xf32>, %m: tensor<4xi1>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  func.return %dy : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'scale_rev' argument 0 has type tensor<8xf32>, expected the primal operand type tensor<4xf32>
+
+// -----
+
+// The primal result slot has the wrong type.
+func.func @scale_rev(%x: tensor<4xf32>, %m: tensor<4xi1>, %y: tensor<8xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  func.return %dy : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'scale_rev' argument 2 has type tensor<8xf32>, expected the primal result type tensor<4xf32>
+
+// -----
+
+// The cotangent slot has the wrong type.
+func.func @scale_rev(%x: tensor<4xf32>, %m: tensor<4xi1>, %y: tensor<4xf32>,
+                     %dy: tensor<8xf32>) -> tensor<4xf32> {
+  %c = stablehlo.constant dense<0.000000e+00> : tensor<4xf32>
+  func.return %c : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'scale_rev' argument 3 has type tensor<8xf32>, expected the cotangent type tensor<4xf32>
+
+// -----
+
+// One active operand, but two cotangents returned.
+func.func @scale_rev(%x: tensor<4xf32>, %m: tensor<4xi1>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+  func.return %dy, %dy : tensor<4xf32>, tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>, %mask : tensor<4xi1>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x, %mask) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>, tensor<4xi1>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: 'scale_rev' returns 2 value(s), expected one cotangent per active operand, i.e. 1

--- a/test/lit_tests/diffrules/stablehlo/custom_call_multi_site.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_multi_site.mlir
@@ -1,0 +1,42 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+
+// Two call sites share one call_target_name and have different adjoints. This is
+// the case a registry keyed on call_target_name could not express, and it is the
+// real shape of the motivating kernel: `mps.metal_kernel_lib` dispatches _fwd,
+// _bwd_q, _bwd_kv and _bwd_b, all under the same target name, configured only by
+// backend_config.
+
+func.func @double_rev(%x: tensor<4xf32>, %y: tensor<4xf32>,
+                      %dy: tensor<4xf32>) -> tensor<4xf32> {
+  %two = stablehlo.constant dense<2.000000e+00> : tensor<4xf32>
+  %res = stablehlo.multiply %dy, %two : tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+func.func @triple_rev(%x: tensor<4xf32>, %y: tensor<4xf32>,
+                      %dy: tensor<4xf32>) -> tensor<4xf32> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
+  %res = stablehlo.multiply %dy, %three : tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %a = stablehlo.custom_call @kernel(%x) {
+    enzyme.reverse = @double_rev,
+    enzyme.active_operands = array<i64: 0>,
+    backend_config = "{\22which\22: \22double\22}"
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  %b = stablehlo.custom_call @kernel(%a) {
+    enzyme.reverse = @triple_rev,
+    enzyme.active_operands = array<i64: 0>,
+    backend_config = "{\22which\22: \22triple\22}"
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %b : tensor<4xf32>
+}
+
+// REVERSE: func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+// Reverse order: the second call site's rule runs first, and each site gets its
+// own reverse function despite sharing @kernel.
+// REVERSE:   call @triple_rev(
+// REVERSE:   call @double_rev(
+// REVERSE:   return

--- a/test/lit_tests/diffrules/stablehlo/custom_call_no_rule.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_no_rule.mlir
@@ -1,0 +1,12 @@
+// RUN: not enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" 2>&1 | FileCheck %s
+
+// A custom call with no enzyme.reverse attribute is still refused, rather than
+// silently differentiating to zero.
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x) : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// CHECK: could not compute the adjoint for this operation
+// CHECK-SAME: stablehlo.custom_call

--- a/test/lit_tests/diffrules/stablehlo/custom_call_nondiff.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_nondiff.mlir
@@ -1,0 +1,15 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+
+// enzyme.nondiff marks the call as a gradient stop: no reverse function is
+// needed and none is called, and no cotangent flows back to the operand.
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @round_to_int(%x) {
+    enzyme.nondiff
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// REVERSE: func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+// REVERSE-NOT: = call @
+// REVERSE: return

--- a/test/lit_tests/diffrules/stablehlo/custom_call_nondiff_precedence.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_nondiff_precedence.mlir
@@ -1,0 +1,26 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+
+// enzyme.nondiff wins over enzyme.reverse: the call is a gradient stop and the
+// reverse function is not called, even though one is named. Pinning the
+// precedence down means a frontend that emits both by accident gets the safe
+// answer rather than an arbitrary one.
+
+func.func @scale_rev(%x: tensor<4xf32>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
+  %res = stablehlo.multiply %dy, %three : tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x) {
+    enzyme.nondiff,
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// REVERSE: func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+// REVERSE-NOT: = call @
+// REVERSE: return

--- a/test/lit_tests/diffrules/stablehlo/custom_call_side_effect.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_side_effect.mlir
@@ -1,0 +1,39 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
+
+// Two properties of the motivating kernel at once: the forward call is marked
+// has_side_effect (the primal is cloned as-is and the caches are pushed around
+// it, so this is fine), and the reverse rule is not itself pure StableHLO -- it
+// contains custom calls of its own, one feeding the next, exactly like
+// _bwd_q producing the `delta` that _bwd_kv consumes. Nothing may try to
+// differentiate the rule's own body.
+
+func.func @scale_rev(%x: tensor<4xf32>, %y: tensor<4xf32>,
+                     %dy: tensor<4xf32>) -> tensor<4xf32> {
+  %delta = stablehlo.custom_call @bwd_first(%x, %dy) {
+    has_side_effect = true
+  } : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  %dx = stablehlo.custom_call @bwd_second(%delta, %y) {
+    has_side_effect = true
+  } : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  func.return %dx : tensor<4xf32>
+}
+
+func.func @main(%x : tensor<4xf32>) -> tensor<4xf32> {
+  %y = stablehlo.custom_call @scale(%x) {
+    enzyme.reverse = @scale_rev,
+    enzyme.active_operands = array<i64: 0>,
+    has_side_effect = true
+  } : (tensor<4xf32>) -> tensor<4xf32>
+  func.return %y : tensor<4xf32>
+}
+
+// The rule's body is untouched, and the ordering between its two calls stays a
+// dataflow edge rather than a scheduling assumption.
+// REVERSE: func.func @scale_rev(
+// REVERSE:   %[[DELTA:.+]] = stablehlo.custom_call @bwd_first(
+// REVERSE:   stablehlo.custom_call @bwd_second(%[[DELTA]],
+
+// REVERSE: func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+// REVERSE:   stablehlo.custom_call @scale(%arg0)
+// REVERSE:   call @scale_rev(
+// REVERSE:   return

--- a/test/lit_tests/diffrules/stablehlo/custom_call_while.mlir
+++ b/test/lit_tests/diffrules/stablehlo/custom_call_while.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --arith-raise | FileCheck %s --check-prefix=REVERSE
+
+// The custom call runs inside a loop, so its cached primal operands and results
+// genuinely have to be pushed once per iteration and popped in reverse -- unlike
+// the straight-line tests, where the push/pop pairs cancel out entirely. This is
+// what exercises cacheValues' two insertion points: operands before the cloned
+// call, results after it.
+
+func.func @scale_rev(%x: tensor<3xf64>, %y: tensor<3xf64>,
+                     %dy: tensor<3xf64>) -> tensor<3xf64> {
+  %three = stablehlo.constant dense<3.000000e+00> : tensor<3xf64>
+  %res = stablehlo.multiply %dy, %three : tensor<3xf64>
+  func.return %res : tensor<3xf64>
+}
+
+func.func @main(%arg0: tensor<3xf64>) -> tensor<3xf64> {
+  %c = stablehlo.constant dense<0> : tensor<i64>
+  %c_10 = stablehlo.constant dense<10> : tensor<i64>
+  %c_1 = stablehlo.constant dense<1> : tensor<i64>
+  %0:2 = stablehlo.while(%iterArg = %c, %iterArg_0 = %arg0) : tensor<i64>, tensor<3xf64>
+   cond {
+    %1 = stablehlo.compare  LT, %iterArg, %c_10,  SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  } do {
+    %2 = stablehlo.add %iterArg, %c_1 : tensor<i64>
+    %3 = stablehlo.custom_call @scale(%iterArg_0) {
+      enzyme.reverse = @scale_rev,
+      enzyme.active_operands = array<i64: 0>
+    } : (tensor<3xf64>) -> tensor<3xf64>
+    stablehlo.return %2, %3 : tensor<i64>, tensor<3xf64>
+  }
+  return %0#1 : tensor<3xf64>
+}
+
+// REVERSE: func.func @main(%arg0: tensor<3xf64>, %arg1: tensor<3xf64>) -> tensor<3xf64> {
+// The primal loop still runs the call, and the caches it pushes survive to the
+// reverse loop, which calls the rule once per iteration.
+// REVERSE:   stablehlo.custom_call @scale(
+// REVERSE:   call @scale_rev(
+// REVERSE:   return


### PR DESCRIPTION
`stablehlo.custom_call` has no `ReverseAutoDiffOpInterface`, so any program containing one fails
reverse-mode AD with `could not compute the adjoint for this operation`. A custom call is opaque by
construction, so the only thing that can supply its adjoint is whoever built it.

This PR adds `AutoDiffCustomCallRev`, which lets a call site carry its own reverse rule as attributes
pointing at an ordinary `func.func`.

```mlir
%o, %lse = stablehlo.custom_call @foo(%q, %k, %v, %mask) {
    enzyme.reverse         = @foo_reverse,
    enzyme.active_operands = array<i64: 0, 1, 2>
} : (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xi1>)
 -> (tensor<8xf32>, tensor<f32>)

func.func @foo_reverse(%q, %k, %v, %mask,   // every primal operand
                       %o, %lse,            // every primal result
                       %do, %dlse)          // the cotangent of every result
    -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)   // one per active operand, in order
```

## Motivation

In many cases, highly efficient and validated GPU kernels already exist (for example those written in `triton`) that users might prefer over XLA generated from tracing programs using JAX or Reactant.jl. Directly embedding these in the lowered MLIR results in a `stablehlo.custom_call`, which Enzyme cannot differentiate. In many cases, the user can also provide a kernel or python / julia for the *reverse*, which can appropriately be added to the MLIR, which is what this PR will allow the user to do.

## Why the rule lives on the call site

Not a registry keyed on `call_target_name`: one target name routinely dispatches many unrelated
kernels through its `backend_config`. The motivating case is a Metal-backed attention kernel where WIP functionality in the `jax-mps` PJRT-plugin defines a `mps.metal_kernel_lib` which dispatches `_fwd`, `_bwd_q`, `_bwd_kv` and `_bwd_b`: a forward and three backwards, all under one name, sharing no adjoint. Per-call-site attributes are also trivially emitted by any frontend that can build a custom call at all.

## Added properties

* `enzyme.reverse` — `FlatSymbolRefAttr` naming a `func.func` in the same module. It is an ordinary function: pure StableHLO, or containing custom calls of its own. This can be obtained from lowering python / julia code or supplying another `stablehlo.custom_call`.
* `enzyme.active_operands` — operand indices that can carry a gradient; anything omitted is treated as constant, which is what a boolean mask needs. Absent, it defaults to every float- or complex-typed operand. Listing a non-float operand is an error rather than a silent no-op, since an integer cotangent would otherwise accumulate through `arith.addi` and look like a gradient.
* `enzyme.nondiff` — gradient stop; takes precedence over `enzyme.reverse`.
* With none of these, the pre-existing error is emitted unchanged. The rule never silently differentiates a custom call to zero.

Results are deliberately *not* filtered the way operands are: every result contributes a cotangent argument, so the argument list stays positional. A result whose cotangent is genuinely zero gets a materialized zero rather than being dropped.

## Constraints

* `output_operand_aliasing` is refused: an aliased result may no longer hold the value its cotangent is computed from, which would make the cached primal result meaningless.
* Vector reverse mode (`width != 1`) is refused; the signature convention is defined for a single cotangent per result.
* The reverse function's signature is fully verified against the call site before the rule fires. A wrong convention here would produce a plausible-looking wrong gradient, so each mismatch is a diagnostic naming the offending position.

`has_side_effect` is fine and is not refused: the primal is cloned as-is and the caches are pushed around it.

## Implementation notes

* Reverse mode clones the primal, so no `AutoDiffOpInterface` (forward-mode) implementation is needed for the rule to be reachable. Forward mode continues to refuse.
* `cacheValues` caches every primal operand and result, since the convention hands all of them to the reverse function.
* The reverse `func.func` is referenced only from an attribute. MLIR's symbol-use scanning walks op attributes, so it survives symbol DCE with no keep-alive mechanism.

## Tests

Added 14 new lit tests in `test/lit_tests/diffrules/stablehlo/custom_call*.mlir`, all using a trivially known adjoint (a scaling, so the reverse is one `stablehlo.multiply`) and checkable with `enzymexlamlir-opt` alone.

| Test | Covers |
|---|---|
| `custom_call` | multi-result call, `i1` operand excluded, zero cotangent for a dead result |
| `custom_call_accumulate` | cotangents accumulate rather than overwrite, on both the result and the operand side |
| `custom_call_default_active` | the implicit float-operand filter, two returned cotangents |
| `custom_call_while` | call inside `stablehlo.while` — caches really pushed and popped per iteration |
| `custom_call_if` | call inside one branch of `stablehlo.if` |
| `custom_call_multi_site` | two sites sharing a `call_target_name` with different reverse functions |
| `custom_call_side_effect` | `has_side_effect`, and a reverse rule that itself contains chained custom calls |
| `custom_call_nondiff` / `_precedence` | gradient stop, and that it wins over `enzyme.reverse` |
| `custom_call_no_rule` | no attributes ⇒ the original error, unchanged |
| `custom_call_forward` | forward mode still refuses |
| `custom_call_aliasing` | `output_operand_aliasing` refused |
| `custom_call_bad_signature` | arity and result-type mismatches |
| `custom_call_invalid` | ten chunks: unknown symbol, out-of-range index, duplicate index, non-float active operand, both wrong attribute kinds, and the four remaining signature mismatches |

## Testing performed

Built and run on `linux/arm64` in the project's CI container (`ghcr.io/enzymead/reactant-docker-images`), bazel 7.7.0, clang, `-c opt`.

* All 14 `custom_call*` lit tests pass.
* Complete test suite `//test/lit_tests/...` 1180/1180 pass, i.e. no existing diffrule is disturbed by attaching `ReverseAutoDiffOpInterface` to `CustomCallOp`.
* End-to-end against a real frontend: used Reactant.jl to emit the attributes and trace a VJP into the module, and the resulting IR (five operands including an `i1` mask, two results, four active operands) was run through this rule. The resulting gradient matches FiniteDiff.jl and operates correctly: the rule is called with the five primal operands, both primal results, the output cotangent, and a materialized zero for the dead residual; the four returned cotangents accumulate into the right operands; the mask gets none (== Array{Bool}); and the permutations surrounding the call are differentiated by Enzyme itself.

## Known limitations according to Claude

* Split reverse mode (`DerivativeMode::ReverseModeGradient`) is untested. No lit test in this repository exercises it for any rule, so there was nothing to model a test on; `cacheValues` uses the same `initAndPushCache` API as the existing reduce/while rules.
* Vector mode (`width > 1`) is refused, and the refusal path itself has no test — again, no existing reverse-mode test in the repo uses a width above 1.
* Complex-typed operands are accepted by the default active-operand filter but untested.
* `enzyme.reverse` is a flat symbol reference, so the rule must live in the symbol table enclosing the call. A reverse function in a nested module will not resolve.
* Interaction with `while` checkpointing is untested.
* Every primal operand and result is cached unconditionally, because the convention passes all of them. Correct, but for a call inside a loop that is per-iteration memory. If it proves costly, a follow-up attribute could narrow what the rule asks to be cached.