### PR TITLE
Load a pointer an affine.if chose within the if's branches

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -848,6 +848,99 @@ struct AffineIfDeadResults : public OpRewritePattern<affine::AffineIfOp> {
   }
 };
 
+struct Pointer2MemrefIf : public OpRewritePattern<enzymexla::Pointer2MemrefOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(enzymexla::Pointer2MemrefOp p2m,
+                                PatternRewriter &rewriter) const override {
+    auto res = dyn_cast<OpResult>(p2m.getOperand());
+    if (!res)
+      return failure();
+    auto ifOp = dyn_cast<affine::AffineIfOp>(res.getOwner());
+    if (!ifOp)
+      return failure();
+    SmallVector<enzymexla::Pointer2MemrefOp> views;
+    for (Operation *user : res.getUsers()) {
+      auto view = dyn_cast<enzymexla::Pointer2MemrefOp>(user);
+      if (!view || view.getType() != p2m.getType())
+        return failure();
+      views.push_back(view);
+    }
+
+    SmallVector<Type> resultTypes(ifOp.getResultTypes());
+    resultTypes[res.getResultNumber()] = p2m.getType();
+
+    rewriter.setInsertionPoint(ifOp);
+    auto newIf =
+        affine::AffineIfOp::create(rewriter, ifOp.getLoc(), resultTypes,
+                                   ifOp.getIntegerSet(), ifOp.getOperands(),
+                                   /*withElseRegion=*/true);
+    for (unsigned r = 0; r < 2; ++r) {
+      Block *oldBlk = r ? ifOp.getElseBlock() : ifOp.getThenBlock();
+      Block *newBlk = r ? newIf.getElseBlock() : newIf.getThenBlock();
+      if (!newBlk->empty())
+        rewriter.eraseOp(newBlk->getTerminator());
+      rewriter.mergeBlocks(oldBlk, newBlk);
+      auto yield = cast<affine::AffineYieldOp>(newBlk->getTerminator());
+      rewriter.setInsertionPoint(yield);
+      auto cl = enzymexla::Pointer2MemrefOp::create(
+          rewriter, p2m.getLoc(), p2m.getType(),
+          yield.getOperand(res.getResultNumber()));
+      rewriter.modifyOpInPlace(
+          yield, [&]() { yield.setOperand(res.getResultNumber(), cl); });
+    }
+
+    for (auto view : views)
+      rewriter.replaceOp(view, newIf.getResult(res.getResultNumber()));
+    rewriter.replaceOp(ifOp, newIf.getResults());
+    return success();
+  }
+};
+
+struct LoadIf : public OpRewritePattern<affine::AffineLoadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineLoadOp ld,
+                                PatternRewriter &rewriter) const override {
+    auto res = dyn_cast<OpResult>(ld.getMemRef());
+    if (!res)
+      return failure();
+    auto ifOp = dyn_cast<affine::AffineIfOp>(res.getOwner());
+    if (!ifOp)
+      return failure();
+    // The branch bodies are recomputed at the load, which speculates them.
+    for (Block *blk : {ifOp.getThenBlock(), ifOp.getElseBlock()})
+      for (auto &op : blk->without_terminator())
+        if (!isPure(&op))
+          return failure();
+
+    SmallVector<Type> resultTypes = {ld.getType()};
+    auto newIf =
+        affine::AffineIfOp::create(rewriter, ifOp.getLoc(), resultTypes,
+                                   ifOp.getIntegerSet(), ifOp.getOperands(),
+                                   /*withElseRegion=*/true);
+    for (unsigned r = 0; r < 2; ++r) {
+      Block *oldBlk = r ? ifOp.getElseBlock() : ifOp.getThenBlock();
+      Block *newBlk = r ? newIf.getElseBlock() : newIf.getThenBlock();
+      OpBuilder::InsertionGuard guard(rewriter);
+      if (!newBlk->empty())
+        rewriter.eraseOp(newBlk->getTerminator());
+      rewriter.setInsertionPointToEnd(newBlk);
+      IRMapping map;
+      for (auto &op : oldBlk->without_terminator())
+        rewriter.clone(op, map);
+      Value mref = map.lookupOrDefault(
+          cast<affine::AffineYieldOp>(oldBlk->getTerminator())
+              .getOperand(res.getResultNumber()));
+      auto ld2 = cast<affine::AffineLoadOp>(rewriter.clone(*ld));
+      ld2.getMemrefMutable().set(mref);
+      affine::AffineYieldOp::create(rewriter, ld.getLoc(), ld2->getResults());
+    }
+    rewriter.replaceOp(ld, newIf.getResults());
+    return success();
+  }
+};
+
 struct LoadSelect : public OpRewritePattern<affine::AffineLoadOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -2416,11 +2509,12 @@ convertLLVMToAffineAccess(Operation *op,
     patterns.insert<SimplifyAllocConst<memref::AllocOp>,
                     SimplifyAllocConst<memref::AllocaOp>,
                     SimplifyAllocConst<gpu::AllocOp, true>>(context);
-    patterns.insert<
-        SimplifyDeadAlloc<memref::AllocaOp>, SimplifyDeadAlloc<memref::AllocOp>,
-        SimplifyDeadAlloc<LLVM::AllocaOp>,
-        SimplifyDeadAlloc<gpu::AllocOp, true>, Pointer2MemrefSelect, LoadSelect,
-        AffineIfDeadResults, SimpleMem2Reg<memref::AllocaOp>>(context);
+    patterns.insert<SimplifyDeadAlloc<memref::AllocaOp>,
+                    SimplifyDeadAlloc<memref::AllocOp>,
+                    SimplifyDeadAlloc<LLVM::AllocaOp>,
+                    SimplifyDeadAlloc<gpu::AllocOp, true>, Pointer2MemrefSelect,
+                    LoadSelect, Pointer2MemrefIf, LoadIf, AffineIfDeadResults,
+                    SimpleMem2Reg<memref::AllocaOp>>(context);
     GreedyRewriteConfig config;
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
     config.enableFolding();

--- a/test/lit_tests/load_if_pointer.mlir
+++ b/test/lit_tests/load_if_pointer.mlir
@@ -1,0 +1,30 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access)" --split-input-file | FileCheck %s
+
+#set = affine_set<()[s0] : (s0 - 1 >= 0)>
+
+// A load through a pointer an affine.if chose becomes the if choosing between
+// the loads, so no pointer crosses the if.
+func.func @load_of_if_ptr(%a: !llvm.ptr, %b: !llvm.ptr, %n: index, %i: index) -> f64 {
+  %p = affine.if #set()[%n] -> !llvm.ptr {
+    affine.yield %a : !llvm.ptr
+  } else {
+    affine.yield %b : !llvm.ptr
+  }
+  %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+  %v = affine.load %m[symbol(%i)] : memref<?xf64>
+  return %v : f64
+}
+
+// CHECK-LABEL: func.func @load_of_if_ptr(
+// CHECK-SAME: %[[A:[a-z0-9]+]]: !llvm.ptr, %[[B:[a-z0-9]+]]: !llvm.ptr
+// CHECK-NOT: !llvm.ptr, f64
+// CHECK: %[[R:.+]] = affine.if #set{{.*}} -> f64 {
+// CHECK: %[[MA:.+]] = "enzymexla.pointer2memref"(%[[A]])
+// CHECK: %[[VA:.+]] = affine.load %[[MA]][symbol(%{{.+}})]
+// CHECK: affine.yield %[[VA]] : f64
+// CHECK: } else {
+// CHECK: %[[MB:.+]] = "enzymexla.pointer2memref"(%[[B]])
+// CHECK: %[[VB:.+]] = affine.load %[[MB]][symbol(%{{.+}})]
+// CHECK: affine.yield %[[VB]] : f64
+// CHECK: }
+// CHECK: return %[[R]] : f64


### PR DESCRIPTION
Now scoped to just the two affine.if analogs of the existing select patterns (the rest of the original bundle is split out: #2930 graceful pointer-constant error, #2931 pointer speculation, #2932 dead if-results, #2933 aggregate-load splitting).

\`MoveSelectToAffine\` turns a pointer select into an \`affine.if\` yielding a pointer whenever the condition is affine, and nothing consumed that form — raising has no tensor for a pointer. Two patterns dissolve it: \`Pointer2MemrefIf\` moves the \`pointer2memref\` views into the branches (all views of one type), and \`LoadIf\` sinks a load of an if-chosen memref into the branches when the bodies are pure to recompute at the load, leaving an \`affine.if\` of the loaded values, which raises as a masked select.

Together with #2930–#2933 (validated as a union): MFEM's mass-integrator TU on \`backend=xla-gpu\` loses every unraised-operand failure and stops only at \`parallel loop has non-constant bounds\` (runtime grid sizes — separate feature); the pointer-select CUDA MWE runs end-to-end on xla-gpu with output identical to vanilla clang; CUDA-backend MWEs stay output-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD