### PR TITLE
Peel dynamic-extent parallel axes into whiles tagged enzymexla.parallel

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -1413,6 +1413,11 @@ static LogicalResult tryRaisingForOpToStableHLOWhile(
   whileOp->getRegion(0).push_back(cond);
   whileOp->getRegion(1).push_back(body);
 
+  // A loop peeled off a parallel axis stays a parallel axis: iterations are
+  // independent, which downstream passes may use without reanalyzing.
+  if (forOp->hasAttr("enzymexla.parallel"))
+    whileOp->setAttr("enzymexla.parallel", builder.getUnitAttr());
+
   if (createdWhileOp)
     *createdWhileOp = whileOp;
 
@@ -3533,6 +3538,92 @@ struct AffineToStableHLORaisingPass
           AffineToStableHLORaisingPass> {
   using AffineToStableHLORaisingBase::AffineToStableHLORaisingBase;
 
+  // A parallel dimension whose extent is only known at runtime cannot become
+  // a tensor axis, but its iterations are still independent: peel each such
+  // dimension into an affine.for tagged enzymexla.parallel, which the while
+  // raising then iterates, leaving the constant-extent dimensions to raise as
+  // axes. The tag rides onto the stablehlo.while so downstream passes know
+  // the iterations commute.
+  static void peelDynamicParallelDims(Operation *root) {
+    SmallVector<affine::AffineParallelOp> worklist;
+    root->walk([&](affine::AffineParallelOp par) { worklist.push_back(par); });
+    for (auto par : worklist) {
+      if (!par.getReductions().empty())
+        continue;
+      unsigned n = par.getNumDims();
+      SmallVector<unsigned> dyn, stat;
+      for (unsigned i = 0; i < n; ++i) {
+        if (getConstant(par.getLowerBoundMap(i)) &&
+            getConstant(par.getUpperBoundMap(i)))
+          stat.push_back(i);
+        else
+          dyn.push_back(i);
+      }
+      if (dyn.empty())
+        continue;
+
+      OpBuilder b(par);
+      Location loc = par.getLoc();
+      SmallVector<Value> ivRepl(n);
+      for (unsigned idx : dyn) {
+        auto forOp = affine::AffineForOp::create(
+            b, loc, par.getLowerBoundsOperands(), par.getLowerBoundMap(idx),
+            par.getUpperBoundsOperands(), par.getUpperBoundMap(idx),
+            par.getSteps()[idx]);
+        forOp->setAttr("enzymexla.parallel", b.getUnitAttr());
+        ivRepl[idx] = forOp.getInductionVar();
+        b.setInsertionPointToStart(forOp.getBody());
+      }
+
+      Block *target;
+      if (!stat.empty()) {
+        SmallVector<AffineExpr> lbounds, ubounds;
+        SmallVector<int32_t> lboundGroup, uboundGroup;
+        SmallVector<int64_t> steps;
+        for (unsigned idx : stat) {
+          auto lm = par.getLowerBoundMap(idx);
+          auto um = par.getUpperBoundMap(idx);
+          lbounds.append(lm.getResults().begin(), lm.getResults().end());
+          ubounds.append(um.getResults().begin(), um.getResults().end());
+          lboundGroup.push_back(lm.getNumResults());
+          uboundGroup.push_back(um.getNumResults());
+          steps.push_back(par.getSteps()[idx]);
+        }
+        auto inner = affine::AffineParallelOp::create(
+            b, loc, TypeRange(), b.getArrayAttr({}),
+            AffineMapAttr::get(
+                AffineMap::get(par.getLowerBoundsMap().getNumDims(),
+                               par.getLowerBoundsMap().getNumSymbols(), lbounds,
+                               par.getContext())),
+            b.getI32TensorAttr(lboundGroup),
+            AffineMapAttr::get(
+                AffineMap::get(par.getUpperBoundsMap().getNumDims(),
+                               par.getUpperBoundsMap().getNumSymbols(), ubounds,
+                               par.getContext())),
+            b.getI32TensorAttr(uboundGroup), b.getI64ArrayAttr(steps),
+            par.getOperands());
+        Block *blk = new Block();
+        for (auto [j, idx] : llvm::enumerate(stat))
+          ivRepl[idx] = blk->addArgument(b.getIndexType(), loc);
+        inner.getRegion().push_back(blk);
+        b.setInsertionPointToEnd(blk);
+        affine::AffineYieldOp::create(b, loc);
+        target = blk;
+      } else {
+        target = b.getInsertionBlock();
+      }
+
+      Block *oldBody = par.getBody();
+      for (unsigned i = 0; i < n; ++i)
+        oldBody->getArgument(i).replaceAllUsesWith(ivRepl[i]);
+      target->getOperations().splice(std::prev(target->getOperations().end()),
+                                     oldBody->getOperations(),
+                                     oldBody->getOperations().begin(),
+                                     std::prev(oldBody->getOperations().end()));
+      par.erase();
+    }
+  }
+
   void runOnOperation() override {
     ParallelContext::Options options{enable_lockstep_for, dump_failed_lockstep,
                                      prefer_while_raising,
@@ -3567,6 +3658,11 @@ struct AffineToStableHLORaisingPass
       }
     });
 
+    // Peeling rewrites loops, so it stays scoped to the regions this pass
+    // actually raises.
+    for (auto func : funcs)
+      peelDynamicParallelDims(func);
+
     SymbolTableCollection symbolTable;
     SymbolUserMap userMap(symbolTable, op);
 
@@ -3584,6 +3680,8 @@ struct AffineToStableHLORaisingPass
     }
     std::vector<enzymexla::GPUWrapperOp> gwrap;
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
+    for (auto g : gwrap)
+      peelDynamicParallelDims(g);
     size_t raised_count = 0;
     for (auto g : gwrap) {
       auto modOp = g->getParentOfType<ModuleOp>();

--- a/test/lit_tests/raising/raise_dynamic_parallel_while.mlir
+++ b/test/lit_tests/raising/raise_dynamic_parallel_while.mlir
@@ -1,0 +1,62 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// A parallel axis whose extent is only known at runtime raises as a
+// stablehlo.while over the raised body, tagged enzymexla.parallel so
+// downstream passes know the iterations are independent.
+func.func @dynkern(%out: memref<100xf64, 1>, %nbuf: memref<i64, 1>) {
+  %n = affine.load %nbuf[] : memref<i64, 1>
+  %ni = arith.index_cast %n : i64 to index
+  affine.parallel (%i) = (0) to (symbol(%ni)) {
+    %iv = arith.index_castui %i : index to i64
+    %v = arith.sitofp %iv : i64 to f64
+    affine.store %v, %out[%i] : memref<100xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @dynkern_raised(
+// CHECK-SAME: %[[OUT:.+]]: tensor<100xf64>, %[[N:.+]]: tensor<i64>
+// CHECK: %[[WHILE:.+]]:3 = stablehlo.while(%[[IV:.+]] = %{{.+}}, %[[BUF:.+]] = %[[OUT]], %{{.+}} = %[[N]]) : tensor<i64>, tensor<100xf64>, tensor<i64> attributes {enzymexla.parallel}
+// CHECK: cond {
+// CHECK: stablehlo.compare LT, %[[IV]], %{{.+}} : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK: } do {
+// CHECK: %[[V:.+]] = stablehlo.broadcast_in_dim %{{.+}}, dims = [] : (tensor<f64>) -> tensor<1xf64>
+// CHECK: stablehlo.dynamic_update_slice %[[BUF]], %[[V]], %[[IV]] : (tensor<100xf64>, tensor<1xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK: return %[[WHILE]]#1, %[[WHILE]]#2 : tensor<100xf64>, tensor<i64>
+
+// -----
+
+// Mixed extents: the static axis stays batched inside the while body, only
+// the dynamic axis is peeled into the while.
+func.func @mixed(%out: memref<16x100xf64, 1>, %nbuf: memref<i64, 1>) {
+  %n = affine.load %nbuf[] : memref<i64, 1>
+  %ni = arith.index_cast %n : i64 to index
+  affine.parallel (%e, %j) = (0, 0) to (symbol(%ni), 16) {
+    %iv = arith.index_castui %j : index to i64
+    %v = arith.sitofp %iv : i64 to f64
+    affine.store %v, %out[%j, %e] : memref<16x100xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @mixed_raised(
+// CHECK: %[[W:.+]]:3 = stablehlo.while(%[[IV:.+]] = %{{.+}}, %[[BUF:.+]] = %{{.+}}, %{{.+}} = %{{.+}}) : tensor<i64>, tensor<16x100xf64>, tensor<i64> attributes {enzymexla.parallel}
+// CHECK: } do {
+// CHECK: %[[UPD:.+]] = stablehlo.broadcast_in_dim %{{.+}}, dims = [0] : (tensor<16xf64>) -> tensor<16x1xf64>
+// CHECK: stablehlo.dynamic_update_slice %[[BUF]], %[[UPD]], %{{.+}}, %[[IV]] : (tensor<16x100xf64>, tensor<16x1xf64>, tensor<i64>, tensor<i64>) -> tensor<16x100xf64>
+
+// -----
+
+// A dynamic parallel loop outside any raised region is left untouched: the
+// peel only applies where raising will consume the result.
+func.func @host(%out: memref<100xf64, 1>, %n: index) -> index {
+  affine.parallel (%i) = (0) to (%n) {
+    %c = arith.constant 1.0 : f64
+    affine.store %c, %out[%i] : memref<100xf64, 1>
+  }
+  return %n : index
+}
+
+// CHECK-LABEL: func.func @host(
+// CHECK: affine.parallel
+// CHECK-NOT: enzymexla.parallel


### PR DESCRIPTION
On top of #2954 (sequential-for while raising): a parallel dimension whose extent is only known at runtime cannot become a static tensor axis, so it is peeled into an enclosing `affine.for` tagged `enzymexla.parallel`; the tag rides onto the raised `stablehlo.while` so downstream passes still know the iterations are independent. Mixed static/dynamic extents keep the static axes batched inside the while body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD