### PR TITLE
Flatten viewed shared-memory scratch so raising sees plain accesses

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3698,10 +3698,17 @@ struct AffineToStableHLORaisingPass
       auto MT = alloca.getType();
       if (!MT.hasStaticShape())
         continue;
-      SmallVector<enzymexla::Pointer2MemrefOp> views;
-      SmallVector<enzymexla::Memref2PointerOp> casts;
+      // Views reach the scratch through chains of address-space casts and
+      // constant-offset geps; each view carries the byte offset its chain
+      // accumulated.
+      SmallVector<std::pair<enzymexla::Pointer2MemrefOp, int64_t>> views;
+      SmallVector<Operation *> chainOps;
       SmallVector<Operation *> directAccesses;
       bool viewedOnly = true;
+      if (!MT.getElementType().isIntOrFloat())
+        continue;
+      int64_t elemBytes = (MT.getElementType().getIntOrFloatBitWidth() + 7) / 8;
+      SmallVector<std::pair<Value, int64_t>> ptrWork;
       for (Operation *user : alloca->getUsers()) {
         auto m2p = dyn_cast<enzymexla::Memref2PointerOp>(user);
         if (!m2p) {
@@ -3721,36 +3728,110 @@ struct AffineToStableHLORaisingPass
           viewedOnly = false;
           break;
         }
-        casts.push_back(m2p);
-        for (Operation *viewUser : m2p->getUsers()) {
+        chainOps.push_back(m2p);
+        ptrWork.push_back({m2p.getResult(), 0});
+      }
+      while (viewedOnly && !ptrWork.empty()) {
+        auto [ptr, off] = ptrWork.pop_back_val();
+        for (Operation *viewUser : ptr.getUsers()) {
+          if (isa<LLVM::AddrSpaceCastOp>(viewUser)) {
+            chainOps.push_back(viewUser);
+            ptrWork.push_back({viewUser->getResult(0), off});
+            continue;
+          }
+          if (auto gep = dyn_cast<LLVM::GEPOp>(viewUser)) {
+            // Only all-constant geps carry a static byte offset.
+            int64_t gepOff = 0;
+            bool constGep =
+                gep.getDynamicIndices().empty() && gep.getIndices().size() >= 1;
+            if (constGep) {
+              DataLayout dl = DataLayout::closest(gep);
+              Type cur = gep.getElemType();
+              auto idxs = gep.getIndices();
+              gepOff = cast<IntegerAttr>(idxs[0]).getInt() *
+                       (int64_t)dl.getTypeSize(cur);
+              for (unsigned i = 1; constGep && i < idxs.size(); ++i) {
+                int64_t want = cast<IntegerAttr>(idxs[i]).getInt();
+                if (auto AT = dyn_cast<LLVM::LLVMArrayType>(cur)) {
+                  cur = AT.getElementType();
+                  gepOff += want * (int64_t)dl.getTypeSize(cur);
+                } else {
+                  constGep = false;
+                }
+              }
+            }
+            if (!constGep) {
+              viewedOnly = false;
+              break;
+            }
+            chainOps.push_back(gep);
+            ptrWork.push_back({gep.getResult(), off + gepOff});
+            continue;
+          }
           auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(viewUser);
           if (!p2m || p2m.getType().getRank() != 1 ||
               p2m.getType().getElementType() != MT.getElementType() ||
+              off % elemBytes != 0 ||
               (p2m.getType().hasStaticShape() &&
-               p2m.getType().getShape()[0] > MT.getNumElements())) {
+               off / elemBytes + p2m.getType().getShape()[0] >
+                   MT.getNumElements())) {
             viewedOnly = false;
             break;
           }
-          views.push_back(p2m);
+          if (off != 0) {
+            // Offset views only rewrite through plain accesses.
+            if (!llvm::all_of(p2m->getUsers(), [&](Operation *u) {
+                  if (isa<affine::AffineLoadOp, memref::LoadOp>(u))
+                    return u->getOperand(0) == p2m.getResult();
+                  if (isa<affine::AffineStoreOp, memref::StoreOp>(u))
+                    return u->getOperand(1) == p2m.getResult();
+                  return false;
+                })) {
+              viewedOnly = false;
+              break;
+            }
+          }
+          views.push_back({p2m, off / elemBytes});
         }
-        if (!viewedOnly)
-          break;
       }
       if (!viewedOnly || views.empty())
         continue;
       OpBuilder b(alloca);
       auto flatTy = MemRefType::get({MT.getNumElements()}, MT.getElementType());
       auto flat = memref::AllocaOp::create(b, alloca.getLoc(), flatTy);
-      for (auto p2m : views) {
+      for (auto [p2m, elemOff] : views) {
+        if (elemOff != 0) {
+          for (Operation *u : llvm::make_early_inc_range(p2m->getUsers())) {
+            if (auto ld = dyn_cast<affine::AffineLoadOp>(u)) {
+              auto m = ld.getMap();
+              ld.setMap(AffineMap::get(m.getNumDims(), m.getNumSymbols(),
+                                       m.getResult(0) + elemOff));
+            } else if (auto st = dyn_cast<affine::AffineStoreOp>(u)) {
+              auto m = st.getMap();
+              st.setMap(AffineMap::get(m.getNumDims(), m.getNumSymbols(),
+                                       m.getResult(0) + elemOff));
+            } else {
+              OpBuilder ab(u);
+              unsigned idxPos = isa<memref::LoadOp>(u) ? 1 : 2;
+              Value c =
+                  arith::ConstantIndexOp::create(ab, u->getLoc(), elemOff);
+              Value ni = arith::AddIOp::create(ab, u->getLoc(),
+                                               u->getOperand(idxPos), c);
+              u->setOperand(idxPos, ni);
+            }
+          }
+        }
         p2m.getResult().replaceAllUsesWith(flat.getResult());
         p2m.erase();
       }
-      for (auto m2p : casts)
-        m2p.erase();
+      for (Operation *c : llvm::reverse(chainOps))
+        if (c->use_empty())
+          c->erase();
       auto linearizeValues = [&](OpBuilder &ab, Location loc,
                                  ValueRange idxs) -> Value {
         Value lin = arith::ConstantIndexOp::create(ab, loc, 0);
         int64_t stride = 1;
+        SmallVector<Value> scaled;
         for (int64_t d = MT.getRank() - 1; d >= 0; --d) {
           Value term = idxs[d];
           if (stride != 1) {

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3110,6 +3110,15 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
 
   if (auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(op)) {
     Value operand = op->getOperand(0), result = op->getResult(0);
+    // A view of a buffer that itself is raised gets a value-semantics
+    // snapshot here: a store through it would silently diverge from the
+    // base. Flattening removes the scratch chains; any store-through view
+    // that remains is unsound.
+    if (operand.getDefiningOp<enzymexla::Memref2PointerOp>())
+      for (Operation *user : result.getUsers())
+        if ((isa<affine::AffineStoreOp, memref::StoreOp>(user) &&
+             user->getOperand(1) == result))
+          return op->emitError("cannot raise a store through an aliasing view");
     auto input = mapping.lookup(operand);
     auto MT = p2m.getType();
     if (!isXLACompatiblePrimitive(MT.getElementType())) {
@@ -3696,11 +3705,18 @@ struct AffineToStableHLORaisingPass
       for (Operation *user : alloca->getUsers()) {
         auto m2p = dyn_cast<enzymexla::Memref2PointerOp>(user);
         if (!m2p) {
-          // A direct affine access can move to the flat buffer with its map
+          // A direct access can move to the flat buffer with its indexing
           // linearized; anything else keeps the chain intact.
-          if (isa<affine::AffineLoadOp, affine::AffineStoreOp>(user)) {
+          if (isa<affine::AffineLoadOp, affine::AffineStoreOp, memref::LoadOp>(
+                  user)) {
             directAccesses.push_back(user);
             continue;
+          }
+          if (auto st = dyn_cast<memref::StoreOp>(user)) {
+            if (st.getMemRef() == alloca.getResult()) {
+              directAccesses.push_back(user);
+              continue;
+            }
           }
           viewedOnly = false;
           break;
@@ -3731,7 +3747,38 @@ struct AffineToStableHLORaisingPass
       }
       for (auto m2p : casts)
         m2p.erase();
+      auto linearizeValues = [&](OpBuilder &ab, Location loc,
+                                 ValueRange idxs) -> Value {
+        Value lin = arith::ConstantIndexOp::create(ab, loc, 0);
+        int64_t stride = 1;
+        for (int64_t d = MT.getRank() - 1; d >= 0; --d) {
+          Value term = idxs[d];
+          if (stride != 1) {
+            Value c = arith::ConstantIndexOp::create(ab, loc, stride);
+            term = arith::MulIOp::create(ab, loc, term, c);
+          }
+          lin = arith::AddIOp::create(ab, loc, lin, term);
+          stride *= MT.getShape()[d];
+        }
+        return lin;
+      };
       for (Operation *access : directAccesses) {
+        if (auto mload = dyn_cast<memref::LoadOp>(access)) {
+          OpBuilder ab(mload);
+          Value lin = linearizeValues(ab, mload.getLoc(), mload.getIndices());
+          Value idxs[] = {lin};
+          mload.getMemrefMutable().assign(flat);
+          mload.getIndicesMutable().assign(idxs);
+          continue;
+        }
+        if (auto mstore = dyn_cast<memref::StoreOp>(access)) {
+          OpBuilder ab(mstore);
+          Value lin = linearizeValues(ab, mstore.getLoc(), mstore.getIndices());
+          Value idxs[] = {lin};
+          mstore.getMemrefMutable().assign(flat);
+          mstore.getIndicesMutable().assign(idxs);
+          continue;
+        }
         AffineMap oldMap = isa<affine::AffineLoadOp>(access)
                                ? cast<affine::AffineLoadOp>(access).getMap()
                                : cast<affine::AffineStoreOp>(access).getMap();

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3677,6 +3677,85 @@ struct AffineToStableHLORaisingPass
     }
   }
 
+  // Shared-memory scratch arrives as a static alloca viewed through a
+  // memref2pointer/pointer2memref round trip that changes shape and address
+  // space, which no access-based raising can see through. When the alloca is
+  // only ever read and written through such flat views, replace the whole
+  // chain with one flat static alloca the raising handles directly.
+  static void flattenViewedScratch(Operation *root) {
+    SmallVector<memref::AllocaOp> allocas;
+    root->walk([&](memref::AllocaOp a) { allocas.push_back(a); });
+    for (auto alloca : allocas) {
+      auto MT = alloca.getType();
+      if (!MT.hasStaticShape())
+        continue;
+      SmallVector<enzymexla::Pointer2MemrefOp> views;
+      SmallVector<enzymexla::Memref2PointerOp> casts;
+      SmallVector<Operation *> directAccesses;
+      bool viewedOnly = true;
+      for (Operation *user : alloca->getUsers()) {
+        auto m2p = dyn_cast<enzymexla::Memref2PointerOp>(user);
+        if (!m2p) {
+          // A direct affine access can move to the flat buffer with its map
+          // linearized; anything else keeps the chain intact.
+          if (isa<affine::AffineLoadOp, affine::AffineStoreOp>(user)) {
+            directAccesses.push_back(user);
+            continue;
+          }
+          viewedOnly = false;
+          break;
+        }
+        casts.push_back(m2p);
+        for (Operation *viewUser : m2p->getUsers()) {
+          auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(viewUser);
+          if (!p2m || p2m.getType().getRank() != 1 ||
+              p2m.getType().getElementType() != MT.getElementType() ||
+              (p2m.getType().hasStaticShape() &&
+               p2m.getType().getShape()[0] > MT.getNumElements())) {
+            viewedOnly = false;
+            break;
+          }
+          views.push_back(p2m);
+        }
+        if (!viewedOnly)
+          break;
+      }
+      if (!viewedOnly || views.empty())
+        continue;
+      OpBuilder b(alloca);
+      auto flatTy = MemRefType::get({MT.getNumElements()}, MT.getElementType());
+      auto flat = memref::AllocaOp::create(b, alloca.getLoc(), flatTy);
+      for (auto p2m : views) {
+        p2m.getResult().replaceAllUsesWith(flat.getResult());
+        p2m.erase();
+      }
+      for (auto m2p : casts)
+        m2p.erase();
+      for (Operation *access : directAccesses) {
+        AffineMap oldMap = isa<affine::AffineLoadOp>(access)
+                               ? cast<affine::AffineLoadOp>(access).getMap()
+                               : cast<affine::AffineStoreOp>(access).getMap();
+        AffineExpr lin = getAffineConstantExpr(0, oldMap.getContext());
+        int64_t stride = 1;
+        for (int64_t d = MT.getRank() - 1; d >= 0; --d) {
+          lin = lin + oldMap.getResult(d) * stride;
+          stride *= MT.getShape()[d];
+        }
+        auto linMap =
+            AffineMap::get(oldMap.getNumDims(), oldMap.getNumSymbols(), lin);
+        if (auto load = dyn_cast<affine::AffineLoadOp>(access)) {
+          load.setMap(linMap);
+          load.getMemrefMutable().assign(flat);
+        } else {
+          auto store = cast<affine::AffineStoreOp>(access);
+          store.setMap(linMap);
+          store.getMemrefMutable().assign(flat);
+        }
+      }
+      alloca.erase();
+    }
+  }
+
   void runOnOperation() override {
     ParallelContext::Options options{enable_lockstep_for, dump_failed_lockstep,
                                      prefer_while_raising,
@@ -3715,6 +3794,7 @@ struct AffineToStableHLORaisingPass
     // actually raises.
     for (auto func : funcs) {
       stripAccessMemorySpaceCasts(func);
+      flattenViewedScratch(func);
       peelDynamicParallelDims(func);
     }
 
@@ -3737,6 +3817,7 @@ struct AffineToStableHLORaisingPass
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
       stripAccessMemorySpaceCasts(g);
+      flattenViewedScratch(g);
       peelDynamicParallelDims(g);
     }
     size_t raised_count = 0;

--- a/test/lit_tests/raising/raise_viewed_scratch.mlir
+++ b/test/lit_tests/raising/raise_viewed_scratch.mlir
@@ -67,3 +67,26 @@ func.func @direct_mix(%out: memref<32xf64, 1>) {
 }
 
 // CHECK-LABEL: func.func private @direct_mix_raised(
+
+// -----
+
+// Views can reach the scratch through an address-space cast and a
+// constant-offset gep; the accumulated byte offset folds into the access
+// indices of the flat buffer.
+func.func @offsetview(%out: memref<8xf64, 1>, %in: memref<8xf64, 1>) {
+  %scr = memref.alloca() : memref<16xf64>
+  %ptr = "enzymexla.memref2pointer"(%scr) : (memref<16xf64>) -> !llvm.ptr<3>
+  %gp = llvm.addrspacecast %ptr : !llvm.ptr<3> to !llvm.ptr
+  %off = llvm.getelementptr inbounds %gp[64] : (!llvm.ptr) -> !llvm.ptr, i8
+  affine.parallel (%t) = (0) to (8) {
+    %view = "enzymexla.pointer2memref"(%off) : (!llvm.ptr) -> memref<?xf64>
+    %v = affine.load %in[%t] : memref<8xf64, 1>
+    affine.store %v, %view[%t] : memref<?xf64>
+    %r = affine.load %view[7 - %t] : memref<?xf64>
+    affine.store %r, %out[%t] : memref<8xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @offsetview_raised(
+// CHECK: stablehlo.reverse

--- a/test/lit_tests/raising/raise_viewed_scratch.mlir
+++ b/test/lit_tests/raising/raise_viewed_scratch.mlir
@@ -1,0 +1,48 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// Shared-memory scratch: a static alloca only accessed through a
+// shape-and-address-space-changing memref2pointer/pointer2memref round trip
+// flattens to one static alloca, which raises as a zero-initialized tensor.
+func.func @kern(%out: memref<32xf64, 1>) {
+  affine.parallel (%i) = (0) to (32) {
+    %a = memref.alloca() : memref<32x1xf64>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<32x1xf64>) -> !llvm.ptr<3>
+    %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64, 3>
+    %c = arith.constant 3.0 : f64
+    affine.store %c, %v[%i] : memref<?xf64, 3>
+    %r = affine.load %v[%i] : memref<?xf64, 3>
+    affine.store %r, %out[%i] : memref<32xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @kern_raised(
+// CHECK-SAME: %[[OUT:.+]]: tensor<32xf64>
+// CHECK: %[[ZERO:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<32xf64>
+// CHECK: stablehlo.dynamic_update_slice %[[ZERO]], %{{.+}} : (tensor<32xf64>, tensor<32xf64>, tensor<i64>) -> tensor<32xf64>
+
+// -----
+
+// A direct affine access moves onto the flat buffer with its map linearized,
+// so a store through the alloca stays visible to a read through the view.
+func.func @mixed_use(%out: memref<32xf64, 1>) {
+  affine.parallel (%i) = (0) to (32) {
+    %a = memref.alloca() : memref<32xf64>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<32xf64>) -> !llvm.ptr<3>
+    %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64, 3>
+    %c = arith.constant 3.0 : f64
+    affine.store %c, %a[%i] : memref<32xf64>
+    %r = affine.load %v[%i] : memref<?xf64, 3>
+    affine.store %r, %out[%i] : memref<32xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @mixed_use_raised(
+// CHECK-SAME: %[[OUT2:.+]]: tensor<32xf64>
+// CHECK: %[[Z:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<32xf64>
+// CHECK: %[[ST:.+]] = stablehlo.dynamic_update_slice %[[Z]], %{{.+}} : (tensor<32xf64>, tensor<32xf64>, tensor<i64>) -> tensor<32xf64>
+// CHECK: %[[RD:.+]] = stablehlo.reshape %[[ST]] : (tensor<32xf64>) -> tensor<32xf64>
+// CHECK: %[[BC:.+]] = stablehlo.broadcast_in_dim %[[RD]], dims = [0]
+// CHECK: stablehlo.dynamic_update_slice %[[OUT2]], %[[BC]], %{{.+}} : (tensor<32xf64>, tensor<32xf64>, tensor<i64>) -> tensor<32xf64>
+

--- a/test/lit_tests/raising/raise_viewed_scratch.mlir
+++ b/test/lit_tests/raising/raise_viewed_scratch.mlir
@@ -46,3 +46,24 @@ func.func @mixed_use(%out: memref<32xf64, 1>) {
 // CHECK: %[[BC:.+]] = stablehlo.broadcast_in_dim %[[RD]], dims = [0]
 // CHECK: stablehlo.dynamic_update_slice %[[OUT2]], %[[BC]], %{{.+}} : (tensor<32xf64>, tensor<32xf64>, tensor<i64>) -> tensor<32xf64>
 
+
+// -----
+
+// The scratch reaches one access directly as a plain memref.load next to the
+// viewed accesses: it moves to the flat buffer with its indexing linearized
+// instead of keeping the whole chain opaque.
+func.func @direct_mix(%out: memref<32xf64, 1>) {
+  affine.parallel (%i) = (0) to (32) {
+    %scr = memref.alloca() : memref<32xf64>
+    %p = "enzymexla.memref2pointer"(%scr) : (memref<32xf64>) -> !llvm.ptr<3>
+    %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64, 3>
+    %c = arith.constant 3.0 : f64
+    affine.store %c, %v[%i] : memref<?xf64, 3>
+    %idx = arith.constant 0 : index
+    %r = memref.load %scr[%idx] : memref<32xf64>
+    affine.store %r, %out[%i] : memref<32xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @direct_mix_raised(


### PR DESCRIPTION
Shared-memory scratch arrives as a static alloca viewed through a `memref2pointer`/`pointer2memref` round trip that changes shape and address space, which no access-based raising can see through. When the alloca is only read and written through such flat views (or direct affine accesses, which move over with their maps linearized), the chain is replaced with one flat static alloca the raising handles directly — scoped to the regions the pass raises.

Now just the flattening, independent of the other pieces split from the original PR: barrier no-op (#2959, merged), broadcast-store mask or-reduce (#2960), uniform buffer select (#2962).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD