### PR TITLE
Error on kernel launches that survive raising under the xla backends

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -5131,6 +5131,20 @@ struct ConvertPolygeistToLLVMPass
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
+    // An xla backend has no raw device memory: buffers live behind the XLA
+    // runtime, so a kernel launch that survived raising would consume
+    // pointers that do not exist on the device. Fail the compile rather
+    // than emit a binary that crashes at runtime.
+    if (StringRef(backend).starts_with("xla")) {
+      bool anyLaunch = false;
+      m->walk([&](gpu::LaunchFuncOp l) {
+        l.emitError("kernel launch survived raising; the ")
+            << backend << " backend cannot execute raw device kernels";
+        anyLaunch = true;
+      });
+      if (anyLaunch)
+        return signalPassFailure();
+    }
     convertModule(m, /* gpuModule */ false);
   }
 };

--- a/test/lit_tests/lowering/xla-no-raw-launch.mlir
+++ b/test/lit_tests/lowering/xla-no-raw-launch.mlir
@@ -1,0 +1,20 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=xla-gpu})" --verify-diagnostics --split-input-file
+
+// An xla backend cannot execute a raw device kernel: any launch that
+// survived raising is a compile-time error, not a runtime crash.
+module attributes {gpu.container_module} {
+  func.func @foo(%c1: index, %arg: memref<?xf32, 1>) {
+    // expected-error@+1 {{kernel launch survived raising; the xla-gpu backend cannot execute raw device kernels}}
+    gpu.launch_func @gpumod::@gpufunc blocks in (%c1, %c1, %c1) threads in (%c1, %c1, %c1) args(%arg : memref<?xf32, 1>)
+    return
+  }
+
+  gpu.module @gpumod [#nvvm.target<O = 3, chip = "sm_120", features = "+ptx73", flags = {}>] attributes {dlti.dl_spec = #dlti.dl_spec<index = 32 : i64>} {
+    gpu.func @gpufunc(%arg0: memref<?xf32, 1>) kernel {
+      %thread_id_x = gpu.thread_id x
+      %ld = memref.load %arg0[%thread_id_x] : memref<?xf32, 1>
+      memref.store %ld, %arg0[%thread_id_x] : memref<?xf32, 1>
+      gpu.return
+    }
+  }
+}


### PR DESCRIPTION
An xla backend has no raw device memory — buffers live behind the XLA runtime — so a `gpu.launch_func` that survived raising would consume device pointers that do not exist, crashing at runtime (the two-worlds problem). `convert-polygeist-to-llvm{backend=xla-*}` now reports every surviving launch as a compile-time error instead of emitting a binary that crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD