### PR TITLE
canonicalize-parallel: see through an or a truncation discards

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -61,7 +61,8 @@ struct TruncOrConst : public OpRewritePattern<arith::TruncIOp> {
       return failure();
     if (!cst.extractBits(intTy.getWidth(), 0).isZero())
       return failure();
-    rewriter.replaceOpWithNewOp<arith::TruncIOp>(trunc, intTy, other);
+    rewriter.modifyOpInPlace(trunc,
+                             [&] { trunc.getInMutable().assign(other); });
     return success();
   }
 };

--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -16,6 +16,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/Threading.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
@@ -33,6 +35,37 @@ using namespace mlir;
 
 namespace {
 
+// A truncation that discards every bit an or set sees through the or. This is
+// how a kernel launch reads its dimensions back out of clang's packed dim3:
+// grid.y lands in the high half of an i64 and the launch takes the low half,
+// and the bits in between are what tie the grid to the size it was computed
+// from.
+struct TruncOrConst : public OpRewritePattern<arith::TruncIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::TruncIOp trunc,
+                                PatternRewriter &rewriter) const override {
+    auto intTy = dyn_cast<IntegerType>(trunc.getType());
+    if (!intTy)
+      return failure();
+    auto ori = trunc.getIn().getDefiningOp<arith::OrIOp>();
+    if (!ori)
+      return failure();
+    APInt cst;
+    Value other;
+    if (matchPattern(ori.getRhs(), m_ConstantInt(&cst)))
+      other = ori.getLhs();
+    else if (matchPattern(ori.getLhs(), m_ConstantInt(&cst)))
+      other = ori.getRhs();
+    else
+      return failure();
+    if (!cst.extractBits(intTy.getWidth(), 0).isZero())
+      return failure();
+    rewriter.replaceOpWithNewOp<arith::TruncIOp>(trunc, intTy, other);
+    return success();
+  }
+};
+
 struct CanonicalizeParallelPass
     : public enzyme::impl::CanonicalizeParallelPassBase<
           CanonicalizeParallelPass> {
@@ -48,6 +81,7 @@ struct CanonicalizeParallelPass
       dialect->getCanonicalizationPatterns(owningPatterns);
     for (RegisteredOperationName op : ctx->getRegisteredOperations())
       op.getCanonicalizationPatterns(owningPatterns, ctx);
+    owningPatterns.add<TruncOrConst>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_trunc_or.mlir
+++ b/test/lit_tests/canonicalize_parallel_trunc_or.mlir
@@ -1,0 +1,37 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel)" --split-input-file | FileCheck %s
+
+// A truncation that discards every bit an or set sees through the or: the
+// dim3 packing of a kernel launch writes grid.y into the high half of an i64
+// and the launch reads back the low half.
+func.func @pack(%n: i32) -> i32 {
+  %c255 = arith.constant 255 : i32
+  %c256 = arith.constant 256 : i32
+  %c4294967296 = arith.constant 4294967296 : i64
+  %a = arith.addi %n, %c255 overflow<nsw> : i32
+  %d = arith.divsi %a, %c256 : i32
+  %e = arith.extui %d : i32 to i64
+  %o = arith.ori %e, %c4294967296 {isDisjoint} : i64
+  %t = arith.trunci %o : i64 to i32
+  return %t : i32
+}
+
+// CHECK-LABEL: func.func @pack(
+// CHECK-NOT: arith.ori
+// CHECK-NOT: arith.trunci
+// CHECK: %[[A:.+]] = arith.addi
+// CHECK: %[[D:.+]] = arith.divsi %[[A]]
+// CHECK: return %[[D]] : i32
+
+// -----
+
+// Bits the truncation keeps stay an or.
+func.func @keepbits(%x: i64) -> i32 {
+  %c3 = arith.constant 3 : i64
+  %o = arith.ori %x, %c3 : i64
+  %t = arith.trunci %o : i64 to i32
+  return %t : i32
+}
+
+// CHECK-LABEL: func.func @keepbits(
+// CHECK: arith.ori
+// CHECK: arith.trunci


### PR DESCRIPTION
Clang's launch ABI packs a dim3 into an i64 — `grid.y` ored into the high half — and the kernel launch reads back the low half, leaving `trunci(ori(extui(grid), 1<<32))` between every grid dimension and the size it was computed from. Upstream arith has no fold for a truncation that discards every bit an or set (LLVM's InstCombine does this trivially), so the launch-bound symbol stays opaque to everything downstream that could relate it to the size — in particular the bound pruning in #2941.

Adds the fold (`trunci(ori(x, C)) → trunci(x)` when the truncation discards all of C's set bits) to the pattern collection `canonicalize-parallel` applies; the existing `trunci(extui(x)) → x` fold then erases the packing entirely, e.g. MFEM's `CuWrap1D` grid collapses to the bare `(N+255) divsi 256`.

Tests: positive (full dim3 pack chain folds to the ceil-div) and negative (an or whose constant survives the truncation stays). Full lit suite green (1193/1193 together with #2941).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD