### PR TITLE
AffineToStableHLORaising: only splat constants a tensor can hold

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3519,7 +3519,11 @@ struct AffineToStableHLORaisingPass
 
           Attribute attr;
 
-          if (matchPattern(arg, m_Constant(&attr))) {
+          // Only splat what a tensor can hold; a pointer constant (null, a
+          // global's address) falls through to the pointer handling and, if
+          // unhandled there, to the unraised-operand report.
+          if (isa<IntegerType, FloatType, IndexType>(arg.getType()) &&
+              matchPattern(arg, m_Constant(&attr))) {
             affine::AffineValueMap accessMap(AffineMap::get(arg.getContext()),
                                              {});
 

--- a/test/lit_tests/raising/raise_ptr_constant_operand.mlir
+++ b/test/lit_tests/raising/raise_ptr_constant_operand.mlir
@@ -1,0 +1,19 @@
+// RUN: not enzymexlamlir-opt %s --raise-affine-to-stablehlo 2>&1 | FileCheck %s
+
+// A pointer constant reaching a kernel is not a value a tensor can hold; it
+// must be reported as an unraised operand, not splatted.
+func.func @null_ptr_operand(%out: memref<?xf64>, %n: i64) {
+  %c1 = arith.constant 1 : index
+  %null = llvm.mlir.zero : !llvm.ptr
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+    affine.parallel (%i) = (0) to (4) {
+      %pi = llvm.ptrtoint %null : !llvm.ptr to i64
+      %v = arith.sitofp %pi : i64 to f64
+      affine.store %v, %out[%i] : memref<?xf64>
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK: failed to raise operand: %{{.+}} = llvm.mlir.zero : !llvm.ptr


### PR DESCRIPTION
Fixes the segfault in #2928. A constant-matching wrapper operand was splatted into a rank-0 tensor of the operand's own type; for a pointer constant (\`llvm.mlir.zero\`, a global's address) that builds a \`DenseElementsAttr\` over a pointer element type, which dispatches to the string-element path and crashes release builds hashing garbage. The splat is now gated to integer/float/index; anything else falls through to the pointer handling and, unhandled there, to the existing \`failed to raise operand\` report. Lit test drives a null-pointer kernel operand through \`not enzymexlamlir-opt\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD