### PR TITLE
Raise sequential affine.for loops over parallel bodies as stablehlo.while

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -812,6 +812,16 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
                         llvm::DenseMap<Value, affine::AffineValueMap> &maps,
                         ParallelContext pc);
 
+// The buffers a loop must carry are the arguments of the block being raised
+// from: the kernel function's entry, or the gpu_wrapper region's block when
+// raising a wrapper in place.
+static Block *getRaisedEntryBlock(Operation *op) {
+  while (op->getParentOp() &&
+         !isa<func::FuncOp, enzymexla::GPUWrapperOp>(op->getParentOp()))
+    op = op->getParentOp();
+  return &op->getParentRegion()->front();
+}
+
 static LogicalResult tryRaisingForOpToStableHLOWhile(
     affine::AffineForOp forOp, IRMapping &parentMapping, OpBuilder &builder,
     llvm::DenseMap<Value, affine::AffineValueMap> &maps, ParallelContext pc,
@@ -888,12 +898,18 @@ emitIfAsSelect(Operation *ifOp, Value cond, affine::AffineValueMap map,
          llvm::zip_equal(thenTerm->getOperands(), elseTerm->getOperands(),
                          ifOp->getResults())) {
       Value a = cond;
+      if (isa<MemRefType, LLVM::LLVMPointerType>(res.getType()))
+        return ifOp->emitError(
+            "cannot raise a branch choosing between buffers");
       Value b = mapping.lookup(thenVal);
       Value c = mapping.lookup(elseVal);
 
       auto mapA = map;
       auto mapB = maps.lookup(b);
       auto mapC = maps.lookup(c);
+      if (!mapA.getAffineMap() || !mapB.getAffineMap() || !mapC.getAffineMap())
+        return ifOp->emitError(
+            "cannot raise branch result without an access map");
 
       Value dsts[] = {b, c};
       affine::AffineValueMap submaps[] = {mapB, mapC};
@@ -1274,35 +1290,60 @@ static LogicalResult tryRaisingForOpToStableHLOWhile(
     stablehlo::WhileOp *createdWhileOp,
     SmallVectorImpl<Value> *carriedBuffers) {
   IRMapping mapping = parentMapping;
-  if (!forOp.hasConstantBounds()) {
-    return forOp.emitError("CPU kernels do not support cluster");
-  }
 
   Value iv = forOp.getInductionVar();
-  InductionVariableRange range{forOp.getConstantLowerBound(),
-                               forOp.getConstantUpperBound(),
-                               forOp.getStepAsInt()};
 
   auto ET = builder.getI64Type();
   auto TT = RankedTensorType::get({}, ET);
+  auto wloc = rewriteLocation(forOp.getLoc(), pc.options.strip_llvm_debuginfo);
 
-  Value lb = stablehlo::ConstantOp::create(
-      builder, rewriteLocation(forOp.getLoc(), pc.options.strip_llvm_debuginfo),
-      TT,
-      SplatElementsAttr::get(
-          TT, ArrayRef<Attribute>(IntegerAttr::get(ET, range.lb))));
-  Value ub = stablehlo::ConstantOp::create(
-      builder, rewriteLocation(forOp.getLoc(), pc.options.strip_llvm_debuginfo),
-      TT,
-      SplatElementsAttr::get(
-          TT, ArrayRef<Attribute>(IntegerAttr::get(ET, range.ub))));
-  Value step = stablehlo::ConstantOp::create(
-      builder, rewriteLocation(forOp.getLoc(), pc.options.strip_llvm_debuginfo),
-      TT,
-      SplatElementsAttr::get(
-          TT, ArrayRef<Attribute>(IntegerAttr::get(ET, range.step))));
+  auto makeConst = [&](int64_t v) -> Value {
+    return stablehlo::ConstantOp::create(
+        builder, wloc, TT,
+        SplatElementsAttr::get(TT,
+                               ArrayRef<Attribute>(IntegerAttr::get(ET, v))));
+  };
 
-  Block *entryBlock = &forOp->getParentOfType<func::FuncOp>().getBody().front();
+  Value lb, ub;
+  if (forOp.hasConstantBounds()) {
+    lb = makeConst(forOp.getConstantLowerBound());
+    ub = makeConst(forOp.getConstantUpperBound());
+  } else {
+    // A while iterates however many times the bounds say at runtime, so the
+    // bounds only need to be evaluated as scalars: a lower bound is the max
+    // of its results, an upper bound the min.
+    auto evalBound = [&](AffineMap map, ValueRange operands,
+                         bool isUpper) -> Value {
+      Value acc;
+      for (AffineExpr expr : map.getResults()) {
+        auto [val, avm] = expandAffineExpr(builder, wloc, expr, operands,
+                                           mapping, map.getNumDims(), pc);
+        if (!val)
+          return nullptr;
+        auto vt = dyn_cast<RankedTensorType>(val.getType());
+        if (!vt || vt.getRank() != 0)
+          return nullptr;
+        if (vt.getElementType() != ET)
+          val = stablehlo::ConvertOp::create(builder, wloc, TT, val);
+        acc = !acc ? val
+                   : (isUpper ? (Value)stablehlo::MinOp::create(builder, wloc,
+                                                                acc, val)
+                              : (Value)stablehlo::MaxOp::create(builder, wloc,
+                                                                acc, val));
+      }
+      return acc;
+    };
+    lb = evalBound(forOp.getLowerBoundMap(), forOp.getLowerBoundOperands(),
+                   /*isUpper=*/false);
+    ub = evalBound(forOp.getUpperBoundMap(), forOp.getUpperBoundOperands(),
+                   /*isUpper=*/true);
+    if (!lb || !ub)
+      return forOp.emitError(
+          "cannot evaluate non-constant loop bounds as scalars");
+  }
+  Value step = makeConst(forOp.getStepAsInt());
+
+  Block *entryBlock = getRaisedEntryBlock(forOp);
 
   Block *cond = new Block(), *body = new Block();
   Value ivInCond = cond->addArgument(
@@ -2407,10 +2448,18 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
         limit = constOp.getValue() + 1;
       } else if (!E.isSymbolicOrConstant()) {
         auto range = computeExprRange(accessValueMap, E);
-        if (!range.has_value())
-          return failure();
-        start = range->step < 0 ? range->ub - range->step : range->lb;
-        limit = range->step < 0 ? range->lb - range->step : range->ub;
+        if (range.has_value()) {
+          start = range->step < 0 ? range->ub - range->step : range->lb;
+          limit = range->step < 0 ? range->lb - range->step : range->ub;
+        } else {
+          // A while-raised loop's IV has no static range, but its store is a
+          // single dynamically-indexed element along this dim: no padding
+          // analysis needed. Only a batched (parallel-IV) dim needs the range.
+          Value iv = getIVForExpr(accessValueMap, E);
+          if (!iv || pc.isParallelIV(iv))
+            return failure();
+          hasRange = false;
+        }
       } else {
         hasRange = false;
       }
@@ -3294,12 +3343,14 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
 
   // Inner for op
   if (auto forOp = dyn_cast<affine::AffineForOp>(op)) {
-    if (pc.options.enableLockstepFor &&
+    if (pc.options.enableLockstepFor && forOp.hasConstantBounds() &&
         tryRaisingLockStepForOpToStableHLO(forOp, mapping, builder, maps, pc)
             .succeeded()) {
       return success();
     }
-    if (pc.options.preferWhileRaising &&
+    // A loop whose trip count is only known at runtime can still iterate as
+    // a while, whatever the preference says.
+    if ((pc.options.preferWhileRaising || !forOp.hasConstantBounds()) &&
         tryRaisingForOpToStableHLOWhile(forOp, mapping, builder, maps, pc)
             .succeeded()) {
       return success();

--- a/test/lit_tests/raising/raise_for_of_parallel.mlir
+++ b/test/lit_tests/raising/raise_for_of_parallel.mlir
@@ -1,0 +1,56 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// A sequential loop whose trip count is only known at runtime iterates as a
+// stablehlo.while; the parallel body raises batched inside it and the buffers
+// it writes are carried through the loop.
+func.func @timeloop(%out: memref<100xf64, 1>, %nbuf: memref<i64, 1>) {
+  %n = affine.load %nbuf[] : memref<i64, 1>
+  %ni = arith.index_cast %n : i64 to index
+  affine.for %t = 0 to %ni {
+    affine.parallel (%i) = (0) to (100) {
+      %v = affine.load %out[%i] : memref<100xf64, 1>
+      %c = arith.constant 1.0 : f64
+      %s = arith.addf %v, %c : f64
+      affine.store %s, %out[%i] : memref<100xf64, 1>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @timeloop_raised(
+// CHECK-SAME: %[[OUT:.+]]: tensor<100xf64>, %[[N:.+]]: tensor<i64>
+// CHECK: %[[WHILE:.+]]:3 = stablehlo.while(%[[IV:.+]] = %{{.+}}, %[[BUF:.+]] = %[[OUT]], %{{.+}} = %[[N]]) : tensor<i64>, tensor<100xf64>, tensor<i64>
+// CHECK: cond {
+// CHECK: stablehlo.compare LT, %[[IV]], %{{.+}} : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK: } do {
+// CHECK: %[[CUR:.+]] = stablehlo.reshape %[[BUF]] : (tensor<100xf64>) -> tensor<100xf64>
+// CHECK: arith.addf %[[CUR]], %{{.+}} : tensor<100xf64>
+// CHECK: return %[[WHILE]]#1, %[[WHILE]]#2 : tensor<100xf64>, tensor<i64>
+
+// -----
+
+// Scratch allocated outside the loop is carried through the while like any
+// other buffer, starting from a zero splat.
+func.func @scratchloop(%out: memref<10xf64, 1>, %nbuf: memref<i64, 1>) {
+  %tmp = memref.alloca() : memref<10xf64>
+  %n = affine.load %nbuf[] : memref<i64, 1>
+  %ni = arith.index_cast %n : i64 to index
+  affine.for %t = 0 to %ni {
+    affine.parallel (%i) = (0) to (10) {
+      %v = affine.load %out[%i] : memref<10xf64, 1>
+      affine.store %v, %tmp[%i] : memref<10xf64>
+    }
+    affine.parallel (%i) = (0) to (10) {
+      %v = affine.load %tmp[9 - %i] : memref<10xf64>
+      affine.store %v, %out[%i] : memref<10xf64, 1>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @scratchloop_raised(
+// CHECK-SAME: %[[OUT2:.+]]: tensor<10xf64>, %[[N2:.+]]: tensor<i64>
+// CHECK: %[[ZERO:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<10xf64>
+// CHECK: stablehlo.while
+// CHECK: } do {
+// CHECK: stablehlo.reverse


### PR DESCRIPTION
Lets a sequential `affine.for` — e.g. a time loop wrapped around parallel kernel regions — raise even when its trip count is only known at runtime:

- loop bounds evaluate symbolically from already-raised values, and the loop becomes a `stablehlo.while` with the induction variable as a rank-0 counter;
- every buffer the body writes is carried through the while (and threaded through the constant-bound unroll path the same way), including scratch from #2955;
- `affine.if` guards may reference symbols (e.g. the enclosing loop IV), and `alignMemoryAccess` handles maps with no IV dims;
- raising works under gpu wrapper regions, not just plain functions.

Builds on #2955 (alloca zero-splat raising); the peeling of dynamic-extent *parallel* axes (and the `enzymexla.parallel` tag) stays in #2944 on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD