### PR TITLE
Fold comparisons using loop bounds

### DIFF
--- a/src/enzyme_ad/jax/Passes/ArithRaising.cpp
+++ b/src/enzyme_ad/jax/Passes/ArithRaising.cpp
@@ -507,10 +507,7 @@ struct RaiseCmpI : public OpRewritePattern<arith::CmpIOp> {
     // Booleans (i1) and unsigned integers lower to PRED/unsigned HLO types,
     // which require an UNSIGNED comparison type regardless of the predicate.
     auto elemType = operandType.getElementType();
-    bool unsignedPredicate = predicate == arith::CmpIPredicate::ugt ||
-                             predicate == arith::CmpIPredicate::uge ||
-                             predicate == arith::CmpIPredicate::ult ||
-                             predicate == arith::CmpIPredicate::ule;
+    bool unsignedPredicate = isUnsignedPredicate(predicate);
     stablehlo::ComparisonType compType =
         (unsignedPredicate || elemType.isUnsignedInteger() ||
          elemType.isInteger(1))

--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -10,7 +10,10 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/IntegerSet.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
+#include "src/enzyme_ad/jax/Utils.h"
+#include "llvm/ADT/ScopeExit.h"
 
 #include <isl/aff.h>
 #include <isl/aff_type.h>
@@ -1185,6 +1188,300 @@ LogicalResult pruneParallelBounds(IslAnalysis &islAnalysis,
   return success();
 }
 
+// The domain of the affine loop and conditional structure around an
+// operation, for the folds below.
+//
+// A domain is the `getDomain` set above (the enclosing affine.for/parallel
+// bounds and affine.if integer sets, conditions that do not convert dropped):
+// one set dimension per induction variable, one parameter per symbol the
+// bounds and conditions depend on. On top of that, every symbol is composed
+// through the arithmetic defining it, as `pruneBoundMap` composes bound
+// operands, and equated with the composition; the values composition stops at
+// are further parameters. A queried value composes the same way, so
+// `blockIdx + gridDim` compared against an extent whose bound shares
+// `gridDim`'s base meets the bound on `blockIdx` in the same parameters.
+//
+// Built per query, as the access simplifications above build theirs: the
+// patterns run under drivers with and without a listener.
+namespace {
+class LoopDomain {
+public:
+  // The domain of the operations in `op`'s block; false when no affine op
+  // encloses the block or its structure does not convert.
+  LoopDomain(isl_ctx *ctx, Operation *op);
+  ~LoopDomain() { isl_set_free(set); }
+  LoopDomain(const LoopDomain &) = delete;
+  LoopDomain &operator=(const LoopDomain &) = delete;
+  explicit operator bool() const { return set != nullptr; }
+
+  // The results of `map` on `operands` as expressions over the dimensions and
+  // parameters of the domain, each operand composed through the arithmetic
+  // defining it; a value composition stops at that is not an induction
+  // variable or a known parameter becomes a new parameter. A value keyed in
+  // `substitution` reads as the value it maps to. Fails when the composition
+  // could not run to completion.
+  FailureOr<SmallVector<AffineExpr>>
+  compose(AffineMap map, ValueRange operands,
+          const DenseMap<Value, Value> *substitution = nullptr);
+
+  // `exprs` over the dimensions and parameters of the domain as isl functions.
+  // Fails when some expression has no affine form (a modulo by a
+  // non-constant). The caller frees the functions.
+  FailureOr<SmallVector<isl_aff *>> getAffs(ArrayRef<AffineExpr> exprs);
+
+  // `values` composed as `compose` describes, as isl functions.
+  FailureOr<SmallVector<isl_aff *>>
+  getAffs(ArrayRef<Value> values,
+          const DenseMap<Value, Value> *substitution = nullptr) {
+    SmallVector<AffineExpr> exprs;
+    for (Value value : values) {
+      FailureOr<AffineExpr> expr = compose(value, substitution);
+      if (failed(expr))
+        return failure();
+      exprs.push_back(*expr);
+    }
+    return getAffs(exprs);
+  }
+
+  // Whether `other` has no point in the domain.
+  bool emptyOnDomain(__isl_take isl_set *other) const {
+    isl_set *inDomain = isl_set_intersect(isl_set_copy(set), other);
+    bool empty = isl_set_is_empty(inDomain) == isl_bool_true;
+    isl_set_free(inDomain);
+    return empty;
+  }
+
+  // Whether `aff` is non-negative on every point of the domain.
+  bool nonNegOnDomain(__isl_keep isl_aff *aff) const {
+    isl_aff *zero = isl_aff_val_on_domain(isl_aff_get_domain_local_space(aff),
+                                          isl_val_zero(ctx));
+    return emptyOnDomain(isl_aff_lt_set(isl_aff_copy(aff), zero));
+  }
+
+  // Set dimensions are the induction variables, parameters the symbols and
+  // the values compositions stopped at.
+  isl_set *set = nullptr;
+
+private:
+  // `value` composed as `compose` describes.
+  FailureOr<AffineExpr> compose(Value value,
+                                const DenseMap<Value, Value> *substitution) {
+    AffineMap map =
+        AffineMap::get(0, 1, getAffineSymbolExpr(0, value.getContext()));
+    FailureOr<SmallVector<AffineExpr>> exprs =
+        compose(map, value, substitution);
+    if (failed(exprs))
+      return failure();
+    return (*exprs)[0];
+  }
+
+  isl_ctx *ctx;
+  // Induction variable to set dimension.
+  DenseMap<Value, unsigned> dimPos;
+  // Symbol or leaf value to parameter.
+  DenseMap<Value, unsigned> paramPos;
+  // The affine scope compositions stay within.
+  Region *scope = nullptr;
+};
+
+LoopDomain::LoopDomain(isl_ctx *ctx, Operation *op) : ctx(ctx) {
+  SmallVector<Operation *> enclosing;
+  affine::getEnclosingAffineOps(*op, &enclosing);
+  scope = getLocalAffineScope(op);
+  if (enclosing.empty() || !scope)
+    return;
+  auto [domain, cst] = ::getDomain(ctx, op, /*overApproximationAllowed=*/true);
+  if (!domain)
+    return;
+  set = domain;
+
+  unsigned numDims = cst.getNumDimVars();
+  for (unsigned pos : llvm::seq(numDims))
+    dimPos[cst.getValue(pos)] = pos;
+  for (auto [pos, symbol] :
+       llvm::enumerate(cst.getMaybeValues(presburger::VarKind::Symbol)))
+    if (symbol)
+      paramPos[*symbol] = pos;
+
+  // Tie each symbol to what it composes to. A symbol composition stops at, or
+  // fails on, is its own parameter and gets no tie. Compose everything before
+  // converting: compositions add parameters, and the conversion works in the
+  // final space.
+  SmallVector<std::pair<Value, unsigned>> symbols(paramPos.begin(),
+                                                  paramPos.end());
+  SmallVector<std::pair<unsigned, AffineExpr>> symbolExprs;
+  for (auto [symbol, pos] : symbols)
+    if (FailureOr<AffineExpr> expr = compose(symbol, /*substitution=*/nullptr);
+        succeeded(expr))
+      symbolExprs.emplace_back(pos, *expr);
+  isl_local_space *localSpace =
+      isl_local_space_from_space(isl_set_get_space(set));
+  llvm::scope_exit freeLocalSpace([&] { isl_local_space_free(localSpace); });
+  AffineExprToIslAffConverter converter{{}, {}, localSpace, ctx};
+  for (unsigned pos : llvm::seq(numDims))
+    converter.dimPosMap[pos] = pos;
+  for (unsigned pos : llvm::seq(isl_set_dim(set, isl_dim_param)))
+    converter.symPosMap[pos] = pos;
+  for (auto [pos, expr] : symbolExprs) {
+    if (expr == getAffineSymbolExpr(pos, expr.getContext()))
+      continue;
+    isl_aff *composedAff = converter.getIslAff(expr);
+    if (!composedAff)
+      continue;
+    isl_aff *symbolAff = isl_aff_var_on_domain(isl_local_space_copy(localSpace),
+                                               isl_dim_param, pos);
+    set = isl_set_intersect(set, isl_aff_eq_set(symbolAff, composedAff));
+  }
+}
+
+FailureOr<SmallVector<AffineExpr>>
+LoopDomain::compose(AffineMap map, ValueRange operands,
+                    const DenseMap<Value, Value> *substitution) {
+  MLIRContext *mlirCtx = map.getContext();
+  SmallVector<Value> composedOperands(operands);
+  // Without a rewriter the composition stops at an operand it would have to
+  // hoist (see composeAffineMapAndOperands).
+  if (!fully2ComposeAffineMapAndOperands(&map, &composedOperands, scope,
+                                         /*throughSymbols=*/true))
+    return failure();
+  SmallVector<AffineExpr> dimReplacements, symbolReplacements;
+  for (auto [index, operand] : llvm::enumerate(composedOperands)) {
+    AffineExpr replacement;
+    auto dim = dimPos.find(operand);
+    if (dim != dimPos.end()) {
+      replacement = getAffineDimExpr(dim->second, mlirCtx);
+    } else if (substitution && substitution->contains(operand)) {
+      FailureOr<AffineExpr> composed =
+          compose(substitution->lookup(operand), substitution);
+      if (failed(composed))
+        return failure();
+      replacement = *composed;
+    } else {
+      auto param = paramPos.find(operand);
+      if (param == paramPos.end()) {
+        unsigned pos = isl_set_dim(set, isl_dim_param);
+        set = isl_set_add_dims(set, isl_dim_param, 1);
+        param = paramPos.try_emplace(operand, pos).first;
+      }
+      replacement = getAffineSymbolExpr(param->second, mlirCtx);
+    }
+    (index < map.getNumDims() ? dimReplacements : symbolReplacements)
+        .push_back(replacement);
+  }
+  SmallVector<AffineExpr> exprs;
+  for (AffineExpr result : map.getResults())
+    exprs.push_back(
+        result.replaceDimsAndSymbols(dimReplacements, symbolReplacements));
+  return exprs;
+}
+
+FailureOr<SmallVector<isl_aff *>>
+LoopDomain::getAffs(ArrayRef<AffineExpr> exprs) {
+  isl_local_space *localSpace =
+      isl_local_space_from_space(isl_set_get_space(set));
+  llvm::scope_exit freeLocalSpace([&] { isl_local_space_free(localSpace); });
+  AffineExprToIslAffConverter converter{{}, {}, localSpace, ctx};
+  for (unsigned pos : llvm::seq(isl_set_dim(set, isl_dim_set)))
+    converter.dimPosMap[pos] = pos;
+  for (unsigned pos : llvm::seq(isl_set_dim(set, isl_dim_param)))
+    converter.symPosMap[pos] = pos;
+  SmallVector<isl_aff *> affs;
+  for (AffineExpr expr : exprs)
+    affs.push_back(converter.getIslAff(expr));
+  if (llvm::is_contained(affs, nullptr)) {
+    for (isl_aff *aff : affs)
+      isl_aff_free(aff);
+    return failure();
+  }
+  return affs;
+}
+
+// The points where `lhs pred rhs` holds; isl compares integers, so an
+// unsigned predicate fails.
+FailureOr<isl_set *> comparisonSet(arith::CmpIPredicate pred,
+                                   __isl_take isl_aff *lhs,
+                                   __isl_take isl_aff *rhs) {
+  using Pred = arith::CmpIPredicate;
+  switch (pred) {
+  case Pred::eq:
+    return isl_aff_eq_set(lhs, rhs);
+  case Pred::ne:
+    return isl_aff_ne_set(lhs, rhs);
+  case Pred::slt:
+    return isl_aff_lt_set(lhs, rhs);
+  case Pred::sle:
+    return isl_aff_le_set(lhs, rhs);
+  case Pred::sgt:
+    return isl_aff_gt_set(lhs, rhs);
+  case Pred::sge:
+    return isl_aff_ge_set(lhs, rhs);
+  case Pred::ult:
+  case Pred::ule:
+  case Pred::ugt:
+  case Pred::uge:
+    break;
+  }
+  isl_aff_free(lhs);
+  isl_aff_free(rhs);
+  return failure();
+}
+
+// Fold an integer comparison to a constant when the enclosing affine loop
+// bounds already decide it — e.g. a peeled grid-stride residual's guard
+// (blockIdx + gridDim compared against an extent sharing gridDim's base) or
+// a thread-id test under a constant-extent axis. As elsewhere in this pass,
+// values are mathematical integers (no wraparound); unsigned predicates are
+// only folded when both sides are provably non-negative on the domain.
+struct FoldCmpUsingLoopBounds : public OpRewritePattern<arith::CmpIOp> {
+  IslAnalysis &islAnalysis;
+  FoldCmpUsingLoopBounds(MLIRContext &context, IslAnalysis &islAnalysis)
+      : OpRewritePattern<arith::CmpIOp>(&context), islAnalysis(islAnalysis) {}
+
+  LogicalResult matchAndRewrite(arith::CmpIOp cmp,
+                                PatternRewriter &rewriter) const override {
+    arith::CmpIPredicate pred = cmp.getPredicate();
+    LoopDomain domain(islAnalysis.getCtx(), cmp);
+    if (!domain)
+      return failure();
+    FailureOr<SmallVector<isl_aff *>> affs =
+        domain.getAffs({cmp.getLhs(), cmp.getRhs()});
+    if (failed(affs))
+      return failure();
+    isl_aff *lhsAff = (*affs)[0], *rhsAff = (*affs)[1];
+    llvm::scope_exit freeAffs([&] {
+      isl_aff_free(lhsAff);
+      isl_aff_free(rhsAff);
+    });
+    if (mlir::enzyme::isUnsignedPredicate(pred)) {
+      if (!(domain.nonNegOnDomain(lhsAff) && domain.nonNegOnDomain(rhsAff)))
+        return failure();
+      pred = mlir::enzyme::signedPredicate(pred);
+    }
+
+    FailureOr<isl_set *> fails =
+        comparisonSet(arith::invertPredicate(pred), isl_aff_copy(lhsAff),
+                      isl_aff_copy(rhsAff));
+    FailureOr<isl_set *> holds =
+        comparisonSet(pred, isl_aff_copy(lhsAff), isl_aff_copy(rhsAff));
+    if (failed(fails) || failed(holds)) {
+      if (succeeded(fails))
+        isl_set_free(*fails);
+      if (succeeded(holds))
+        isl_set_free(*holds);
+      return failure();
+    }
+    bool alwaysTrue = domain.emptyOnDomain(*fails);
+    bool alwaysFalse = domain.emptyOnDomain(*holds);
+    if (!alwaysTrue && !alwaysFalse)
+      return failure();
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+        cmp, rewriter.getBoolAttr(alwaysTrue));
+    return success();
+  }
+};
+
+} // namespace
+
 struct SimplifyAffineExprsPass
     : public enzyme::impl::SimplifyAffineExprsPassBase<
           SimplifyAffineExprsPass> {
@@ -1193,21 +1490,13 @@ struct SimplifyAffineExprsPass
     IslAnalysis ia;
 
     Operation *op = getOperation();
-    IRRewriter rewriter(op->getContext());
-    op->walk([&](Operation *op) {
-      if (auto cop = dyn_cast<AffineLoadOp>(op))
-        (void)handleAffineAccessOp(ia, cop);
-      else if (auto cop = dyn_cast<AffineStoreOp>(op))
-        (void)handleAffineAccessOp(ia, cop);
-      else if (auto cop = dyn_cast<AffineVectorLoadOp>(op))
-        (void)handleAffineAccessOp(ia, cop);
-      else if (auto cop = dyn_cast<AffineVectorStoreOp>(op))
-        (void)handleAffineAccessOp(ia, cop);
-      else if (auto cop = dyn_cast<AffineIfOp>(op))
-        (void)handleAffineIfOp(ia, cop);
-      else if (auto cop = dyn_cast<AffineParallelOp>(op))
-        (void)pruneParallelBounds(ia, cop, rewriter);
-    });
+    // Constants stay where they are.
+    RewritePatternSet patterns(op->getContext());
+    populateAffineExprSimplificationPatterns(ia, patterns);
+    GreedyRewriteConfig config;
+    config.enableConstantCSE(false);
+    if (failed(applyPatternsGreedily(op, std::move(patterns), config)))
+      signalPassFailure();
   }
 };
 
@@ -1255,7 +1544,8 @@ void mlir::populateAffineExprSimplificationPatterns(
     SimplifyAccessAffineExprs<affine::AffineVectorLoadOp>,
     SimplifyAccessAffineExprs<affine::AffineVectorStoreOp>,
     SimplifyIfAffineExprs,
-    PruneParallelBounds
+    PruneParallelBounds,
+    FoldCmpUsingLoopBounds
   >(*patterns.getContext(), islAnalysis);
   // clang-format on
 }

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -1065,6 +1065,36 @@ static arith::CmpIPredicate swapPredicate(arith::CmpIPredicate pred) {
   llvm_unreachable("unknown cmpi predicate kind");
 }
 
+/// Whether the predicate compares its operands as unsigned integers.
+static bool isUnsignedPredicate(arith::CmpIPredicate pred) {
+  switch (pred) {
+  case arith::CmpIPredicate::ult:
+  case arith::CmpIPredicate::ule:
+  case arith::CmpIPredicate::ugt:
+  case arith::CmpIPredicate::uge:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/// The signed predicate comparing the same way as `pred`; the same as `pred`
+/// on values both known non-negative.
+static arith::CmpIPredicate signedPredicate(arith::CmpIPredicate pred) {
+  switch (pred) {
+  case arith::CmpIPredicate::ult:
+    return arith::CmpIPredicate::slt;
+  case arith::CmpIPredicate::ule:
+    return arith::CmpIPredicate::sle;
+  case arith::CmpIPredicate::ugt:
+    return arith::CmpIPredicate::sgt;
+  case arith::CmpIPredicate::uge:
+    return arith::CmpIPredicate::sge;
+  default:
+    return pred;
+  }
+}
+
 SmallVector<int64_t> findReshapeInsertionDims(RankedTensorType inputType,
                                               RankedTensorType outputType);
 SmallVector<int64_t> findReshapeInsertionDims(ArrayRef<int64_t> inputShape,

--- a/test/lit_tests/affine_if_recreate.mlir
+++ b/test/lit_tests/affine_if_recreate.mlir
@@ -18,7 +18,7 @@ func.func @under_loop(%n: index, %m: index, %out: memref<?xf64>, %v: f64) {
   return
 }
 
-// CHECK-DAG: #[[MOD:.+]] = affine_set<(d0)[s0] : ((s0 * 5 + 3) mod 2 - 1 >= 0)>
+// CHECK-DAG: #[[MOD:.+]] = affine_set<()[s0] : ((s0 * 5 + 3) mod 2 - 1 >= 0)>
 // CHECK-DAG: #[[SUM:.+]] = affine_set<(d0)[s0] : (d0 + s0 * 3 - 1 >= 0)>
 // CHECK-DAG: #[[DIV:.+]] = affine_set<(d0)[s0, s1] : ((d0 + 1) floordiv 4 + -s0 + s1 * 2 + 2 == 0)>
 // CHECK-LABEL: func.func @under_loop(
@@ -36,6 +36,6 @@ func.func @top(%n: index, %i: index, %out: memref<?xf64>, %v: f64) {
   return
 }
 
-// CHECK: #[[TOP:.+]] = affine_set<(d0)[s0] : (d0 + s0 floordiv 4 - 1 >= 0)>
+// CHECK: #[[TOP:.+]] = affine_set<()[s0, s1] : (s1 + s0 floordiv 4 - 1 >= 0)>
 // CHECK-LABEL: func.func @top(
 // CHECK: affine.if #[[TOP]](

--- a/test/lit_tests/parallel_bound_cmp_fold.mlir
+++ b/test/lit_tests/parallel_bound_cmp_fold.mlir
@@ -1,0 +1,143 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(simplify-affine-exprs)" --split-input-file %s | FileCheck %s
+// RUN: enzymexlamlir-opt --affine-cfg --split-input-file %s | FileCheck %s --check-prefix=CFG
+
+// The residual of a peeled grid-stride loop guards on blockIdx + gridDim < N
+// where the parallel extent and gridDim share a base: infeasible for any
+// blockIdx >= 0, so the comparison folds to false.
+func.func @gridstride(%n: index, %out: memref<?xi1>) {
+  affine.parallel (%b) = (0) to (symbol(%n)) {
+    %bi = arith.index_castui %b : index to i32
+    %ni = arith.index_castui %n : index to i32
+    %e1 = arith.addi %bi, %ni : i32
+    %dead = arith.cmpi slt, %e1, %ni : i32
+    affine.store %dead, %out[%b] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @gridstride(
+// CHECK-NOT: arith.cmpi
+// CHECK: %[[F:.+]] = arith.constant false
+// CHECK: affine.store %[[F]],
+
+// -----
+
+// Thread-id tests under constant-extent axes fold, unsigned ones included
+// since a thread id is non-negative.
+func.func @tid(%out: memref<?xi1>) {
+  affine.parallel (%t1, %t2) = (0, 0) to (2, 2) {
+    %a = arith.index_castui %t1 : index to i32
+    %b = arith.index_castui %t2 : index to i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %x = arith.cmpi ugt, %a, %c1 : i32
+    %y = arith.cmpi ult, %b, %c2 : i32
+    %z = arith.andi %x, %y : i1
+    affine.store %z, %out[%t1 * 2 + %t2] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @tid(
+// CHECK-NOT: arith.cmpi
+
+// -----
+
+// A comparison against an unrelated symbol is not decided by the bounds and
+// must survive.
+func.func @keep(%n: index, %m: index, %out: memref<?xi1>) {
+  affine.parallel (%b) = (0) to (symbol(%n)) {
+    %bi = arith.index_castui %b : index to i32
+    %mi = arith.index_castui %m : index to i32
+    %q = arith.cmpi slt, %bi, %mi : i32
+    affine.store %q, %out[%b] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @keep(
+// CHECK: arith.cmpi slt
+
+// -----
+
+// Unsigned predicates only fold when both sides are provably non-negative on
+// the domain: a subtraction that can go negative must survive `ult`.
+func.func @unsigned_guard(%out: memref<?xi1>) {
+  affine.parallel (%t) = (0) to (8) {
+    %a = arith.index_castui %t : index to i32
+    %c4 = arith.constant 4 : i32
+    %d = arith.subi %a, %c4 : i32
+    %q = arith.cmpi ult, %d, %c4 : i32
+    affine.store %q, %out[%t] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @unsigned_guard(
+// CHECK: arith.cmpi ult
+
+// -----
+
+// The else region of a single-inequality set is its complement: there
+// n <= 0, deciding a comparison against zero.
+func.func @ifelse(%n: index, %flag: memref<?xi1>) {
+  %c0_i32 = arith.constant 0 : i32
+  affine.for %i = 0 to 4 {
+    affine.if affine_set<()[s0] : (s0 - 1 >= 0)>()[%n] {
+    } else {
+      %ni = arith.index_cast %n : index to i32
+      %pos = arith.cmpi sgt, %ni, %c0_i32 : i32
+      affine.store %pos, %flag[%i] : memref<?xi1>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @ifelse(
+// CHECK-NOT: arith.cmpi
+// CHECK: %[[F:.+]] = arith.constant false
+// CHECK: affine.store %[[F]],
+
+// -----
+
+// The else region of a multi-constraint set is a disjunction and carries no
+// usable constraint: nothing folds.
+func.func @ifelse_keep(%n: index, %m: index, %flag: memref<?xi1>) {
+  %c0_i32 = arith.constant 0 : i32
+  affine.for %i = 0 to 4 {
+    affine.if affine_set<()[s0, s1] : (s0 - 1 >= 0, s1 - 1 >= 0)>()[%n, %m] {
+    } else {
+      %ni = arith.index_cast %n : index to i32
+      %pos = arith.cmpi sgt, %ni, %c0_i32 : i32
+      affine.store %pos, %flag[%i] : memref<?xi1>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @ifelse_keep(
+// CHECK: arith.cmpi sgt
+
+// -----
+
+// Within affine-cfg the fold shares a driver with the raising: a loop the
+// raising makes affine puts its body in the domain, and the comparison
+// against its bound inside folds.
+func.func @raised(%n: index, %out: memref<?xi1>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  affine.parallel (%t) = (0) to (symbol(%n)) {
+    %ni = arith.index_castui %n : index to i32
+    scf.for %j = %c0_i32 to %ni step %c1_i32 : i32 {
+      %ji = arith.index_castui %j : i32 to index
+      %q = arith.cmpi slt, %j, %ni : i32
+      memref.store %q, %out[%ji] : memref<?xi1>
+    }
+  }
+  return
+}
+
+// CFG-LABEL: func.func @raised(
+// CFG-NOT: arith.cmpi
+// CFG: %[[T:.+]] = arith.constant true
+// CFG: affine.store %[[T]],

--- a/test/lit_tests/simplify-affine-exprs.mlir
+++ b/test/lit_tests/simplify-affine-exprs.mlir
@@ -7,6 +7,8 @@ func.func private @kern$par0(%memref_arg: memref<?x20x30xi64, 1>, %idx : index, 
     affine.store %2, %memref_arg[%arg1, %arg2 floordiv 30, %arg3 mod 30] : memref<?x20x30xi64, 1>
     %l = affine.load %memref_arg[%arg1, %arg2 floordiv 10, %arg3 mod 20] : memref<?x20x30xi64, 1>
     %l2 = affine.load %memref_arg[%arg1 + symbol(%idx2), %arg2 floordiv 10, %arg3 mod 20] : memref<?x20x30xi64, 1>
+    affine.store %l, %memref_arg[%arg1, 0, 0] : memref<?x20x30xi64, 1>
+    affine.store %l2, %memref_arg[%arg1, 0, 1] : memref<?x20x30xi64, 1>
   }
   return
 }
@@ -104,7 +106,7 @@ module {
 
 // -----
 
-// CHECK: affine_set<(d0, d1) : (d1 - 3 >= 0, -d1 + 8 >= 0)>
+// CHECK: affine_set<(d0) : (d0 - 3 >= 0, -d0 + 8 >= 0)>
 
 module {
   func.func private @foo(%arg0: memref<26x40xf64, 1>) {


### PR DESCRIPTION
An integer comparison the enclosing affine loops and conditionals already decide folds to a constant: the guard of a peeled grid-stride residual (`blockIdx + gridDim` against an extent sharing `gridDim`'s base), a thread-id test under a constant-extent axis, a test under the else of a single-inequality `affine.if`.

`LoopDomain` builds the isl domain of an operation's block: the enclosing bounds and integer sets as `getDomain` computes them, with every symbol composed through the arithmetic defining it (as `pruneBoundMap` composes bound operands) and equated with the composition, so the compared values compose into the same parameters. Values are mathematical integers, which is what isl compares, so `comparisonSet` takes signed predicates only; an unsigned predicate is rewritten to its signed form once both sides are proven non-negative on the domain, and is left alone otherwise. The domain is built per query, as the access simplifications build theirs, so the pattern runs under drivers with and without a listener.

`FoldCmpUsingLoopBounds` is a pattern of `populateAffineExprSimplificationPatterns`, so affine-cfg applies it in the driver that raises loops — `@raised` in the test has the comparison against the bound of a loop the raising made affine fold. simplify-affine-exprs is now that pattern set under the greedy driver and nothing else: the handler walk and the trailing `recreateExpr` walk were the same rewrites (`handleAffineIfOp` recreates its set itself).

Scoped to the comparison fold as discussed; the min/max fold (#3091), the decided-trip-count unroll (#3092) and the never-looping `scf.while` fold (#3093) follow on top of this one, and the bitwise-or split against a power of two is its own PR on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
