### PR TITLE
Or-reduce scatter mask axes the store does not index

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -1443,18 +1443,47 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
             /*indexVectorDim*/ (int64_t)gridShape.size()),
         sliceSizes);
 
-    // Broadcast the mask from its IV-space to the update's grid shape.
+    // Broadcast the mask from its IV-space to the update's grid shape. A
+    // mask axis over an IV the store does not index or-reduces away first:
+    // the update is already known invariant along it (a variant update
+    // bailed above), so the store happens when any lane's mask is set.
     Value mask = pc.mask;
     affine::AffineValueMap maskMap = maps.lookup(mask);
     SmallVector<int64_t> maskBroadcastDims;
-    for (auto E : maskMap.getAffineMap().getResults()) {
+    SmallVector<int64_t> maskReduceDims;
+    for (auto [mi, E] : llvm::enumerate(maskMap.getAffineMap().getResults())) {
       Value maskIV = getIVForExpr(maskMap, E);
+      bool onGrid = false;
       for (auto [k, iv] : llvm::enumerate(ivs)) {
         if (iv == maskIV) {
           maskBroadcastDims.push_back((int64_t)k);
+          onGrid = true;
           break;
         }
       }
+      if (!onGrid)
+        maskReduceDims.push_back((int64_t)mi);
+    }
+    if (!maskReduceDims.empty()) {
+      auto boolTy = RankedTensorType::get({}, builder.getI1Type());
+      Value initFalse = stablehlo::ConstantOp::create(
+          builder, loc, boolTy,
+          SplatElementsAttr::get(boolTy, builder.getBoolAttr(false)));
+      auto reduce = stablehlo::ReduceOp::create(
+          builder, loc, ValueRange{mask}, ValueRange{initFalse},
+          builder.getDenseI64ArrayAttr(maskReduceDims));
+      Block *body = new Block();
+      reduce.getBody().push_back(body);
+      body->addArgument(boolTy, loc);
+      body->addArgument(boolTy, loc);
+      {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointToStart(body);
+        Value ored = stablehlo::OrOp::create(builder, loc, body->getArgument(0),
+                                             body->getArgument(1));
+        stablehlo::ReturnOp::create(builder, loc, ored);
+      }
+      mask = reduce.getResult(0);
     }
     auto gridTy = cast<RankedTensorType>(update.getType());
     auto maskGridTy =

--- a/test/lit_tests/raising/raise_broadcast_store.mlir
+++ b/test/lit_tests/raising/raise_broadcast_store.mlir
@@ -224,7 +224,6 @@ func.func @row_large(%out: memref<256x4096xf64, 1>, %in: memref<256x4096xf64, 1>
 // OPT-NEXT:  }
 
 // -----
-
 // The block-wide pattern: scratch filled by every lane, one lane broadcasting
 // a scalar, a barrier, then every lane combining both. The barrier is a
 // no-op in raised form and the broadcast mask or-reduces over the thread
@@ -342,4 +341,122 @@ func.func @bcast(%out: memref<?xf64, 1>, %in: memref<?xf64, 1>, %nbuf: memref<i6
 // OPT-NEXT:      stablehlo.return %9, %8, %iterArg_4, %iterArg_5 : tensor<i64>, tensor<?xf64>, tensor<?xf64>, tensor<i64>
 // OPT-NEXT:    }
 // OPT-NEXT:    return %0#1, %0#2, %0#3 : tensor<?xf64>, tensor<?xf64>, tensor<i64>
+// OPT-NEXT:  }
+
+// -----
+// The non-affine store path: a mask axis the scatter grid does not carry
+// (the tid==0 guard) or-reduces instead of producing a rank-mismatched
+// broadcast.
+func.func @bcast_scatter(%out: memref<100xf64, 1>, %in: memref<100xf64, 1>) {
+  affine.parallel (%e, %t) = (0, 0) to (4, 32) {
+    %v = affine.load %in[%e * 25] : memref<100xf64, 1>
+    affine.if affine_set<(d0) : (d0 == 0)>(%t) {
+      %ei = arith.index_castui %e : index to i64
+      %e2 = arith.muli %ei, %ei : i64
+      %idx = arith.index_cast %e2 : i64 to index
+      memref.store %v, %out[%idx] : memref<100xf64, 1>
+    }
+  }
+  return
+}
+
+// CHECK:    func.func private @bcast_scatter_raised(%arg0: tensor<100xf64>, %arg1: tensor<100xf64>) -> (tensor<100xf64>, tensor<100xf64>) {
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4xi64>
+// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<4xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<4xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<4xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_0 : tensor<4xi64>
+// CHECK-NEXT:    %3 = stablehlo.iota dim = 0 : tensor<32xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<0> : tensor<32xi64>
+// CHECK-NEXT:    %4 = stablehlo.add %3, %c_1 : tensor<32xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<32xi64>
+// CHECK-NEXT:    %5 = stablehlo.multiply %4, %c_2 : tensor<32xi64>
+// CHECK-NEXT:    %6 = stablehlo.slice %arg1 [0:100:25] : (tensor<100xf64>) -> tensor<4xf64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<32xi64>
+// CHECK-NEXT:    %7 = stablehlo.compare EQ, %5, %c_3 : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi1>
+// CHECK-NEXT:    %8 = arith.muli %2, %2 : tensor<4xi64>
+// CHECK-NEXT:    %9 = stablehlo.reshape %8 : (tensor<4xi64>) -> tensor<4x1xi64>
+// CHECK-NEXT:    %10 = "stablehlo.gather"(%arg0, %9) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<100xf64>, tensor<4x1xi64>) -> tensor<4xf64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<false> : tensor<i1>
+// CHECK-NEXT:    %11 = stablehlo.reduce(%7 init: %c_4) applies stablehlo.or across dimensions = [0] : (tensor<32xi1>, tensor<i1>) -> tensor<i1>
+// CHECK-NEXT:    %12 = stablehlo.broadcast_in_dim %11, dims = [] : (tensor<i1>) -> tensor<4xi1>
+// CHECK-NEXT:    %13 = stablehlo.select %12, %6, %10 : tensor<4xi1>, tensor<4xf64>
+// CHECK-NEXT:    %14 = "stablehlo.scatter"(%arg0, %9, %13) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<100xf64>, tensor<4x1xi64>, tensor<4xf64>) -> tensor<100xf64>
+// CHECK-NEXT:    return %14, %arg1 : tensor<100xf64>, tensor<100xf64>
+// CHECK-NEXT:  }
+
+// OPT:  module {
+// OPT-NEXT:  func.func private @bcast_scatter_raised(%arg0: tensor<100xf64>, %arg1: tensor<100xf64>) -> (tensor<100xf64>, tensor<100xf64>) {
+// OPT-NEXT:    %c = stablehlo.constant dense<{{\[\[}}0], [1], [4], [9]]> : tensor<4x1xi64>
+// OPT-NEXT:    %0 = stablehlo.slice %arg1 [0:100:25] : (tensor<100xf64>) -> tensor<4xf64>
+// OPT-NEXT:    %1 = "stablehlo.scatter"(%arg0, %c, %0) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+// OPT-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// OPT-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// OPT-NEXT:    }) : (tensor<100xf64>, tensor<4x1xi64>, tensor<4xf64>) -> tensor<100xf64>
+// OPT-NEXT:    return %1, %arg1 : tensor<100xf64>, tensor<100xf64>
+// OPT-NEXT:  }
+
+// -----
+// The scatter path at scale, 4096 elements by 256 lanes: the lane mask the
+// scatter grid does not carry is a pad too large to constant-fold.
+func.func @bcast_scatter_large(%out: memref<8192xf64, 1>, %in: memref<4096xf64, 1>) {
+  affine.parallel (%e, %t) = (0, 0) to (4096, 256) {
+    %v = affine.load %in[%e] : memref<4096xf64, 1>
+    affine.if affine_set<(d0) : (d0 == 0)>(%t) {
+      %ei = arith.index_castui %e : index to i64
+      %e2 = arith.muli %ei, %ei : i64
+      %c4095 = arith.constant 4095 : i64
+      %masked = arith.andi %e2, %c4095 : i64
+      %idx = arith.index_cast %masked : i64 to index
+      memref.store %v, %out[%idx] : memref<8192xf64, 1>
+    }
+  }
+  return
+}
+
+// CHECK:    func.func private @bcast_scatter_large_raised(%arg0: tensor<8192xf64>, %arg1: tensor<4096xf64>) -> (tensor<8192xf64>, tensor<4096xf64>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<4095> : tensor<i64>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4096xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<4096xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c_0 : tensor<4096xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<4096xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_1 : tensor<4096xi64>
+// CHECK-NEXT:    %3 = stablehlo.iota dim = 0 : tensor<256xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<256xi64>
+// CHECK-NEXT:    %4 = stablehlo.add %3, %c_2 : tensor<256xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<1> : tensor<256xi64>
+// CHECK-NEXT:    %5 = stablehlo.multiply %4, %c_3 : tensor<256xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<256xi64>
+// CHECK-NEXT:    %6 = stablehlo.compare EQ, %5, %c_4 : (tensor<256xi64>, tensor<256xi64>) -> tensor<256xi1>
+// CHECK-NEXT:    %7 = arith.muli %2, %2 : tensor<4096xi64>
+// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i64>) -> tensor<4096xi64>
+// CHECK-NEXT:    %9 = arith.andi %7, %8 : tensor<4096xi64>
+// CHECK-NEXT:    %10 = stablehlo.reshape %9 : (tensor<4096xi64>) -> tensor<4096x1xi64>
+// CHECK-NEXT:    %11 = "stablehlo.gather"(%arg0, %10) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<8192xf64>, tensor<4096x1xi64>) -> tensor<4096xf64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<false> : tensor<i1>
+// CHECK-NEXT:    %12 = stablehlo.reduce(%6 init: %c_5) applies stablehlo.or across dimensions = [0] : (tensor<256xi1>, tensor<i1>) -> tensor<i1>
+// CHECK-NEXT:    %13 = stablehlo.broadcast_in_dim %12, dims = [] : (tensor<i1>) -> tensor<4096xi1>
+// CHECK-NEXT:    %14 = stablehlo.select %13, %arg1, %11 : tensor<4096xi1>, tensor<4096xf64>
+// CHECK-NEXT:    %15 = "stablehlo.scatter"(%arg0, %10, %14) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<8192xf64>, tensor<4096x1xi64>, tensor<4096xf64>) -> tensor<8192xf64>
+// CHECK-NEXT:    return %15, %arg1 : tensor<8192xf64>, tensor<4096xf64>
+// CHECK-NEXT:  }
+
+// OPT:  module {
+// OPT-NEXT:  func.func private @bcast_scatter_large_raised(%arg0: tensor<8192xf64>, %arg1: tensor<4096xf64>) -> (tensor<8192xf64>, tensor<4096xf64>) {
+// OPT-NEXT:    %c = stablehlo.constant dense<4095> : tensor<4096xi64>
+// OPT-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4096xi64>
+// OPT-NEXT:    %1 = arith.muli %0, %0 : tensor<4096xi64>
+// OPT-NEXT:    %2 = arith.andi %1, %c : tensor<4096xi64>
+// OPT-NEXT:    %3 = stablehlo.reshape %2 : (tensor<4096xi64>) -> tensor<4096x1xi64>
+// OPT-NEXT:    %4 = "stablehlo.scatter"(%arg0, %3, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// OPT-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// OPT-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// OPT-NEXT:    }) : (tensor<8192xf64>, tensor<4096x1xi64>, tensor<4096xf64>) -> tensor<8192xf64>
+// OPT-NEXT:    return %4, %arg1 : tensor<8192xf64>, tensor<4096xf64>
 // OPT-NEXT:  }


### PR DESCRIPTION
Stacked on #2945; one commit. The non-affine store path silently skipped mask axes whose induction variable is not a scatter grid axis, emitting a `broadcast_in_dim` whose dimension count no longer matched the mask's rank (69 instances on the MFEM mass-kernels TU once loop folding exposed the path). Such an axis is the single-lane broadcast shape the affine path already handles: the update is known invariant along it (a variant update bailed earlier), so or-reduce the mask over it and scatter under the reduced predicate.

Test: `raising/raise_viewed_scratch.mlir` `@bcast_scatter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD