### PR TITLE
Run every raising-pipeline rewrite driver at normal region simplification

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -6599,6 +6599,7 @@ void AffineCFGPass::runOnOperation() {
   IslAnalysis islAnalysis;
   populateAffineExprSimplificationPatterns(islAnalysis, rpl);
   GreedyRewriteConfig config;
+  config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
   config.enableFolding();
   if (failed(applyPatternsGreedily(getOperation(), std::move(rpl), config))) {
     signalPassFailure();

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -3668,6 +3668,7 @@ void CanonicalizeFor::runOnOperation() {
           MoveSideEffectFreeWhile>(getOperation()->getContext());
   //    WhileLICM,
   GreedyRewriteConfig config;
+  config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
   config.enableFolding();
   config.setMaxIterations(247);
   if (failed(applyPatternsGreedily(getOperation(), std::move(rpl), config))) {

--- a/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
@@ -1117,9 +1117,12 @@ struct CanonicalizeLoopsPass
         patterns.add<PartialIfToSelect<false>>(&getContext());
       }
 
-      if (failed(
-              applyPatternsGreedily(getOperation(), std::move(patterns),
-                                    GreedyRewriteConfig().enableFolding()))) {
+      if (failed(applyPatternsGreedily(
+              getOperation(), std::move(patterns),
+              GreedyRewriteConfig()
+                  .enableFolding()
+                  .setRegionSimplificationLevel(
+                      GreedySimplifyRegionLevel::Normal)))) {
         signalPassFailure();
         return;
       }
@@ -1373,6 +1376,7 @@ struct CanonicalizeLoopsPass
       RewritePatternSet patterns(&getContext());
       addSingleIter(patterns, &getContext());
       GreedyRewriteConfig config;
+      config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
       config.enableFolding();
       if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
                                        config))) {

--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -4729,7 +4729,11 @@ struct ConvertPolygeistToLLVMPass
         return signalPassFailure();
       }
       if (failed(applyPatternsGreedily(
-              mod, {}, GreedyRewriteConfig().enableFolding()))) {
+              mod, {},
+              GreedyRewriteConfig()
+                  .enableFolding()
+                  .setRegionSimplificationLevel(
+                      GreedySimplifyRegionLevel::Normal)))) {
         mod->emitError() << "failed to apply folding";
         return signalPassFailure();
       }

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -2137,6 +2137,7 @@ convertLLVMToAffineAccess(Operation *op,
                     SimplifyDeadAlloc<gpu::AllocOp, true>, Pointer2MemrefSelect,
                     LoadSelect, SimpleMem2Reg<memref::AllocaOp>>(context);
     GreedyRewriteConfig config;
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     config.enableFolding();
     if (applyPatternsGreedily(op, std::move(patterns), config).failed())
       return failure();
@@ -2162,6 +2163,7 @@ struct LLVMToAffineAccessPass
     RewritePatternSet patterns(context);
     populateRemoveIVPatterns(patterns);
     GreedyRewriteConfig config;
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     config.enableFolding();
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
                                      config))) {

--- a/src/enzyme_ad/jax/Passes/LLVMToControlFlow.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToControlFlow.cpp
@@ -99,8 +99,14 @@ struct ConvertLLVMToControlFlow
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     mlir::cf::populateLLVMToControlFlowConversionPatterns(patterns);
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
-                                     GreedyRewriteConfig().enableFolding())))
+    // Aggressive region simplification merges structurally identical
+    // blocks -- including cold error tails differing only in constants,
+    // which LLVM cannot split back apart and whose merged setup its
+    // machine passes then hoist into the hot path.
+    if (failed(applyPatternsGreedily(
+            getOperation(), std::move(patterns),
+            GreedyRewriteConfig().enableFolding().setRegionSimplificationLevel(
+                GreedySimplifyRegionLevel::Normal))))
       signalPassFailure();
   }
 };

--- a/src/enzyme_ad/jax/Passes/ParallelLower.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLower.cpp
@@ -1345,6 +1345,8 @@ void ConvertCudaRTtoCPU::runOnOperation() {
   {
     mlir::RewritePatternSet rpl(getOperation()->getContext());
     GreedyRewriteConfig config;
+    config.setRegionSimplificationLevel(
+        GreedySimplifyRegionLevel::Normal);
     config.enableFolding();
     (void)applyPatternsGreedily(getOperation(), std::move(rpl), config);
   }

--- a/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/LLVMToTessera.cpp
@@ -360,6 +360,7 @@ struct LLVMToTesseraPass
     patterns.add<CallOpRewrite, ReturnOpRewrite>(ctx);
 
     GreedyRewriteConfig config;
+    config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     config.setUseTopDownTraversal(true);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
                                      config))) {

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraApplyPDL.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraApplyPDL.cpp
@@ -56,7 +56,10 @@ struct TesseraApplyPDLPass
     patternList.add(std::move(pdlPattern));
 
     // Invoke the pattern driver with the provided patterns.
-    if (failed(applyPatternsGreedily(module, std::move(patternList)))) {
+    if (failed(applyPatternsGreedily(
+            module, std::move(patternList),
+            GreedyRewriteConfig().setRegionSimplificationLevel(
+                GreedySimplifyRegionLevel::Normal)))) {
       llvm::errs() << "Failed to apply PDL patterns\n";
       signalPassFailure();
     }

--- a/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/Tessera/TesseraToLLVM.cpp
@@ -257,7 +257,10 @@ struct TesseraToLLVMPass
     patterns.add<DefineOpRewrite>(typeConverter, ctx);
     patterns.add<CallOpRewrite, ReturnOpRewrite>(ctx);
 
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(
+            getOperation(), std::move(patterns),
+            GreedyRewriteConfig().setRegionSimplificationLevel(
+                GreedySimplifyRegionLevel::Normal)))) {
       llvm::errs() << "Failed to convert tessera dialect operations to LLVM "
                       "dialect operations\n";
       return signalPassFailure();

--- a/test/lit_tests/no-identical-block-merge.mlir
+++ b/test/lit_tests/no-identical-block-merge.mlir
@@ -1,0 +1,29 @@
+// RUN: enzymexlamlir-opt %s --convert-llvm-to-cf | FileCheck %s
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for | FileCheck %s
+// RUN: enzymexlamlir-opt %s --llvm-to-tessera | FileCheck %s
+
+// Cold error tails that are structurally identical modulo constants must not
+// be merged: LLVM cannot split a shared tail apart again, and its machine
+// passes hoist the merged tail's setup into the hot path, taxing every call.
+
+llvm.func @use(i64)
+llvm.func @twin_tails(%c: i1) {
+  llvm.cond_br %c, ^bb1, ^bb2
+^bb1:
+  %a = llvm.mlir.constant(27 : i64) : i64
+  llvm.call @use(%a) : (i64) -> ()
+  llvm.br ^bb3
+^bb2:
+  %b = llvm.mlir.constant(20 : i64) : i64
+  llvm.call @use(%b) : (i64) -> ()
+  llvm.br ^bb3
+^bb3:
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @twin_tails
+// CHECK: ^bb1:
+// CHECK-NEXT: llvm.call @use
+// CHECK: ^bb2:
+// CHECK-NEXT: llvm.call @use
+// CHECK: ^bb3:


### PR DESCRIPTION
Root-causes the steady per-launch host overhead investigated after the sink work. The greedy driver's default **aggressive region simplification** merges structurally identical blocks module-wide — including a host function's cold error tails that differ only in constants, exactly the shape `MFEM_VERIFY` produces at every call site. Traced on an MFEM-style reproducer with a per-pass block-count bisect, which exposed a *masking chain*: `convert-llvm-to-cf`, then `canonicalize-scf-for`, then `llvm-to-tessera`/`tessera-to-llvm` each merged the blocks once the previous merger was fixed (the first link, `inline-enzyme-regions`, is fixed in EnzymeAD/Enzyme#3166). This PR sets `GreedySimplifyRegionLevel::Normal` on every rewrite driver the raising pipeline runs — the policy `canonicalize-parallel` already adopted, where aggressive merging was a *correctness* bug (invoke successor operands).

## Why merging identical blocks loses performance

The merge converts *conditionally-executed* cold code into *unconditionally-paid* hot-path cost, through three compounding mechanisms, all visible in the captured disassembly:

1. **PHI-of-constants pushes cold setup into hot predecessors.** The error tails were identical except for constants (message string, lengths 27 and 20). Merging turns those into block arguments — PHIs at LLVM level. A PHI's incoming values must be materialized *in the predecessors*, and the predecessors of the merged tail are the hot-path blocks ending in the "did the check fail?" branch. So `mov $0x1b`, `mov $0x14`, `lea <error-string>`, and the ostringstream buffer addresses execute on the hot path, before a branch that is essentially never taken. Unmerged, each tail owns its setup and pays it only on failure.

2. **Live-across-hot-region values defeat shrink-wrapping.** The hoisted values must survive from entry to the (potential) cold branch — across the whole hot region, which contains calls — forcing them into callee-saved registers: three extra CSR pushes and a doubled frame (0x338 vs 0x1a0). Vanilla shrink-wraps, saving only what the hot path needs; with the merge, every call pays the fat prologue/epilogue. Cachegrind shows the cost is pure extra executed instructions (+13/call, +19% total) with branch counts and mispredictions *byte-identical*.

3. **It is a one-way door.** Undoing the merge is tail duplication, and both IR-level SimplifyCFG and machine tail-dup refuse to duplicate blocks containing calls (the ostringstream/throw sequence); the PHI-of-constants shape also blocks jump-threading. Vanilla clang never merges these in the first place because its block-combining heuristics are frequency-aware (a block feeding noreturn/throw is statically cold); MLIR's `mergeIdenticalBlocks` has no frequency model — it is unconditional structural CSE of blocks.

The telling paradox: the merged function is statically **smaller** (159 vs 178 instructions — block fusion is a code-*size* optimization) yet executes **+19% more instructions**. It is an `-Os`-shaped transform firing in an `-O3` context, applied by a canonicalizer whose job is normalization, not code placement — and the backend it feeds cannot undo it.

## Validation

Reproducer restored to hot-path parity with vanilla clang (8.79 vs 8.84ns median, was +10%; stack frame byte-identical at 0x1a0). New lit test covering the three mergers; bazel lit 1189/1189; full MFEM CUDA rebuild through the fixed pipeline — 74/74 GPU suite, correct numerics, benchmark profile unchanged. (The bench's remaining quad-forward-local ~1.10x is *not* closed by this — its carrier is still open — but the systematic host-code pessimization fixed here affects every EH-dense TU.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD