### PR TITLE
Normalize invoke-form CUDA runtime calls before launch-recognition rewrites

### DIFF
--- a/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
+++ b/src/enzyme_ad/jax/Passes/GPULaunchRecognition.cpp
@@ -137,6 +137,36 @@ struct GPULaunchRecognitionPass
     SymbolTableCollection symbolTable;
     symbolTable.getSymbolTable(getOperation());
     StringSet<> seenErrors;
+    // With exception handling preserved these runtime calls arrive in
+    // invoke form; none of them throw, so turn each into a call plus a
+    // branch to the normal destination so the rewrites below see them.
+    {
+      SmallVector<LLVM::InvokeOp> invokes;
+      getOperation()->walk([&](LLVM::InvokeOp inv) {
+        auto callee = inv.getCallee();
+        if (!callee)
+          return;
+        for (StringRef name :
+             {"cudaMalloc", "cudaFree",
+              "cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags",
+              "cudaFuncGetAttributes", "cudaFuncSetCacheConfig", "cudaMemcpy",
+              "cudaMemset", "cudaMemsetAsync", "cudaMemcpy2D"})
+          if (*callee == name) {
+            invokes.push_back(inv);
+            return;
+          }
+      });
+      for (auto inv : invokes) {
+        OpBuilder builder(inv);
+        auto call =
+            LLVM::CallOp::create(builder, inv.getLoc(), inv.getResultTypes(),
+                                 inv.getCalleeAttr(), inv.getCalleeOperands());
+        inv->replaceAllUsesWith(call->getResults());
+        LLVM::BrOp::create(builder, inv.getLoc(), inv.getNormalDestOperands(),
+                           inv.getNormalDest());
+        inv->erase();
+      }
+    }
     getOperation()->walk([&](LLVM::CallOp call) {
       auto callee = call.getCallee();
       OpBuilder builder(call);

--- a/test/lit_tests/glr_runtime_invoke.mlir
+++ b/test/lit_tests/glr_runtime_invoke.mlir
@@ -1,0 +1,28 @@
+// RUN: enzymexlamlir-opt %s --gpu-launch-recognition | FileCheck %s
+
+// With exception handling preserved, CUDA runtime calls arrive in invoke
+// form; they cannot throw, so they normalize to calls the runtime rewrites
+// see — here an invoked cudaMalloc still becomes a gpu.alloc.
+module {
+  llvm.func @cudaMalloc(!llvm.ptr, i64) -> i32
+  llvm.func @__gxx_personality_v0(...) -> i32
+  llvm.func @alloc(%slot: !llvm.ptr, %n: i64) -> i32 attributes {personality = @__gxx_personality_v0} {
+    %e = llvm.invoke @cudaMalloc(%slot, %n) to ^ok unwind ^lp : (!llvm.ptr, i64) -> i32
+  ^ok:
+    llvm.return %e : i32
+  ^lp:
+    %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+    %one = llvm.mlir.constant(1 : i32) : i32
+    llvm.return %one : i32
+  }
+}
+
+// CHECK-LABEL: llvm.func @alloc(
+// CHECK-NOT: llvm.invoke @cudaMalloc
+// CHECK: %[[M:.+]] = gpu.alloc (%{{.+}}) : memref<?xi8, 1>
+// CHECK: %[[P:.+]] = "enzymexla.memref2pointer"(%[[M]])
+// CHECK: llvm.store %[[P]], %arg0
+// CHECK: %[[Z:.+]] = llvm.mlir.zero : i32
+// CHECK: llvm.br ^[[OK:.+]]{{$}}
+// CHECK: ^[[OK]]:
+// CHECK: llvm.return %[[Z]] : i32


### PR DESCRIPTION
With exception handling preserved, `cudaMalloc`/`cudaFree`/`cudaMemcpy` and friends arrive as `llvm.invoke`, which `replaceRuntime`'s call-only walk never saw — so a kernel-less allocator TU (MFEM's `general/cuda.cpp`) kept raw `cudaMalloc` and its allocations never became backend buffers on the xla path. These functions cannot throw: each such invoke becomes a call plus a branch to its normal destination before the rewrites run.

Paired with a plugin-side change letting TUs with host CUDA-runtime use round-trip even when the device side is empty; with both, `cuda.cpp` compiles to pure `reactantXLAMalloc/Free/Memcpy` with zero raw allocator references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD