### PR TITLE
MoveWhileToFor: accept a duplicated increment feeding the condition

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1310,8 +1310,17 @@ struct WhileToForHelper {
             auto beforeYield = cast<scf::ConditionOp>(
                 loop.getBefore().front().getTerminator());
             auto inductValue = beforeYield.getArgs()[ba3.getArgNumber()];
+            // The condition may pass a duplicate of the increment (clang
+            // often emits the addi twice); accept a structurally identical
+            // add of the same operands.
             if (inductValue != steppingVal) {
-              continue;
+              auto inductAdd = inductValue.getDefiningOp<AddIOp>();
+              if (!inductAdd || !((inductAdd.getLhs() == add.getLhs() &&
+                                   inductAdd.getRhs() == add.getRhs()) ||
+                                  (inductAdd.getLhs() == add.getRhs() &&
+                                   inductAdd.getRhs() == add.getLhs()))) {
+                continue;
+              }
             }
             arg = ba2;
           }

--- a/test/lit_tests/canonicalizefor/while_logical_negation_conjunct.mlir
+++ b/test/lit_tests/canonicalizefor/while_logical_negation_conjunct.mlir
@@ -9,7 +9,9 @@
 //
 // (The condition arrives as select(%ok, %more, false) and reaches
 // WhileLogicalNegation as andi %ok, %more; the duplicated increment is as the
-// frontend spelled it, and keeps MoveWhileToFor from converting the loop.)
+// frontend spelled it. MoveWhileToFor accepts the duplicate and converts the
+// loop; the forwarded %ok must ride the shadow argument, updated on the
+// failing evaluation too, and never collapse to the constant false.)
 
 llvm.func @all_set(%deps: !llvm.ptr, %flags: !llvm.ptr, %n: i64) -> i1 {
   %c0_i32 = arith.constant 0 : i32
@@ -36,9 +38,39 @@ llvm.func @all_set(%deps: !llvm.ptr, %flags: !llvm.ptr, %n: i64) -> i1 {
   llvm.return %r#1 : i1
 }
 
-// CHECK-LABEL: llvm.func @all_set
-// CHECK:         %[[R:.+]]:2 = scf.while
-// CHECK:         llvm.return %[[R]]#1 : i1
+// CHECK-LABEL: llvm.func @all_set(
+// CHECK-SAME: %[[DEPS:.+]]: !llvm.ptr, %[[FLAGS:.+]]: !llvm.ptr, %[[N:.+]]: i64
+// CHECK-NEXT: %[[FALSE:.+]] = arith.constant false
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : i64
+// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : i64
+// CHECK-NEXT: %[[PI64:.+]] = ub.poison : i64
+// CHECK-NEXT: %[[PI1:.+]] = ub.poison : i1
+// CHECK-NEXT: %[[TRUE:.+]] = arith.constant true
+// CHECK-NEXT: %[[MAX:.+]] = arith.maxsi %[[N]], %[[C1]] : i64
+// CHECK-NEXT: %[[UB:.+]] = arith.addi %[[MAX]], %[[C1]] : i64
+// CHECK-NEXT: %[[FOR:.+]]:4 = scf.for %[[IV:.+]] = %[[C1]] to %[[UB]] step %[[C1]] iter_args(%[[I:.+]] = %[[C0]], %[[SHI:.+]] = %[[PI64]], %[[SHOK:.+]] = %[[PI1]], %[[LIVE:.+]] = %[[TRUE]]) -> (i64, i64, i1, i1)  : i64 {
+// CHECK-NEXT: %[[BODY:.+]]:3 = scf.if %[[LIVE]] -> (i64, i1, i1) {
+// CHECK-NEXT: %[[P:.+]] = llvm.getelementptr inbounds %[[DEPS]][%[[I]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+// CHECK-NEXT: %[[D:.+]] = llvm.load %[[P]] {alignment = 4 : i64} : !llvm.ptr -> i32
+// CHECK-NEXT: %[[D64:.+]] = arith.extsi %[[D]] : i32 to i64
+// CHECK-NEXT: %[[Q:.+]] = llvm.getelementptr inbounds %[[FLAGS]][%[[D64]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+// CHECK-NEXT: %[[F8:.+]] = llvm.load %[[Q]] {alignment = 1 : i64} : !llvm.ptr -> i8
+// CHECK-NEXT: %[[OK:.+]] = arith.trunci %[[F8]] : i8 to i1
+// CHECK-NEXT: %[[INC:.+]] = arith.addi %[[I]], %[[C1]] : i64
+// CHECK-NEXT: scf.yield %[[INC]], %[[OK]], %[[OK]] : i64, i1, i1
+// CHECK-NEXT: } else {
+// CHECK-NEXT: scf.yield %[[SHI]], %[[SHOK]], %[[FALSE]] : i64, i1, i1
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[MORE:.+]] = arith.cmpi slt, %[[IV]], %[[N]] : i64
+// CHECK-NEXT: %[[CONT:.+]] = arith.andi %[[MORE]], %[[BODY]]#2 : i1
+// CHECK-NEXT: %[[NI:.+]] = scf.if %[[CONT]] -> (i64) {
+// CHECK-NEXT: scf.yield %[[BODY]]#0 : i64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: scf.yield %[[PI64]] : i64
+// CHECK-NEXT: }
+// CHECK-NEXT: scf.yield %[[NI]], %[[BODY]]#0, %[[BODY]]#1, %[[BODY]]#2 : i64, i64, i1, i1
+// CHECK-NEXT: }
+// CHECK-NEXT: llvm.return %[[FOR]]#2 : i1
 
 // -----
 

--- a/test/lit_tests/whiletofor_dup_step.mlir
+++ b/test/lit_tests/whiletofor_dup_step.mlir
@@ -1,0 +1,75 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for | FileCheck %s
+
+// The rotated grid-stride reduction loop: the exit is a conjunction of the
+// induction bound and a data-dependent in-bounds test, and clang emits the
+// increment twice -- the condition passes one copy while the compare uses
+// the other. The structurally identical add must not block the conversion.
+func.func @gridstride(%N: i32, %ipt: i32, %bs: i32, %tid: i32, %woff: i32, %buf: memref<?xf64>) -> f64 {
+  %cst = arith.constant 0.0 : f64
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %r:2 = scf.while (%acc = %cst, %idx = %c0_i32) : (f64, i32) -> (f64, i32) {
+    %t0 = arith.addi %idx, %woff overflow<nsw> : i32
+    %t1 = arith.muli %t0, %bs : i32
+    %i = arith.addi %t1, %tid : i32
+    %inb = arith.cmpi slt, %i, %N : i32
+    %next = arith.addi %idx, %c1_i32 overflow<nsw, nuw> : i32
+    %next2 = arith.addi %idx, %c1_i32 overflow<nsw, nuw> : i32
+    %ne = arith.cmpi ne, %next2, %ipt : i32
+    %acc2 = scf.if %inb -> (f64) {
+      %ii = arith.index_cast %i : i32 to index
+      %v = memref.load %buf[%ii] : memref<?xf64>
+      %s = arith.addf %acc, %v : f64
+      scf.yield %s : f64
+    } else {
+      scf.yield %acc : f64
+    }
+    %cond = arith.andi %inb, %ne : i1
+    scf.condition(%cond) %acc2, %next : f64, i32
+  } do {
+  ^bb0(%a: f64, %i2: i32):
+    scf.yield %a, %i2 : f64, i32
+  }
+  return %r#0 : f64
+}
+
+// CHECK-LABEL: func.func @gridstride(
+// CHECK-SAME: %[[N:.+]]: i32, %[[IPT:.+]]: i32, %[[BS:.+]]: i32, %[[TID:.+]]: i32, %[[WOFF:.+]]: i32, %[[BUF:.+]]: memref<?xf64>
+// CHECK-NEXT: %[[FALSE:.+]] = arith.constant false
+// CHECK-NEXT: %[[CST:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : i32
+// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-NEXT: %[[PF:.+]] = ub.poison : f64
+// CHECK-NEXT: %[[PI:.+]] = ub.poison : i32
+// CHECK-NEXT: %[[TRUE:.+]] = arith.constant true
+// CHECK-NEXT: %[[MAX:.+]] = arith.maxsi %[[IPT]], %[[C1]] : i32
+// CHECK-NEXT: %[[UB:.+]] = arith.addi %[[MAX]], %[[C1]] : i32
+// CHECK-NEXT: %[[FOR:.+]]:5 = scf.for %[[IV:.+]] = %[[C1]] to %[[UB]] step %[[C1]] iter_args(%[[ACC:.+]] = %[[CST]], %[[IDX:.+]] = %[[C0]], %[[SHF:.+]] = %[[PF]], %[[SHI:.+]] = %[[PI]], %[[LIVE:.+]] = %[[TRUE]]) -> (f64, i32, f64, i32, i1)  : i32 {
+// CHECK-NEXT: %[[BODY:.+]]:3 = scf.if %[[LIVE]] -> (f64, i32, i1) {
+// CHECK-NEXT: %[[T0:.+]] = arith.addi %[[IDX]], %[[WOFF]] overflow<nsw> : i32
+// CHECK-NEXT: %[[T1:.+]] = arith.muli %[[T0]], %[[BS]] : i32
+// CHECK-NEXT: %[[I:.+]] = arith.addi %[[T1]], %[[TID]] : i32
+// CHECK-NEXT: %[[INB:.+]] = arith.cmpi slt, %[[I]], %[[N]] : i32
+// CHECK-NEXT: %[[NEXT:.+]] = arith.addi %[[IDX]], %[[C1]] overflow<nsw, nuw> : i32
+// CHECK-NEXT: %[[SUM:.+]] = scf.if %[[INB]] -> (f64) {
+// CHECK-NEXT: %[[II:.+]] = arith.index_cast %[[I]] : i32 to index
+// CHECK-NEXT: %[[V:.+]] = memref.load %[[BUF]][%[[II]]] : memref<?xf64>
+// CHECK-NEXT: %[[ADD:.+]] = arith.addf %[[ACC]], %[[V]] : f64
+// CHECK-NEXT: scf.yield %[[ADD]] : f64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: scf.yield %[[ACC]] : f64
+// CHECK-NEXT: }
+// CHECK-NEXT: scf.yield %[[SUM]], %[[NEXT]], %[[INB]] : f64, i32, i1
+// CHECK-NEXT: } else {
+// CHECK-NEXT: scf.yield %[[SHF]], %[[SHI]], %[[FALSE]] : f64, i32, i1
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[MORE:.+]] = arith.cmpi slt, %[[IV]], %[[IPT]] : i32
+// CHECK-NEXT: %[[CONT:.+]] = arith.andi %[[MORE]], %[[BODY]]#2 : i1
+// CHECK-NEXT: %[[RES:.+]]:2 = scf.if %[[CONT]] -> (f64, i32) {
+// CHECK-NEXT: scf.yield %[[BODY]]#0, %[[BODY]]#1 : f64, i32
+// CHECK-NEXT: } else {
+// CHECK-NEXT: scf.yield %[[PF]], %[[PI]] : f64, i32
+// CHECK-NEXT: }
+// CHECK-NEXT: scf.yield %[[RES]]#0, %[[RES]]#1, %[[BODY]]#0, %[[BODY]]#1, %[[BODY]]#2 : f64, i32, f64, i32, i1
+// CHECK-NEXT: }
+// CHECK-NEXT: return %[[FOR]]#2 : f64


### PR DESCRIPTION
MFEM's `reducers.hpp` grid-stride phase (every `Vector` reduction) rotates into an `scf.while` whose exit is `andi(i < N, idx+1 != items_per_thread)` — a shape `MoveWhileToFor`'s conjunction support handles — but clang emits the `idx+1` increment twice, and the pattern's SSA-identity check between the compare operand and the `scf.condition`-forwarded value rejected it (CSE upstream would also mask it, but the pattern shouldn't depend on that). Accept a structurally identical add of the same operands.

With this, the loop converts to an `scf.for` over `items_per_thread` with the `i < N` residual as a carried guard, unblocking raising of the reduction kernels' serial phase under `xla-gpu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD