### PR TITLE
PolygeistMem2Reg: fold piece stores into the slot value

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2168,6 +2168,53 @@ static bool extractPath(Type from, uint64_t at, Type want, const DataLayout &dl,
   return false;
 }
 
+// The leaves of an aggregate that a range of bytes covers: every leaf the
+// range touches must lie whole inside it, and bytes of the range no leaf
+// claims are padding. Fails where a leaf straddles the range's edge.
+static bool coveredLeaves(Type from, uint64_t at, uint64_t size,
+                          const DataLayout &dl,
+                          SmallVectorImpl<std::pair<uint64_t, Type>> &leaves,
+                          uint64_t base = 0) {
+  auto fromSize = typeSize(from, dl);
+  if (!fromSize)
+    return false;
+  if (base + *fromSize <= at || base >= at + size)
+    return true;
+  if (auto ST = dyn_cast<LLVM::LLVMStructType>(from)) {
+    uint64_t byte = 0;
+    for (Type member : ST.getBody()) {
+      auto msize = typeSize(member, dl);
+      if (!msize)
+        return false;
+      if (!ST.isPacked())
+        byte = llvm::alignTo(byte, dl.getTypeABIAlignment(member));
+      if (!coveredLeaves(member, at, size, dl, leaves, base + byte))
+        return false;
+      byte += *msize;
+    }
+    return true;
+  }
+  if (auto AT = dyn_cast<LLVM::LLVMArrayType>(from)) {
+    auto esize = typeSize(AT.getElementType(), dl);
+    if (!esize || !*esize)
+      return false;
+    for (uint64_t i = 0; i < AT.getNumElements(); i++)
+      if (!coveredLeaves(AT.getElementType(), at, size, dl, leaves,
+                         base + i * *esize))
+        return false;
+    return true;
+  }
+  if (base < at || base + *fromSize > at + size)
+    return false;
+  leaves.emplace_back(base, from);
+  return true;
+}
+
+static bool isLittleEndian(const DataLayout &dl) {
+  auto endian = dyn_cast_or_null<StringAttr>(dl.getEndianness());
+  return !endian || endian.getValue() == "little";
+}
+
 bool PolygeistMem2Reg::forwardStoreToLoad(
     mlir::Value AI, OffsetTree idx,
     SmallVectorImpl<Operation *> &loadOpsToErase,
@@ -2193,6 +2240,17 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   auto dropUnaskedReads = llvm::scope_exit([&transferReads]() {
     for (auto *read : llvm::reverse(transferReads))
       if (read->getResult(0).use_empty())
+        read->erase();
+  });
+  // Reads created to name the value flowing into a piece store. Forwarding
+  // one is not progress -- the store that needed it is still there, and the
+  // round after names the value again -- so they never mark change, and one
+  // left dead is dropped rather than left to be found as a load next round.
+  SmallPtrSet<Operation *, 2> syntheticReads;
+  auto dropDeadSyntheticReads = llvm::scope_exit([&]() {
+    for (auto *read : syntheticReads)
+      if (read->getResult(0).use_empty() &&
+          !llvm::is_contained(loadOpsToErase, read))
         read->erase();
   });
   // Values built while folding piece stores into the slot's value, dropped
@@ -2338,13 +2396,31 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           break;
         case Match::Contains: {
           // Writing a piece of the slot writes a piece of its value, as long
-          // as there is a way into it that lands that piece.
+          // as there is a way into it that lands that piece. An integer
+          // written over several leaves -- merged adjacent field stores, or a
+          // field store widened over padding -- lands a slice on each leaf it
+          // covers.
           Type held = elType ? elType : idx.getBase();
           Type written = cast<enzyme::StoreLikeInterface>(storeOp)
                              .getStoredValue()
                              .getType();
           SmallVector<int64_t> path;
           if (held && extractPath(held, at, written, dl, path)) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "Matching Piece Store: " << *storeOp << "\n");
+            containedStores[storeOp] = at;
+            allStoreOps.insert(storeOp);
+            break;
+          }
+          auto wsize = typeSize(written, dl);
+          SmallVector<std::pair<uint64_t, Type>> leaves;
+          if (held && wsize && isa<IntegerType>(written) &&
+              isLittleEndian(dl) &&
+              coveredLeaves(held, at, *wsize, dl, leaves) && !leaves.empty() &&
+              leaves.size() <= 8 && llvm::all_of(leaves, [&](auto &leaf) {
+                SmallVector<int64_t> lpath;
+                return extractPath(held, leaf.first, leaf.second, dl, lpath);
+              })) {
             LLVM_DEBUG(llvm::dbgs()
                        << "Matching Piece Store: " << *storeOp << "\n");
             containedStores[storeOp] = at;
@@ -2798,26 +2874,96 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           } else if (auto storeOp = dyn_cast<enzyme::StoreLikeInterface>(a)) {
             if (allStoreOps.count(storeOp)) {
               auto contained = containedStores.find(a);
+              Value baseRaw = nullptr;
+              if (contained != containedStores.end()) {
+                if (lastVal->val) {
+                  baseRaw = lastVal->val;
+                } else if (!lastVal->overwritten &&
+                           isa_and_nonnull<LLVM::LLVMPointerType>(
+                               AI.getType()) &&
+                           idx.matches(accessOffsets(elType), dl) ==
+                               Match::Exact &&
+                           LLVM::isCompatibleType(elType)) {
+                  // The value coming in has no name here yet: read it out of
+                  // the slot it still sits in, and let the forwarding treat
+                  // that read like any other load of the slot.
+                  OpBuilder builder(a);
+                  Value incoming =
+                      LLVM::LoadOp::create(builder, a->getLoc(), elType, AI);
+                  loadOps.insert(incoming.getDefiningOp());
+                  syntheticReads.insert(incoming.getDefiningOp());
+                  replaceValue(incoming, lastVal);
+                  baseRaw = incoming;
+                }
+              }
               if (contained == containedStores.end()) {
                 lastVal = metaMap.get(storeOp.getStoredValue());
-              } else if (lastVal->val) {
+              } else if (baseRaw) {
                 // A store of a piece leaves the rest as it was: fold it into
                 // the value already there.
-                Value base = castToType(elType, lastVal->val, a);
+                uint64_t at = contained->second;
+                Value base = castToType(elType, baseRaw, a);
                 Value piece = storeOp.getStoredValue();
+                OpBuilder builder(a);
                 SmallVector<int64_t> path;
-                bool found = extractPath(elType, contained->second,
-                                         piece.getType(), dl, path);
-                (void)found;
-                assert(found && "a piece that was named cannot be landed");
-                Value built = piece;
-                if (!path.empty()) {
-                  OpBuilder builder(a);
-                  built = LLVM::InsertValueOp::create(builder, a->getLoc(),
-                                                      base, piece, path);
-                  synthesized.push_back(built.getDefiningOp());
+                if (extractPath(elType, at, piece.getType(), dl, path)) {
+                  Value built;
+                  if (path.empty()) {
+                    built = castToType(elType, piece, a);
+                  } else {
+                    Type pathTy =
+                        aggregateFieldOffset(elType, path, dl)->second;
+                    built = LLVM::InsertValueOp::create(
+                        builder, a->getLoc(), base,
+                        castToType(pathTy, piece, a), path);
+                    synthesized.push_back(built.getDefiningOp());
+                  }
+                  lastVal = metaMap.get(built);
+                } else {
+                  // An integer over several leaves: each gets its slice.
+                  uint64_t wsize = *typeSize(piece.getType(), dl);
+                  SmallVector<std::pair<uint64_t, Type>> leaves;
+                  bool found = coveredLeaves(elType, at, wsize, dl, leaves);
+                  (void)found;
+                  assert(found && !leaves.empty() &&
+                         "a piece that was named cannot be landed");
+                  Value built = base;
+                  for (auto &[off, leafTy] : leaves) {
+                    uint64_t delta = off - at;
+                    uint64_t lsize = *typeSize(leafTy, dl);
+                    Value v = piece;
+                    if (delta) {
+                      Value amt = LLVM::ConstantOp::create(
+                          builder, a->getLoc(), v.getType(),
+                          builder.getIntegerAttr(v.getType(), delta * 8));
+                      synthesized.push_back(amt.getDefiningOp());
+                      v = LLVM::LShrOp::create(builder, a->getLoc(), v, amt);
+                      synthesized.push_back(v.getDefiningOp());
+                    }
+                    if (lsize < wsize) {
+                      v = LLVM::TruncOp::create(
+                          builder, a->getLoc(),
+                          builder.getIntegerType(lsize * 8), v);
+                      synthesized.push_back(v.getDefiningOp());
+                    }
+                    SmallVector<int64_t> lpath;
+                    bool leafFound =
+                        extractPath(elType, off, leafTy, dl, lpath);
+                    (void)leafFound;
+                    assert(leafFound && "a named leaf cannot be landed");
+                    // The path may stop above the leaf at a wrapper of the
+                    // same extent; the value goes in as what the path names.
+                    Type pathTy =
+                        lpath.empty()
+                            ? elType
+                            : aggregateFieldOffset(elType, lpath, dl)->second;
+                    v = castToType(pathTy, v, a);
+                    built = LLVM::InsertValueOp::create(builder, a->getLoc(),
+                                                        built, v, lpath);
+                    synthesized.push_back(built.getDefiningOp());
+                  }
+                  lastVal = metaMap.get(built);
                 }
-                lastVal = metaMap.get(built);
               } else {
                 // No value to build on: past this store the slot holds an
                 // unknown with one piece changed, which is unknown.
@@ -3007,7 +3153,8 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     Value val = pair.second->materialize(true);
     assert(val);
 
-    changed = true;
+    if (!syntheticReads.count(pair.first.getDefiningOp()))
+      changed = true;
     assert(pair.first != val);
     assert(val.getType() == elType);
     val = valueFor(pair.first, val);
@@ -3016,8 +3163,10 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
                << " replaced " << pair.first << " with " << val << "\n");
     metaMap.replaceValue(pair.first, val);
 
-    // Record this to erase later.
-    loadOpsToErase.push_back(pair.first.getDefiningOp());
+    // Record this to erase later. A synthetic read is not the caller's to
+    // erase -- or to count as progress -- and is dropped on the way out.
+    if (!syntheticReads.count(pair.first.getDefiningOp()))
+      loadOpsToErase.push_back(pair.first.getDefiningOp());
     loadOps.erase(pair.first.getDefiningOp());
   }
   replaceableValues.clear();

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -1924,6 +1924,20 @@ static void collectLeaves(OpBuilder &b, Value val,
   }
 }
 
+static void collectLeafTypes(Type t, SmallVectorImpl<Type> &out) {
+  if (auto ST = dyn_cast<LLVM::LLVMStructType>(t)) {
+    for (Type m : ST.getBody())
+      collectLeafTypes(m, out);
+    return;
+  }
+  if (auto AT = dyn_cast<LLVM::LLVMArrayType>(t)) {
+    for (unsigned i = 0; i < AT.getNumElements(); ++i)
+      collectLeafTypes(AT.getElementType(), out);
+    return;
+  }
+  out.push_back(t);
+}
+
 Value castToType(Type elType, Value val, Operation *op) {
   if (val.getType() == elType)
     return val;
@@ -1995,9 +2009,86 @@ Value castToType(Type elType, Value val, Operation *op) {
                                          b.getDenseI64ArrayAttr({0}));
     }
   }
+  if ((isa<IntegerType, FloatType>(val.getType())) &&
+      isa<LLVM::LLVMStructType, LLVM::LLVMArrayType>(elType)) {
+    // A scalar spelling of a small aggregate goes through the matching
+    // vector, the inverse of the leaf collection above and with the same
+    // element correspondence.
+    SmallVector<Type> leafTypes;
+    collectLeafTypes(elType, leafTypes);
+    if (!leafTypes.empty() && isa<IntegerType, FloatType>(leafTypes[0]) &&
+        llvm::all_of(leafTypes, [&](Type t) { return t == leafTypes[0]; })) {
+      auto vecType = VectorType::get(leafTypes.size(), leafTypes[0]);
+      DataLayout dl(op->getParentOfType<ModuleOp>());
+      if (dl.getTypeSize(vecType) == dl.getTypeSize(val.getType())) {
+        Value vec = LLVM::BitcastOp::create(b, val.getLoc(), vecType, val);
+        Value agg = LLVM::UndefOp::create(b, val.getLoc(), elType);
+        unsigned leafIdx = 0;
+        SmallVector<int64_t> path;
+        std::function<Value(Value, Type)> fill = [&](Value agg,
+                                                     Type t) -> Value {
+          if (auto ST = dyn_cast<LLVM::LLVMStructType>(t)) {
+            for (auto &&[i, m] : llvm::enumerate(ST.getBody())) {
+              path.push_back(i);
+              agg = fill(agg, m);
+              path.pop_back();
+            }
+            return agg;
+          }
+          if (auto AT = dyn_cast<LLVM::LLVMArrayType>(t)) {
+            for (unsigned i = 0; i < AT.getNumElements(); ++i) {
+              path.push_back(i);
+              agg = fill(agg, AT.getElementType());
+              path.pop_back();
+            }
+            return agg;
+          }
+          Value idx = LLVM::ConstantOp::create(b, val.getLoc(), b.getI32Type(),
+                                               b.getI32IntegerAttr(leafIdx++));
+          Value elem =
+              LLVM::ExtractElementOp::create(b, val.getLoc(), vec, idx);
+          return LLVM::InsertValueOp::create(b, val.getLoc(), agg, elem, path);
+        };
+        return fill(agg, elType);
+      }
+    }
+  }
   llvm::errs() << " mismatched load type, needed: " << elType << " found "
                << val << "\n";
   llvm_unreachable("mismatched type");
+}
+
+// Whether castToType can spell src as dst. Conservative: a subset of what it
+// handles is enough, since callers fall back to slicing or to leaving the
+// memory operation in place.
+static bool castCompatible(Type dst, Type src) {
+  if (dst == src)
+    return true;
+  auto scalar = [](Type t) {
+    return isa<IntegerType, FloatType, LLVM::LLVMPointerType>(t);
+  };
+  if (scalar(dst) && scalar(src))
+    return true;
+  auto uniformScalar = [&](Type t, Type &leaf) {
+    SmallVector<Type> leaves;
+    collectLeafTypes(t, leaves);
+    if (leaves.empty() || !isa<IntegerType, FloatType>(leaves[0]))
+      return false;
+    if (!llvm::all_of(leaves, [&](Type l) { return l == leaves[0]; }))
+      return false;
+    leaf = leaves[0];
+    return true;
+  };
+  Type leaf;
+  if (isa<IntegerType, FloatType>(src) &&
+      isa<LLVM::LLVMStructType, LLVM::LLVMArrayType>(dst) &&
+      uniformScalar(dst, leaf))
+    return true;
+  if (isa<IntegerType, FloatType>(dst) &&
+      isa<LLVM::LLVMStructType, LLVM::LLVMArrayType>(src) &&
+      uniformScalar(src, leaf))
+    return true;
+  return false;
 }
 
 // Whether every position the value is passed at carries the given attribute
@@ -2406,11 +2497,18 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
                              .getType();
           SmallVector<int64_t> path;
           if (held && extractPath(held, at, written, dl, path)) {
-            LLVM_DEBUG(llvm::dbgs()
-                       << "Matching Piece Store: " << *storeOp << "\n");
-            containedStores[storeOp] = at;
-            allStoreOps.insert(storeOp);
-            break;
+            // The path may land at a spelling of the piece rather than its
+            // type; only claim the store if that spelling is reachable.
+            Type landing = path.empty()
+                               ? held
+                               : aggregateFieldOffset(held, path, dl)->second;
+            if (castCompatible(landing, written)) {
+              LLVM_DEBUG(llvm::dbgs()
+                         << "Matching Piece Store: " << *storeOp << "\n");
+              containedStores[storeOp] = at;
+              allStoreOps.insert(storeOp);
+              break;
+            }
           }
           auto wsize = typeSize(written, dl);
           SmallVector<std::pair<uint64_t, Type>> leaves;
@@ -2906,7 +3004,13 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
                 Value piece = storeOp.getStoredValue();
                 OpBuilder builder(a);
                 SmallVector<int64_t> path;
-                if (extractPath(elType, at, piece.getType(), dl, path)) {
+                Type landing;
+                if (extractPath(elType, at, piece.getType(), dl, path) &&
+                    (landing =
+                         path.empty()
+                             ? elType
+                             : aggregateFieldOffset(elType, path, dl)->second,
+                     castCompatible(landing, piece.getType()))) {
                   Value built;
                   if (path.empty()) {
                     built = castToType(elType, piece, a);

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2179,6 +2179,8 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
   std::set<mlir::Operation *> transferLoads;
   // Loads of a piece of the slot, and how far into it that piece lies.
   DenseMap<mlir::Operation *, uint64_t> containedLoads;
+  // Stores of a piece of the slot, and how far into it that piece lands.
+  DenseMap<mlir::Operation *, uint64_t> containedStores;
   mlir::Location loc = AI.getLoc();
   std::set<mlir::Operation *> allStoreOps;
   // Reads standing for what a transfer moved. One is worth the load it costs
@@ -2192,6 +2194,14 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
     for (auto *read : llvm::reverse(transferReads))
       if (read->getResult(0).use_empty())
         read->erase();
+  });
+  // Values built while folding piece stores into the slot's value, dropped
+  // where nothing came to ask for them.
+  SmallVector<Operation *> synthesized;
+  auto dropUnaskedSynthesized = llvm::scope_exit([&synthesized]() {
+    for (auto *op : llvm::reverse(synthesized))
+      if (op->getResult(0).use_empty())
+        op->erase();
   });
 
   if (idx.isUnknown())
@@ -2320,12 +2330,29 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
         LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << *loadOp << "\n");
       };
       auto matchStore = [&](Operation *storeOp, OffsetTree accessed) {
-        switch (idx.matches(tree.add(accessed, dl), dl)) {
+        uint64_t at = 0;
+        switch (idx.matches(tree.add(accessed, dl), dl, &at)) {
         case Match::Exact:
           LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << *storeOp << "\n");
           allStoreOps.insert(storeOp);
           break;
-        case Match::Contains:
+        case Match::Contains: {
+          // Writing a piece of the slot writes a piece of its value, as long
+          // as there is a way into it that lands that piece.
+          Type held = elType ? elType : idx.getBase();
+          Type written = cast<enzyme::StoreLikeInterface>(storeOp)
+                             .getStoredValue()
+                             .getType();
+          SmallVector<int64_t> path;
+          if (held && extractPath(held, at, written, dl, path)) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "Matching Piece Store: " << *storeOp << "\n");
+            containedStores[storeOp] = at;
+            allStoreOps.insert(storeOp);
+            break;
+          }
+          LLVM_FALLTHROUGH;
+        }
         case Match::Maybe:
           LLVM_DEBUG(llvm::dbgs()
                      << "Mabye Aliasing Store: " << *storeOp << "\n");
@@ -2685,6 +2712,18 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
                        << "\nstarting block: lastVal=" << *lastVal << "\n";
                    block.print(llvm::dbgs()); llvm::dbgs() << "\n";);
         for (auto *a : ops) {
+          if (a == AI.getDefiningOp() && !containedStores.empty() &&
+              isa<LLVM::AllocaOp, memref::AllocaOp, memref::AllocOp>(a) &&
+              LLVM::isCompatibleType(elType)) {
+            // The slot begins undefined, which gives the first piece store a
+            // value to build on. Later unknown writes still overwrite this,
+            // and after those piece stores have nothing to build on again.
+            OpBuilder builder(a->getBlock(), std::next(a->getIterator()));
+            Value undef = LLVM::UndefOp::create(builder, a->getLoc(), elType);
+            synthesized.push_back(undef.getDefiningOp());
+            lastVal = metaMap.get(undef);
+            continue;
+          }
           if (StoringOperations.count(a)) {
             // erase a, in case overwritten later in metamap replacement/lookup.
             StoringOperations.erase(a);
@@ -2758,7 +2797,32 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
             }
           } else if (auto storeOp = dyn_cast<enzyme::StoreLikeInterface>(a)) {
             if (allStoreOps.count(storeOp)) {
-              lastVal = metaMap.get(storeOp.getStoredValue());
+              auto contained = containedStores.find(a);
+              if (contained == containedStores.end()) {
+                lastVal = metaMap.get(storeOp.getStoredValue());
+              } else if (lastVal->val) {
+                // A store of a piece leaves the rest as it was: fold it into
+                // the value already there.
+                Value base = castToType(elType, lastVal->val, a);
+                Value piece = storeOp.getStoredValue();
+                SmallVector<int64_t> path;
+                bool found = extractPath(elType, contained->second,
+                                         piece.getType(), dl, path);
+                (void)found;
+                assert(found && "a piece that was named cannot be landed");
+                Value built = piece;
+                if (!path.empty()) {
+                  OpBuilder builder(a);
+                  built = LLVM::InsertValueOp::create(builder, a->getLoc(),
+                                                      base, piece, path);
+                  synthesized.push_back(built.getDefiningOp());
+                }
+                lastVal = metaMap.get(built);
+              } else {
+                // No value to build on: past this store the slot holds an
+                // unknown with one piece changed, which is unknown.
+                lastVal = emptyValue;
+              }
             }
           } else {
             // since not storing operation the value at the start of every block

--- a/test/lit_tests/mem2reg_contained.mlir
+++ b/test/lit_tests/mem2reg_contained.mlir
@@ -78,8 +78,8 @@ llvm.func @straddling_read(%val: !llvm.struct<(i32, i32, i32, i32)>) -> i64 {
 
 // -----
 
-// A write of a part says nothing of the rest, so what was there before it does
-// not reach a read after it.
+// A write of a part folds into the value in the slot, leaving the rest as it
+// was: a read after it reads out of the folded value.
 llvm.func @write_of_a_part(%val: !llvm.struct<(i32, i32)>, %other: i32) -> i32 {
   %c1 = llvm.mlir.constant(1 : i32) : i32
   %mem = llvm.alloca %c1 x !llvm.struct<(i32, i32)> : (i32) -> !llvm.ptr
@@ -92,8 +92,10 @@ llvm.func @write_of_a_part(%val: !llvm.struct<(i32, i32)>, %other: i32) -> i32 {
 }
 
 // CHECK-LABEL: llvm.func @write_of_a_part(
-// CHECK: %[[LD:.+]] = llvm.load
-// CHECK: llvm.return %[[LD]] : i32
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: !llvm.struct<(i32, i32)>, %[[OTHER:[a-z0-9]+]]: i32
+// CHECK: %[[INS:.+]] = llvm.insertvalue %[[OTHER]], %[[VAL]][1]
+// CHECK: %[[F:.+]] = llvm.extractvalue %[[INS]][0]
+// CHECK: llvm.return %[[F]] : i32
 
 // -----
 

--- a/test/lit_tests/mem2reg_piece_stores.mlir
+++ b/test/lit_tests/mem2reg_piece_stores.mlir
@@ -68,3 +68,59 @@ llvm.func @piece_after_unknown(%x: i32) -> !llvm.struct<(i32, i32)> {
 // CHECK: llvm.store
 // CHECK: %[[LD:.+]] = llvm.load
 // CHECK: llvm.return %[[LD]]
+
+// -----
+
+// The fields are written in one block and the whole read in another: the
+// value crosses as a block argument, undef seed and all.
+llvm.func @useB(!llvm.struct<(i32, f64)>)
+llvm.func @across_blocks(%x: i32, %y: f64, %c: i1) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %p = llvm.alloca %c1 x !llvm.struct<(i32, f64)> : (i32) -> !llvm.ptr
+  cf.cond_br %c, ^bb1, ^bb1
+^bb1:
+  %g0 = llvm.getelementptr %p[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+  llvm.store %x, %g0 : i32, !llvm.ptr
+  %g1 = llvm.getelementptr %p[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+  llvm.store %y, %g1 : f64, !llvm.ptr
+  %v = llvm.load %p : !llvm.ptr -> !llvm.struct<(i32, f64)>
+  llvm.call @useB(%v) : (!llvm.struct<(i32, f64)>) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @across_blocks(
+// CHECK-SAME: %[[X:[a-z0-9]+]]: i32, %[[Y:[a-z0-9]+]]: f64
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[U:.+]] = llvm.mlir.undef : !llvm.struct<(i32, f64)>
+// CHECK: %[[I0:.+]] = llvm.insertvalue %[[X]], %[[U]][0]
+// CHECK: %[[I1:.+]] = llvm.insertvalue %[[Y]], %[[I0]][1]
+// CHECK: llvm.call @useB(%[[I1]])
+
+// -----
+
+// An integer written over a field and the padding after it lands its slice on
+// the field; one written over two fields lands a slice on each.
+llvm.func @usew(!llvm.struct<(struct<(i32, ptr)>, i32, i32)>)
+llvm.func @wide_stores(%pair: i64, %two: i64) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %p = llvm.alloca %c1 x !llvm.struct<(struct<(i32, ptr)>, i32, i32)> : (i32) -> !llvm.ptr
+  llvm.store %pair, %p : i64, !llvm.ptr
+  %g = llvm.getelementptr %p[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i32, ptr)>, i32, i32)>
+  llvm.store %two, %g : i64, !llvm.ptr
+  %v = llvm.load %p : !llvm.ptr -> !llvm.struct<(struct<(i32, ptr)>, i32, i32)>
+  llvm.call @usew(%v) : (!llvm.struct<(struct<(i32, ptr)>, i32, i32)>) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @wide_stores(
+// CHECK-SAME: %[[PAIR:[a-z0-9]+]]: i64, %[[TWO:[a-z0-9]+]]: i64
+// CHECK-NOT: llvm.alloca
+// CHECK-DAG: %[[PLO:.+]] = llvm.trunc %[[PAIR]] : i64 to i32
+// CHECK: llvm.insertvalue %[[PLO]], %{{.+}}[0, 0]
+// CHECK-DAG: %[[TLO:.+]] = llvm.trunc %[[TWO]] : i64 to i32
+// CHECK: llvm.insertvalue %[[TLO]], %{{.+}}[1]
+// CHECK: %[[C32:.+]] = llvm.mlir.constant(32 : i64) : i64
+// CHECK: %[[SH:.+]] = llvm.lshr %[[TWO]], %[[C32]]
+// CHECK: %[[THI:.+]] = llvm.trunc %[[SH]] : i64 to i32
+// CHECK: %[[FIN:.+]] = llvm.insertvalue %[[THI]], %{{.+}}[2]
+// CHECK: llvm.call @usew(%[[FIN]])

--- a/test/lit_tests/mem2reg_piece_stores.mlir
+++ b/test/lit_tests/mem2reg_piece_stores.mlir
@@ -124,3 +124,31 @@ llvm.func @wide_stores(%pair: i64, %two: i64) {
 // CHECK: %[[THI:.+]] = llvm.trunc %[[SH]] : i64 to i32
 // CHECK: %[[FIN:.+]] = llvm.insertvalue %[[THI]], %{{.+}}[2]
 // CHECK: llvm.call @usew(%[[FIN]])
+
+// -----
+
+// An integer stored over an aggregate member of the same extent -- a dim3
+// pair written as one i64 -- lands as the aggregate, spelled through the
+// matching vector.
+llvm.func @used(!llvm.struct<(i32, ptr, array<2 x i32>)>)
+llvm.func @dims_pair(%v: !llvm.struct<(i32, ptr, array<2 x i32>)>, %pair: i64) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %p = llvm.alloca %c1 x !llvm.struct<(i32, ptr, array<2 x i32>)> : (i32) -> !llvm.ptr
+  llvm.store %v, %p : !llvm.struct<(i32, ptr, array<2 x i32>)>, !llvm.ptr
+  %g = llvm.getelementptr %p[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, ptr, array<2 x i32>)>
+  llvm.store %pair, %g : i64, !llvm.ptr
+  %w = llvm.load %p : !llvm.ptr -> !llvm.struct<(i32, ptr, array<2 x i32>)>
+  llvm.call @used(%w) : (!llvm.struct<(i32, ptr, array<2 x i32>)>) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @dims_pair(
+// CHECK-SAME: %[[V:[a-z0-9]+]]: !llvm.struct<(i32, ptr, array<2 x i32>)>, %[[PAIR:[a-z0-9]+]]: i64
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[VEC:.+]] = llvm.bitcast %[[PAIR]] : i64 to vector<2xi32>
+// CHECK: %[[E0:.+]] = llvm.extractelement %[[VEC]]
+// CHECK: llvm.insertvalue %[[E0]], %{{.+}}[0]
+// CHECK: %[[E1:.+]] = llvm.extractelement %[[VEC]]
+// CHECK: %[[ARR:.+]] = llvm.insertvalue %[[E1]], %{{.+}}[1]
+// CHECK: %[[FIN:.+]] = llvm.insertvalue %[[ARR]], %[[V]][2]
+// CHECK: llvm.call @used(%[[FIN]])

--- a/test/lit_tests/mem2reg_piece_stores.mlir
+++ b/test/lit_tests/mem2reg_piece_stores.mlir
@@ -1,0 +1,70 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+// A slot built one field at a time holds the fields folded over the undefined
+// value the allocation began with, and a read of the whole takes that.
+llvm.func @use(!llvm.struct<(i32, f64)>)
+llvm.func @built_by_fields(%x: i32, %y: f64) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i32, f64)> : (i32) -> !llvm.ptr
+  %f0 = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+  llvm.store %x, %f0 : i32, !llvm.ptr
+  %f1 = llvm.getelementptr %mem[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+  llvm.store %y, %f1 : f64, !llvm.ptr
+  %v = llvm.load %mem : !llvm.ptr -> !llvm.struct<(i32, f64)>
+  llvm.call @use(%v) : (!llvm.struct<(i32, f64)>) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @built_by_fields(
+// CHECK-SAME: %[[X:[a-z0-9]+]]: i32, %[[Y:[a-z0-9]+]]: f64
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[U:.+]] = llvm.mlir.undef : !llvm.struct<(i32, f64)>
+// CHECK: %[[I0:.+]] = llvm.insertvalue %[[X]], %[[U]][0]
+// CHECK: %[[I1:.+]] = llvm.insertvalue %[[Y]], %[[I0]][1]
+// CHECK: llvm.call @use(%[[I1]])
+
+// -----
+
+// A field written into an element of an array member lands at its path.
+llvm.func @usef(f64, f64)
+llvm.func @field_in_array(%v: !llvm.struct<(i32, array<4 x f64>)>, %e: f64) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i32, array<4 x f64>)> : (i32) -> !llvm.ptr
+  llvm.store %v, %mem : !llvm.struct<(i32, array<4 x f64>)>, !llvm.ptr
+  %g = llvm.getelementptr %mem[0, 1, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, array<4 x f64>)>
+  llvm.store %e, %g : f64, !llvm.ptr
+  %g1 = llvm.getelementptr %mem[0, 1, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, array<4 x f64>)>
+  %a = llvm.load %g1 : !llvm.ptr -> f64
+  %g2 = llvm.getelementptr %mem[0, 1, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, array<4 x f64>)>
+  %b = llvm.load %g2 : !llvm.ptr -> f64
+  llvm.call @usef(%a, %b) : (f64, f64) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @field_in_array(
+// CHECK-SAME: %[[VAL:[a-z0-9]+]]: !llvm.struct<(i32, array<4 x f64>)>, %[[E:[a-z0-9]+]]: f64
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[INS:.+]] = llvm.insertvalue %[[E]], %[[VAL]][1, 2]
+// CHECK: %[[A:.+]] = llvm.extractvalue %[[INS]][1, 1]
+// CHECK: llvm.call @usef(%[[A]], %[[E]])
+
+// -----
+
+// A piece store after a write this cannot see has nothing to fold into: what
+// the slot holds after it is unknown, and the read after stays a read.
+llvm.func @clobber(!llvm.ptr)
+llvm.func @piece_after_unknown(%x: i32) -> !llvm.struct<(i32, i32)> {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.struct<(i32, i32)> : (i32) -> !llvm.ptr
+  llvm.call @clobber(%mem) : (!llvm.ptr) -> ()
+  %f0 = llvm.getelementptr %mem[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+  llvm.store %x, %f0 : i32, !llvm.ptr
+  %v = llvm.load %mem : !llvm.ptr -> !llvm.struct<(i32, i32)>
+  llvm.return %v : !llvm.struct<(i32, i32)>
+}
+
+// CHECK-LABEL: llvm.func @piece_after_unknown(
+// CHECK: llvm.call @clobber(
+// CHECK: llvm.store
+// CHECK: %[[LD:.+]] = llvm.load
+// CHECK: llvm.return %[[LD]]


### PR DESCRIPTION
Piece stores of a slot previously landed in \`AliasingStoreOperations\`, blocking forwarding for any load after them. This is exactly the host side of the CUDA by-value kernel-argument bridge: the capture struct is built one field at a time and then loaded whole to cross into the GPU region, so the whole-struct load never forwarded and the struct survived to \`raise-affine-to-stablehlo\`, which has no struct support — a hard failure for every struct-capturing kernel (i.e. every MFEM \`DeviceTensor\` kernel) on the xla-gpu backend.

**Commit 1 — fold piece stores into the slot value.** The slot's value past a piece store is the value before it with that piece inserted (\`llvm.insertvalue\`), and a fresh alloca begins as \`undef\` so field-by-field initialization has a value to build on — the dual of the existing extractvalue support for piece loads out of whole stores. A piece store with no known value to fold into (an unknown write in between) conservatively resets the slot to unknown, as before.

**Commit 2 — what real MFEM TUs additionally need:**
- *Integer stores over several leaves.* Clang merges adjacent field stores and widens stores over padding (an \`i64\` at offset 8 covering \`{i32 field, padding}\`). \`coveredLeaves()\` enumerates the leaves a byte range covers (each must lie whole inside it; unclaimed bytes are padding), and the fold lands an \`lshr\`/\`trunc\` slice on each leaf (little-endian only, ≤8 leaves). The insert path can stop above a leaf at a same-extent wrapper (\`array<1 x i32>\`), so slices are cast to the type at the path.
- *Cross-block piece stores.* When the alloca is in an earlier block, the incoming value has no SSA name at the store; a synthetic whole-slot read created right before the store names it, and the existing deferred block-argument machinery forwards it like any load. Synthetic reads never count as progress and never enter the caller's erase loop — either one re-arms the outer fixpoint every round (observed: 5000+ rounds/min, effectively a hang).

The \`BranchOpInterface\` generalization that lets forwarding cross \`llvm.cond_br\`/\`llvm.invoke\` edges is now its own PR (#2934); this PR stands alone on cf terminators, and composes with #2934 for the CUDA launch shape (every launch sits behind an \`__cudaPopCallConfiguration\` invoke).

**Results** (union with #2934, on \`fem/integ/bilininteg_mass_pa.cpp\`, xla-gpu): surviving lambda-capture structs at raise time 10 → 5 (the remaining 5 are inside \`PAMassApply*\` bodies, not launch operands); zero \`failed to raise\` operand errors from by-value captures; pipeline-prefix replay minutes → ~1.3s. \`mwe_byval_static.cu\` (struct capture, static indexing) compiles and runs end-to-end on \`backend=xla-gpu\` with output identical to vanilla clang. CUDA backend verified against vanilla clang on the byval MWEs.

Tests: \`mem2reg_piece_stores.mlir\` (field-built slot read whole; piece store into an array member; piece store after an unknown write stays unforwarded; cross-block fold via added block args, cf terminators; merged/widened i64 stores), \`write_of_a_part\` in \`mem2reg_contained.mlir\` updated from documenting the bail to checking the fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD