### PR TITLE
Don't batch or unroll checkpoint segment loops

### DIFF
--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -37,6 +37,7 @@
 #include "src/enzyme_ad/jax/Implementations/XLADerivatives.h"
 #include "src/enzyme_ad/jax/Utils.h"
 #include <cstdint>
+#include <utility>
 
 using namespace mlir;
 using namespace mlir::enzyme;
@@ -554,6 +555,29 @@ class AutoDiffWhileRev
         ReshapeOpCreate(builder, val.getLoc(), val, updateShape), startIndices);
 
     return arr;
+  }
+
+  // Runs `build`, then marks every `stablehlo.while` it added under `scope` as
+  // a checkpoint segment loop (see markCheckpointSegmentLoop).
+  // LoopCheckpointing creates the scaffold's loops itself, through hooks that
+  // are not told what they are building, so there is no per-loop place to mark
+  // from; the loops it just created are exactly the ones that were not there
+  // before. `scope` has to outlive the call -- the scaffold replaces the loop
+  // being differentiated, so pass an ancestor of it, not the loop.
+  template <typename BuildFn>
+  static auto markScaffoldLoops(Operation *scope, BuildFn &&build) {
+    DenseSet<Operation *> before;
+    scope->walk([&](stablehlo::WhileOp op) { before.insert(op); });
+
+    auto result = std::forward<BuildFn>(build)();
+
+    if (result) {
+      scope->walk([&](stablehlo::WhileOp op) {
+        if (!before.contains(op))
+          markCheckpointSegmentLoop(op);
+      });
+    }
+    return result;
   }
 
   static stablehlo::WhileOp makeForLoop(OpBuilder &builder, Location loc,
@@ -1174,9 +1198,12 @@ public:
         }
       }
 
-      if (auto r = tryCreateReverseModeAdjoint(whileOp, orig, builder, gutils,
+      Operation *scope = builder.getInsertionBlock()->getParentOp();
+      if (auto r = markScaffoldLoops(scope, [&] {
+            return tryCreateReverseModeAdjoint(whileOp, orig, builder, gutils,
                                                caches, carriedActive,
-                                               incomingGradients))
+                                               incomingGradients);
+          }))
         return *r;
     }
 
@@ -1367,7 +1394,9 @@ public:
 
         if (needsCheckpointing(whileOp) ||
             needsBinomialCheckpointing(whileOp)) {
-          if (auto caches = tryCacheValues(whileOp, orig, gutils))
+          Operation *scope = newWhile->getParentOp();
+          if (auto caches = markScaffoldLoops(
+                  scope, [&] { return tryCacheValues(whileOp, orig, gutils); }))
             return *caches;
         }
 

--- a/src/enzyme_ad/jax/Passes/AutoBatching.cpp
+++ b/src/enzyme_ad/jax/Passes/AutoBatching.cpp
@@ -884,6 +884,17 @@ static bool definedOutside(Value v, Operation *op) {
 
 LogicalResult GreedyWhileLoopBatchFission::matchAndRewriteImpl(
     stablehlo::WhileOp whileOp, PatternRewriter &rewriter) const {
+  // Never fission a checkpoint segment loop. Batching trades memory for
+  // parallelism by computing every iteration at once; for a loop that
+  // checkpointed reverse-mode AD created specifically to keep only one segment
+  // live, that rebuilds the very tape the recompute was paying to avoid. Such a
+  // loop only becomes eligible in the first place when the segment length
+  // divides the trip count evenly (LoopCheckpointing::segmentLength returns the
+  // constant nInner rather than a select), so without this guard peak memory
+  // silently depends on that divisibility.
+  if (isCheckpointSegmentLoop(whileOp))
+    return rewriter.notifyMatchFailure(whileOp, "checkpoint segment loop");
+
   auto info = WhileLoopInfo(whileOp);
   auto computeInfoSuccess = info.computeInfo();
   if (computeInfoSuccess.failed())
@@ -1794,6 +1805,11 @@ bool liftOperationByBatching(
 
 mlir::LogicalResult WhileElementwiseReductionToReduce::matchAndRewriteImpl(
     stablehlo::WhileOp whileOp, PatternRewriter &rewriter) const {
+  // Same reasoning as GreedyWhileLoopBatchFission: lifting the reduction
+  // materializes every iteration of the segment at once.
+  if (isCheckpointSegmentLoop(whileOp))
+    return rewriter.notifyMatchFailure(whileOp, "checkpoint segment loop");
+
   auto &body = whileOp.getBody().front();
   auto term = body.getTerminator();
   if (!term) {

--- a/src/enzyme_ad/jax/Passes/AutoBatching.cpp
+++ b/src/enzyme_ad/jax/Passes/AutoBatching.cpp
@@ -892,7 +892,7 @@ LogicalResult GreedyWhileLoopBatchFission::matchAndRewriteImpl(
   // divides the trip count evenly (LoopCheckpointing::segmentLength returns the
   // constant nInner rather than a select), so without this guard peak memory
   // silently depends on that divisibility.
-  if (isCheckpointSegmentLoop(whileOp))
+  if (isOrContainsCheckpointSegmentLoop(whileOp))
     return rewriter.notifyMatchFailure(whileOp, "checkpoint segment loop");
 
   auto info = WhileLoopInfo(whileOp);
@@ -1807,7 +1807,7 @@ mlir::LogicalResult WhileElementwiseReductionToReduce::matchAndRewriteImpl(
     stablehlo::WhileOp whileOp, PatternRewriter &rewriter) const {
   // Same reasoning as GreedyWhileLoopBatchFission: lifting the reduction
   // materializes every iteration of the segment at once.
-  if (isCheckpointSegmentLoop(whileOp))
+  if (isOrContainsCheckpointSegmentLoop(whileOp))
     return rewriter.notifyMatchFailure(whileOp, "checkpoint segment loop");
 
   auto &body = whileOp.getBody().front();

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.cpp
@@ -53,7 +53,7 @@ LogicalResult unrollWhileOp(mlir::stablehlo::WhileOp op, RewriterBase &rewriter,
   // Unrolling a checkpoint segment loop makes every iteration of the segment
   // live at once, which is what the checkpointing was paying recompute to
   // avoid. See markCheckpointSegmentLoop.
-  if (isCheckpointSegmentLoop(op))
+  if (isOrContainsCheckpointSegmentLoop(op))
     return failure();
 
   WhileLoopInfo info(op);

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOUnroll.cpp
@@ -18,6 +18,7 @@
 
 #include "src/enzyme_ad/jax/CheckedRewrite.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
+#include "src/enzyme_ad/jax/Utils.h"
 #include "xla/mlir_hlo/mhlo/IR/hlo_ops.h"
 
 #include "stablehlo/dialect/StablehloOps.h"
@@ -48,6 +49,12 @@ LogicalResult unrollWhileOp(mlir::stablehlo::WhileOp op, RewriterBase &rewriter,
                             int64_t maxNumIterations,
                             int64_t maxOperationThreshold,
                             SmallVectorImpl<Value> *replacements) {
+
+  // Unrolling a checkpoint segment loop makes every iteration of the segment
+  // live at once, which is what the checkpointing was paying recompute to
+  // avoid. See markCheckpointSegmentLoop.
+  if (isCheckpointSegmentLoop(op))
+    return failure();
 
   WhileLoopInfo info(op);
   if (info.computeInfo().failed() || !info.isConstant())

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -416,6 +416,30 @@ T getAttributeFromIR(Value val, StringRef attrName, T unknownValue) {
   return enumAttr.getValue();
 }
 
+/// Marks a `stablehlo.while` that belongs to the scaffold checkpointed
+/// reverse-mode AD builds around one checkpoint segment -- the forward
+/// recompute, the reverse sweep, or the outer walk over segments.
+///
+/// Such a loop exists *in order to* bound peak memory: checkpointing pays
+/// recompute so that only one segment's intermediates are live at a time. Any
+/// rewrite that materializes its iteration space -- batching, fission,
+/// unrolling -- undoes exactly that trade and rebuilds the full tape the loop
+/// was created to avoid. Passes that would do so must skip loops carrying this
+/// attribute; see `isCheckpointSegmentLoop`.
+constexpr llvm::StringLiteral kCheckpointSegmentAttrName =
+    "enzymexla.checkpoint_segment";
+
+inline void markCheckpointSegmentLoop(mlir::Operation *op) {
+  op->setAttr(kCheckpointSegmentAttrName,
+              mlir::UnitAttr::get(op->getContext()));
+}
+
+/// True if `op` is a checkpoint-segment loop whose iteration space must not be
+/// materialized. See `markCheckpointSegmentLoop` for the rationale.
+inline bool isCheckpointSegmentLoop(mlir::Operation *op) {
+  return op->hasAttr(kCheckpointSegmentAttrName);
+}
+
 /// Get bounds attribute from IR. Bounds are stored as ArrayAttr with two
 /// IntegerAttr elements [min, max] under the attribute name "enzymexla.bounds".
 /// Returns nullopt if the attribute is not found or malformed.

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -440,6 +440,30 @@ inline bool isCheckpointSegmentLoop(mlir::Operation *op) {
   return op->hasAttr(kCheckpointSegmentAttrName);
 }
 
+/// True if `op` is a checkpoint-segment loop, or encloses one.
+///
+/// The mark is not guaranteed to survive on every loop of the scaffold. A
+/// rewrite that has to widen a loop -- to carry the checkpoint snapshots out,
+/// say -- cannot mutate results in place, so it builds a fresh op, and a fresh
+/// op does not inherit discardable attributes. An outer scaffold loop can
+/// therefore lose the mark while the segment loop nested inside it keeps it.
+///
+/// Materializing the outer loop rebuilds the same tape as materializing the
+/// inner one, so enclosing a marked loop counts the same as carrying the mark.
+/// This is deliberately conservative: it also covers a user loop that happens
+/// to wrap a checkpointed region, where fission would undo the checkpointing
+/// just as thoroughly.
+inline bool isOrContainsCheckpointSegmentLoop(mlir::Operation *op) {
+  if (isCheckpointSegmentLoop(op))
+    return true;
+  return op
+      ->walk([](mlir::Operation *nested) {
+        return isCheckpointSegmentLoop(nested) ? mlir::WalkResult::interrupt()
+                                               : mlir::WalkResult::advance();
+      })
+      .wasInterrupted();
+}
+
 /// Get bounds attribute from IR. Bounds are stored as ArrayAttr with two
 /// IntegerAttr elements [min, max] under the attribute name "enzymexla.bounds".
 /// Returns nullopt if the attribute is not found or malformed.

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing.mlir
@@ -136,7 +136,7 @@ module {
 // CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
 // CHECK-NEXT:     } do {
 // CHECK-NEXT:       %2 = stablehlo.multiply %iterArg, %c_0 : tensor<i64>
-// CHECK-NEXT:       %3:2 = stablehlo.while(%iterArg_6 = %c_1, %iterArg_7 = %iterArg_4) : tensor<i64>, tensor<f64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:       %3:2 = stablehlo.while(%iterArg_6 = %c_1, %iterArg_7 = %iterArg_4) : tensor<i64>, tensor<f64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:       cond {
 // CHECK-NEXT:         %7 = stablehlo.compare LT, %iterArg_6, %c_0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:         stablehlo.return %7 : tensor<i1>

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing3.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing3.mlir
@@ -73,7 +73,7 @@ module {
 // CHECK-NEXT:       %4 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:       stablehlo.return %4 : tensor<i1>
 // CHECK-NEXT:     } do {
-// CHECK-NEXT:       %4:3 = stablehlo.while(%iterArg_11 = %c_3, %iterArg_12 = %iterArg_7, %iterArg_13 = %iterArg_8) : tensor<i64>, tensor<31xi64>, tensor<31xf64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:       %4:3 = stablehlo.while(%iterArg_11 = %c_3, %iterArg_12 = %iterArg_7, %iterArg_13 = %iterArg_8) : tensor<i64>, tensor<31xi64>, tensor<31xf64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:       cond {
 // CHECK-NEXT:         %10 = stablehlo.compare LT, %iterArg_11, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:         stablehlo.return %10 : tensor<i1>

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial.mlir
@@ -93,7 +93,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:    %c_7 = stablehlo.constant dense<5> : tensor<i64>
 // CHECK-NEXT:    %c_8 = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-NEXT:    %cst_9 = stablehlo.constant dense<6.28318548> : tensor<3xf32>
-// CHECK-NEXT:    %0:5 = stablehlo.while(%iterArg = %c_8, %iterArg_10 = %c_8, %iterArg_11 = %cst_2, %iterArg_12 = %cst_4, %iterArg_13 = %c_3) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<2x3xf32>, tensor<2xi64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:    %0:5 = stablehlo.while(%iterArg = %c_8, %iterArg_10 = %c_8, %iterArg_11 = %cst_2, %iterArg_12 = %cst_4, %iterArg_13 = %c_3) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<2x3xf32>, tensor<2xi64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:    cond {
 // CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_5 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
@@ -139,7 +139,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:        %31 = stablehlo.maximum %30, %c_6 : tensor<i64>
 // CHECK-NEXT:        stablehlo.return %31 : tensor<i64>
 // CHECK-NEXT:      }) : (tensor<i1>) -> tensor<i64>
-// CHECK-NEXT:      %13:2 = stablehlo.while(%iterArg_14 = %c_8, %iterArg_15 = %iterArg_11) : tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:      %13:2 = stablehlo.while(%iterArg_14 = %c_8, %iterArg_15 = %iterArg_11) : tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:      cond {
 // CHECK-NEXT:        %16 = stablehlo.compare LT, %iterArg_14, %12 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:        stablehlo.return %16 : tensor<i1>
@@ -154,7 +154,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:      %15 = stablehlo.add %iterArg, %c_6 : tensor<i64>
 // CHECK-NEXT:      stablehlo.return %15, %14, %13#1, %3, %5 : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<2x3xf32>, tensor<2xi64>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %1:5 = stablehlo.while(%iterArg = %c_8, %iterArg_10 = %c_5, %iterArg_11 = %cst_1, %iterArg_12 = %0#3, %iterArg_13 = %0#4) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<2x3xf32>, tensor<2xi64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:    %1:5 = stablehlo.while(%iterArg = %c_8, %iterArg_10 = %c_5, %iterArg_11 = %cst_1, %iterArg_12 = %0#3, %iterArg_13 = %0#4) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<2x3xf32>, tensor<2xi64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:    cond {
 // CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_7 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
@@ -216,7 +216,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:        %31 = stablehlo.compare EQ, %30, %3 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:        %32 = stablehlo.subtract %30, %c_6 : tensor<i64>
 // CHECK-NEXT:        %33 = stablehlo.select %31, %32, %30 : tensor<i1>, tensor<i64>
-// CHECK-NEXT:        %34:2 = stablehlo.while(%iterArg_19 = %iterArg_14, %iterArg_20 = %iterArg_16) : tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:        %34:2 = stablehlo.while(%iterArg_19 = %iterArg_14, %iterArg_20 = %iterArg_16) : tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:        cond {
 // CHECK-NEXT:          %36 = stablehlo.compare LT, %iterArg_19, %33 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:          stablehlo.return %36 : tensor<i1>

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_dynamic.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_dynamic.mlir
@@ -102,7 +102,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:    %c_8 = stablehlo.constant dense<1> : tensor<i64>
 // CHECK-NEXT:    %cst_9 = stablehlo.constant dense<6.28318548> : tensor<3xf32>
 // CHECK-NEXT:    %c_10 = stablehlo.constant dense<10> : tensor<i64>
-// CHECK-NEXT:    %0:7 = stablehlo.while(%iterArg = %c_7, %iterArg_11 = %c_7, %iterArg_12 = %c_10, %iterArg_13 = %cst_3, %iterArg_14 = %c_6, %iterArg_15 = %cst_5, %iterArg_16 = %c_6) : tensor<i64>, tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3xi64>, tensor<3x3xf32>, tensor<3xi64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:    %0:7 = stablehlo.while(%iterArg = %c_7, %iterArg_11 = %c_7, %iterArg_12 = %c_10, %iterArg_13 = %cst_3, %iterArg_14 = %c_6, %iterArg_15 = %cst_5, %iterArg_16 = %c_6) : tensor<i64>, tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3xi64>, tensor<3x3xf32>, tensor<3xi64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:    cond {
 // CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
@@ -150,7 +150,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:        %33 = stablehlo.maximum %32, %c_8 : tensor<i64>
 // CHECK-NEXT:        stablehlo.return %33 : tensor<i64>
 // CHECK-NEXT:      }) : (tensor<i1>) -> tensor<i64>
-// CHECK-NEXT:      %15:3 = stablehlo.while(%iterArg_17 = %c_7, %iterArg_18 = %iterArg_12, %iterArg_19 = %iterArg_13) : tensor<i64>, tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:      %15:3 = stablehlo.while(%iterArg_17 = %c_7, %iterArg_18 = %iterArg_12, %iterArg_19 = %iterArg_13) : tensor<i64>, tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:      cond {
 // CHECK-NEXT:        %18 = stablehlo.compare LT, %iterArg_17, %14 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:        stablehlo.return %18 : tensor<i1>
@@ -170,7 +170,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:      %17 = stablehlo.add %iterArg, %c_8 : tensor<i64>
 // CHECK-NEXT:      stablehlo.return %17, %16, %15#1, %15#2, %3, %5, %7 : tensor<i64>, tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3xi64>, tensor<3x3xf32>, tensor<3xi64>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %1:6 = stablehlo.while(%iterArg = %c_7, %iterArg_11 = %c_1, %iterArg_12 = %cst_2, %iterArg_13 = %0#4, %iterArg_14 = %0#5, %iterArg_15 = %0#6) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3xi64>, tensor<3x3xf32>, tensor<3xi64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:    %1:6 = stablehlo.while(%iterArg = %c_7, %iterArg_11 = %c_1, %iterArg_12 = %cst_2, %iterArg_13 = %0#4, %iterArg_14 = %0#5, %iterArg_15 = %0#6) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3xi64>, tensor<3x3xf32>, tensor<3xi64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:    cond {
 // CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_10 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
@@ -236,7 +236,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:        %37 = stablehlo.compare EQ, %36, %3 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:        %38 = stablehlo.subtract %36, %c_8 : tensor<i64>
 // CHECK-NEXT:        %39 = stablehlo.select %37, %38, %36 : tensor<i1>, tensor<i64>
-// CHECK-NEXT:        %40:3 = stablehlo.while(%iterArg_23 = %iterArg_16, %iterArg_24 = %iterArg_18, %iterArg_25 = %iterArg_19) : tensor<i64>, tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:        %40:3 = stablehlo.while(%iterArg_23 = %iterArg_16, %iterArg_24 = %iterArg_18, %iterArg_25 = %iterArg_19) : tensor<i64>, tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:        cond {
 // CHECK-NEXT:          %42 = stablehlo.compare LT, %iterArg_23, %39 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:          stablehlo.return %42 : tensor<i1>

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_iv.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_iv.mlir
@@ -77,7 +77,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:    %c_8 = stablehlo.constant dense<1> : tensor<i64>
 // CHECK-NEXT:    %c_9 = stablehlo.constant dense<10> : tensor<i64>
 // CHECK-NEXT:    %cst_10 = stablehlo.constant dense<6.28318548> : tensor<3xf32>
-// CHECK-NEXT:    %0:5 = stablehlo.while(%iterArg = %c_7, %iterArg_11 = %c_7, %iterArg_12 = %cst_1, %iterArg_13 = %cst_5, %iterArg_14 = %c_4) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3x3xf32>, tensor<3xi64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:    %0:5 = stablehlo.while(%iterArg = %c_7, %iterArg_11 = %c_7, %iterArg_12 = %cst_1, %iterArg_13 = %cst_5, %iterArg_14 = %c_4) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3x3xf32>, tensor<3xi64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:    cond {
 // CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_6 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
@@ -123,7 +123,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:        %31 = stablehlo.maximum %30, %c_8 : tensor<i64>
 // CHECK-NEXT:        stablehlo.return %31 : tensor<i64>
 // CHECK-NEXT:      }) : (tensor<i1>) -> tensor<i64>
-// CHECK-NEXT:      %13:2 = stablehlo.while(%iterArg_15 = %c_7, %iterArg_16 = %iterArg_12) : tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:      %13:2 = stablehlo.while(%iterArg_15 = %c_7, %iterArg_16 = %iterArg_12) : tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:      cond {
 // CHECK-NEXT:        %16 = stablehlo.compare LT, %iterArg_15, %12 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:        stablehlo.return %16 : tensor<i1>
@@ -143,7 +143,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:      %15 = stablehlo.add %iterArg, %c_8 : tensor<i64>
 // CHECK-NEXT:      stablehlo.return %15, %14, %13#1, %3, %5 : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3x3xf32>, tensor<3xi64>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %1:5 = stablehlo.while(%iterArg = %c_7, %iterArg_11 = %c_6, %iterArg_12 = %cst_2, %iterArg_13 = %0#3, %iterArg_14 = %0#4) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3x3xf32>, tensor<3xi64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:    %1:5 = stablehlo.while(%iterArg = %c_7, %iterArg_11 = %c_6, %iterArg_12 = %cst_2, %iterArg_13 = %0#3, %iterArg_14 = %0#4) : tensor<i64>, tensor<i64>, tensor<3xf32>, tensor<3x3xf32>, tensor<3xi64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:    cond {
 // CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_9 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
@@ -205,7 +205,7 @@ module @reactant_df attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas
 // CHECK-NEXT:        %33 = stablehlo.compare EQ, %32, %3 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:        %34 = stablehlo.subtract %32, %c_8 : tensor<i64>
 // CHECK-NEXT:        %35 = stablehlo.select %33, %34, %32 : tensor<i1>, tensor<i64>
-// CHECK-NEXT:        %36:2 = stablehlo.while(%iterArg_20 = %iterArg_15, %iterArg_21 = %iterArg_17) : tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:        %36:2 = stablehlo.while(%iterArg_20 = %iterArg_15, %iterArg_21 = %iterArg_17) : tensor<i64>, tensor<3xf32> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:        cond {
 // CHECK-NEXT:          %38 = stablehlo.compare LT, %iterArg_20, %35 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:          stablehlo.return %38 : tensor<i1>

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_nested.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_nested.mlir
@@ -44,7 +44,7 @@ module @reactant_gradmyfunc attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
 // CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<3xf64>
 // CHECK-NEXT:    %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
-// CHECK-NEXT:    %0:2 = stablehlo.while(%iterArg = %c_5, %iterArg_7 = %arg0) : tensor<i64>, tensor<3xf64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:    %0:2 = stablehlo.while(%iterArg = %c_5, %iterArg_7 = %arg0) : tensor<i64>, tensor<3xf64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:    cond {
 // CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
@@ -52,12 +52,12 @@ module @reactant_gradmyfunc attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
 // CHECK-NEXT:      %2 = stablehlo.multiply %iterArg, %c {enzymexla.bounds = {{.*}} : tensor<i64>
 // CHECK-NEXT:      %3 = stablehlo.add %c_4, %2 {enzymexla.bounds = {{.*}} : tensor<i64>
 // CHECK-NEXT:      %4 = stablehlo.minimum %c_2, %3 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      %5:2 = stablehlo.while(%iterArg_8 = %c_5, %iterArg_9 = %iterArg_7) : tensor<i64>, tensor<3xf64> attributes {enzyme.disable_mincut}
+// CHECK-NEXT:      %5:2 = stablehlo.while(%iterArg_8 = %c_5, %iterArg_9 = %iterArg_7) : tensor<i64>, tensor<3xf64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
 // CHECK-NEXT:      cond {
 // CHECK-NEXT:        %7 = stablehlo.compare LT, %iterArg_8, %4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:        stablehlo.return %7 : tensor<i1>
 // CHECK-NEXT:      } do {
-// CHECK-NEXT:        %7:2 = stablehlo.while(%iterArg_10 = %c_5, %iterArg_11 = %iterArg_9) : tensor<i64>, tensor<3xf64> attributes {enzyme.checkpoint_period = 3 : i64, enzyme.disable_mincut, enzyme.enable_checkpointing = true}
+// CHECK-NEXT:        %7:2 = stablehlo.while(%iterArg_10 = %c_5, %iterArg_11 = %iterArg_9) : tensor<i64>, tensor<3xf64> attributes {enzyme.checkpoint_period = 3 : i64, enzyme.disable_mincut, enzyme.enable_checkpointing = true, enzymexla.checkpoint_segment}
 // CHECK-NEXT:        cond {
 // CHECK-NEXT:          %9 = stablehlo.compare LT, %iterArg_10, %c_4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
 // CHECK-NEXT:          stablehlo.return %9 : tensor<i1>


### PR DESCRIPTION
### Problem

Peak memory of a checkpointed reverse pass depends on whether the segments divide the trip count.

`LoopCheckpointing::segmentLength` returns the constant `nInner` when they divide evenly, and a `select` when they don't. A constant trip count makes the segment loop eligible for `GreedyWhileLoopBatchFission`, which hoists every induction-indexed user out of the loop and computes all iterations at once. That rebuilds the whole tape the checkpointing was paying recompute to avoid.

So the divisible case, which should be the cheapest, is the one that blows up.

### Fix

Mark the loops the checkpointing scaffold creates with `enzymexla.checkpoint_segment`, and skip them in the three passes that would materialize their iteration space: `GreedyWhileLoopBatchFission`, `WhileElementwiseReductionToReduce`, and `enzyme-hlo-unroll`.

Marking happens where Enzyme-JAX calls into `LoopCheckpointing`, by diffing the `stablehlo.while` ops before and after the call. The shared code builds the scaffold through hooks that are not told what they are building, so there is no per-loop place to mark from.

The mark does not survive on every loop of the scaffold. A rewrite that widens a loop to carry the checkpoint snapshots out cannot add results in place, so it builds a fresh op, and a fresh op inherits no discardable attributes. The guard therefore also fires on a loop that encloses a marked one, since fissioning the outer loop rebuilds the same tape.

### Evidence

Ablating `greedy_while_loop_batch_fission` from the pipeline, at every trip count where the segments divide. Measured before checkpointing moved into `LoopCheckpointing`, so periods are stated as segment lengths.

    iters  seg  mincut  peak GiB  peak GiB   time s   time s
                          normal  no-fission  normal  no-fission
    -----  ---  ------  --------  ----------  ------  ----------
       25    5     off     22.97       22.92   0.495       0.528
      100   10     off     36.31       36.15   1.888       2.019
      400   20     off     63.85       62.60   7.493       8.009
     1600   40     off    118.77      115.52  30.900      33.024
       25    5      on     22.54        9.54   0.409       0.426
      100   10      on     36.19       10.03   1.573       1.622
      400   20      on     63.48       11.02   6.254       6.507
     1600   40      on    118.07       12.99       -      26.642

Gradients bit-identical in every cell.

With mincut on, the divisible trip counts drop by 2.4x to 9.1x, and the gap grows with the trip count: 13 GiB at 25 iterations, 105 GiB at 1600. They land alongside the neighbouring non-divisible trip counts, which measure 9.79, 10.48, 11.86 and 14.68 GiB at 50, 200, 800 and 3200. The divisible line does not merely improve, it stops being a separate line.

With mincut off, peak memory moves by at most 2.7%, so this is a separate issue from that one.

Ablation is a pessimistic bound on the patch. It drops the pattern everywhere, which costs a flat 6.9% of gradient time on the mincut-off line where the pattern is doing useful work and is not the memory problem. Skipping only the scaffold loops should not pay that. Where the pattern does fire, the cost is 3-4%.
