### PR TITLE
libdevice raising: map minimumnum/maximumnum intrinsics to arith

### DIFF
--- a/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
+++ b/src/enzyme_ad/jax/Passes/LibDeviceFuncsRaisingPass.cpp
@@ -958,6 +958,32 @@ struct NVVMRsqrtApproxRaising : public OpRewritePattern<LLVM::CallIntrinsicOp> {
   }
 };
 
+// The minimumnum/maximumnum intrinsics have no first-class llvm dialect op,
+// so they arrive as llvm.call_intrinsic. Like __nv_fmin/__nv_fmax they treat
+// a NaN operand as missing data, which is arith.minnumf/maxnumf.
+struct MinMaxNumIntrinsicRaising
+    : public OpRewritePattern<LLVM::CallIntrinsicOp> {
+  using OpRewritePattern<LLVM::CallIntrinsicOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::CallIntrinsicOp op,
+                                PatternRewriter &rewriter) const override {
+    StringRef intrin = op.getIntrin();
+    bool isMin = intrin.starts_with("llvm.minimumnum.");
+    if (!isMin && !intrin.starts_with("llvm.maximumnum."))
+      return failure();
+    if (op.getArgs().size() != 2 || op->getNumResults() != 1 ||
+        !isa<FloatType>(op->getResult(0).getType()))
+      return failure();
+    if (isMin)
+      rewriter.replaceOpWithNewOp<arith::MinNumFOp>(op, op.getArgs()[0],
+                                                    op.getArgs()[1]);
+    else
+      rewriter.replaceOpWithNewOp<arith::MaxNumFOp>(op, op.getArgs()[0],
+                                                    op.getArgs()[1]);
+    return success();
+  }
+};
+
 struct ReadOnlyAllocaElim : public OpRewritePattern<LLVM::AllocaOp> {
   ReadOnlyAllocaElim(MLIRContext *context)
       : OpRewritePattern<LLVM::AllocaOp>(context, /*benefit=*/1) {}
@@ -1421,6 +1447,7 @@ void populateLLVMToMathPatterns(MLIRContext *context,
 
   patterns.add<BarrierConvert>(converter);
   patterns.add<NVVMRsqrtApproxRaising>(converter);
+  patterns.add<MinMaxNumIntrinsicRaising>(converter);
 
   patterns
       .add<GPUConvert<NVVM::BlockDimXOp, gpu::BlockDimOp, gpu::Dimension::x>>(

--- a/test/lit_tests/minimumnum_raise.mlir
+++ b/test/lit_tests/minimumnum_raise.mlir
@@ -1,0 +1,15 @@
+// RUN: enzymexlamlir-opt %s --libdevice-funcs-raise | FileCheck %s
+
+// minimumnum/maximumnum arrive as llvm.call_intrinsic (no first-class llvm
+// dialect op) and treat NaN as missing data, i.e. arith.minnumf/maxnumf.
+func.func @minmax(%a: f64, %b: f64, %c: f32, %d: f32) -> (f64, f32) {
+  %0 = llvm.call_intrinsic "llvm.minimumnum.f64"(%a, %b) : (f64, f64) -> f64
+  %1 = llvm.call_intrinsic "llvm.maximumnum.f32"(%c, %d) : (f32, f32) -> f32
+  return %0, %1 : f64, f32
+}
+
+// CHECK-LABEL: func.func @minmax(
+// CHECK-SAME: %[[A:.+]]: f64, %[[B:.+]]: f64, %[[C:.+]]: f32, %[[D:.+]]: f32
+// CHECK: %[[MIN:.+]] = arith.minnumf %[[A]], %[[B]] : f64
+// CHECK: %[[MAX:.+]] = arith.maxnumf %[[C]], %[[D]] : f32
+// CHECK: return %[[MIN]], %[[MAX]] : f64, f32


### PR DESCRIPTION
`llvm.minimumnum`/`llvm.maximumnum` have no first-class llvm dialect op, so they arrive as `llvm.call_intrinsic` and nothing raised them — MFEM's `Vector` min/max reductions hit this compiling under `xla-gpu` (clang emits `minimumnum` for `fmin`). Like `__nv_fmin`/`__nv_fmax`, they treat a NaN operand as missing data, which is `arith.minnumf`/`maxnumf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD