### PR TITLE
Prune affine.if results nothing reads

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -2175,12 +2175,11 @@ convertLLVMToAffineAccess(Operation *op,
     patterns.insert<SimplifyAllocConst<memref::AllocOp>,
                     SimplifyAllocConst<memref::AllocaOp>,
                     SimplifyAllocConst<gpu::AllocOp, true>>(context);
-    patterns.insert<SimplifyDeadAlloc<memref::AllocaOp>,
-                    SimplifyDeadAlloc<memref::AllocOp>,
-                    SimplifyDeadAlloc<LLVM::AllocaOp>,
-                    SimplifyDeadAlloc<gpu::AllocOp, true>, Pointer2MemrefSelect,
-                    LoadSelect, AffineIfDeadResults,
-                    SimpleMem2Reg<memref::AllocaOp>>(context);
+    patterns.insert<
+        SimplifyDeadAlloc<memref::AllocaOp>, SimplifyDeadAlloc<memref::AllocOp>,
+        SimplifyDeadAlloc<LLVM::AllocaOp>,
+        SimplifyDeadAlloc<gpu::AllocOp, true>, Pointer2MemrefSelect, LoadSelect,
+        AffineIfDeadResults, SimpleMem2Reg<memref::AllocaOp>>(context);
     GreedyRewriteConfig config;
     config.enableFolding();
     if (applyPatternsGreedily(op, std::move(patterns), config).failed())

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -825,19 +825,19 @@ struct AffineIfDeadResults : public OpRewritePattern<affine::AffineIfOp> {
         affine::AffineIfOp::create(rewriter, ifOp.getLoc(), newTypes,
                                    ifOp.getIntegerSet(), ifOp.getOperands(),
                                    /*withElseRegion=*/true);
+    // The new branches take the old regions wholesale, and the existing
+    // yields just drop the dead operands.
     for (unsigned r = 0; r < 2; ++r) {
-      Block *oldBlk = r ? ifOp.getElseBlock() : ifOp.getThenBlock();
-      Block *newBlk = r ? newIf.getElseBlock() : newIf.getThenBlock();
-      if (!newBlk->empty())
-        rewriter.eraseOp(newBlk->getTerminator());
-      rewriter.mergeBlocks(oldBlk, newBlk);
-      auto yield = cast<affine::AffineYieldOp>(newBlk->getTerminator());
+      Region &oldRegion = r ? ifOp.getElseRegion() : ifOp.getThenRegion();
+      Region &newRegion = r ? newIf.getElseRegion() : newIf.getThenRegion();
+      rewriter.inlineRegionBefore(oldRegion, newRegion, newRegion.begin());
+      rewriter.eraseBlock(&newRegion.back());
+      auto yield =
+          cast<affine::AffineYieldOp>(newRegion.front().getTerminator());
       SmallVector<Value> ops;
       for (unsigned i : keep)
         ops.push_back(yield.getOperand(i));
-      rewriter.setInsertionPoint(yield);
-      affine::AffineYieldOp::create(rewriter, yield.getLoc(), ops);
-      rewriter.eraseOp(yield);
+      rewriter.modifyOpInPlace(yield, [&] { yield->setOperands(ops); });
     }
     for (auto [j, i] : llvm::enumerate(keep))
       rewriter.replaceAllUsesWith(ifOp.getResult(i), newIf.getResult(j));

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -802,6 +802,50 @@ struct Pointer2MemrefSelect
   }
 };
 
+struct AffineIfDeadResults : public OpRewritePattern<affine::AffineIfOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineIfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    if (ifOp.getNumResults() == 0)
+      return failure();
+    SmallVector<unsigned> keep;
+    for (OpResult res : ifOp.getResults())
+      if (!res.use_empty())
+        keep.push_back(res.getResultNumber());
+    if (keep.size() == ifOp.getNumResults())
+      return failure();
+
+    SmallVector<Type> newTypes;
+    for (unsigned i : keep)
+      newTypes.push_back(ifOp.getResult(i).getType());
+
+    rewriter.setInsertionPoint(ifOp);
+    auto newIf =
+        affine::AffineIfOp::create(rewriter, ifOp.getLoc(), newTypes,
+                                   ifOp.getIntegerSet(), ifOp.getOperands(),
+                                   /*withElseRegion=*/true);
+    for (unsigned r = 0; r < 2; ++r) {
+      Block *oldBlk = r ? ifOp.getElseBlock() : ifOp.getThenBlock();
+      Block *newBlk = r ? newIf.getElseBlock() : newIf.getThenBlock();
+      if (!newBlk->empty())
+        rewriter.eraseOp(newBlk->getTerminator());
+      rewriter.mergeBlocks(oldBlk, newBlk);
+      auto yield = cast<affine::AffineYieldOp>(newBlk->getTerminator());
+      SmallVector<Value> ops;
+      for (unsigned i : keep)
+        ops.push_back(yield.getOperand(i));
+      rewriter.setInsertionPoint(yield);
+      affine::AffineYieldOp::create(rewriter, yield.getLoc(), ops);
+      rewriter.eraseOp(yield);
+    }
+    for (auto [j, i] : llvm::enumerate(keep))
+      rewriter.replaceAllUsesWith(ifOp.getResult(i), newIf.getResult(j));
+    rewriter.eraseOp(ifOp);
+    return success();
+  }
+};
+
 struct LoadSelect : public OpRewritePattern<affine::AffineLoadOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -2135,7 +2179,8 @@ convertLLVMToAffineAccess(Operation *op,
                     SimplifyDeadAlloc<memref::AllocOp>,
                     SimplifyDeadAlloc<LLVM::AllocaOp>,
                     SimplifyDeadAlloc<gpu::AllocOp, true>, Pointer2MemrefSelect,
-                    LoadSelect, SimpleMem2Reg<memref::AllocaOp>>(context);
+                    LoadSelect, AffineIfDeadResults,
+                    SimpleMem2Reg<memref::AllocaOp>>(context);
     GreedyRewriteConfig config;
     config.enableFolding();
     if (applyPatternsGreedily(op, std::move(patterns), config).failed())

--- a/test/lit_tests/affine_if_dead_results.mlir
+++ b/test/lit_tests/affine_if_dead_results.mlir
@@ -1,0 +1,21 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access)" --split-input-file | FileCheck %s
+#set = affine_set<()[s0] : (s0 - 1 >= 0)>
+
+// A result nothing reads is not yielded, which is what lets a pointer the if
+// no longer needs disappear.
+func.func @dead_if_result(%a: !llvm.ptr, %m: memref<?xf64>, %n: index) -> f64 {
+  %r:2 = affine.if #set()[%n] -> (!llvm.ptr, f64) {
+    %v = affine.load %m[0] : memref<?xf64>
+    affine.yield %a, %v : !llvm.ptr, f64
+  } else {
+    %v = affine.load %m[1] : memref<?xf64>
+    affine.yield %a, %v : !llvm.ptr, f64
+  }
+  return %r#1 : f64
+}
+
+// CHECK-LABEL: func.func @dead_if_result(
+// CHECK-NOT: !llvm.ptr, f64
+// CHECK: %[[R:.+]] = affine.if #set{{.*}} -> f64 {
+// CHECK: affine.yield %{{.+}} : f64
+// CHECK: return %[[R]] : f64

--- a/test/lit_tests/raising/affinecfg_affine_if_side_effect_symbol.mlir
+++ b/test/lit_tests/raising/affinecfg_affine_if_side_effect_symbol.mlir
@@ -31,7 +31,7 @@ module {
 // value as an arith.select; it materializes a bodiless affine.if over the same
 // set instead, yielding the two hoisted arms.  isValidDim accepts valid
 // symbols, so the legalized set operands stay legal at the new location.  The
-// storing affine.if is left where it is.
+// storing affine.if is left where it is, with its now-dead result pruned.
 
 // CHECK:         #map = affine_map<()[s0, s1] -> (s0 - s1)>
 // CHECK:         #set = affine_set<()[s0] : (s0 - 1 >= 0)>
@@ -48,12 +48,10 @@ module {
 // CHECK:           }
 // CHECK:           %[[HOISTEDI:.+]] = arith.index_cast %[[HOISTED]] : i32 to index
 // CHECK:           %[[OUTER:.+]] = scf.if %[[C2]] -> (i32) {
-// CHECK:             %{{.+}} = affine.if #set(){{\[}}%[[NI]]] -> i32 {
-// CHECK:               affine.yield %[[C0_I32]] : i32
-// CHECK:             } else {
+// CHECK:             affine.if #set(){{\[}}%[[NI]]] {
+// CHECK-NEXT:        } else {
 // CHECK:               %[[SI:.+]] = arith.index_cast %[[SQ]] : i32 to index
 // CHECK:               memref.store %[[SQ]], %[[MEM]]{{\[}}%[[SI]]] : memref<?xi32>
-// CHECK:               affine.yield %[[SQ]] : i32
 // CHECK:             }
 // CHECK:             %[[APP:.+]] = affine.apply #map(){{\[}}%[[NI]], %[[HOISTEDI]]]
 // CHECK:             %[[LOAD:.+]] = memref.load %[[MEM]]{{\[}}%[[APP]]] : memref<?xi32>


### PR DESCRIPTION
An \`affine.if\` result with no uses still forces its yields, and a dead pointer yield — the leftover half of a partially dissolved (pointer, value) pair — kept whole MFEM kernels unraisable through a dead \`affine.yield %ptr\`. Rebuild the if with only the results something reads, preserving the branch bodies and their effects. The existing \`affinecfg_affine_if_side_effect_symbol.mlir\` expectation updates accordingly (its hoisted if's result was already dead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD