### PR TITLE
Preserve the source's launch bounds through raising

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -263,56 +263,95 @@ struct AddLaunchBounds : public OpRewritePattern<gpu::LaunchFuncOp> {
     // gpu::LaunchFuncOp's)
     auto gpuFuncOp = launchOp->getParentOfType<ModuleOp>().lookupSymbol(
         launchOp.getKernel());
+
+    // Launch bounds the kernel was compiled with: clang encodes
+    // __launch_bounds__(maxThreads, minBlocks) as nvvm annotations, which the
+    // importer carries in the device function's passthrough and launch
+    // recognition copies onto the error op.
+    int32_t srcMaxntid = 0, srcMinctasm = 0;
+    if (auto err = launchOp->getParentOfType<enzymexla::GPUErrorOp>()) {
+      if (auto attr =
+              dyn_cast_or_null<ArrayAttr>(err->getAttr("passthrough"))) {
+        for (auto a : attr) {
+          auto ar = dyn_cast<ArrayAttr>(a);
+          if (!ar || ar.size() != 2)
+            continue;
+          auto s0 = dyn_cast<StringAttr>(ar[0]);
+          auto s1 = dyn_cast<StringAttr>(ar[1]);
+          if (!s0 || !s1)
+            continue;
+          if (s0.getValue() == "nvvm.maxntid")
+            s1.getValue().getAsInteger(10, srcMaxntid);
+          if (s0.getValue() == "nvvm.minctasm")
+            s1.getValue().getAsInteger(10, srcMinctasm);
+        }
+      }
+    }
+
     auto blockDims = launchOp.getBlockSizeOperandValues();
     auto bx = getConstantInteger(blockDims.x);
     auto by = getConstantInteger(blockDims.y);
     auto bz = getConstantInteger(blockDims.z);
-    if (!bx || !by || !bz) {
-      // The kernel must stay launchable at every legal block size; without
-      // a bound ptxas may allocate registers for a small block and larger
-      // launches fail with too-many-resources.
-      llvm::StringRef attrName = "nvvm.maxntid";
-      if (gpuFuncOp->hasAttr(attrName))
-        return failure();
-      gpuFuncOp->setAttr(attrName, rewriter.getDenseI32ArrayAttr({1024, 1, 1}));
+
+    // The preserved bounds promise the block shape the kernel was compiled
+    // with. Runtime dimensions are the original launch's own values; a
+    // constant block size only matches when it reproduces the recorded
+    // original, not when the kernel was re-blocked.
+    bool shapeMatches = !bx || !by || !bz;
+    if (!shapeMatches)
+      if (auto err = launchOp->getParentOfType<enzymexla::GPUErrorOp>())
+        if (auto orig =
+                err->getAttrOfType<IntegerAttr>("reactant.launch_block_size"))
+          shapeMatches = orig.getInt() == (*bx) * (*by) * (*bz);
+
+    bool changed = false;
+    if (srcMinctasm > 0 && shapeMatches &&
+        !gpuFuncOp->hasAttr("nvvm.minctasm")) {
       gpuFuncOp->setAttr(
-          "rocdl.max_flat_work_group_size",
-          rewriter.getIntegerAttr(rewriter.getIndexType(), 1024));
-      return success();
+          "nvvm.minctasm",
+          rewriter.getIntegerAttr(rewriter.getI32Type(), srcMinctasm));
+      changed = true;
     }
-    // TODO should we only set idx or separately set idx, idy, idz? clang seems
-    // to only set idx to the total num
-    // TODO grab the attr name from the NVVM dialect after bumping llvm
-    bool succeeded = false;
-    int blockSize = *bx * *by * *bz;
-    // A kernel with a known block size already gets its bound from that
-    // attribute during lowering; adding it here would duplicate it.
+    if (!bx || !by || !bz) {
+      // The kernel must stay launchable at every block size its callers may
+      // use: the bound it was compiled with when there is one, the
+      // architecture maximum otherwise; without any bound ptxas may allocate
+      // registers for a small block and larger launches fail with
+      // too-many-resources. maxntid is enforced as a total across dimensions
+      // (the driver checks the derived maxThreadsPerBlock, and ptxas budgets
+      // by the product), so {N, 1, 1} admits any legal block shape of up to
+      // N threads, including multidimensional ones.
+      if (!gpuFuncOp->hasAttr("nvvm.maxntid")) {
+        int32_t cap = srcMaxntid > 0 ? srcMaxntid : 1024;
+        gpuFuncOp->setAttr("nvvm.maxntid",
+                           rewriter.getDenseI32ArrayAttr({cap, 1, 1}));
+        gpuFuncOp->setAttr(
+            "rocdl.max_flat_work_group_size",
+            rewriter.getIntegerAttr(rewriter.getIndexType(), cap));
+        changed = true;
+      }
+      return success(changed);
+    }
+    // A statically known block size is the exact bound: it wins over any
+    // looser bound the source declared. A kernel with known_block_size gets
+    // it from that attribute during lowering; adding it here would duplicate
+    // it.
     if (gpuFuncOp->hasAttr("known_block_size"))
-      return failure();
-    llvm::StringRef attrName = "nvvm.maxntid";
+      return success(changed);
+    // TODO grab the attr name from the NVVM dialect after bumping llvm
     auto ntid = rewriter.getDenseI32ArrayAttr(
         {(int32_t)*bx, (int32_t)*by, (int32_t)*bz});
-    if (!gpuFuncOp->hasAttr(attrName)) {
-      gpuFuncOp->setAttr(attrName, ntid);
-      succeeded = true;
-    } else {
-      assert(ntid == gpuFuncOp->getAttr(attrName));
-      succeeded = false;
+    if (gpuFuncOp->getAttr("nvvm.maxntid") != ntid) {
+      gpuFuncOp->setAttr("nvvm.maxntid", ntid);
+      changed = true;
     }
-    attrName = "rocdl.max_flat_work_group_size";
-    if (!gpuFuncOp->hasAttr(attrName)) {
-      gpuFuncOp->setAttr(attrName, rewriter.getIntegerAttr(
-                                       rewriter.getIndexType(), blockSize));
-      assert(succeeded);
-      (void)succeeded;
-      return success();
-    } else {
-      assert(blockSize ==
-             dyn_cast<IntegerAttr>(gpuFuncOp->getAttr(attrName)).getInt());
-      assert(!succeeded);
-      (void)succeeded;
-      return failure();
+    int blockSize = *bx * *by * *bz;
+    auto flat = rewriter.getIntegerAttr(rewriter.getIndexType(), blockSize);
+    if (gpuFuncOp->getAttr("rocdl.max_flat_work_group_size") != flat) {
+      gpuFuncOp->setAttr("rocdl.max_flat_work_group_size", flat);
+      changed = true;
     }
+    return success(changed);
   }
 };
 
@@ -1901,6 +1940,22 @@ struct ParallelToGPULaunch : public OpRewritePattern<enzymexla::GPUWrapperOp> {
       if (auto attr = wrapper->getAttr(atname)) {
         errOp->setAttr(atname, attr);
       }
+    // The launch bounds riding the passthrough promise a specific block
+    // shape: record the original block size so their consumer can tell a
+    // reproduced shape from a re-blocked one.
+    {
+      int64_t orig = 1;
+      bool known = true;
+      for (unsigned i = 3; i < 6 && known; i++) {
+        if (auto c = getConstantInteger(wrapper.getOperand(i)))
+          orig *= *c;
+        else
+          known = false;
+      }
+      if (known)
+        errOp->setAttr("reactant.launch_block_size",
+                       rewriter.getI64IntegerAttr(orig));
+    }
     rewriter.setInsertionPointToStart(errOp.getBody());
     rewriter.eraseOp(wrapper.getBody()->getTerminator());
     rewriter.inlineBlockBefore(wrapper.getBody(),

--- a/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertParallelToGPU.cpp
@@ -267,21 +267,36 @@ struct AddLaunchBounds : public OpRewritePattern<gpu::LaunchFuncOp> {
     auto bx = getConstantInteger(blockDims.x);
     auto by = getConstantInteger(blockDims.y);
     auto bz = getConstantInteger(blockDims.z);
-    if (!bx || !by || !bz)
-      return failure();
+    if (!bx || !by || !bz) {
+      // The kernel must stay launchable at every legal block size; without
+      // a bound ptxas may allocate registers for a small block and larger
+      // launches fail with too-many-resources.
+      llvm::StringRef attrName = "nvvm.maxntid";
+      if (gpuFuncOp->hasAttr(attrName))
+        return failure();
+      gpuFuncOp->setAttr(attrName, rewriter.getDenseI32ArrayAttr({1024, 1, 1}));
+      gpuFuncOp->setAttr(
+          "rocdl.max_flat_work_group_size",
+          rewriter.getIntegerAttr(rewriter.getIndexType(), 1024));
+      return success();
+    }
     // TODO should we only set idx or separately set idx, idy, idz? clang seems
     // to only set idx to the total num
     // TODO grab the attr name from the NVVM dialect after bumping llvm
     bool succeeded = false;
     int blockSize = *bx * *by * *bz;
-    llvm::StringRef attrName = "nvvm.maxntidx";
+    // A kernel with a known block size already gets its bound from that
+    // attribute during lowering; adding it here would duplicate it.
+    if (gpuFuncOp->hasAttr("known_block_size"))
+      return failure();
+    llvm::StringRef attrName = "nvvm.maxntid";
+    auto ntid = rewriter.getDenseI32ArrayAttr(
+        {(int32_t)*bx, (int32_t)*by, (int32_t)*bz});
     if (!gpuFuncOp->hasAttr(attrName)) {
-      gpuFuncOp->setAttr(attrName, rewriter.getIntegerAttr(
-                                       rewriter.getIndexType(), blockSize));
+      gpuFuncOp->setAttr(attrName, ntid);
       succeeded = true;
     } else {
-      assert(blockSize ==
-             dyn_cast<IntegerAttr>(gpuFuncOp->getAttr(attrName)).getInt());
+      assert(ntid == gpuFuncOp->getAttr(attrName));
       succeeded = false;
     }
     attrName = "rocdl.max_flat_work_group_size";

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -214,7 +214,8 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
         pass_pipeline += ",convert-cudart-to-hiprt";
       if (backend != "cpu") {
         pass_pipeline += ",convert-parallel-to-gpu1,symbol-dce,gpu-kernel-outlining," + canonicalize + ",symbol-dce,";
-        pass_pipeline += "convert-parallel-to-gpu2{backend=";
+        pass_pipeline +=
+            "convert-parallel-to-gpu2{emitGPUKernelLaunchBounds=true backend=";
         pass_pipeline += backend;
         pass_pipeline += "}";
         pass_pipeline += ",lower-aligned-affine-accesses,lower-affine";

--- a/test/lit_tests/lowering/launch-bounds-cap.mlir
+++ b/test/lit_tests/lowering/launch-bounds-cap.mlir
@@ -1,0 +1,28 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu2{emitGPUKernelLaunchBounds=true backend=cuda})" | FileCheck %s
+
+// A kernel launched with runtime block sizes must stay launchable at every
+// legal size: without a bound ptxas allocates registers as if the block were
+// small, and a larger launch fails at runtime with too-many-resources. The
+// cap is the architecture maximum. A kernel with constant launch sizes gets
+// them as its bound.
+
+module attributes {gpu.container_module} {
+  gpu.module @mod [#nvvm.target] {
+    gpu.func @dyn() kernel {
+      gpu.return
+    }
+    gpu.func @stat() kernel {
+      gpu.return
+    }
+  }
+  func.func @launch(%n: index) {
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    gpu.launch_func @mod::@dyn blocks in (%c1, %c1, %c1) threads in (%n, %n, %n)
+    gpu.launch_func @mod::@stat blocks in (%c1, %c1, %c1) threads in (%c64, %c1, %c64)
+    return
+  }
+}
+
+// CHECK: gpu.func @dyn() kernel attributes {nvvm.maxntid = array<i32: 1024, 1, 1>, rocdl.max_flat_work_group_size = 1024 : index}
+// CHECK: gpu.func @stat() kernel attributes {nvvm.maxntid = array<i32: 64, 1, 64>, rocdl.max_flat_work_group_size = 4096 : index}

--- a/test/lit_tests/lowering/launch-bounds-preserve.mlir
+++ b/test/lit_tests/lowering/launch-bounds-preserve.mlir
@@ -1,0 +1,81 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-parallel-to-gpu2{backend=cuda emitGPUKernelLaunchBounds=true})" | FileCheck %s
+
+// __launch_bounds__(maxThreads, minBlocks) arrives from the device IR as
+// nvvm passthrough pairs on the error op; both must land on the kernel, and
+// the preserved maxntid beats the architecture-maximum fallback when the
+// block size is not known.
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, gpu.container_module, llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+
+  func.func @main(%n: index, %out: memref<100xf64, 1>) -> i32 {
+    %c1 = arith.constant 1 : index
+    %c0_i32 = arith.constant 0 : i32
+    %0 = "enzymexla.gpu_error"() ({
+      gpu.launch_func @main_kernel::@main_kernel blocks in (%n, %c1, %c1) threads in (%n, %c1, %c1) args(%out : memref<100xf64, 1>)
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) {passthrough = [["target-cpu", "sm_120"], ["nvvm.maxntid", "128"], ["nvvm.minctasm", "4"]]} : () -> index
+    return %c0_i32 : i32
+  }
+
+  // With statically known threads the exact bound wins over the declared one,
+  // and without a matching recorded original shape the minctasm promise does
+  // not transfer.
+  func.func @second(%n: index, %out: memref<100xf64, 1>) -> i32 {
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %c0_i32 = arith.constant 0 : i32
+    %1 = "enzymexla.gpu_error"() ({
+      gpu.launch_func @second_kernel::@second_kernel blocks in (%n, %c1, %c1) threads in (%c64, %c1, %c1) args(%out : memref<100xf64, 1>)
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) {passthrough = [["target-cpu", "sm_120"], ["nvvm.maxntid", "128"], ["nvvm.minctasm", "4"]]} : () -> index
+    return %c0_i32 : i32
+  }
+
+  // Constant dims that reproduce the recorded original shape keep minctasm.
+  func.func @third(%n: index, %out: memref<100xf64, 1>) -> i32 {
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %c0_i32 = arith.constant 0 : i32
+    %2 = "enzymexla.gpu_error"() ({
+      gpu.launch_func @third_kernel::@third_kernel blocks in (%n, %c1, %c1) threads in (%c64, %c1, %c1) args(%out : memref<100xf64, 1>)
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) {passthrough = [["target-cpu", "sm_120"], ["nvvm.maxntid", "128"], ["nvvm.minctasm", "4"]], reactant.launch_block_size = 64 : i64} : () -> index
+    return %c0_i32 : i32
+  }
+
+  gpu.module @main_kernel {
+    gpu.func @main_kernel(%arg0: memref<100xf64, 1>) kernel {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 1.0 : f64
+      memref.store %cst, %arg0[%c0] : memref<100xf64, 1>
+      gpu.return
+    }
+  }
+  gpu.module @second_kernel {
+    gpu.func @second_kernel(%arg0: memref<100xf64, 1>) kernel {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 2.0 : f64
+      memref.store %cst, %arg0[%c0] : memref<100xf64, 1>
+      gpu.return
+    }
+  }
+  gpu.module @third_kernel {
+    gpu.func @third_kernel(%arg0: memref<100xf64, 1>) kernel {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 3.0 : f64
+      memref.store %cst, %arg0[%c0] : memref<100xf64, 1>
+      gpu.return
+    }
+  }
+}
+
+// CHECK: gpu.module @main_kernel [#nvvm.target<O = 3, chip = "sm_120"
+// CHECK: gpu.func @main_kernel
+// CHECK-SAME: nvvm.maxntid = array<i32: 128, 1, 1>
+// CHECK-SAME: nvvm.minctasm = 4 : i32
+// CHECK: gpu.func @second_kernel
+// CHECK-SAME: nvvm.maxntid = array<i32: 64, 1, 1>
+// CHECK-NOT: nvvm.minctasm
+// CHECK: gpu.func @third_kernel
+// CHECK-SAME: nvvm.maxntid = array<i32: 64, 1, 1>
+// CHECK-SAME: nvvm.minctasm = 4 : i32


### PR DESCRIPTION
Re-opened against main: #2904 was accidentally merged into its stack base (`pb/launch-bounds-cap`) rather than main, so this PR carries the two commits of that stack as one unit and supersedes #2895.

Commit 1 (from #2895): enable launch-bounds emission in the raise pipeline, cap kernels with runtime block sizes at the architecture maximum (without a bound ptxas may allocate registers for a small block and larger launches fail with too-many-resources), emit `nvvm.maxntid` in its modern array form, and skip kernels whose `known_block_size` already yields the exact bound during lowering.

Commit 2 (reviewed on #2904): preserve the source's own `__launch_bounds__(maxThreads, minBlocks)`. clang encodes them as nvvm annotations; the importer carries them as passthrough pairs, ParallelLower stamps them onto the GPU wrapper (whose operands are the original launch dimensions), and the wrapper-to-launch conversion forwards them onto the error op together with the recorded original block size. `AddLaunchBounds` then ranks bounds by tightness and validity: a statically known block size is exact and wins outright; a preserved source bound beats the architecture-maximum fallback for runtime-sized launches; and the preserved `minctasm` transfers only when the kernel's block shape is the one the source promised it for — runtime dimensions are the original launch's own values, and a constant size must reproduce the recorded original rather than a re-blocked alternative.

Verified end-to-end on a `__launch_bounds__(128, 4)` MWE: the raised PTX carries `.maxntid 128, 1, 1` and `.minnctapersm 4`, matching vanilla clang's device output, where previously the minctasm was silently dropped. Lit tests cover the runtime-dims, re-blocked (CHECK-NOT minctasm), and shape-matching cases plus the runtime-size cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD