### PR TITLE
Gate the MPI FFI handlers on non-Windows builds

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -97,10 +97,16 @@ cc_library(
     srcs =
         [
             "xla_ffi/register.cc",
-        ] + glob([
-            "xla_ffi/host/**/*.cc",
-            "xla_ffi/cuda/**/*.cc",
-        ]),
+        ] + glob(
+            [
+                "xla_ffi/host/**/*.cc",
+                "xla_ffi/cuda/**/*.cc",
+            ],
+            exclude = ["xla_ffi/host/mpi.cc"],
+        ) + select({
+            "@xla//xla/tsl:windows": [],
+            "//conditions:default": ["xla_ffi/host/mpi.cc"],
+        }),
     hdrs =
         [
             "xla_ffi/export_macro.h",
@@ -116,11 +122,13 @@ cc_library(
     deps = [
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/strings:str_format",
-        "@mpitrampoline",
         "@xla//xla/ffi:ffi_api",
         "@xla//xla/ffi/api:c_api",
         "@xla//xla/ffi/api:ffi",
     ] + select({
+        "@xla//xla/tsl:windows": [],
+        "//conditions:default": ["@mpitrampoline"],
+    }) + select({
         "@local_config_cuda//:is_cuda_enabled": [
             "@jax//jaxlib:ffi_helpers",
             "@jax//jaxlib/cuda:cuda_blas_handle_pool",

--- a/src/enzyme_ad/jax/xla_ffi/host/register.cc
+++ b/src/enzyme_ad/jax/xla_ffi/host/register.cc
@@ -7,7 +7,10 @@ namespace ffi_internal {
 
 void registerEnzymeJaXXLAHostFFI() {
   registerEnzymeJaXXLAHostThrowErrorFFI();
+#ifndef _WIN32
+  // MPItrampoline is POSIX-only (dlfcn), so Windows builds skip MPI.
   registerEnzymeJaXXLAHostMPIFFI();
+#endif
 }
 
 } // namespace ffi_internal


### PR DESCRIPTION
Follow-up to #2822, which broke the Windows jll build ([log](https://github.com/EnzymeAD/Enzyme-JAX/actions/runs/32874360711/job/97889499884?pr=2955)): MPItrampoline needs `dlfcn.h` and its MPI ABI static_asserts fail under mingw.

Windows builds (via `@xla//xla/tsl:windows`) now drop the `@mpitrampoline` dependency and exclude `xla_ffi/host/mpi.cc`; `registerEnzymeJaXXLAHostFFI` skips the MPI registration under `_WIN32`. Non-Windows builds are unchanged (verified `:xla_ffi` builds on Linux with the selects in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD