### PR TITLE
Raise block barriers as no-ops

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3388,6 +3388,13 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     return success();
   }
 
+  // Raised execution is ordered over whole tensors: a store over a batched
+  // thread axis completes for the entire axis before the next op runs, which
+  // is exactly what the barrier guaranteed.
+  if (isa<enzymexla::BarrierOp>(op)) {
+    return success();
+  }
+
   return op->emitError("cannot raise op to stablehlo") << *op;
 }
 

--- a/test/lit_tests/raising/raise_barrier.mlir
+++ b/test/lit_tests/raising/raise_barrier.mlir
@@ -1,0 +1,20 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// A block-wide barrier over a batched thread axis is a no-op in raised form:
+// whole-tensor updates are already ordered, so the write to scratch is
+// complete before any lane reads it back.
+func.func @barrier(%out: memref<32xf64, 1>, %in: memref<32xf64, 1>) {
+  %scr = memref.alloca() : memref<32xf64>
+  affine.parallel (%t) = (0) to (32) {
+    %v = affine.load %in[%t] : memref<32xf64, 1>
+    affine.store %v, %scr[%t] : memref<32xf64>
+    "enzymexla.barrier"(%t) : (index) -> ()
+    %x = affine.load %scr[31 - %t] : memref<32xf64>
+    affine.store %x, %out[%t] : memref<32xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @barrier_raised(
+// CHECK-NOT: enzymexla.barrier
+// CHECK: stablehlo.reverse


### PR DESCRIPTION
Raised execution is ordered over whole tensors: a store over a batched thread axis completes for the entire axis before the next op runs, which is exactly what the barrier guaranteed. Split out of #2945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD