### PR TITLE
PartialIfToSelect: pointer values are safe to recompute outside the if

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeLoops.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/IntegerSet.h"
@@ -971,11 +972,12 @@ public:
         if (!ifOp->isAncestor(op))
           return v;
         // Recomputing an op defined inside the if outside of it speculates it,
-        // so only do so when speculation is enabled. Integer and index values
-        // are always safe to speculate, as they aren't differentiable and thus
-        // cannot introduce strong-zero-like numeric changes during
-        // differentiation.
-        if (!Speculate && !v.getType().isIntOrIndex())
+        // so only do so when speculation is enabled. Integer, index, and
+        // pointer values are always safe to speculate, as they aren't
+        // differentiable and thus cannot introduce strong-zero-like numeric
+        // changes during differentiation.
+        if (!Speculate && !v.getType().isIntOrIndex() &&
+            !isa<LLVM::LLVMPointerType>(v.getType()))
           return std::nullopt;
         if (op->getNumRegions() > 0)
           return std::nullopt;

--- a/test/lit_tests/partial_if_to_select_ptr.mlir
+++ b/test/lit_tests/partial_if_to_select_ptr.mlir
@@ -1,0 +1,20 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm.func(canonicalize-loops))" | FileCheck %s
+
+// Pointer arithmetic is as safe to speculate as integer arithmetic, so a
+// pure pointer-yielding branch becomes a select without speculate_if.
+llvm.func @ptr_if_to_select(%c: i1, %base: !llvm.ptr, %i: i64) -> !llvm.ptr {
+  %r = scf.if %c -> (!llvm.ptr) {
+    scf.yield %base : !llvm.ptr
+  } else {
+    %g = llvm.getelementptr inbounds %base[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    scf.yield %g : !llvm.ptr
+  }
+  llvm.return %r : !llvm.ptr
+}
+
+// CHECK-LABEL: llvm.func @ptr_if_to_select(
+// CHECK-SAME: %[[C:[a-z0-9]+]]: i1, %[[BASE:[a-z0-9]+]]: !llvm.ptr, %[[I:[a-z0-9]+]]: i64
+// CHECK-NOT: scf.if
+// CHECK: %[[G:.+]] = llvm.getelementptr inbounds %[[BASE]][%[[I]]]
+// CHECK: %[[S:.+]] = arith.select %[[C]], %[[BASE]], %[[G]] : !llvm.ptr
+// CHECK: llvm.return %[[S]] : !llvm.ptr


### PR DESCRIPTION
The no-speculation gate allowed only integer and index values, though a pure pointer computation (a \`getelementptr\`) is exactly as safe: pointers are not differentiable values and cannot introduce strong-zero-like numeric changes under differentiation. MFEM's \`constant coefficient ? C(0,0) : C(q,e)\` pointer choice now becomes an \`arith.select\` without \`speculate_if\`, which is what lets the select-dissolution patterns downstream (#2929 and friends) see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD