### PR TITLE
[sparse_tensor] initial support for spmm

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -1400,6 +1400,7 @@ cc_library(
         "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:SCFUtils",
         "@llvm-project//mlir:SideEffectInterfaces",
+        "@llvm-project//mlir:SparseTensorDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:ToLLVMIRTranslation",

--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -753,6 +753,43 @@ def TridiagonalSolveOp: EnzymeXLA_Op<"linalg.tridiagonal_solve", [Pure]> {
   }];
 }
 
+// Sparse Ops
+
+def SparseSpMMOp : EnzymeXLA_Op<"sparse.spmm", [Pure, SameOperandsAndResultElementType]> {
+  let summary = "Sparse matrix times dense vector/matrix product";
+
+  let description = [{
+    output := alpha * A * B + beta * C
+
+    where `A` is a 2-d sparse tensor (e.g. the result of a
+    `sparse_tensor.assemble`) and `B`, `C` and `output` are dense vectors
+    (spmv) or matrices (spmm) of matching shapes. `alpha` and `beta` are 0-d
+    tensors.
+  }];
+
+  let arguments = (ins
+    TensorFloat:$alpha,
+    HLO_Tensor:$A,
+    HLO_Tensor:$B,
+    TensorFloat:$beta,
+    HLO_Tensor:$C
+  );
+
+  let results = (outs
+    HLO_Tensor:$output
+  );
+
+  let assemblyFormat = [{
+    $alpha `,` $A `,` $B `,` $beta `,` $C attr-dict `:` functional-type(operands, results)
+  }];
+
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "Value":$A, "Value":$B)>
+  ];
+}
+
 def LUFactorizationOp: EnzymeXLA_Op<"linalg.lu", [Pure]> {
   let summary = "LU factorization operation with RowMaximum pivoting.";
 

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1260,6 +1260,64 @@ void GemmOp::build(OpBuilder &builder, OperationState &result, Value A, Value B,
                                     builder.getContext(), transb));
 }
 
+LogicalResult enzymexla::SparseSpMMOp::verify() {
+  auto typeA = cast<RankedTensorType>(getA().getType());
+  auto typeB = cast<RankedTensorType>(getB().getType());
+  auto typeC = cast<RankedTensorType>(getC().getType());
+
+  if (typeA.getRank() != 2) {
+    return emitOpError("A must be a 2-d tensor");
+  }
+  if (typeB.getRank() != 1 && typeB.getRank() != 2) {
+    return emitOpError("B must be a vector or a matrix");
+  }
+  if (typeC.getRank() != typeB.getRank()) {
+    return emitOpError("Ranks of B and C must match");
+  }
+  if (typeA.getShape()[1] != typeB.getShape()[0]) {
+    return emitOpError("Inner dimensions of A and B must match");
+  }
+  if (typeC.getShape()[0] != typeA.getShape()[0]) {
+    return emitOpError("First dimensions of A and C must match");
+  }
+  if (typeB.getRank() == 2 && typeB.getShape()[1] != typeC.getShape()[1]) {
+    return emitOpError("Second dimensions of B and C must match");
+  }
+  if (getResult().getType() != typeC) {
+    return emitOpError("Result type must match C's type");
+  }
+
+  return success();
+}
+
+void SparseSpMMOp::build(OpBuilder &builder, OperationState &result, Value A,
+                         Value B) {
+  auto typeA = cast<RankedTensorType>(A.getType());
+  auto typeB = cast<RankedTensorType>(B.getType());
+  auto elementType = typeA.getElementType();
+
+  SmallVector<int64_t> shapeC{typeA.getShape()[0]};
+  if (typeB.getRank() == 2) {
+    shapeC.push_back(typeB.getShape()[1]);
+  }
+
+  auto typeScalar = RankedTensorType::get({}, elementType);
+  auto alpha = stablehlo::ConstantOp::create(
+      builder, result.location, typeScalar,
+      cast<ElementsAttr>(makeAttr(typeScalar, 1)));
+  auto beta = stablehlo::ConstantOp::create(
+      builder, result.location, typeScalar,
+      cast<ElementsAttr>(makeAttr(typeScalar, 0)));
+
+  auto typeC = RankedTensorType::get(shapeC, elementType);
+  auto C =
+      stablehlo::ConstantOp::create(builder, result.location, typeC,
+                                    cast<ElementsAttr>(makeAttr(typeC, 0)));
+
+  result.addTypes(typeC);
+  result.addOperands({alpha, A, B, beta, C});
+}
+
 LogicalResult enzymexla::SyrkOp::verify() {
   auto CType = cast<RankedTensorType>(getC().getType());
   bool isComplex = false;

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1310,9 +1310,8 @@ void SparseSpMMOp::build(OpBuilder &builder, OperationState &result, Value A,
       cast<ElementsAttr>(makeAttr(typeScalar, 0)));
 
   auto typeC = RankedTensorType::get(shapeC, elementType);
-  auto C =
-      stablehlo::ConstantOp::create(builder, result.location, typeC,
-                                    cast<ElementsAttr>(makeAttr(typeC, 0)));
+  auto C = stablehlo::ConstantOp::create(
+      builder, result.location, typeC, cast<ElementsAttr>(makeAttr(typeC, 0)));
 
   result.addTypes(typeC);
   result.addOperands({alpha, A, B, beta, C});

--- a/src/enzyme_ad/jax/Passes/LowerEnzymeXLASparse.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerEnzymeXLASparse.cpp
@@ -1,4 +1,4 @@
-//===- LowerSparseCSR.cpp - Lower CSR sparse products to custom calls -----===//
+//===- LowerEnzymeXLASparse.cpp - Lower enzymexla.sparse to custom calls --===//
 //
 // Lowers CSR sparse matrix products to library custom calls in two steps:
 //
@@ -25,11 +25,11 @@
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "stablehlo/dialect/StablehloOps.h"
 
-#define DEBUG_TYPE "lower-sparse-csr"
+#define DEBUG_TYPE "lower-enzymexla-sparse"
 
 namespace mlir {
 namespace enzyme {
-#define GEN_PASS_DEF_LOWERSPARSECSRPASS
+#define GEN_PASS_DEF_LOWERENZYMEXLASPARSEPASS
 #include "src/enzyme_ad/jax/Passes/Passes.h.inc"
 } // namespace enzyme
 } // namespace mlir
@@ -228,8 +228,9 @@ struct LowerSparseSpMM : public OpRewritePattern<enzymexla::SparseSpMMOp> {
   }
 };
 
-struct LowerSparseCSRPass
-    : public enzyme::impl::LowerSparseCSRPassBase<LowerSparseCSRPass> {
+struct LowerEnzymeXLASparsePass
+    : public enzyme::impl::LowerEnzymeXLASparsePassBase<
+          LowerEnzymeXLASparsePass> {
   void runOnOperation() override {
     auto *context = &getContext();
     RewritePatternSet patterns(context);

--- a/src/enzyme_ad/jax/Passes/LowerSparseCSR.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerSparseCSR.cpp
@@ -174,7 +174,7 @@ struct LowerSparseSpMM : public OpRewritePattern<enzymexla::SparseSpMMOp> {
           getSHLOLayout(rewriter, {1, 1, 1, rhsRank, resTy.getRank()},
                         {true, true, true, true, true}, 2),
           /*result_layouts*/
-          getSHLOLayout(rewriter, {resTy.getRank()}, {true}, 2),
+          getSHLOLayout(rewriter, {resTy.getRank()}, SmallVector<bool>{true}, 2),
           /*output_operand_aliases*/
           rewriter.getArrayAttr({stablehlo::OutputOperandAliasAttr::get(
               op.getContext(), {}, 4, {})}),
@@ -202,7 +202,7 @@ struct LowerSparseSpMM : public OpRewritePattern<enzymexla::SparseSpMMOp> {
         getSHLOLayout(rewriter, {1, 1, 1, rhsRank}, {true, true, true, true},
                       2),
         /*result_layouts*/
-        getSHLOLayout(rewriter, {resTy.getRank()}, {true}, 2),
+        getSHLOLayout(rewriter, {resTy.getRank()}, SmallVector<bool>{true}, 2),
         /*output_operand_aliases*/ rewriter.getArrayAttr({}),
         /*result_tilings*/ nullptr);
 

--- a/src/enzyme_ad/jax/Passes/LowerSparseCSR.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerSparseCSR.cpp
@@ -174,7 +174,8 @@ struct LowerSparseSpMM : public OpRewritePattern<enzymexla::SparseSpMMOp> {
           getSHLOLayout(rewriter, {1, 1, 1, rhsRank, resTy.getRank()},
                         {true, true, true, true, true}, 2),
           /*result_layouts*/
-          getSHLOLayout(rewriter, {resTy.getRank()}, SmallVector<bool>{true}, 2),
+          getSHLOLayout(rewriter, {resTy.getRank()}, SmallVector<bool>{true},
+                        2),
           /*output_operand_aliases*/
           rewriter.getArrayAttr({stablehlo::OutputOperandAliasAttr::get(
               op.getContext(), {}, 4, {})}),
@@ -217,8 +218,7 @@ struct LowerSparseSpMM : public OpRewritePattern<enzymexla::SparseSpMMOp> {
                                      broadcastScalar(op.getAlpha()));
     }
     if (!betaIsZero) {
-      Value scaledC = stablehlo::MulOp::create(rewriter, op.getLoc(),
-                                               op.getC(),
+      Value scaledC = stablehlo::MulOp::create(rewriter, op.getLoc(), op.getC(),
                                                broadcastScalar(op.getBeta()));
       out = stablehlo::AddOp::create(rewriter, op.getLoc(), out, scaledC);
     }

--- a/src/enzyme_ad/jax/Passes/LowerSparseCSR.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerSparseCSR.cpp
@@ -1,15 +1,26 @@
 //===- LowerSparseCSR.cpp - Lower CSR sparse products to custom calls -----===//
 //
-// Rewrites `stablehlo.dot_general` ops whose lhs is a CSR-encoded
-// `sparse_tensor.assemble` result into a
-// `stablehlo.custom_call @reactant_csr_matmul` on the raw CSR buffers, so
-// that no sparse-encoded tensor types survive. The custom call is
-// implemented via cuSPARSE ("CUDA") / hipSPARSE ("ROCM").
+// Lowers CSR sparse matrix products to library custom calls in two steps:
+//
+//  1. `stablehlo.dot_general` ops whose lhs is a CSR-encoded
+//     `sparse_tensor.assemble` result are raised to the semantic
+//     `enzymexla.sparse.spmm` op (with alpha = 1, beta = 0).
+//  2. `enzymexla.sparse.spmm` ops are lowered to
+//     `stablehlo.custom_call @reactant_csr_matmul` (beta == 0) or
+//     `stablehlo.custom_call @reactant_csr_matmul_acc` (fused
+//     alpha*A*B + beta*C, with C aliased to the output) on the raw CSR
+//     buffers, so that no sparse-encoded tensor types survive. When alpha or
+//     beta are not compile-time constants the scaling/accumulation is emitted
+//     as explicit stablehlo ops around the plain product instead.
+//
+// The custom calls are implemented via cuSPARSE ("CUDA") / hipSPARSE ("ROCM").
 //
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/enzyme_ad/jax/Dialect/Dialect.h"
+#include "src/enzyme_ad/jax/Dialect/Ops.h"
 #include "src/enzyme_ad/jax/Passes/LinalgUtils.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "stablehlo/dialect/StablehloOps.h"
@@ -27,25 +38,45 @@ using namespace mlir;
 
 namespace {
 
-struct CSRDotGeneralToCustomCall
-    : public OpRewritePattern<stablehlo::DotGeneralOp> {
+// Returns the defining `sparse_tensor.assemble` of `A` if `A` is a
+// statically-shaped CSR-encoded matrix assembled from (positions,
+// coordinates), values buffers.
+static sparse_tensor::AssembleOp getCSRAssemble(Value A) {
+  auto assemble = A.getDefiningOp<sparse_tensor::AssembleOp>();
+  if (!assemble)
+    return nullptr;
+
+  auto spTy = cast<RankedTensorType>(A.getType());
+  auto enc = sparse_tensor::getSparseTensorEncoding(spTy);
+  if (!enc || enc.getLvlRank() != 2 || !enc.isIdentity() ||
+      !enc.isDenseLvl(0) || !enc.isCompressedLvl(1))
+    return nullptr;
+  if (assemble.getLevels().size() != 2)
+    return nullptr;
+  if (!spTy.hasStaticShape())
+    return nullptr;
+
+  return assemble;
+}
+
+static std::optional<double> extractConstantScalar(Value val) {
+  DenseElementsAttr attr;
+  if (!matchPattern(val, m_Constant(&attr)))
+    return std::nullopt;
+  if (!isa<FloatType>(cast<RankedTensorType>(val.getType()).getElementType()))
+    return std::nullopt;
+  return attr.getSplatValue<APFloat>().convertToDouble();
+}
+
+// Raise `dot_general(assemble(...), B)` to `enzymexla.sparse.spmm` with
+// alpha = 1, beta = 0.
+struct RaiseCSRDotGeneral : public OpRewritePattern<stablehlo::DotGeneralOp> {
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(stablehlo::DotGeneralOp op,
                                 PatternRewriter &rewriter) const override {
-    auto assemble = op.getLhs().getDefiningOp<sparse_tensor::AssembleOp>();
-    if (!assemble)
+    if (!getCSRAssemble(op.getLhs()))
       return failure();
-
-    auto spTy = cast<RankedTensorType>(op.getLhs().getType());
-    auto enc = sparse_tensor::getSparseTensorEncoding(spTy);
-    if (!enc || enc.getLvlRank() != 2 || !enc.isIdentity() ||
-        !enc.isDenseLvl(0) || !enc.isCompressedLvl(1))
-      return rewriter.notifyMatchFailure(op, "lhs is not CSR-encoded");
-
-    if (assemble.getLevels().size() != 2)
-      return rewriter.notifyMatchFailure(
-          op, "expected positions + coordinates level buffers");
 
     if (sparse_tensor::getSparseTensorEncoding(op.getRhs().getType()) ||
         sparse_tensor::getSparseTensorEncoding(op.getType()))
@@ -55,8 +86,17 @@ struct CSRDotGeneralToCustomCall
     int64_t rhsRank = rhsTy.getRank();
     if (rhsRank != 1 && rhsRank != 2)
       return rewriter.notifyMatchFailure(op, "rhs must be a vector or matrix");
-    if (!rhsTy.hasStaticShape() || !spTy.hasStaticShape())
+    if (!rhsTy.hasStaticShape())
       return rewriter.notifyMatchFailure(op, "expected static shapes");
+    if (!rhsTy.getElementType().isF32() && !rhsTy.getElementType().isF64())
+      return rewriter.notifyMatchFailure(op, "only f32/f64 are supported");
+
+    auto spTy = cast<RankedTensorType>(op.getLhs().getType());
+    auto resTy = cast<RankedTensorType>(op.getType());
+    if (spTy.getElementType() != rhsTy.getElementType() ||
+        resTy.getElementType() != rhsTy.getElementType())
+      return rewriter.notifyMatchFailure(
+          op, "mixed element types are not supported");
 
     auto dims = op.getDotDimensionNumbers();
     if (!dims.getLhsBatchingDimensions().empty() ||
@@ -66,31 +106,97 @@ struct CSRDotGeneralToCustomCall
       return rewriter.notifyMatchFailure(
           op, "only plain A * x / A * B contractions are supported");
 
+    rewriter.replaceOpWithNewOp<enzymexla::SparseSpMMOp>(op, op.getLhs(),
+                                                         op.getRhs());
+    return success();
+  }
+};
+
+// Lower `enzymexla.sparse.spmm` on a CSR-assembled matrix to custom calls.
+struct LowerSparseSpMM : public OpRewritePattern<enzymexla::SparseSpMMOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(enzymexla::SparseSpMMOp op,
+                                PatternRewriter &rewriter) const override {
+    auto assemble = getCSRAssemble(op.getA());
+    if (!assemble)
+      return rewriter.notifyMatchFailure(
+          op, "A is not a CSR-encoded sparse_tensor.assemble result");
+
+    auto spTy = cast<RankedTensorType>(op.getA().getType());
+    auto resTy = cast<RankedTensorType>(op.getType());
+    auto rhsTy = cast<RankedTensorType>(op.getB().getType());
+    int64_t rhsRank = rhsTy.getRank();
+    if (!rhsTy.hasStaticShape() || !resTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected static shapes");
+    if (!resTy.getElementType().isF32() && !resTy.getElementType().isF64())
+      return rewriter.notifyMatchFailure(op, "only f32/f64 are supported");
+
     Value rowptr = assemble.getLevels()[0];
     Value colind = assemble.getLevels()[1];
     Value nzval = assemble.getValues();
 
+    auto alphaConst = extractConstantScalar(op.getAlpha());
+    auto betaConst = extractConstantScalar(op.getBeta());
+    bool betaIsZero = betaConst && *betaConst == 0.0;
+
     // `sparse_tensor` coordinates are 0-based.
     SmallVector<NamedAttribute> configAttrs = {
-        rewriter.getNamedAttr("m", rewriter.getI64IntegerAttr(
-                                       spTy.getDimSize(0))),
-        rewriter.getNamedAttr("n", rewriter.getI64IntegerAttr(
-                                       spTy.getDimSize(1))),
+        rewriter.getNamedAttr("m",
+                              rewriter.getI64IntegerAttr(spTy.getDimSize(0))),
+        rewriter.getNamedAttr("n",
+                              rewriter.getI64IntegerAttr(spTy.getDimSize(1))),
         rewriter.getNamedAttr("transpose", rewriter.getI64IntegerAttr(0)),
         rewriter.getNamedAttr("index_base", rewriter.getI64IntegerAttr(0)),
     };
 
-    auto resTy = cast<RankedTensorType>(op.getType());
+    auto apiVersion = stablehlo::CustomCallApiVersionAttr::get(
+        rewriter.getContext(),
+        stablehlo::CustomCallApiVersion::API_VERSION_TYPED_FFI);
+
+    if (alphaConst && betaConst && !betaIsZero) {
+      // Fully fused alpha*A*B + beta*C in a single library call, with C
+      // aliased to the output buffer.
+      configAttrs.push_back(rewriter.getNamedAttr(
+          "alpha", rewriter.getF64FloatAttr(*alphaConst)));
+      configAttrs.push_back(
+          rewriter.getNamedAttr("beta", rewriter.getF64FloatAttr(*betaConst)));
+
+      auto customCall = stablehlo::CustomCallOp::create(
+          rewriter, op.getLoc(), TypeRange{resTy},
+          ValueRange{rowptr, colind, nzval, op.getB(), op.getC()},
+          rewriter.getStringAttr("reactant_csr_matmul_acc"),
+          /*has_side_effect*/ nullptr,
+          /*backend_config*/ rewriter.getDictionaryAttr(configAttrs),
+          /*api_version*/ apiVersion,
+          /*called_computations*/ nullptr,
+          /*operand_layouts*/
+          getSHLOLayout(rewriter, {1, 1, 1, rhsRank, resTy.getRank()},
+                        {true, true, true, true, true}, 2),
+          /*result_layouts*/
+          getSHLOLayout(rewriter, {resTy.getRank()}, {true}, 2),
+          /*output_operand_aliases*/
+          rewriter.getArrayAttr({stablehlo::OutputOperandAliasAttr::get(
+              op.getContext(), {}, 4, {})}),
+          /*result_tilings*/ nullptr);
+
+      rewriter.replaceOp(op, customCall.getResults());
+      return success();
+    }
+
+    // Plain product, with a constant alpha folded into the call. Runtime
+    // alpha/beta scaling and accumulation are emitted as explicit stablehlo
+    // ops around it.
+    configAttrs.push_back(rewriter.getNamedAttr(
+        "alpha", rewriter.getF64FloatAttr(alphaConst.value_or(1.0))));
+
     auto customCall = stablehlo::CustomCallOp::create(
         rewriter, op.getLoc(), TypeRange{resTy},
-        ValueRange{rowptr, colind, nzval, op.getRhs()},
+        ValueRange{rowptr, colind, nzval, op.getB()},
         rewriter.getStringAttr("reactant_csr_matmul"),
         /*has_side_effect*/ nullptr,
         /*backend_config*/ rewriter.getDictionaryAttr(configAttrs),
-        /*api_version*/
-        stablehlo::CustomCallApiVersionAttr::get(
-            rewriter.getContext(),
-            stablehlo::CustomCallApiVersion::API_VERSION_TYPED_FFI),
+        /*api_version*/ apiVersion,
         /*called_computations*/ nullptr,
         /*operand_layouts*/
         getSHLOLayout(rewriter, {1, 1, 1, rhsRank}, {true, true, true, true},
@@ -100,7 +206,24 @@ struct CSRDotGeneralToCustomCall
         /*output_operand_aliases*/ rewriter.getArrayAttr({}),
         /*result_tilings*/ nullptr);
 
-    rewriter.replaceOp(op, customCall.getResults());
+    Value out = customCall.getResult(0);
+    auto broadcastScalar = [&](Value scalar) {
+      return stablehlo::BroadcastInDimOp::create(
+          rewriter, op.getLoc(), resTy, scalar,
+          rewriter.getDenseI64ArrayAttr({}));
+    };
+    if (!alphaConst) {
+      out = stablehlo::MulOp::create(rewriter, op.getLoc(), out,
+                                     broadcastScalar(op.getAlpha()));
+    }
+    if (!betaIsZero) {
+      Value scaledC = stablehlo::MulOp::create(rewriter, op.getLoc(),
+                                               op.getC(),
+                                               broadcastScalar(op.getBeta()));
+      out = stablehlo::AddOp::create(rewriter, op.getLoc(), out, scaledC);
+    }
+
+    rewriter.replaceOp(op, out);
     return success();
   }
 };
@@ -110,7 +233,7 @@ struct LowerSparseCSRPass
   void runOnOperation() override {
     auto *context = &getContext();
     RewritePatternSet patterns(context);
-    patterns.add<CSRDotGeneralToCustomCall>(context);
+    patterns.add<RaiseCSRDotGeneral, LowerSparseSpMM>(context);
 
     GreedyRewriteConfig config;
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
@@ -130,14 +253,16 @@ struct LowerSparseCSRPass
       op->erase();
 
     // XLA cannot consume sparse-encoded tensor types, so any surviving
-    // sparse_tensor op is an error.
+    // sparse_tensor (or unlowerable enzymexla.sparse) op is an error.
     auto walkResult = getOperation()->walk([&](Operation *op) {
       if (isa_and_nonnull<sparse_tensor::SparseTensorDialect>(
-              op->getDialect())) {
+              op->getDialect()) ||
+          isa<enzymexla::SparseSpMMOp>(op)) {
         op->emitError()
-            << "unsupported use of the sparse_tensor dialect: only CSR "
-               "`A * x` / `A * B` products consumed by `stablehlo.dot_general` "
-               "can be lowered";
+            << "unsupported use of sparse tensors: only CSR "
+               "`alpha * A * B + beta * C` products (`enzymexla.sparse.spmm` "
+               "or `stablehlo.dot_general` on a `sparse_tensor.assemble` "
+               "result) can be lowered";
         return WalkResult::interrupt();
       }
       return WalkResult::advance();

--- a/src/enzyme_ad/jax/Passes/LowerSparseCSR.cpp
+++ b/src/enzyme_ad/jax/Passes/LowerSparseCSR.cpp
@@ -1,0 +1,150 @@
+//===- LowerSparseCSR.cpp - Lower CSR sparse products to custom calls -----===//
+//
+// Rewrites `stablehlo.dot_general` ops whose lhs is a CSR-encoded
+// `sparse_tensor.assemble` result into a
+// `stablehlo.custom_call @reactant_csr_matmul` on the raw CSR buffers, so
+// that no sparse-encoded tensor types survive. The custom call is
+// implemented via cuSPARSE ("CUDA") / hipSPARSE ("ROCM").
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/enzyme_ad/jax/Passes/LinalgUtils.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+#define DEBUG_TYPE "lower-sparse-csr"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_LOWERSPARSECSRPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+struct CSRDotGeneralToCustomCall
+    : public OpRewritePattern<stablehlo::DotGeneralOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(stablehlo::DotGeneralOp op,
+                                PatternRewriter &rewriter) const override {
+    auto assemble = op.getLhs().getDefiningOp<sparse_tensor::AssembleOp>();
+    if (!assemble)
+      return failure();
+
+    auto spTy = cast<RankedTensorType>(op.getLhs().getType());
+    auto enc = sparse_tensor::getSparseTensorEncoding(spTy);
+    if (!enc || enc.getLvlRank() != 2 || !enc.isIdentity() ||
+        !enc.isDenseLvl(0) || !enc.isCompressedLvl(1))
+      return rewriter.notifyMatchFailure(op, "lhs is not CSR-encoded");
+
+    if (assemble.getLevels().size() != 2)
+      return rewriter.notifyMatchFailure(
+          op, "expected positions + coordinates level buffers");
+
+    if (sparse_tensor::getSparseTensorEncoding(op.getRhs().getType()) ||
+        sparse_tensor::getSparseTensorEncoding(op.getType()))
+      return rewriter.notifyMatchFailure(op, "rhs and result must be dense");
+
+    auto rhsTy = cast<RankedTensorType>(op.getRhs().getType());
+    int64_t rhsRank = rhsTy.getRank();
+    if (rhsRank != 1 && rhsRank != 2)
+      return rewriter.notifyMatchFailure(op, "rhs must be a vector or matrix");
+    if (!rhsTy.hasStaticShape() || !spTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected static shapes");
+
+    auto dims = op.getDotDimensionNumbers();
+    if (!dims.getLhsBatchingDimensions().empty() ||
+        !dims.getRhsBatchingDimensions().empty() ||
+        dims.getLhsContractingDimensions() != ArrayRef<int64_t>{1} ||
+        dims.getRhsContractingDimensions() != ArrayRef<int64_t>{0})
+      return rewriter.notifyMatchFailure(
+          op, "only plain A * x / A * B contractions are supported");
+
+    Value rowptr = assemble.getLevels()[0];
+    Value colind = assemble.getLevels()[1];
+    Value nzval = assemble.getValues();
+
+    // `sparse_tensor` coordinates are 0-based.
+    SmallVector<NamedAttribute> configAttrs = {
+        rewriter.getNamedAttr("m", rewriter.getI64IntegerAttr(
+                                       spTy.getDimSize(0))),
+        rewriter.getNamedAttr("n", rewriter.getI64IntegerAttr(
+                                       spTy.getDimSize(1))),
+        rewriter.getNamedAttr("transpose", rewriter.getI64IntegerAttr(0)),
+        rewriter.getNamedAttr("index_base", rewriter.getI64IntegerAttr(0)),
+    };
+
+    auto resTy = cast<RankedTensorType>(op.getType());
+    auto customCall = stablehlo::CustomCallOp::create(
+        rewriter, op.getLoc(), TypeRange{resTy},
+        ValueRange{rowptr, colind, nzval, op.getRhs()},
+        rewriter.getStringAttr("reactant_csr_matmul"),
+        /*has_side_effect*/ nullptr,
+        /*backend_config*/ rewriter.getDictionaryAttr(configAttrs),
+        /*api_version*/
+        stablehlo::CustomCallApiVersionAttr::get(
+            rewriter.getContext(),
+            stablehlo::CustomCallApiVersion::API_VERSION_TYPED_FFI),
+        /*called_computations*/ nullptr,
+        /*operand_layouts*/
+        getSHLOLayout(rewriter, {1, 1, 1, rhsRank}, {true, true, true, true},
+                      2),
+        /*result_layouts*/
+        getSHLOLayout(rewriter, {resTy.getRank()}, {true}, 2),
+        /*output_operand_aliases*/ rewriter.getArrayAttr({}),
+        /*result_tilings*/ nullptr);
+
+    rewriter.replaceOp(op, customCall.getResults());
+    return success();
+  }
+};
+
+struct LowerSparseCSRPass
+    : public enzyme::impl::LowerSparseCSRPassBase<LowerSparseCSRPass> {
+  void runOnOperation() override {
+    auto *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<CSRDotGeneralToCustomCall>(context);
+
+    GreedyRewriteConfig config;
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
+                                     config))) {
+      signalPassFailure();
+    }
+
+    // The greedy driver DCEs `sparse_tensor.assemble` ops it visited; sweep
+    // any remaining unused ones so the check below only reports genuinely
+    // unsupported usage.
+    SmallVector<Operation *> deadAssembles;
+    getOperation()->walk([&](sparse_tensor::AssembleOp assemble) {
+      if (assemble->use_empty())
+        deadAssembles.push_back(assemble);
+    });
+    for (Operation *op : deadAssembles)
+      op->erase();
+
+    // XLA cannot consume sparse-encoded tensor types, so any surviving
+    // sparse_tensor op is an error.
+    auto walkResult = getOperation()->walk([&](Operation *op) {
+      if (isa_and_nonnull<sparse_tensor::SparseTensorDialect>(
+              op->getDialect())) {
+        op->emitError()
+            << "unsupported use of the sparse_tensor dialect: only CSR "
+               "`A * x` / `A * B` products consumed by `stablehlo.dot_general` "
+               "can be lowered";
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (walkResult.wasInterrupted())
+      signalPassFailure();
+  }
+};
+
+} // namespace

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -674,8 +674,8 @@ def LowerEnzymeXLABLASPass : Pass<"lower-enzymexla-blas"> {
   ];
 }
 
-def LowerSparseCSRPass : Pass<"lower-sparse-csr"> {
-  let summary = "Lower CSR sparse matrix products to custom calls";
+def LowerEnzymeXLASparsePass : Pass<"lower-enzymexla-sparse"> {
+  let summary = "Lower enzymexla.sparse ops to stablehlo custom calls";
   let description = [{
     Raises `stablehlo.dot_general` ops whose lhs is a CSR-encoded
     `sparse_tensor.assemble` result to `enzymexla.sparse.spmm`, and lowers

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -675,18 +675,23 @@ def LowerEnzymeXLABLASPass : Pass<"lower-enzymexla-blas"> {
 }
 
 def LowerSparseCSRPass : Pass<"lower-sparse-csr"> {
-  let summary = "Lower CSR sparse_tensor dot_general products to custom calls";
+  let summary = "Lower CSR sparse matrix products to custom calls";
   let description = [{
-    Rewrites `stablehlo.dot_general` ops whose lhs is a CSR-encoded
-    `sparse_tensor.assemble` result into a
-    `stablehlo.custom_call @reactant_csr_matmul` operating directly on the raw
-    CSR buffers (positions, coordinates, values), so that only dense tensor
-    types remain. The custom call is implemented via cuSPARSE/hipSPARSE.
-    Any `sparse_tensor` op that survives the rewrite is reported as an error.
+    Raises `stablehlo.dot_general` ops whose lhs is a CSR-encoded
+    `sparse_tensor.assemble` result to `enzymexla.sparse.spmm`, and lowers
+    `enzymexla.sparse.spmm` ops into `stablehlo.custom_call
+    @reactant_csr_matmul` / `@reactant_csr_matmul_acc` operating directly on
+    the raw CSR buffers (positions, coordinates, values), so that only dense
+    tensor types remain. Constant `alpha`/`beta` are fused into a single
+    library call (with `C` aliased to the output); runtime scalars are
+    emitted as explicit stablehlo scaling around the plain product. The
+    custom calls are implemented via cuSPARSE/hipSPARSE. Any sparse op that
+    survives the rewrite is reported as an error.
   }];
   let dependentDialects = [
     "stablehlo::StablehloDialect",
     "sparse_tensor::SparseTensorDialect",
+    "enzymexla::EnzymeXLADialect",
   ];
 }
 

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -674,6 +674,22 @@ def LowerEnzymeXLABLASPass : Pass<"lower-enzymexla-blas"> {
   ];
 }
 
+def LowerSparseCSRPass : Pass<"lower-sparse-csr"> {
+  let summary = "Lower CSR sparse_tensor dot_general products to custom calls";
+  let description = [{
+    Rewrites `stablehlo.dot_general` ops whose lhs is a CSR-encoded
+    `sparse_tensor.assemble` result into a
+    `stablehlo.custom_call @reactant_csr_matmul` operating directly on the raw
+    CSR buffers (positions, coordinates, values), so that only dense tensor
+    types remain. The custom call is implemented via cuSPARSE/hipSPARSE.
+    Any `sparse_tensor` op that survives the rewrite is reported as an error.
+  }];
+  let dependentDialects = [
+    "stablehlo::StablehloDialect",
+    "sparse_tensor::SparseTensorDialect",
+  ];
+}
+
 def LowerImpulseToStableHLOPass : Pass<"lower-impulse-to-stablehlo"> {
   let summary = "Lower Impulse dialect ops to StableHLO";
   let description = [{

--- a/test/lit_tests/sparse/csr_matmul.mlir
+++ b/test/lit_tests/sparse/csr_matmul.mlir
@@ -7,7 +7,7 @@
 // CHECK-NOT: sparse_tensor
 // CHECK: %[[Y:.+]] = stablehlo.custom_call @reactant_csr_matmul(%arg0, %arg1, %arg2, %arg3)
 // CHECK-SAME: api_version = 4 : i32
-// CHECK-SAME: backend_config = {index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
+// CHECK-SAME: backend_config = {alpha = 1.000000e+00 : f64, index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
 // CHECK-SAME: (tensor<11xi64>, tensor<20xi64>, tensor<20xf64>, tensor<8xf64>) -> tensor<10xf64>
 // CHECK-NOT: sparse_tensor
 // CHECK: return %[[Y]]
@@ -20,7 +20,7 @@ func.func @spmv(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor
 // CHECK-LABEL: func.func @spmm
 // CHECK-NOT: sparse_tensor
 // CHECK: %[[Y:.+]] = stablehlo.custom_call @reactant_csr_matmul(%arg0, %arg1, %arg2, %arg3)
-// CHECK-SAME: backend_config = {index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
+// CHECK-SAME: backend_config = {alpha = 1.000000e+00 : f64, index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
 // CHECK-SAME: operand_layouts = [dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>, dense<[0, 1]> : tensor<2xindex>]
 // CHECK-SAME: result_layouts = [dense<[0, 1]> : tensor<2xindex>]
 // CHECK-SAME: (tensor<11xi64>, tensor<20xi64>, tensor<20xf64>, tensor<8x3xf64>) -> tensor<10x3xf64>

--- a/test/lit_tests/sparse/csr_matmul.mlir
+++ b/test/lit_tests/sparse/csr_matmul.mlir
@@ -1,0 +1,59 @@
+// RUN: enzymexlamlir-opt --lower-sparse-csr %s | FileCheck %s
+
+#csr = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed), posWidth = 64, crdWidth = 64 }>
+#csr32 = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed), posWidth = 32, crdWidth = 32 }>
+
+// CHECK-LABEL: func.func @spmv
+// CHECK-NOT: sparse_tensor
+// CHECK: %[[Y:.+]] = stablehlo.custom_call @reactant_csr_matmul(%arg0, %arg1, %arg2, %arg3)
+// CHECK-SAME: api_version = 4 : i32
+// CHECK-SAME: backend_config = {index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
+// CHECK-SAME: (tensor<11xi64>, tensor<20xi64>, tensor<20xf64>, tensor<8xf64>) -> tensor<10xf64>
+// CHECK-NOT: sparse_tensor
+// CHECK: return %[[Y]]
+func.func @spmv(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>, %x: tensor<8xf64>) -> tensor<10xf64> {
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
+  %y = stablehlo.dot_general %A, %x, contracting_dims = [1] x [0] : (tensor<10x8xf64, #csr>, tensor<8xf64>) -> tensor<10xf64>
+  return %y : tensor<10xf64>
+}
+
+// CHECK-LABEL: func.func @spmm
+// CHECK-NOT: sparse_tensor
+// CHECK: %[[Y:.+]] = stablehlo.custom_call @reactant_csr_matmul(%arg0, %arg1, %arg2, %arg3)
+// CHECK-SAME: backend_config = {index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
+// CHECK-SAME: operand_layouts = [dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>, dense<[0, 1]> : tensor<2xindex>]
+// CHECK-SAME: result_layouts = [dense<[0, 1]> : tensor<2xindex>]
+// CHECK-SAME: (tensor<11xi64>, tensor<20xi64>, tensor<20xf64>, tensor<8x3xf64>) -> tensor<10x3xf64>
+// CHECK-NOT: sparse_tensor
+// CHECK: return %[[Y]]
+func.func @spmm(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>, %B: tensor<8x3xf64>) -> tensor<10x3xf64> {
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
+  %y = stablehlo.dot_general %A, %B, contracting_dims = [1] x [0] : (tensor<10x8xf64, #csr>, tensor<8x3xf64>) -> tensor<10x3xf64>
+  return %y : tensor<10x3xf64>
+}
+
+// CHECK-LABEL: func.func @spmv_i32
+// CHECK-NOT: sparse_tensor
+// CHECK: %[[Y:.+]] = stablehlo.custom_call @reactant_csr_matmul(%arg0, %arg1, %arg2, %arg3)
+// CHECK-SAME: (tensor<11xi32>, tensor<20xi32>, tensor<20xf32>, tensor<8xf32>) -> tensor<10xf32>
+// CHECK-NOT: sparse_tensor
+// CHECK: return %[[Y]]
+func.func @spmv_i32(%rowptr: tensor<11xi32>, %colind: tensor<20xi32>, %nzval: tensor<20xf32>, %x: tensor<8xf32>) -> tensor<10xf32> {
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi32>, tensor<20xi32>), tensor<20xf32> to tensor<10x8xf32, #csr32>
+  %y = stablehlo.dot_general %A, %x, contracting_dims = [1] x [0] : (tensor<10x8xf32, #csr32>, tensor<8xf32>) -> tensor<10xf32>
+  return %y : tensor<10xf32>
+}
+
+// A single assemble feeding two dot_generals: both get lowered and the
+// assemble is erased.
+// CHECK-LABEL: func.func @shared_assemble
+// CHECK-NOT: sparse_tensor
+// CHECK: stablehlo.custom_call @reactant_csr_matmul
+// CHECK: stablehlo.custom_call @reactant_csr_matmul
+// CHECK-NOT: sparse_tensor
+func.func @shared_assemble(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>, %x: tensor<8xf64>, %B: tensor<8x3xf64>) -> (tensor<10xf64>, tensor<10x3xf64>) {
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
+  %y = stablehlo.dot_general %A, %x, contracting_dims = [1] x [0] : (tensor<10x8xf64, #csr>, tensor<8xf64>) -> tensor<10xf64>
+  %Z = stablehlo.dot_general %A, %B, contracting_dims = [1] x [0] : (tensor<10x8xf64, #csr>, tensor<8x3xf64>) -> tensor<10x3xf64>
+  return %y, %Z : tensor<10xf64>, tensor<10x3xf64>
+}

--- a/test/lit_tests/sparse/csr_matmul.mlir
+++ b/test/lit_tests/sparse/csr_matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt --lower-sparse-csr %s | FileCheck %s
+// RUN: enzymexlamlir-opt --lower-enzymexla-sparse %s | FileCheck %s
 
 #csr = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed), posWidth = 64, crdWidth = 64 }>
 #csr32 = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed), posWidth = 32, crdWidth = 32 }>

--- a/test/lit_tests/sparse/csr_unsupported.mlir
+++ b/test/lit_tests/sparse/csr_unsupported.mlir
@@ -5,7 +5,7 @@
 // A sparse tensor that escapes as a function result cannot be lowered to a
 // custom call and must be reported instead of being handed to XLA.
 func.func @escaping_sparse(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>) -> tensor<10x8xf64, #csr> {
-  // expected-error @below {{unsupported use of the sparse_tensor dialect: only CSR `A * x` / `A * B` products consumed by `stablehlo.dot_general` can be lowered}}
+  // expected-error @below {{unsupported use of sparse tensors}}
   %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
   return %A : tensor<10x8xf64, #csr>
 }

--- a/test/lit_tests/sparse/csr_unsupported.mlir
+++ b/test/lit_tests/sparse/csr_unsupported.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt --lower-sparse-csr --verify-diagnostics %s
+// RUN: enzymexlamlir-opt --lower-enzymexla-sparse --verify-diagnostics %s
 
 #csr = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed), posWidth = 64, crdWidth = 64 }>
 

--- a/test/lit_tests/sparse/csr_unsupported.mlir
+++ b/test/lit_tests/sparse/csr_unsupported.mlir
@@ -1,0 +1,11 @@
+// RUN: enzymexlamlir-opt --lower-sparse-csr --verify-diagnostics %s
+
+#csr = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed), posWidth = 64, crdWidth = 64 }>
+
+// A sparse tensor that escapes as a function result cannot be lowered to a
+// custom call and must be reported instead of being handed to XLA.
+func.func @escaping_sparse(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>) -> tensor<10x8xf64, #csr> {
+  // expected-error @below {{unsupported use of the sparse_tensor dialect: only CSR `A * x` / `A * B` products consumed by `stablehlo.dot_general` can be lowered}}
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
+  return %A : tensor<10x8xf64, #csr>
+}

--- a/test/lit_tests/sparse/spmm.mlir
+++ b/test/lit_tests/sparse/spmm.mlir
@@ -1,0 +1,76 @@
+// RUN: enzymexlamlir-opt --lower-sparse-csr %s | FileCheck %s
+
+#csr = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed), posWidth = 64, crdWidth = 64 }>
+
+// Constant alpha/beta: fully fused into a single accumulating library call
+// with C aliased to the output.
+// CHECK-LABEL: func.func @fused
+// CHECK-NOT: sparse_tensor
+// CHECK: %[[Y:.+]] = stablehlo.custom_call @reactant_csr_matmul_acc(%arg0, %arg1, %arg2, %arg3, %arg4)
+// CHECK-SAME: api_version = 4 : i32
+// CHECK-SAME: backend_config = {alpha = 2.000000e+00 : f64, beta = 3.000000e+00 : f64, index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
+// CHECK-SAME: output_operand_aliases = [#stablehlo.output_operand_alias<output_tuple_indices = [], operand_index = 4, operand_tuple_indices = []>]
+// CHECK-SAME: (tensor<11xi64>, tensor<20xi64>, tensor<20xf64>, tensor<8xf64>, tensor<10xf64>) -> tensor<10xf64>
+// CHECK-NOT: sparse_tensor
+// CHECK: return %[[Y]]
+func.func @fused(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>, %x: tensor<8xf64>, %C: tensor<10xf64>) -> tensor<10xf64> {
+  %alpha = stablehlo.constant dense<2.0> : tensor<f64>
+  %beta = stablehlo.constant dense<3.0> : tensor<f64>
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
+  %y = enzymexla.sparse.spmm %alpha, %A, %x, %beta, %C : (tensor<f64>, tensor<10x8xf64, #csr>, tensor<8xf64>, tensor<f64>, tensor<10xf64>) -> tensor<10xf64>
+  return %y : tensor<10xf64>
+}
+
+// Constant beta == 0: no accumulation, alpha folded into the plain call and
+// C unused.
+// CHECK-LABEL: func.func @beta_zero
+// CHECK-NOT: sparse_tensor
+// CHECK: %[[Y:.+]] = stablehlo.custom_call @reactant_csr_matmul(%arg0, %arg1, %arg2, %arg3)
+// CHECK-SAME: backend_config = {alpha = 2.000000e+00 : f64, index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
+// CHECK-SAME: (tensor<11xi64>, tensor<20xi64>, tensor<20xf64>, tensor<8x3xf64>) -> tensor<10x3xf64>
+// CHECK-NOT: sparse_tensor
+// CHECK: return %[[Y]]
+func.func @beta_zero(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>, %B: tensor<8x3xf64>, %C: tensor<10x3xf64>) -> tensor<10x3xf64> {
+  %alpha = stablehlo.constant dense<2.0> : tensor<f64>
+  %beta = stablehlo.constant dense<0.0> : tensor<f64>
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
+  %y = enzymexla.sparse.spmm %alpha, %A, %B, %beta, %C : (tensor<f64>, tensor<10x8xf64, #csr>, tensor<8x3xf64>, tensor<f64>, tensor<10x3xf64>) -> tensor<10x3xf64>
+  return %y : tensor<10x3xf64>
+}
+
+// Runtime alpha/beta: plain library call plus explicit stablehlo scaling and
+// accumulation.
+// CHECK-LABEL: func.func @runtime_scalars
+// CHECK-NOT: sparse_tensor
+// CHECK: %[[CC:.+]] = stablehlo.custom_call @reactant_csr_matmul(%arg0, %arg1, %arg2, %arg3)
+// CHECK-SAME: backend_config = {alpha = 1.000000e+00 : f64, index_base = 0 : i64, m = 10 : i64, n = 8 : i64, transpose = 0 : i64}
+// CHECK: %[[AB:.+]] = stablehlo.broadcast_in_dim %arg5, dims = [] : (tensor<f64>) -> tensor<10xf64>
+// CHECK: %[[SCALED:.+]] = stablehlo.multiply %[[CC]], %[[AB]]
+// CHECK: %[[BB:.+]] = stablehlo.broadcast_in_dim %arg6, dims = [] : (tensor<f64>) -> tensor<10xf64>
+// CHECK: %[[SC:.+]] = stablehlo.multiply %arg4, %[[BB]]
+// CHECK: %[[Y:.+]] = stablehlo.add %[[SCALED]], %[[SC]]
+// CHECK-NOT: sparse_tensor
+// CHECK: return %[[Y]]
+func.func @runtime_scalars(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>, %x: tensor<8xf64>, %C: tensor<10xf64>, %alpha: tensor<f64>, %beta: tensor<f64>) -> tensor<10xf64> {
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
+  %y = enzymexla.sparse.spmm %alpha, %A, %x, %beta, %C : (tensor<f64>, tensor<10x8xf64, #csr>, tensor<8xf64>, tensor<f64>, tensor<10xf64>) -> tensor<10xf64>
+  return %y : tensor<10xf64>
+}
+
+// Constant alpha with runtime beta: alpha still folds into the call, beta
+// accumulates explicitly.
+// CHECK-LABEL: func.func @runtime_beta
+// CHECK-NOT: sparse_tensor
+// CHECK: %[[CC:.+]] = stablehlo.custom_call @reactant_csr_matmul(%arg0, %arg1, %arg2, %arg3)
+// CHECK-SAME: backend_config = {alpha = 2.000000e+00 : f64,
+// CHECK: %[[BB:.+]] = stablehlo.broadcast_in_dim %arg5, dims = [] : (tensor<f64>) -> tensor<10xf64>
+// CHECK: %[[SC:.+]] = stablehlo.multiply %arg4, %[[BB]]
+// CHECK: %[[Y:.+]] = stablehlo.add %[[CC]], %[[SC]]
+// CHECK-NOT: sparse_tensor
+// CHECK: return %[[Y]]
+func.func @runtime_beta(%rowptr: tensor<11xi64>, %colind: tensor<20xi64>, %nzval: tensor<20xf64>, %x: tensor<8xf64>, %C: tensor<10xf64>, %beta: tensor<f64>) -> tensor<10xf64> {
+  %alpha = stablehlo.constant dense<2.0> : tensor<f64>
+  %A = sparse_tensor.assemble (%rowptr, %colind), %nzval : (tensor<11xi64>, tensor<20xi64>), tensor<20xf64> to tensor<10x8xf64, #csr>
+  %y = enzymexla.sparse.spmm %alpha, %A, %x, %beta, %C : (tensor<f64>, tensor<10x8xf64, #csr>, tensor<8xf64>, tensor<f64>, tensor<10xf64>) -> tensor<10xf64>
+  return %y : tensor<10xf64>
+}

--- a/test/lit_tests/sparse/spmm.mlir
+++ b/test/lit_tests/sparse/spmm.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt --lower-sparse-csr %s | FileCheck %s
+// RUN: enzymexlamlir-opt --lower-enzymexla-sparse %s | FileCheck %s
 
 #csr = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : dense, d1 : compressed), posWidth = 64, crdWidth = 64 }>
 


### PR DESCRIPTION
Per discussion in https://github.com/EnzymeAD/Reactant.jl/pull/3198#issuecomment-5339491689, introduce a custom `sparse.spmm` op that `stablehlo.dot_general` on a sparse CSR tensor is lowered to, which then gets translated into calls to either cuSPARSE or hipSPARSE. I'm not too familiar with this code base and most of this was written by Claude, but upon review this seemed like a sensible approach to me. I was also able to successfully test this on CUDA 13.1 at least