### PR TITLE
CI: bust GB-25 Julia depot cache

### DIFF
--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -112,15 +112,6 @@ jobs:
         uses: julia-actions/cache@v3.2.0
         with:
           gcp-bucket: ${{ (contains(matrix.os, 'linux') && 'enzyme-ci-transient' ) || '' }}
-          # NOTE: bump this prefix to bust the Julia depot cache.  The previous
-          # `enzymejax-gb25/` caches contain a truncated
-          # ~/.julia/artifacts/3cd7a8e8fe264178b19b591f55b041d2018717a7 (the
-          # CUDA_Compiler_jll cuda+13 artifact) which is missing
-          # nvvm/lib64/libnvvm.so.  Julia's `_artifact_str` short-circuits on
-          # `isdir()`, so a partial artifact directory is never re-downloaded and
-          # `CUDA_Compiler_jll.__init__` fails to dlopen it forever, breaking
-          # precompilation of CUDA.jl and everything downstream.
-          # See https://github.com/JuliaGPU/CUDA.jl/issues/3242
           key-prefix: enzymejax-gb25-v2/
 
       - name: Modify Enzyme-JAX commit

--- a/.github/workflows/test-gb-25.yml
+++ b/.github/workflows/test-gb-25.yml
@@ -112,7 +112,16 @@ jobs:
         uses: julia-actions/cache@v3.2.0
         with:
           gcp-bucket: ${{ (contains(matrix.os, 'linux') && 'enzyme-ci-transient' ) || '' }}
-          key-prefix: enzymejax-gb25/
+          # NOTE: bump this prefix to bust the Julia depot cache.  The previous
+          # `enzymejax-gb25/` caches contain a truncated
+          # ~/.julia/artifacts/3cd7a8e8fe264178b19b591f55b041d2018717a7 (the
+          # CUDA_Compiler_jll cuda+13 artifact) which is missing
+          # nvvm/lib64/libnvvm.so.  Julia's `_artifact_str` short-circuits on
+          # `isdir()`, so a partial artifact directory is never re-downloaded and
+          # `CUDA_Compiler_jll.__init__` fails to dlopen it forever, breaking
+          # precompilation of CUDA.jl and everything downstream.
+          # See https://github.com/JuliaGPU/CUDA.jl/issues/3242
+          key-prefix: enzymejax-gb25-v2/
 
       - name: Modify Enzyme-JAX commit
         timeout-minutes: 1


### PR DESCRIPTION
The GB-25 TPU jobs have failed on every run since 2026-08-10 with:

```
ERROR: LoadError: InitError: could not load library "/root/.julia/artifacts/3cd7a8e8fe264178b19b591f55b041d2018717a7/nvvm/lib64/libnvvm.so"
... cannot open shared object file: No such file or directory
  [4] __init__()
    @ CUDA_Compiler_jll ~/.julia/packages/CUDA_Compiler_jll/llq1P/src/wrappers/x86_64-linux-gnu-cuda+13.jl:25
```

taking down precompilation of CUDA.jl and 11 other direct dependencies.

**The cached depot is corrupt.** That artifact directory exists in the `enzymejax-gb25/` GCS cache but is truncated — it's missing `nvvm/lib64/libnvvm.so`. The upstream tarball is fine (I unpacked `CUDA_Compiler.v0.4.4.x86_64-linux-gnu-cuda+13.tar.gz`; it has `nvvm/lib64/libnvvm.so -> libnvvm.so.4 -> libnvvm.so.4.0.0`), and the exact same `CUDA_Compiler_jll v0.4.4+1` loaded fine in this job on Aug 5 and Aug 7. The restored depot size on this cache lineage went 2.5G → 3.0G → **2.2G**, with the first failure on the run that restored 2.2G. The action streams `tar | zstd` straight to GCS with `save-always: true`, and tar preserves entry order — a truncated stream gives exactly this shape (`bin/` present, `nvvm/` cut off).

It can't self-heal: `Artifacts._artifact_str` returns early on `isdir(dir)` before it ever consults `LazyArtifacts`, so a partially populated artifact directory is never repaired or re-downloaded. Every run restores the same poisoned cache and fails identically.

Bumping `key-prefix` forces one cold depot and clears it.

The upstream half of this — `CUDA_Compiler_jll` selecting `cuda=13` on machines with no CUDA at all and then *eagerly* `dlopen`ing that lazy artifact in `__init__`, so a single damaged file is fatal rather than a graceful `is_available() == false` — is reported as JuliaGPU/CUDA.jl#3242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aZpb1twqmSgSYLdminc3y
