### PR TITLE
Preserve the source's launch bounds through raising

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -263,56 +263,92 @@ struct AddLaunchBounds : public OpRewritePattern<gpu::LaunchFuncOp> {
     // gpu::LaunchFuncOp's)
     auto gpuFuncOp = launchOp->getParentOfType<ModuleOp>().lookupSymbol(
         launchOp.getKernel());
+
+    // Launch bounds the kernel was compiled with: clang encodes
+    // __launch_bounds__(maxThreads, minBlocks) as nvvm annotations, which the
+    // importer carries in the device function's passthrough and launch
+    // recognition copies onto the error op.
+    int32_t srcMaxntid = 0, srcMinctasm = 0;
+    if (auto err = launchOp->getParentOfType<enzymexla::GPUErrorOp>()) {
+      if (auto attr =
+              dyn_cast_or_null<ArrayAttr>(err->getAttr("passthrough"))) {
+        for (auto a : attr) {
+          auto ar = dyn_cast<ArrayAttr>(a);
+          if (!ar || ar.size() != 2)
+            continue;
+          auto s0 = dyn_cast<StringAttr>(ar[0]);
+          auto s1 = dyn_cast<StringAttr>(ar[1]);
+          if (!s0 || !s1)
+            continue;
+          if (s0.getValue() == "nvvm.maxntid")
+            s1.getValue().getAsInteger(10, srcMaxntid);
+          if (s0.getValue() == "nvvm.minctasm")
+            s1.getValue().getAsInteger(10, srcMinctasm);
+        }
+      }
+    }
+
     auto blockDims = launchOp.getBlockSizeOperandValues();
     auto bx = getConstantInteger(blockDims.x);
     auto by = getConstantInteger(blockDims.y);
     auto bz = getConstantInteger(blockDims.z);
-    if (!bx || !by || !bz) {
-      // The kernel must stay launchable at every legal block size; without
-      // a bound ptxas may allocate registers for a small block and larger
-      // launches fail with too-many-resources.
-      llvm::StringRef attrName = "nvvm.maxntid";
-      if (gpuFuncOp->hasAttr(attrName))
-        return failure();
-      gpuFuncOp->setAttr(attrName, rewriter.getDenseI32ArrayAttr({1024, 1, 1}));
+
+    // The preserved bounds promise the block shape the kernel was compiled
+    // with. Runtime dimensions are the original launch's own values; a
+    // constant block size only matches when it reproduces the recorded
+    // original, not when the kernel was re-blocked.
+    bool shapeMatches = !bx || !by || !bz;
+    if (!shapeMatches)
+      if (auto err = launchOp->getParentOfType<enzymexla::GPUErrorOp>())
+        if (auto orig =
+                err->getAttrOfType<IntegerAttr>("reactant.launch_block_size"))
+          shapeMatches = orig.getInt() == (*bx) * (*by) * (*bz);
+
+    bool changed = false;
+    if (srcMinctasm > 0 && shapeMatches &&
+        !gpuFuncOp->hasAttr("nvvm.minctasm")) {
       gpuFuncOp->setAttr(
-          "rocdl.max_flat_work_group_size",
-          rewriter.getIntegerAttr(rewriter.getIndexType(), 1024));
-      return success();
+          "nvvm.minctasm",
+          rewriter.getIntegerAttr(rewriter.getI32Type(), srcMinctasm));
+      changed = true;
     }
-    // TODO should we only set idx or separately set idx, idy, idz? clang seems
-    // to only set idx to the total num
-    // TODO grab the attr name from the NVVM dialect after bumping llvm
-    bool succeeded = false;
-    int blockSize = *bx * *by * *bz;
-    // A kernel with a known block size already gets its bound from that
-    // attribute during lowering; adding it here would duplicate it.
+    if (!bx || !by || !bz) {
+      // The kernel must stay launchable at every block size its callers may
+      // use: the bound it was compiled with when there is one, the
+      // architecture maximum otherwise; without any bound ptxas may allocate
+      // registers for a small block and larger launches fail with
+      // too-many-resources.
+      if (!gpuFuncOp->hasAttr("nvvm.maxntid")) {
+        int32_t cap = srcMaxntid > 0 ? srcMaxntid : 1024;
+        gpuFuncOp->setAttr("nvvm.maxntid",
+                           rewriter.getDenseI32ArrayAttr({cap, 1, 1}));
+        gpuFuncOp->setAttr(
+            "rocdl.max_flat_work_group_size",
+            rewriter.getIntegerAttr(rewriter.getIndexType(), cap));
+        changed = true;
+      }
+      return success(changed);
+    }
+    // A statically known block size is the exact bound: it wins over any
+    // looser bound the source declared. A kernel with known_block_size gets
+    // it from that attribute during lowering; adding it here would duplicate
+    // it.
     if (gpuFuncOp->hasAttr("known_block_size"))
-      return failure();
-    llvm::StringRef attrName = "nvvm.maxntid";
+      return success(changed);
+    // TODO grab the attr name from the NVVM dialect after bumping llvm
     auto ntid = rewriter.getDenseI32ArrayAttr(
         {(int32_t)*bx, (int32_t)*by, (int32_t)*bz});
-    if (!gpuFuncOp->hasAttr(attrName)) {
-      gpuFuncOp->setAttr(attrName, ntid);
-      succeeded = true;
-    } else {
-      assert(ntid == gpuFuncOp->getAttr(attrName));
-      succeeded = false;
+    if (gpuFuncOp->getAttr("nvvm.maxntid") != ntid) {
+      gpuFuncOp->setAttr("nvvm.maxntid", ntid);
+      changed = true;
     }
-    attrName = "rocdl.max_flat_work_group_size";
-    if (!gpuFuncOp->hasAttr(attrName)) {
-      gpuFuncOp->setAttr(attrName, rewriter.getIntegerAttr(
-                                       rewriter.getIndexType(), blockSize));
-      assert(succeeded);
-      (void)succeeded;
-      return success();
-    } else {
-      assert(blockSize ==
-             dyn_cast<IntegerAttr>(gpuFuncOp->getAttr(attrName)).getInt());
-      assert(!succeeded);
-      (void)succeeded;
-      return failure();
+    int blockSize = *bx * *by * *bz;
+    auto flat = rewriter.getIntegerAttr(rewriter.getIndexType(), blockSize);
+    if (gpuFuncOp->getAttr("rocdl.max_flat_work_group_size") != flat) {
+      gpuFuncOp->setAttr("rocdl.max_flat_work_group_size", flat);
+      changed = true;
     }
+    return success(changed);
   }
 };
 
@@ -1901,6 +1937,22 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       if (auto attr = wrapper->getAttr(atname)) {
         errOp->setAttr(atname, attr);
       }
+    // The launch bounds riding the passthrough promise a specific block
+    // shape: record the original block size so their consumer can tell a
+    // reproduced shape from a re-blocked one.
+    {
+      int64_t orig = 1;
+      bool known = true;
+      for (unsigned i = 3; i < 6 && known; i++) {
+        if (auto c = getConstantInteger(wrapper.getOperand(i)))
+          orig *= *c;
+        else
+          known = false;
+      }
+      if (known)
+        errOp->setAttr("reactant.launch_block_size",
+                       rewriter.getI64IntegerAttr(orig));
+    }
     rewriter.setInsertionPointToStart(errOp.getBody());
     rewriter.eraseOp(wrapper.getBody()->getTerminator());
     rewriter.inlineBlockBefore(wrapper.getBody(),

--- a/test/lit_tests/lowering/launch-bounds-preserve.mlir
+++ b/test/lit_tests/lowering/launch-bounds-preserve.mlir
@@ -1,0 +1,81 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu2{backend=cuda emitGPUKernelLaunchBounds=true})" | FileCheck %s
+
+// __launch_bounds__(maxThreads, minBlocks) arrives from the device IR as
+// nvvm passthrough pairs on the error op; both must land on the kernel, and
+// the preserved maxntid beats the architecture-maximum fallback when the
+// block size is not known.
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, gpu.container_module, llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+
+  func.func @main(%n: index, %out: memref<100xf64, 1>) -> i32 {
+    %c1 = arith.constant 1 : index
+    %c0_i32 = arith.constant 0 : i32
+    %0 = "enzymexla.gpu_error"() ({
+      gpu.launch_func @main_kernel::@main_kernel blocks in (%n, %c1, %c1) threads in (%n, %c1, %c1) args(%out : memref<100xf64, 1>)
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) {passthrough = [["target-cpu", "sm_120"], ["nvvm.maxntid", "128"], ["nvvm.minctasm", "4"]]} : () -> index
+    return %c0_i32 : i32
+  }
+
+  // With statically known threads the exact bound wins over the declared one,
+  // and without a matching recorded original shape the minctasm promise does
+  // not transfer.
+  func.func @second(%n: index, %out: memref<100xf64, 1>) -> i32 {
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %c0_i32 = arith.constant 0 : i32
+    %1 = "enzymexla.gpu_error"() ({
+      gpu.launch_func @second_kernel::@second_kernel blocks in (%n, %c1, %c1) threads in (%c64, %c1, %c1) args(%out : memref<100xf64, 1>)
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) {passthrough = [["target-cpu", "sm_120"], ["nvvm.maxntid", "128"], ["nvvm.minctasm", "4"]]} : () -> index
+    return %c0_i32 : i32
+  }
+
+  // Constant dims that reproduce the recorded original shape keep minctasm.
+  func.func @third(%n: index, %out: memref<100xf64, 1>) -> i32 {
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %c0_i32 = arith.constant 0 : i32
+    %2 = "enzymexla.gpu_error"() ({
+      gpu.launch_func @third_kernel::@third_kernel blocks in (%n, %c1, %c1) threads in (%c64, %c1, %c1) args(%out : memref<100xf64, 1>)
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) {passthrough = [["target-cpu", "sm_120"], ["nvvm.maxntid", "128"], ["nvvm.minctasm", "4"]], reactant.launch_block_size = 64 : i64} : () -> index
+    return %c0_i32 : i32
+  }
+
+  gpu.module @main_kernel {
+    gpu.func @main_kernel(%arg0: memref<100xf64, 1>) kernel {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 1.0 : f64
+      memref.store %cst, %arg0[%c0] : memref<100xf64, 1>
+      gpu.return
+    }
+  }
+  gpu.module @second_kernel {
+    gpu.func @second_kernel(%arg0: memref<100xf64, 1>) kernel {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 2.0 : f64
+      memref.store %cst, %arg0[%c0] : memref<100xf64, 1>
+      gpu.return
+    }
+  }
+  gpu.module @third_kernel {
+    gpu.func @third_kernel(%arg0: memref<100xf64, 1>) kernel {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 3.0 : f64
+      memref.store %cst, %arg0[%c0] : memref<100xf64, 1>
+      gpu.return
+    }
+  }
+}
+
+// CHECK: gpu.module @main_kernel [#nvvm.target<O = 3, chip = "sm_120"
+// CHECK: gpu.func @main_kernel
+// CHECK-SAME: nvvm.maxntid = array<i32: 128, 1, 1>
+// CHECK-SAME: nvvm.minctasm = 4 : i32
+// CHECK: gpu.func @second_kernel
+// CHECK-SAME: nvvm.maxntid = array<i32: 64, 1, 1>
+// CHECK-NOT: nvvm.minctasm
+// CHECK: gpu.func @third_kernel
+// CHECK-SAME: nvvm.maxntid = array<i32: 64, 1, 1>
+// CHECK-SAME: nvvm.minctasm = 4 : i32


### PR DESCRIPTION
Reworked per review: the computed `minCtasTarget` knob is gone. With the serializer sink (#2907) addressing the register-pressure root cause, the right mechanism for occupancy targets is the source's own `__launch_bounds__(maxThreads, minBlocks)` — which clang already encodes as nvvm annotations that the importer carries onto the device function's passthrough and launch recognition already copies onto the error op. This PR simply consumes them: `nvvm.minctasm` and `nvvm.maxntid` are parsed where the target attributes are read and set on the kernel, with the preserved maxntid replacing the architecture-maximum fallback for runtime-block kernels (never overriding an exact `known_block_size`).

Verified end-to-end on a `__launch_bounds__(128, 4)` MWE: the raised PTX carries `.maxntid 128, 1, 1` and `.minnctapersm 4`, matching vanilla clang's device output, where previously the minctasm was silently dropped. Stacked on #2895; no pipeline options or env vars involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD