### PR TITLE
Make canonicalize-parallel's multithreading opt-in

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -87,9 +87,14 @@ struct CanonicalizeParallelPass
       (void)applyOpPatternsGreedily(loose, patterns, looseConfig);
     }
 
-    parallelForEach(ctx, targets, [&](Operation *op) {
-      (void)applyPatternsGreedily(op, patterns, config);
-    });
+    if (parallel) {
+      parallelForEach(ctx, targets, [&](Operation *op) {
+        (void)applyPatternsGreedily(op, patterns, config);
+      });
+    } else {
+      for (Operation *op : targets)
+        (void)applyPatternsGreedily(op, patterns, config);
+    }
   }
 };
 

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -455,6 +455,11 @@ def SROAWrappersPass : Pass<"sroa-wrappers", "mlir::ModuleOp"> {
 
 def CanonicalizeParallelPass : Pass<"canonicalize-parallel"> {
   let summary = "Canonicalize top-level ops in parallel, confining region simplification to each";
+  let options = [Option<
+      "parallel", "parallel", "bool", "false",
+      "Rewrite top-level ops on the context's thread pool; without it "
+      "they are processed serially, still confining region "
+      "simplification to each op">];
 }
 
 def LibDeviceFuncsRaisingPass : Pass<"libdevice-funcs-raise"> {

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -112,6 +112,9 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
 
   using namespace llvm;
   using namespace mlir;
+  const std::string canonicalize =
+      options->parallelCanonicalize ? "canonicalize-parallel{parallel=true}"
+                                    : "canonicalize-parallel{parallel=false}";
   // clang-format off
   std::string pass_pipeline =
       "inline{default-pipeline=canonicalize "
@@ -121,7 +124,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
   pass_pipeline += backend;
   pass_pipeline += "}";
   pass_pipeline += ","
-      "canonicalize-parallel,libdevice-funcs-raise,restore-preserve-nvvm,canonicalize-parallel,"
+      "" + canonicalize + ",libdevice-funcs-raise,restore-preserve-nvvm," + canonicalize + ","
       "inline-enzyme-regions,symbol-dce,";
   
   if (backend == "cpu")
@@ -129,23 +132,23 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
   else
     pass_pipeline += "parallel-lower{wrapParallelOps=true},";
   pass_pipeline += "llvm-to-"
-      "memref-access,polygeist-mem2reg,canonicalize-parallel,convert-llvm-to-cf,"
-      "canonicalize-parallel,polygeist-mem2reg,canonicalize-parallel,enzyme-lift-cf-to-scf,"
-      "canonicalize-parallel,"
+      "memref-access,polygeist-mem2reg," + canonicalize + ",convert-llvm-to-cf,"
+      "" + canonicalize + ",polygeist-mem2reg," + canonicalize + ",enzyme-lift-cf-to-scf,"
+      "" + canonicalize + ","
       "func.func(canonicalize-loops),"
       "llvm.func(canonicalize-loops),"
       "canonicalize-scf-for,"
-      "canonicalize-parallel,affine-cfg,canonicalize-parallel,"
+      "" + canonicalize + ",affine-cfg," + canonicalize + ","
       "func.func(canonicalize-loops),"
       "llvm.func(canonicalize-loops),"
-      "canonicalize-parallel,llvm-to-affine-access,"
-      "canonicalize-parallel,delinearize-indexing,canonicalize-parallel,simplify-affine-exprs,"
-      "affine-cfg,canonicalize-parallel,llvm-to-affine-access,canonicalize-parallel,"
+      "" + canonicalize + ",llvm-to-affine-access,"
+      "" + canonicalize + ",delinearize-indexing," + canonicalize + ",simplify-affine-exprs,"
+      "affine-cfg," + canonicalize + ",llvm-to-affine-access," + canonicalize + ","
       "func.func(affine-loop-invariant-code-motion),"
-      "canonicalize-parallel,sort-memory,llvm-to-tessera,tessera-apply-pdl,tessera-to-llvm,";
+      "" + canonicalize + ",sort-memory,llvm-to-tessera,tessera-apply-pdl,tessera-to-llvm,";
   if (StringRef(backend).starts_with("xla")) {
       pass_pipeline += "func.func(kernelcast),raise-affine-to-stablehlo{prefer_while_raising=false "
-      "dump_failed_lockstep=true},canonicalize-parallel,arith-raise{stablehlo=true},"
+      "dump_failed_lockstep=true}," + canonicalize + ",arith-raise{stablehlo=true},"
       "symbol-dce";
       if (outfile.size() && getenv("EXPORT_REACTANT")) {
         pass_pipeline += ",print{filename="+outfile+".mlir}";
@@ -156,7 +159,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       } else {
         pass_pipeline += ",parallel-serialization,";
       }
-      pass_pipeline += "canonicalize-parallel,hoist-allocas,convert-polygeist-to-llvm{backend=";
+      pass_pipeline += "" + canonicalize + ",hoist-allocas,convert-polygeist-to-llvm{backend=";
       pass_pipeline += backend;
       pass_pipeline += "}";
   } else {
@@ -198,9 +201,9 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
         // fail translation to LLVM IR.
         "lower-llvm-ext,"
         "inline{default-pipeline=canonicalize max-iterations=4},"
-        "polygeist-mem2reg,canonicalize-parallel,symbol-dce,"
+        "polygeist-mem2reg," + canonicalize + ",symbol-dce,"
         // canonicalize-parallel here folds away memref.subview ops before gpu-kernel-outlining
-        "canonicalize-parallel,cse";
+        "" + canonicalize + ",cse";
       if (options->removeAtomics)
         pass_pipeline += ",affine-cfg,remove-atomics";
       if (options->sortBlockMemory)
@@ -210,7 +213,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       if (backend == "rocm")
         pass_pipeline += ",convert-cudart-to-hiprt";
       if (backend != "cpu") {
-        pass_pipeline += ",convert-parallel-to-gpu1,symbol-dce,gpu-kernel-outlining,canonicalize-parallel,symbol-dce,";
+        pass_pipeline += ",convert-parallel-to-gpu1,symbol-dce,gpu-kernel-outlining," + canonicalize + ",symbol-dce,";
         pass_pipeline += "convert-parallel-to-gpu2{backend=";
         pass_pipeline += backend;
         pass_pipeline += "}";
@@ -221,7 +224,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       } else {
 	      pass_pipeline += ",parallel-serialization,";
       }
-      pass_pipeline += "canonicalize-parallel,hoist-allocas,convert-polygeist-to-llvm{backend=";
+      pass_pipeline += "" + canonicalize + ",hoist-allocas,convert-polygeist-to-llvm{backend=";
       pass_pipeline += backend;
       pass_pipeline += "},strip-"
       "gpu-info,gpu-"

--- a/src/enzyme_ad/jax/raise.h
+++ b/src/enzyme_ad/jax/raise.h
@@ -43,6 +43,10 @@ struct MLIRRoundTripOptions {
   // The per-pass verification re-walks the whole module's symbol table and
   // dominance ~65 times; on large TUs that is a third of the pipeline.
   bool verifyEach;
+  // Let canonicalize-parallel use the context's thread pool. Off by default:
+  // every clang process would otherwise spin up a hardware-concurrency pool,
+  // oversubscribing the machine under a parallel build.
+  bool parallelCanonicalize;
 };
 
 extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,

--- a/test/lit_tests/canonicalize-parallel-flag.mlir
+++ b/test/lit_tests/canonicalize-parallel-flag.mlir
@@ -1,0 +1,20 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel | FileCheck %s
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel{parallel=true})" | FileCheck %s
+
+module {
+  func.func @f(%arg0: i64) -> i64 {
+    %c0 = arith.constant 0 : i64
+    %0 = arith.addi %arg0, %c0 : i64
+    return %0 : i64
+  }
+  func.func @g(%arg0: i64) -> i64 {
+    %c1 = arith.constant 1 : i64
+    %0 = arith.muli %arg0, %c1 : i64
+    return %0 : i64
+  }
+}
+
+// CHECK-LABEL: func.func @f
+// CHECK-NEXT: return %arg0 : i64
+// CHECK-LABEL: func.func @g
+// CHECK-NEXT: return %arg0 : i64


### PR DESCRIPTION
`canonicalize-parallel` runs `parallelForEach` over top-level ops, which lazily creates a hardware-concurrency thread pool inside every process running the pipeline. Under `ninja -jN` each clang already has a core, so N compile jobs × N-thread pools oversubscribes the machine quadratically — single-TU compiles get the parallel speedup, but whole-project builds thrash.

This gates the thread-pool use behind a `parallel` pass option, **off by default**. The serial mode keeps the pass's main win — region simplification confined to one top-level op per rewrite instead of fixpointing over the whole module — it only drops the intra-process fan-out. `MLIRRoundTripOptions` grows a matching `parallelCanonicalize` field (appended, default false) which the raise pipeline forwards by rewriting the pass invocations to `canonicalize-parallel{parallel=true}`; the Reactant-side companion adds the field to its struct copy with a `REACTANT_CANON_PARALLEL` env hook, mirroring `verifyEach`.

Tradeoff to be aware of: a *single* interactive compile of a huge TU loses the parallel canonicalize speedup unless the flag is set; batch builds should gain overall. Lit test covers both modes producing identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD