### PR TITLE
Batch dynamic_(update_)slice with varying indices as scatter/gather

### DIFF
--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -4296,9 +4296,8 @@ buildBatchedStartIndexTensor(Operation *op, OpBuilder &builder,
 
       Value lowerBound = makeIntegerConstant(loc, builder, elemTy, 0);
       Value upperBound = makeIntegerConstant(loc, builder, elemTy, limit);
-      column =
-          stablehlo::ClampOp::create(builder, loc, lowerBound, column,
-                                      upperBound);
+      column = stablehlo::ClampOp::create(builder, loc, lowerBound, column,
+                                          upperBound);
     }
 
     columns.push_back(

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -4220,6 +4220,204 @@ struct SHLOSliceOpBatchInterface
   }
 };
 
+// Returns true if `batched` provably holds the same value in every batch
+// element, i.e. it was produced by broadcasting an unbatched value along the
+// batch dimensions (which is what the batching machinery emits for operands
+// that are invariant across the batch), or it is a splat constant.
+//
+// When every start index of a dynamic_slice/dynamic_update_slice is batch
+// invariant we can keep using a single dynamic_slice/dynamic_update_slice on
+// the batched operand. Otherwise the op has to be lowered to a gather/scatter,
+// since one (update-)slice cannot express a different offset per batch element.
+static bool isBatchInvariant(Value batched, ArrayRef<int64_t> batchSizes) {
+  SplatElementsAttr splat;
+  if (matchPattern(batched, m_Constant(&splat)))
+    return true;
+
+  auto bcast = batched.getDefiningOp<stablehlo::BroadcastInDimOp>();
+  if (!bcast)
+    return false;
+
+  // `broadcast_dimensions` maps operand dimensions onto result dimensions. If
+  // no batch dimension is mapped onto, every batch dimension is an expanded
+  // (broadcast) dimension and the value does not vary across the batch.
+  for (int64_t dim : bcast.getBroadcastDimensions())
+    if (dim < (int64_t)batchSizes.size())
+      return false;
+  return true;
+}
+
+static bool allStartIndicesBatchInvariant(Operation::operand_range startIndices,
+                                          IRMapping &mapper,
+                                          ArrayRef<int64_t> batchSizes) {
+  return llvm::all_of(startIndices, [&](Value sIndex) {
+    return isBatchInvariant(mapper.lookup(sIndex), batchSizes);
+  });
+}
+
+// Assembles the index tensor shared by the gather/scatter lowerings of a
+// batched dynamic_slice/dynamic_update_slice: the batched (scalar) start index
+// of each original dimension becomes one column of a
+// [batchSizes..., numOrigDims] tensor whose trailing dimension is the index
+// vector dimension.
+//
+// `clampLimits`, when provided, holds the largest in-bounds start index per
+// original dimension. dynamic_slice/dynamic_update_slice clamp out-of-bounds
+// start indices, and gather clamps too, but scatter instead silently drops
+// out-of-bounds updates - so the clamp must be materialized for the scatter
+// lowering.
+static Value
+buildBatchedStartIndexTensor(Operation *op, OpBuilder &builder,
+                             Operation::operand_range startIndices,
+                             IRMapping &mapper, ArrayRef<int64_t> batchSizes,
+                             std::optional<ArrayRef<int64_t>> clampLimits) {
+  Location loc = op->getLoc();
+  auto elemTy =
+      cast<RankedTensorType>(startIndices[0].getType()).getElementType();
+  auto intTy = cast<IntegerType>(elemTy);
+
+  SmallVector<int64_t> columnShape(batchSizes.begin(), batchSizes.end());
+  columnShape.push_back(1);
+  auto columnTy = RankedTensorType::get(columnShape, elemTy);
+
+  SmallVector<Value> columns;
+  for (auto [i, sIndex] : llvm::enumerate(startIndices)) {
+    Value column = mapper.lookup(sIndex);
+
+    if (clampLimits) {
+      // An index type too narrow to hold the limit cannot represent an
+      // out-of-bounds-above index either, so the upper clamp is a no-op there.
+      int64_t limit = (*clampLimits)[i];
+      int64_t typeMax =
+          intTy.isUnsigned()
+              ? (int64_t)APInt::getMaxValue(intTy.getWidth()).getZExtValue()
+              : APInt::getSignedMaxValue(intTy.getWidth()).getSExtValue();
+      limit = std::min(limit, typeMax);
+
+      column = stablehlo::ClampOp::create(
+          builder, loc, makeIntegerConstant(loc, builder, elemTy, 0), column,
+          makeIntegerConstant(loc, builder, elemTy, limit));
+    }
+
+    columns.push_back(
+        stablehlo::ReshapeOp::create(builder, loc, columnTy, column)
+            .getResult());
+  }
+
+  if (columns.size() == 1)
+    return columns.front();
+
+  SmallVector<int64_t> indicesShape(batchSizes.begin(), batchSizes.end());
+  indicesShape.push_back(columns.size());
+  return stablehlo::ConcatenateOp::create(
+             builder, loc, RankedTensorType::get(indicesShape, elemTy), columns,
+             /*dimension=*/batchSizes.size())
+      .getResult();
+}
+
+// Lowers a batched dynamic_slice whose start indices vary across the batch to
+// a gather, which can apply a distinct offset per batch element.
+static LogicalResult batchDynamicSliceAsGather(stablehlo::DynamicSliceOp op,
+                                               OpBuilder &builder,
+                                               IRMapping &mapper,
+                                               ArrayRef<int64_t> batchSizes) {
+  Location loc = op.getLoc();
+  int64_t numBatchDims = batchSizes.size();
+
+  Value operand = mapper.lookup(op.getOperand());
+  auto operandTy = cast<RankedTensorType>(operand.getType());
+  int64_t origRank = operandTy.getRank() - numBatchDims;
+
+  // gather clamps its start indices exactly like dynamic_slice does, so no
+  // explicit clamp is needed here.
+  Value startIndices = buildBatchedStartIndexTensor(
+      op, builder, op.getStartIndices(), mapper, batchSizes, std::nullopt);
+
+  SmallVector<int64_t> batchDims(numBatchDims);
+  std::iota(batchDims.begin(), batchDims.end(), 0);
+
+  SmallVector<int64_t> offsetDims(origRank);
+  std::iota(offsetDims.begin(), offsetDims.end(), numBatchDims);
+
+  SmallVector<int64_t> startIndexMap(origRank);
+  std::iota(startIndexMap.begin(), startIndexMap.end(), numBatchDims);
+
+  SmallVector<int64_t> sliceSizes(numBatchDims, 1);
+  llvm::append_range(sliceSizes, op.getSliceSizes());
+
+  auto gatherOp = stablehlo::GatherOp::create(
+      builder, loc, operand, startIndices,
+      stablehlo::GatherDimensionNumbersAttr::get(
+          op.getContext(), offsetDims, /*collapsedSliceDims=*/{},
+          /*operandBatchingDims=*/batchDims,
+          /*startIndicesBatchingDims=*/batchDims, startIndexMap,
+          /*indexVectorDim=*/numBatchDims),
+      sliceSizes, /*indicesAreSorted=*/false);
+
+  mapper.map(op.getResult(), gatherOp.getResult());
+  return success();
+}
+
+// Lowers a batched dynamic_update_slice whose start indices vary across the
+// batch to a scatter, which can apply a distinct offset per batch element.
+static LogicalResult
+batchDynamicUpdateSliceAsScatter(stablehlo::DynamicUpdateSliceOp op,
+                                 OpBuilder &builder, IRMapping &mapper,
+                                 ArrayRef<int64_t> batchSizes) {
+  Location loc = op.getLoc();
+  int64_t numBatchDims = batchSizes.size();
+
+  Value operand = mapper.lookup(op.getOperand());
+  Value update = mapper.lookup(op.getUpdate());
+  auto operandTy = cast<RankedTensorType>(operand.getType());
+  auto updateTy = cast<RankedTensorType>(update.getType());
+  int64_t origRank = operandTy.getRank() - numBatchDims;
+
+  // Largest in-bounds start index for each original dimension.
+  SmallVector<int64_t> clampLimits;
+  for (int64_t i = 0; i < origRank; i++)
+    clampLimits.push_back(operandTy.getShape()[numBatchDims + i] -
+                          updateTy.getShape()[numBatchDims + i]);
+
+  Value scatterIndices =
+      buildBatchedStartIndexTensor(op, builder, op.getStartIndices(), mapper,
+                                   batchSizes, ArrayRef<int64_t>(clampLimits));
+
+  SmallVector<int64_t> batchDims(numBatchDims);
+  std::iota(batchDims.begin(), batchDims.end(), 0);
+
+  // The update window covers the original (non-batch) dimensions.
+  SmallVector<int64_t> updateWindowDims(origRank);
+  std::iota(updateWindowDims.begin(), updateWindowDims.end(), numBatchDims);
+
+  SmallVector<int64_t> scatterDimsToOperandDims(origRank);
+  std::iota(scatterDimsToOperandDims.begin(), scatterDimsToOperandDims.end(),
+            numBatchDims);
+
+  auto scatterOp = stablehlo::ScatterOp::create(
+      builder, loc, ValueRange{operand}, scatterIndices, ValueRange{update},
+      stablehlo::ScatterDimensionNumbersAttr::get(
+          op.getContext(), updateWindowDims,
+          /*insertedWindowDims=*/{}, /*inputBatchingDims=*/batchDims,
+          /*scatterIndicesBatchingDims=*/batchDims, scatterDimsToOperandDims,
+          /*indexVectorDim=*/numBatchDims),
+      /*indicesAreSorted=*/false, /*uniqueIndices=*/true);
+
+  {
+    Block *updateBody = new Block();
+    scatterOp.getUpdateComputation().push_back(updateBody);
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(updateBody);
+    auto scalarTy = RankedTensorType::get({}, operandTy.getElementType());
+    updateBody->addArgument(scalarTy, loc);
+    Value newValue = updateBody->addArgument(scalarTy, loc);
+    stablehlo::ReturnOp::create(builder, loc, newValue);
+  }
+
+  mapper.map(op.getResult(), scatterOp.getResult(0));
+  return success();
+}
+
 SmallVector<Value> computeBatchedStartIndices(Operation *op, OpBuilder &builder,
                                               SmallVector<Value> startIndices,
                                               IRMapping &mapper,
@@ -4263,6 +4461,12 @@ struct SHLODynamicSliceOpBatchInterface
                                   ArrayRef<int64_t> batchSizes) const {
     auto op = cast<stablehlo::DynamicSliceOp>(src);
 
+    // A single dynamic_slice has one start index per dimension, so it can only
+    // represent the batched op when the indices do not vary across the batch.
+    if (!allStartIndicesBatchInvariant(op.getStartIndices(), mapper,
+                                       batchSizes))
+      return batchDynamicSliceAsGather(op, builder, mapper, batchSizes);
+
     SmallVector<Value> startIndices = computeBatchedStartIndices(
         op, builder, op.getStartIndices(), mapper, batchSizes);
 
@@ -4289,6 +4493,13 @@ struct SHLODynamicUpdateSliceOpBatchInterface
                                   IRMapping &mapper,
                                   ArrayRef<int64_t> batchSizes) const {
     auto op = cast<stablehlo::DynamicUpdateSliceOp>(src);
+
+    // A single dynamic_update_slice has one start index per dimension, so it
+    // can only represent the batched op when the indices do not vary across
+    // the batch.
+    if (!allStartIndicesBatchInvariant(op.getStartIndices(), mapper,
+                                       batchSizes))
+      return batchDynamicUpdateSliceAsScatter(op, builder, mapper, batchSizes);
 
     SmallVector<Value> startIndices = computeBatchedStartIndices(
         op, builder, op.getStartIndices(), mapper, batchSizes);

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -4294,9 +4294,11 @@ buildBatchedStartIndexTensor(Operation *op, OpBuilder &builder,
               : APInt::getSignedMaxValue(intTy.getWidth()).getSExtValue();
       limit = std::min(limit, typeMax);
 
-      column = stablehlo::ClampOp::create(
-          builder, loc, makeIntegerConstant(loc, builder, elemTy, 0), column,
-          makeIntegerConstant(loc, builder, elemTy, limit));
+      Value lowerBound = makeIntegerConstant(loc, builder, elemTy, 0);
+      Value upperBound = makeIntegerConstant(loc, builder, elemTy, limit);
+      column =
+          stablehlo::ClampOp::create(builder, loc, lowerBound, column,
+                                      upperBound);
     }
 
     columns.push_back(

--- a/test/lit_tests/batchtests/dus_varying_indices.mlir
+++ b/test/lit_tests/batchtests/dus_varying_indices.mlir
@@ -1,0 +1,83 @@
+// RUN: enzymexlamlir-opt %s --enzyme-batch | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-batch | stablehlo-translate - --interpret --allow-unregistered-dialect
+
+// Numeric check that batching a dynamic_update_slice with per-batch-varying
+// start indices preserves dynamic_update_slice semantics. Batch element 2 uses
+// an out-of-bounds row index: dynamic_update_slice clamps it, while scatter
+// would drop the update, so the lowering has to materialize the clamp.
+
+func.func @batched(%operand: tensor<3x2x5xf64>, %update: tensor<3x1x1xf64>, %i: tensor<3xi32>, %j: tensor<3xi32>) -> tensor<3x2x5xf64> {
+    %0 = enzyme.batch @dus(%operand, %update, %i, %j) {batch_shape = array<i64: 3>} : (tensor<3x2x5xf64>, tensor<3x1x1xf64>, tensor<3xi32>, tensor<3xi32>) -> tensor<3x2x5xf64>
+    return %0 : tensor<3x2x5xf64>
+}
+
+func.func @dus(%operand: tensor<2x5xf64>, %update: tensor<1x1xf64>, %i: tensor<i32>, %j: tensor<i32>) -> tensor<2x5xf64> {
+    %0 = stablehlo.dynamic_update_slice %operand, %update, %i, %j : (tensor<2x5xf64>, tensor<1x1xf64>, tensor<i32>, tensor<i32>) -> tensor<2x5xf64>
+    return %0 : tensor<2x5xf64>
+}
+
+func.func @main() {
+    %operand = stablehlo.constant dense<0.0> : tensor<3x2x5xf64>
+    %update = stablehlo.constant dense<[[[1.0]], [[2.0]], [[3.0]]]> : tensor<3x1x1xf64>
+    // Row index 7 for batch element 2 is out of bounds and must clamp to 1.
+    %i = stablehlo.constant dense<[0, 1, 7]> : tensor<3xi32>
+    %j = stablehlo.constant dense<[0, 3, 2]> : tensor<3xi32>
+
+    %res = func.call @batched(%operand, %update, %i, %j) : (tensor<3x2x5xf64>, tensor<3x1x1xf64>, tensor<3xi32>, tensor<3xi32>) -> tensor<3x2x5xf64>
+
+    %expected = stablehlo.constant dense<[
+      [[1.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0]],
+      [[0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 2.0, 0.0]],
+      [[0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 3.0, 0.0, 0.0]]
+    ]> : tensor<3x2x5xf64>
+    "check.expect_eq"(%res, %expected) : (tensor<3x2x5xf64>, tensor<3x2x5xf64>) -> ()
+
+    // Cross-check each batch element against a plain, unbatched
+    // dynamic_update_slice evaluated by the interpreter.
+    %zero2x5 = stablehlo.constant dense<0.0> : tensor<2x5xf64>
+    %u0 = stablehlo.constant dense<1.0> : tensor<1x1xf64>
+    %i0 = stablehlo.constant dense<0> : tensor<i32>
+    %j0 = stablehlo.constant dense<0> : tensor<i32>
+    %ref0 = func.call @dus(%zero2x5, %u0, %i0, %j0) : (tensor<2x5xf64>, tensor<1x1xf64>, tensor<i32>, tensor<i32>) -> tensor<2x5xf64>
+    %got0 = stablehlo.slice %res [0:1, 0:2, 0:5] : (tensor<3x2x5xf64>) -> tensor<1x2x5xf64>
+    %got0r = stablehlo.reshape %got0 : (tensor<1x2x5xf64>) -> tensor<2x5xf64>
+    "check.expect_eq"(%got0r, %ref0) : (tensor<2x5xf64>, tensor<2x5xf64>) -> ()
+
+    %u1 = stablehlo.constant dense<2.0> : tensor<1x1xf64>
+    %i1 = stablehlo.constant dense<1> : tensor<i32>
+    %j1 = stablehlo.constant dense<3> : tensor<i32>
+    %ref1 = func.call @dus(%zero2x5, %u1, %i1, %j1) : (tensor<2x5xf64>, tensor<1x1xf64>, tensor<i32>, tensor<i32>) -> tensor<2x5xf64>
+    %got1 = stablehlo.slice %res [1:2, 0:2, 0:5] : (tensor<3x2x5xf64>) -> tensor<1x2x5xf64>
+    %got1r = stablehlo.reshape %got1 : (tensor<1x2x5xf64>) -> tensor<2x5xf64>
+    "check.expect_eq"(%got1r, %ref1) : (tensor<2x5xf64>, tensor<2x5xf64>) -> ()
+
+    // Out-of-bounds start index: the unbatched op clamps, so the batched one must too.
+    %u2 = stablehlo.constant dense<3.0> : tensor<1x1xf64>
+    %i2 = stablehlo.constant dense<7> : tensor<i32>
+    %j2 = stablehlo.constant dense<2> : tensor<i32>
+    %ref2 = func.call @dus(%zero2x5, %u2, %i2, %j2) : (tensor<2x5xf64>, tensor<1x1xf64>, tensor<i32>, tensor<i32>) -> tensor<2x5xf64>
+    %got2 = stablehlo.slice %res [2:3, 0:2, 0:5] : (tensor<3x2x5xf64>) -> tensor<1x2x5xf64>
+    %got2r = stablehlo.reshape %got2 : (tensor<1x2x5xf64>) -> tensor<2x5xf64>
+    "check.expect_eq"(%got2r, %ref2) : (tensor<2x5xf64>, tensor<2x5xf64>) -> ()
+
+    return
+}
+
+// CHECK: func.func private @batched_dus(%arg0: tensor<3x2x5xf64>, %arg1: tensor<3x1x1xf64>, %arg2: tensor<3xi32>, %arg3: tensor<3xi32>) -> tensor<3x2x5xf64> {
+// The dynamic_update_slice clamp has to be materialized: scatter drops
+// out-of-bounds updates rather than clamping them.
+// CHECK-NEXT:    %[[LO0:.+]] = stablehlo.constant dense<0> : tensor<i32>
+// CHECK-NEXT:    %[[HI0:.+]] = stablehlo.constant dense<1> : tensor<i32>
+// CHECK-NEXT:    %[[C0:.+]] = stablehlo.clamp %[[LO0]], %arg2, %[[HI0]] : (tensor<i32>, tensor<3xi32>, tensor<i32>) -> tensor<3xi32>
+// CHECK-NEXT:    %[[R0:.+]] = stablehlo.reshape %[[C0]] : (tensor<3xi32>) -> tensor<3x1xi32>
+// CHECK-NEXT:    %[[LO1:.+]] = stablehlo.constant dense<0> : tensor<i32>
+// CHECK-NEXT:    %[[HI1:.+]] = stablehlo.constant dense<4> : tensor<i32>
+// CHECK-NEXT:    %[[C1:.+]] = stablehlo.clamp %[[LO1]], %arg3, %[[HI1]] : (tensor<i32>, tensor<3xi32>, tensor<i32>) -> tensor<3xi32>
+// CHECK-NEXT:    %[[R1:.+]] = stablehlo.reshape %[[C1]] : (tensor<3xi32>) -> tensor<3x1xi32>
+// CHECK-NEXT:    %[[IDX:.+]] = stablehlo.concatenate %[[R0]], %[[R1]], dim = 1 : (tensor<3x1xi32>, tensor<3x1xi32>) -> tensor<3x2xi32>
+// CHECK-NEXT:    %[[RES:.+]] = "stablehlo.scatter"(%arg0, %[[IDX]], %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1, 2], input_batching_dims = [0], scatter_indices_batching_dims = [0], scatter_dims_to_operand_dims = [1, 2], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:    ^bb0(%arg4: tensor<f64>, %arg5: tensor<f64>):
+// CHECK-NEXT:      stablehlo.return %arg5 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<3x2x5xf64>, tensor<3x2xi32>, tensor<3x1x1xf64>) -> tensor<3x2x5xf64>
+// CHECK-NEXT:    return %[[RES]] : tensor<3x2x5xf64>
+// CHECK-NEXT: }

--- a/test/lit_tests/batchtests/dynamic_slice_varying_indices.mlir
+++ b/test/lit_tests/batchtests/dynamic_slice_varying_indices.mlir
@@ -1,0 +1,74 @@
+// RUN: enzymexlamlir-opt %s --enzyme-batch | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-batch | stablehlo-translate - --interpret --allow-unregistered-dialect
+
+// Numeric check that batching a dynamic_slice with per-batch-varying start
+// indices preserves dynamic_slice semantics, including the clamping of
+// out-of-bounds start indices (gather clamps the same way, so no explicit
+// clamp is emitted).
+
+func.func @batched(%operand: tensor<3x2x5xf64>, %i: tensor<3xi32>, %j: tensor<3xi32>) -> tensor<3x1x1xf64> {
+    %0 = enzyme.batch @ds(%operand, %i, %j) {batch_shape = array<i64: 3>} : (tensor<3x2x5xf64>, tensor<3xi32>, tensor<3xi32>) -> tensor<3x1x1xf64>
+    return %0 : tensor<3x1x1xf64>
+}
+
+func.func @ds(%operand: tensor<2x5xf64>, %i: tensor<i32>, %j: tensor<i32>) -> tensor<1x1xf64> {
+    %0 = stablehlo.dynamic_slice %operand, %i, %j, sizes = [1, 1] : (tensor<2x5xf64>, tensor<i32>, tensor<i32>) -> tensor<1x1xf64>
+    return %0 : tensor<1x1xf64>
+}
+
+func.func @main() {
+    %operand = stablehlo.constant dense<[
+      [[0.0, 1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0, 9.0]],
+      [[10.0, 11.0, 12.0, 13.0, 14.0], [15.0, 16.0, 17.0, 18.0, 19.0]],
+      [[20.0, 21.0, 22.0, 23.0, 24.0], [25.0, 26.0, 27.0, 28.0, 29.0]]
+    ]> : tensor<3x2x5xf64>
+    // Row index 7 for batch element 2 is out of bounds and must clamp to 1.
+    %i = stablehlo.constant dense<[0, 1, 7]> : tensor<3xi32>
+    %j = stablehlo.constant dense<[0, 3, 2]> : tensor<3xi32>
+
+    %res = func.call @batched(%operand, %i, %j) : (tensor<3x2x5xf64>, tensor<3xi32>, tensor<3xi32>) -> tensor<3x1x1xf64>
+
+    // batch 0 -> operand[0][0][0] = 0, batch 1 -> operand[1][1][3] = 18,
+    // batch 2 -> operand[2][clamp(7)=1][2] = 27
+    %expected = stablehlo.constant dense<[[[0.0]], [[18.0]], [[27.0]]]> : tensor<3x1x1xf64>
+    "check.expect_eq"(%res, %expected) : (tensor<3x1x1xf64>, tensor<3x1x1xf64>) -> ()
+
+    // Cross-check each batch element against a plain, unbatched dynamic_slice.
+    %s0 = stablehlo.slice %operand [0:1, 0:2, 0:5] : (tensor<3x2x5xf64>) -> tensor<1x2x5xf64>
+    %s0r = stablehlo.reshape %s0 : (tensor<1x2x5xf64>) -> tensor<2x5xf64>
+    %i0 = stablehlo.constant dense<0> : tensor<i32>
+    %j0 = stablehlo.constant dense<0> : tensor<i32>
+    %ref0 = func.call @ds(%s0r, %i0, %j0) : (tensor<2x5xf64>, tensor<i32>, tensor<i32>) -> tensor<1x1xf64>
+    %got0 = stablehlo.slice %res [0:1, 0:1, 0:1] : (tensor<3x1x1xf64>) -> tensor<1x1x1xf64>
+    %got0r = stablehlo.reshape %got0 : (tensor<1x1x1xf64>) -> tensor<1x1xf64>
+    "check.expect_eq"(%got0r, %ref0) : (tensor<1x1xf64>, tensor<1x1xf64>) -> ()
+
+    %s1 = stablehlo.slice %operand [1:2, 0:2, 0:5] : (tensor<3x2x5xf64>) -> tensor<1x2x5xf64>
+    %s1r = stablehlo.reshape %s1 : (tensor<1x2x5xf64>) -> tensor<2x5xf64>
+    %i1 = stablehlo.constant dense<1> : tensor<i32>
+    %j1 = stablehlo.constant dense<3> : tensor<i32>
+    %ref1 = func.call @ds(%s1r, %i1, %j1) : (tensor<2x5xf64>, tensor<i32>, tensor<i32>) -> tensor<1x1xf64>
+    %got1 = stablehlo.slice %res [1:2, 0:1, 0:1] : (tensor<3x1x1xf64>) -> tensor<1x1x1xf64>
+    %got1r = stablehlo.reshape %got1 : (tensor<1x1x1xf64>) -> tensor<1x1xf64>
+    "check.expect_eq"(%got1r, %ref1) : (tensor<1x1xf64>, tensor<1x1xf64>) -> ()
+
+    %s2 = stablehlo.slice %operand [2:3, 0:2, 0:5] : (tensor<3x2x5xf64>) -> tensor<1x2x5xf64>
+    %s2r = stablehlo.reshape %s2 : (tensor<1x2x5xf64>) -> tensor<2x5xf64>
+    %i2 = stablehlo.constant dense<7> : tensor<i32>
+    %j2 = stablehlo.constant dense<2> : tensor<i32>
+    %ref2 = func.call @ds(%s2r, %i2, %j2) : (tensor<2x5xf64>, tensor<i32>, tensor<i32>) -> tensor<1x1xf64>
+    %got2 = stablehlo.slice %res [2:3, 0:1, 0:1] : (tensor<3x1x1xf64>) -> tensor<1x1x1xf64>
+    %got2r = stablehlo.reshape %got2 : (tensor<1x1x1xf64>) -> tensor<1x1xf64>
+    "check.expect_eq"(%got2r, %ref2) : (tensor<1x1xf64>, tensor<1x1xf64>) -> ()
+
+    return
+}
+
+// CHECK: func.func private @batched_ds(%arg0: tensor<3x2x5xf64>, %arg1: tensor<3xi32>, %arg2: tensor<3xi32>) -> tensor<3x1x1xf64> {
+// No clamp here: gather clamps its start indices exactly like dynamic_slice.
+// CHECK-NEXT:    %[[R0:.+]] = stablehlo.reshape %arg1 : (tensor<3xi32>) -> tensor<3x1xi32>
+// CHECK-NEXT:    %[[R1:.+]] = stablehlo.reshape %arg2 : (tensor<3xi32>) -> tensor<3x1xi32>
+// CHECK-NEXT:    %[[IDX:.+]] = stablehlo.concatenate %[[R0]], %[[R1]], dim = 1 : (tensor<3x1xi32>, tensor<3x1xi32>) -> tensor<3x2xi32>
+// CHECK-NEXT:    %[[RES:.+]] = "stablehlo.gather"(%arg0, %[[IDX]]) <{dimension_numbers = #stablehlo.gather<offset_dims = [1, 2], operand_batching_dims = [0], start_indices_batching_dims = [0], start_index_map = [1, 2], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1>}> : (tensor<3x2x5xf64>, tensor<3x2xi32>) -> tensor<3x1x1xf64>
+// CHECK-NEXT:    return %[[RES]] : tensor<3x1x1xf64>
+// CHECK-NEXT: }


### PR DESCRIPTION

Closes https://github.com/enzymeAD/Reactant.jl/issues/3197.



## Problem

`computeBatchedStartIndices` unconditionally slices element 0 out of each batched start index and reuses it for the whole batch:

```cpp
for (auto sIndex : startIndices) {
  // We need to slice and extract a single element
  auto newStartIndex = stablehlo::SliceOp::create(   // [0:1] - always element 0
      builder, op->getLoc(), mapper.lookup(sIndex), innerSliceStarts, ...);
```

That is only valid when the index is uniform across the batch. When it genuinely varies, every batch element silently gets batch element 0's offset. Both `SHLODynamicSliceOpBatchInterface` and `SHLODynamicUpdateSliceOpBatchInterface` were affected.

`GreedyWhileLoopBatchFission` reaches this on reverse-pass gradient accumulation: the taped per-iteration indices are classified `BatchLiftingMode::DYNAMIC_SLICE` — explicitly batch-*varying* — and handed to `enzyme.batch` of a `dynamic_update_slice` anyway.

Reduced repro, before this change:

```mlir
func.func private @batched_f(%arg0: tensor<3x2x5xf64>, %arg1: tensor<3x1x1xf64>, %arg2: tensor<3xi32>, %arg3: tensor<3xi32>) -> tensor<3x2x5xf64> {
  %0 = stablehlo.slice %arg2 [0:1] : (tensor<3xi32>) -> tensor<1xi32>   // indices 1, 2 dropped
  %1 = stablehlo.reshape %0 : (tensor<1xi32>) -> tensor<i32>
  %4 = stablehlo.dynamic_update_slice %arg0, %arg1, %c, %1, %3 : ...
}
```

The user-visible symptom was a wrong reverse-mode gradient for `sum(x[i, perm[i]])`. All updates landed in one cell:

| | primal | gradient |
|---|---|---|
| reference | 96.0 | five `1.0` at `(i, permᵢ)` |
| before | 96.0 | single `5.0` at `(4,1)` |
| after | 96.0 | five `1.0` — matches reference |

Loops of up to 4 iterations are unrolled by `enzyme_hlo_unroll(4)` and never reach batch fission, so this only appeared from 5 iterations up.

## Fix

Returning `failure()` from `createBatch` is not a usable bail-out — on failure `batchCloneBlock` falls through to a generic clone with remapped operands. So the varying case is detected and lowered to an op that *can* express a distinct offset per batch element: **scatter** for `dynamic_update_slice`, **gather** for `dynamic_slice`.

```cpp
// A single dynamic_update_slice has one start index per dimension, so it can
// only represent the batched op when the indices do not vary across the batch.
if (!allStartIndicesBatchInvariant(op.getStartIndices(), mapper, batchSizes))
  return batchDynamicUpdateSliceAsScatter(op, builder, mapper, batchSizes);
```

Both lowerings use `input_batching_dims`/`scatter_indices_batching_dims` (resp. `operand_batching_dims`/`start_indices_batching_dims`), so they generalize to multi-dimensional batch shapes without iota index columns.

**Clamping.** `dynamic_update_slice` clamps out-of-bounds start indices (`adjusted_start_indices = clamp(0, start_indices, shape(operand) - shape(update))`) whereas scatter *drops* out-of-bounds updates, so the scatter lowering materializes the clamp explicitly. `gather` clamps like `dynamic_slice` does, so the gather lowering does not need one. The clamp limit is capped at the index type's max, since a type too narrow to hold the limit cannot represent an out-of-bounds-above index either.

**No change for uniform indices.** An index counts as invariant when it is a splat constant or a `broadcast_in_dim` that does not map onto a batch dimension — exactly what the batching machinery emits for such operands. Emitting scatter unconditionally was not an option: `ScatterToDynamicUpdateSlice` requires empty `insertedWindowDims` and full `updateWindowDims` coverage, which a batched scatter never satisfies, so it would not recover the fast path.

## Testing

Two new tests in `test/lit_tests/batchtests/`, each with a FileCheck RUN line pinning the emitted lowering and an interpret RUN line checking semantics. The interpret half cross-checks every batch element against a plain unbatched `dynamic_(update_)slice` and deliberately uses an out-of-bounds index (7 into a size-2 dim) so the clamp cannot be dropped unnoticed.

Full lit suite passes. Existing `batchtests/dus.mlir` (splat index) is bit-for-bit unchanged.

## Note

`GreedyWhileLoopBatchFission` still hands varying indices to `enzyme.batch`; it now just gets a correct lowering. That means the reverse-pass loop becomes a scatter that materializes a `[numIters, ...]` intermediate and reduces it away. Whether that beats keeping the loop is a perf question not evaluated here; if it does not, an early cost check in `liftOperationByBatching` would be the place for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZH967niuewFm9MMFLQiwY