### PR TITLE
Do not raise a kernel whose function is a bare declaration

### DIFF
--- a/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
+++ b/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
@@ -478,6 +478,8 @@ enum __device_builtin__ cudaMemcpyKind
         }
       }
       auto cur = launch.first;
+      if (cur.isExternal())
+        continue;
       gpu::GPUFuncOp gpufunc = nullptr;
       bool local_use_launch_func = use_launch_func || captured;
       if (local_use_launch_func) {

--- a/test/lit_tests/lowering/launch-recognition-external-kernel.mlir
+++ b/test/lit_tests/lowering/launch-recognition-external-kernel.mlir
@@ -1,0 +1,23 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(gpu-launch-recognition{backend=cuda})" | FileCheck %s
+
+// A kernel referenced only through runtime queries whose device body lives in
+// another translation unit is a bare declaration; it cannot be raised into a
+// gpu.func (which requires a body), so recognition must leave it and its
+// users untouched.
+
+module {
+  llvm.func @cudaFuncGetAttributes(!llvm.ptr, !llvm.ptr) -> i32
+  llvm.func @"reactant$_Z19__device_stub__kernILi3EEvPd"(!llvm.ptr) attributes {target_cpu = "x86-64"}
+  llvm.func @query() {
+    %c1 = llvm.mlir.constant(1 : i32) : i32
+    %attrs = llvm.alloca %c1 x !llvm.array<56 x i8> : (i32) -> !llvm.ptr
+    %fn = llvm.mlir.addressof @"reactant$_Z19__device_stub__kernILi3EEvPd" : !llvm.ptr
+    %r = llvm.call @cudaFuncGetAttributes(%attrs, %fn) : (!llvm.ptr, !llvm.ptr) -> i32
+    llvm.return
+  }
+}
+
+// CHECK-NOT: gpu.module
+// CHECK: llvm.func @reactant$_Z19__device_stub__kernILi3EEvPd(!llvm.ptr)
+// CHECK: %[[FN:.+]] = llvm.mlir.addressof @reactant$_Z19__device_stub__kernILi3EEvPd
+// CHECK: llvm.call @cudaFuncGetAttributes(%{{.+}}, %[[FN]])


### PR DESCRIPTION
Companion to EnzymeAD/Reactant#81 (see the discussion there and on #2885). With the plugin now uniformly binding kernel pointers in runtime queries to `reactant$` symbols, a query-only or extern-stub TU presents recognition with a **bodyless declaration** as the kernel. Recognition moved that declaration into a `gpu.func`, producing a kernel with no blocks — invalid IR that the verifier rejects under `enzymexlamlir-opt` but which segfaults `GPUFuncOpLowering` in production (per-pass verification is off), or survives to serialization dressed in the declaration's host `x86-64`/`+x87` attributes and dies with `ptxas fatal: Value 'x86-64' is not defined for option 'gpu-name'`.

Bail on external functions at the capture point, leaving the calls and pointer uses on their original runtime path, so a genuinely unresolvable device symbol surfaces at link time.

Validated end-to-end with the merged Reactant fix: the query-only MWE (`cudaFuncGetAttributes` on an `extern template` kernel under `-fgpu-rdc`), the query+launch MWE, the extern-template direct-launch MWE, and the indirect `cudaLaunchKernel` MWE all compile; the new lit test covers the query-only shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD