### PR TITLE
Erase invoke-form CUDA runtime calls on the xla/cpu backends

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -4968,6 +4968,28 @@ struct ConvertPolygeistToLLVMPass
           }
         }
       });
+      // The invoke form arrives when exception handling is preserved; these
+      // runtime calls cannot throw, so the invoke becomes its result (zero)
+      // and a branch to the normal destination.
+      m->walk([=](LLVM::InvokeOp inv) {
+        if (auto callee = inv.getCallee()) {
+          for (auto e : toErase) {
+            if (*callee == e) {
+              OpBuilder builder(inv);
+              if (inv->getNumResults()) {
+                auto replace = LLVM::ZeroOp::create(
+                    builder, inv.getLoc(), inv->getResult(0).getType());
+                inv->replaceAllUsesWith(ArrayRef<Value>{replace.getResult()});
+              }
+              LLVM::BrOp::create(builder, inv.getLoc(),
+                                 inv.getNormalDestOperands(),
+                                 inv.getNormalDest());
+              inv->erase();
+              return;
+            }
+          }
+        }
+      });
       m->walk([=](LLVM::LLVMFuncOp call) {
         for (auto e : toErase) {
           if (call.getName() == e) {
@@ -4999,6 +5021,28 @@ struct ConvertPolygeistToLLVMPass
                 call->replaceAllUsesWith(replace);
               }
               call->erase();
+            }
+          }
+        }
+      });
+      // The invoke form arrives when exception handling is preserved; these
+      // runtime calls cannot throw, so the invoke becomes its result (zero)
+      // and a branch to the normal destination.
+      m->walk([=](LLVM::InvokeOp inv) {
+        if (auto callee = inv.getCallee()) {
+          for (auto e : toErase) {
+            if (*callee == e) {
+              OpBuilder builder(inv);
+              if (inv->getNumResults()) {
+                auto replace = LLVM::ZeroOp::create(
+                    builder, inv.getLoc(), inv->getResult(0).getType());
+                inv->replaceAllUsesWith(ArrayRef<Value>{replace.getResult()});
+              }
+              LLVM::BrOp::create(builder, inv.getLoc(),
+                                 inv.getNormalDestOperands(),
+                                 inv.getNormalDest());
+              inv->erase();
+              return;
             }
           }
         }

--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -4969,18 +4969,13 @@ struct ConvertPolygeistToLLVMPass
         }
       });
       // The invoke form arrives when exception handling is preserved; these
-      // runtime calls cannot throw, so the invoke becomes its result (zero)
-      // and a branch to the normal destination.
+      // cannot throw and their results are unused, so each becomes a branch
+      // to its normal destination.
       m->walk([=](LLVM::InvokeOp inv) {
         if (auto callee = inv.getCallee()) {
           for (auto e : toErase) {
             if (*callee == e) {
               OpBuilder builder(inv);
-              if (inv->getNumResults()) {
-                auto replace = LLVM::ZeroOp::create(
-                    builder, inv.getLoc(), inv->getResult(0).getType());
-                inv->replaceAllUsesWith(ArrayRef<Value>{replace.getResult()});
-              }
               LLVM::BrOp::create(builder, inv.getLoc(),
                                  inv.getNormalDestOperands(),
                                  inv.getNormalDest());

--- a/test/lit_tests/lowering/xla_erase_invoke.mlir
+++ b/test/lit_tests/lowering/xla_erase_invoke.mlir
@@ -6,7 +6,16 @@
 // declaration for the LLVM translator to trip over.
 module {
   llvm.func @cudaGetLastError() -> i32
+  llvm.func @cudaThreadSynchronize() -> i32
   llvm.func @__gxx_personality_v0(...) -> i32
+  llvm.func @sync() attributes {personality = @__gxx_personality_v0} {
+    %e = llvm.invoke @cudaThreadSynchronize() to ^ok unwind ^lp : () -> i32
+  ^ok:
+    llvm.return
+  ^lp:
+    %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    llvm.return
+  }
   llvm.func @use(%c: i1) -> i32 attributes {personality = @__gxx_personality_v0} {
     %z = llvm.mlir.constant(0 : i32) : i32
     llvm.cond_br %c, ^call, ^done(%z : i32)
@@ -22,6 +31,12 @@ module {
     llvm.return %one : i32
   }
 }
+
+// An invoked cudaThreadSynchronize has no used result: it reduces to a plain
+// branch.
+// CHECK-LABEL: llvm.func @sync(
+// CHECK-NOT: cudaThreadSynchronize
+// CHECK-NOT: llvm.mlir.zero
 
 // CHECK-LABEL: llvm.func @use(
 // CHECK-NOT: cudaGetLastError

--- a/test/lit_tests/lowering/xla_erase_invoke.mlir
+++ b/test/lit_tests/lowering/xla_erase_invoke.mlir
@@ -1,0 +1,31 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=xla-gpu})" | FileCheck %s
+
+// cudaGetLastError arrives in invoke form when exception handling is
+// preserved; it cannot throw, so it becomes its (zero) result and a branch
+// to the normal destination — leaving no reference to the erased
+// declaration for the LLVM translator to trip over.
+module {
+  llvm.func @cudaGetLastError() -> i32
+  llvm.func @__gxx_personality_v0(...) -> i32
+  llvm.func @use(%c: i1) -> i32 attributes {personality = @__gxx_personality_v0} {
+    %z = llvm.mlir.constant(0 : i32) : i32
+    llvm.cond_br %c, ^call, ^done(%z : i32)
+  ^call:
+    %e = llvm.invoke @cudaGetLastError() to ^fwd unwind ^lp : () -> i32
+  ^fwd:
+    llvm.br ^done(%e : i32)
+  ^done(%r: i32):
+    llvm.return %r : i32
+  ^lp:
+    %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    %one = llvm.mlir.constant(1 : i32) : i32
+    llvm.return %one : i32
+  }
+}
+
+// CHECK-LABEL: llvm.func @use(
+// CHECK-NOT: cudaGetLastError
+// CHECK: %[[Z:.+]] = llvm.mlir.zero : i32
+// CHECK: llvm.br ^[[FWD:.+]]{{$}}
+// CHECK: ^[[FWD]]:
+// CHECK: llvm.br ^{{.+}}(%[[Z]] : i32)


### PR DESCRIPTION
The xla/cpu lowerings erase `cudaGetLastError`/`cudaDeviceSynchronize` calls and their declarations, but only in **call** form — with exception handling preserved these arrive as `llvm.invoke`, which survived and left a reference to the erased declaration that the LLVM translator segfaulted on (`lookupNonFunctionSymbolCallee`). These functions cannot throw, so the invoke becomes its (zero) result plus a branch to the normal destination.

Found compiling MFEM's `bilininteg_mass_pa.cpp` end-to-end with `-reactant-backend=xla-gpu`; with this, both MFEM mass TUs compile through the plugin on the xla path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD