### PR TITLE
[ConvertParallelToGPU1] prevent emit a block that exceeds the capability on blockDim.z

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -1871,6 +1871,11 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     if (!blockPop)
       return failure();
 
+    // The blockDim.x the wrapper records, read before the wrapper is replaced
+    Value originalBlockX;
+    if (wrapper->getNumOperands() == 6)
+      originalBlockX = wrapper->getOperand(3);
+
     // Only mutate once the match is certain: an op created before a bail
     // marks the IR changed on every scan, so a wrapper this pattern cannot
     // convert -- such as one whose bounds have to stay beside the parallel,
@@ -1902,11 +1907,52 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       else
         gridBounds[i] = oneindex;
     }
-    Value blockBounds[3];
     auto popBlockBounds = getUpperBounds(blockPop);
+
+    constexpr uint64_t MAX_BLOCK_DIM[3] = {1024, 1024, 64};
+    auto overflowsAt = [&](unsigned pos, Value bound) {
+      APInt cst;
+
+      if (!matchPattern(bound, m_ConstantInt(&cst)))
+        return false;
+      return cst.ugt(MAX_BLOCK_DIM[pos]);
+    };
+
+    SmallVector<unsigned, 3> blockOrder;
+    for (unsigned i = 0; i < popBlockBounds.size(); i++)
+      blockOrder.push_back(i);
+
+    bool overflows = false;
+    for (unsigned i = 0; i < popBlockBounds.size() && i < 3; i++)
+      overflows |= overflowsAt(i, popBlockBounds[i]);
+
+    // Only a block that does not fit is reordered
+    if (overflows) {
+      // The dimension the original launch had on blockDim.x goes back to x
+      std::stable_sort(
+          blockOrder.begin(), blockOrder.end(), [&](unsigned a, unsigned b) {
+            bool aIsX = originalBlockX && popBlockBounds[a] == originalBlockX;
+            bool bIsX = originalBlockX && popBlockBounds[b] == originalBlockX;
+            if (aIsX != bIsX)
+              return aIsX;
+            APInt ca, cb;
+            if (matchPattern(popBlockBounds[a], m_ConstantInt(&ca)) &&
+                matchPattern(popBlockBounds[b], m_ConstantInt(&cb)))
+              return ca.ugt(cb);
+            return false;
+          });
+    }
+
+    // The inverse: where each of the parallel op's dimensions ended up, so
+    // that a body reads the thread id of the dimension it is bounded by.
+    SmallVector<unsigned, 3> blockDimOfArg(popBlockBounds.size());
+    for (unsigned i = 0; i < blockOrder.size(); i++)
+      blockDimOfArg[blockOrder[i]] = i;
+
+    Value blockBounds[3];
     for (unsigned int i = 0; i < 3; i++) {
       if (i < popBlockBounds.size())
-        blockBounds[i] = popBlockBounds[i];
+        blockBounds[i] = popBlockBounds[blockOrder[i]];
       else
         blockBounds[i] = oneindex;
     }
@@ -1954,7 +2000,7 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
     rewriter.setInsertionPointToStart(launchBlock);
     SmallVector<Value, 3> argReplacements;
     for (auto en : llvm::enumerate(blockPop.getBody()->getArguments())) {
-      gpu::Dimension dim = getDim(en.index());
+      gpu::Dimension dim = getDim(blockDimOfArg[en.index()]);
       auto blockIdx = gpu::ThreadIdOp::create(
           rewriter, loc, mlir::IndexType::get(rewriter.getContext()), dim);
       argReplacements.push_back(blockIdx);

--- a/test/lit_tests/lowering/convert-parallel-to-gpu1-block-dim-z.mlir
+++ b/test/lit_tests/lowering/convert-parallel-to-gpu1-block-dim-z.mlir
@@ -1,0 +1,99 @@
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=512 enzymexlamlir-opt %s --split-input-file --pass-pipeline="builtin.module(canonicalize-parallel,convert-parallel-to-gpu1)" | FileCheck %s --check-prefix=BS512
+// RUN: env POLYGEIST_GPU_KERNEL_BLOCK_SIZE=1024 enzymexlamlir-opt %s --split-input-file --pass-pipeline="builtin.module(canonicalize-parallel,convert-parallel-to-gpu1)" | FileCheck %s --check-prefix=BS1024
+
+// blockDim.x and blockDim.y hold 1024 threads, blockDim.z stops at 64, and
+// dimensions become x, y and z by position. createSplitOp builds the block by
+// inserting at the front, so the dimension the launch had on blockDim.x is
+// pushed toward z by every dimension taken in ahead of it.
+
+// <<<dim3(2,2), 128>>>: at a requested 512 the whole grid is taken into the
+// block, 2*2*128 filling it exactly, and 128 lands on z where it cannot
+// launch. At 1024 the same thing happens with budget to spare.
+
+func.func @absorbed_into_block(%out: memref<?xf64, 1>, %v: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c128 = arith.constant 128 : index
+  "enzymexla.gpu_wrapper"(%c2, %c2, %c1, %c128, %c1, %c1) ({
+    scf.parallel (%bx, %by) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) {
+      scf.parallel (%tx) = (%c0) to (%c128) step (%c1) {
+        %i = arith.addi %bx, %by : index
+        %j = arith.addi %i, %tx : index
+        memref.store %v, %out[%j] : memref<?xf64, 1>
+        scf.reduce
+      }
+      scf.reduce
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// BS512-LABEL:  func.func @absorbed_into_block(
+// BS512:        gpu.launch blocks({{.*}}) in ({{.*}}) threads({{.*}}) in (%{{[^ ]+}} = %c128, %{{[^ ]+}} = %c2, %{{[^ ]+}} = %c2)
+// BS512:        gpu.thread_id x
+// BS1024-LABEL: func.func @absorbed_into_block(
+// BS1024:       gpu.launch blocks({{.*}}) in ({{.*}}) threads({{.*}}) in (%{{[^ ]+}} = %c128, %{{[^ ]+}} = %c2, %{{[^ ]+}} = %c2)
+
+// -----
+
+// The other way a dimension reaches z: the split prepends the dimension it
+// creates, shifting everything already in the block one place along. Only at
+// 1024 is there room for the split to fire.
+
+func.func @split_prepended(%out: memref<?xf64, 1>, %v: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c128 = arith.constant 128 : index
+  "enzymexla.gpu_wrapper"(%c4, %c4, %c1, %c128, %c1, %c1) ({
+    scf.parallel (%bx, %by) = (%c0, %c0) to (%c4, %c4) step (%c1, %c1) {
+      scf.parallel (%tx) = (%c0) to (%c128) step (%c1) {
+        %i = arith.addi %bx, %by : index
+        %j = arith.addi %i, %tx : index
+        memref.store %v, %out[%j] : memref<?xf64, 1>
+        scf.reduce
+      }
+      scf.reduce
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// BS512-LABEL:  func.func @split_prepended(
+// BS512:        gpu.launch blocks({{.*}}) in ({{.*}}) threads({{.*}}) in (%{{[^ ]+}} = %c4, %{{[^ ]+}} = %c128, %{{[^ ]+}} = %c1)
+// BS1024-LABEL: func.func @split_prepended(
+// BS1024:       gpu.launch blocks({{.*}}) in ({{.*}}) threads({{.*}}) in (%{{[^ ]+}} = %c128, %{{[^ ]+}} = %c4, %{{[^ ]+}} = %c2)
+// BS1024:       gpu.thread_id x
+
+// -----
+
+// A block that fits is left exactly where it was, displaced blockDim.x and
+// all: 8 threads on z is legal, so nothing here is this pass's business.
+
+func.func @already_fits(%out: memref<?xf64, 1>, %v: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c8 = arith.constant 8 : index
+  "enzymexla.gpu_wrapper"(%c2, %c2, %c1, %c8, %c1, %c1) ({
+    scf.parallel (%bx, %by) = (%c0, %c0) to (%c2, %c2) step (%c1, %c1) {
+      scf.parallel (%tx) = (%c0) to (%c8) step (%c1) {
+        %i = arith.addi %bx, %by : index
+        %j = arith.addi %i, %tx : index
+        memref.store %v, %out[%j] : memref<?xf64, 1>
+        scf.reduce
+      }
+      scf.reduce
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// BS512-LABEL:  func.func @already_fits(
+// BS512:        gpu.launch blocks({{.*}}) in ({{.*}}) threads({{.*}}) in (%{{[^ ]+}} = %c2, %{{[^ ]+}} = %c2, %{{[^ ]+}} = %c8)
+// BS1024-LABEL: func.func @already_fits(
+// BS1024:       gpu.launch blocks({{.*}}) in ({{.*}}) threads({{.*}}) in (%{{[^ ]+}} = %c2, %{{[^ ]+}} = %c2, %{{[^ ]+}} = %c8)


### PR DESCRIPTION
**Root Cause**:
An ordinary `k<<<dim3(2,2),128>>>()` when POLYGEIST_GPU_KERNEL_BLOCK_SIZE=512 lowers to `threads in (2,2,128)`: 
1. `ParallelLower` generate wrapper + two scf.parallel loops (grid parallel (2,2) around block parallel (128))
2. Upstream `canonicalize-parallel`  outer++inner -> flat (2,2,128) 128 is now at the last
3. `createSplitOp` scans backwards and inserts at the front, and the verification is a product not about cap
  ```
i=2    1128 = 128 <= 512   ->  [128]
  i=1    1282 = 256 <= 512   ->  [2, 128]
  i=0    256*2 = 512 <= 512   ->  [2, 2, 128]
```
4. position fill [0] -> x=2 [1] -> y=2 [2] -> z=128

The same source is legal at a requested 128 or 256 and not at 512, and both 512 and 1024 are in this pass's own `ALTERNATIVE_KERNEL_BLOCK_SIZES`.

**Fix**
A block whose dimensions already fit is emitted unchanged. One that does not is reordered, within two rules:
- the dimension the wrapper records as the launch's own `blockDim.x` takes x (trust the source code that map contiguous dimension onto `threadIdx.x`)
- the rest follow in descending order of extent


