### PR TITLE
Raise a uniform branch between read-only buffers as a whole-tensor select

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -898,9 +898,36 @@ emitIfAsSelect(Operation *ifOp, Value cond, affine::AffineValueMap map,
          llvm::zip_equal(thenTerm->getOperands(), elseTerm->getOperands(),
                          ifOp->getResults())) {
       Value a = cond;
-      if (isa<MemRefType, LLVM::LLVMPointerType>(res.getType()))
-        return ifOp->emitError(
-            "cannot raise a branch choosing between buffers");
+      if (isa<MemRefType, LLVM::LLVMPointerType>(res.getType())) {
+        // A branch choosing between whole buffers raises as a select of the
+        // whole tensors when the choice is uniform and nothing writes through
+        // it; a write would have to fan back out into both source buffers.
+        Value thenBuf = mapping.lookupOrNull(thenVal);
+        Value elseBuf = mapping.lookupOrNull(elseVal);
+        auto condTy = dyn_cast<RankedTensorType>(cond.getType());
+        // The select captures the buffers as of this point, so nothing may
+        // write to them (through the select or directly) or later reads
+        // through the select would miss the write.
+        auto loadOnly = [&](Value buf) {
+          return llvm::all_of(buf.getUsers(), [&](Operation *user) {
+            return isa<affine::AffineLoadOp, memref::LoadOp,
+                       affine::AffineVectorLoadOp>(user) ||
+                   user == ifOp || user == thenTerm || user == elseTerm;
+          });
+        };
+        bool readOnly = loadOnly(res) && loadOnly(thenVal) && loadOnly(elseVal);
+        if (!thenBuf || !elseBuf || thenBuf.getType() != elseBuf.getType() ||
+            !condTy || condTy.getRank() != 0 || !readOnly)
+          return ifOp->emitError(
+              "cannot raise a branch choosing between buffers");
+        auto sel = stablehlo::SelectOp::create(
+            builder,
+            rewriteLocation(ifOp->getLoc(), pc.options.strip_llvm_debuginfo),
+            cond, thenBuf, elseBuf);
+        mapping.map(res, sel.getResult());
+        maps[sel.getResult()] = maps.lookup(thenBuf);
+        continue;
+      }
       Value b = mapping.lookup(thenVal);
       Value c = mapping.lookup(elseVal);
 

--- a/test/lit_tests/raising/raise_buffer_select.mlir
+++ b/test/lit_tests/raising/raise_buffer_select.mlir
@@ -1,0 +1,22 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// A uniform branch choosing between two read-only buffers raises as a select
+// of the whole tensors.
+func.func @bufsel(%a: memref<100xf64, 1>, %b: memref<100xf64, 1>, %out: memref<100xf64, 1>, %flagbuf: memref<i64, 1>) {
+  %f = affine.load %flagbuf[] : memref<i64, 1>
+  %fi = arith.index_cast %f : i64 to index
+  affine.parallel (%i) = (0) to (100) {
+    %buf = affine.if affine_set<()[s0] : (s0 - 1 >= 0)>()[%fi] -> memref<100xf64, 1> {
+      affine.yield %a : memref<100xf64, 1>
+    } else {
+      affine.yield %b : memref<100xf64, 1>
+    }
+    %v = affine.load %buf[%i] : memref<100xf64, 1>
+    affine.store %v, %out[%i] : memref<100xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @bufsel_raised(
+// CHECK: stablehlo.select %{{.+}}, %arg0, %arg1 : tensor<i1>, tensor<100xf64>
+


### PR DESCRIPTION
Re-land of #2961: at the moment that PR was merged its base was still the stacked branch `pb/broadcast-store-reduce` (the retarget to main raced with the merge), so the content landed on the side branch rather than main. Identical content, now targeting main.

The select captures the buffers as of the branch, so the choice must be uniform (rank-0 condition) and nothing may write through or around it; anything else keeps the existing refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD