### PR TITLE
Convert rotated halving do-whiles to log-space fors

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -3003,12 +3003,14 @@ struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
 
   LogicalResult matchAndRewrite(WhileOp loop,
                                 PatternRewriter &rewriter) const override {
-    // The after region must be a pure passthrough.
+    // The after region must be a pure passthrough: every yielded value is an
+    // after block argument, whose position names the condition operand it
+    // forwards. The order need not match the before arguments.
     Block &after = loop.getAfter().front();
     auto afterYield = cast<scf::YieldOp>(after.getTerminator());
-    for (auto [i, o] : llvm::enumerate(afterYield.getOperands())) {
+    for (Value o : afterYield.getOperands()) {
       auto ba = dyn_cast<BlockArgument>(o);
-      if (!ba || ba.getOwner() != &after || ba.getArgNumber() != i)
+      if (!ba || ba.getOwner() != &after)
         return failure();
     }
 
@@ -3026,12 +3028,34 @@ struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
     auto iv = dyn_cast<BlockArgument>(shift.getLhs());
     if (!iv || iv.getOwner() != &loop.getBefore().front())
       return failure();
-    unsigned ivIdx = iv.getArgNumber();
-    if (condOp.getArgs()[ivIdx] != shift.getResult())
+    // The induction variable is a before argument, but condition operands
+    // are indexed by the after arguments: the after yield translates between
+    // the two spaces.
+    unsigned beforeIvIdx = iv.getArgNumber();
+    unsigned afterIvIdx =
+        cast<BlockArgument>(afterYield.getOperand(beforeIvIdx)).getArgNumber();
+    if (condOp.getArgs()[afterIvIdx] != shift.getResult())
       return failure();
+    // Every other result must be fed back into some before slot so its final
+    // value survives as a result of the for.
+    SmallVector<int> resultSlot(loop.getNumResults(), -1);
+    {
+      unsigned fi = 0;
+      for (auto [i, o] : llvm::enumerate(afterYield.getOperands())) {
+        if (i == beforeIvIdx)
+          continue;
+        unsigned resIdx = cast<BlockArgument>(o).getArgNumber();
+        if (resultSlot[resIdx] == -1)
+          resultSlot[resIdx] = fi;
+        fi++;
+      }
+    }
+    for (auto [resIdx, slot] : llvm::enumerate(resultSlot))
+      if (slot == -1 && resIdx != afterIvIdx)
+        return failure();
 
     Location loc = loop.getLoc();
-    Value start = loop.getInits()[ivIdx];
+    Value start = loop.getInits()[beforeIvIdx];
     Type ivTy = iv.getType();
     unsigned width = ivTy.getIntOrFloatBitWidth();
 
@@ -3049,12 +3073,14 @@ struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
 
     SmallVector<Value> inits;
     for (auto [i, init] : llvm::enumerate(loop.getInits()))
-      if (i != ivIdx)
+      if (i != beforeIvIdx)
         inits.push_back(init);
 
     auto forOp = ForOp::create(rewriter, loc, lb, ub, step, inits);
-    if (auto *autoTerm = forOp.getBody()->getTerminator())
-      rewriter.eraseOp(autoTerm);
+    // The builder only adds an implicit yield when there are no iter args;
+    // drop it so the cloned body can yield the carried values.
+    if (!forOp.getBody()->empty())
+      rewriter.eraseOp(&forOp.getBody()->back());
     rewriter.setInsertionPointToStart(forOp.getBody());
     Value k = arith::IndexCastUIOp::create(rewriter, loc, ivTy,
                                            forOp.getInductionVar());
@@ -3064,7 +3090,7 @@ struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
     unsigned fi = 0;
     for (auto [i, arg] :
          llvm::enumerate(loop.getBefore().front().getArguments())) {
-      if (i == ivIdx)
+      if (i == beforeIvIdx)
         map.map(arg, curIv);
       else
         map.map(arg, forOp.getRegionIterArgs()[fi++]);
@@ -3072,19 +3098,20 @@ struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
     for (Operation &op : loop.getBefore().front().without_terminator())
       rewriter.clone(op, map);
     SmallVector<Value> yields;
-    for (auto [i, v] : llvm::enumerate(condOp.getArgs()))
-      if (i != ivIdx)
-        yields.push_back(map.lookupOrDefault(v));
+    for (auto [i, o] : llvm::enumerate(afterYield.getOperands()))
+      if (i != beforeIvIdx)
+        yields.push_back(map.lookupOrDefault(
+            condOp.getArgs()[cast<BlockArgument>(o).getArgNumber()]));
     scf::YieldOp::create(rewriter, loc, yields);
 
     // At the exit the forwarded shift result is zero; other results carry.
     rewriter.setInsertionPoint(loop);
     SmallVector<Value> repl;
-    fi = 0;
     for (auto [i, res] : llvm::enumerate(loop.getResults()))
       repl.push_back(
-          i == ivIdx ? ConstantIntOp::create(rewriter, loc, ivTy, 0).getResult()
-                     : forOp.getResult(fi++));
+          i == afterIvIdx
+              ? ConstantIntOp::create(rewriter, loc, ivTy, 0).getResult()
+              : forOp.getResult(resultSlot[i]));
     rewriter.replaceOp(loop, repl);
     return success();
   }

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -3057,14 +3057,22 @@ struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
     Location loc = loop.getLoc();
     Value start = loop.getInits()[beforeIvIdx];
     Type ivTy = iv.getType();
-    unsigned width = ivTy.getIntOrFloatBitWidth();
+    // An index variable has no fixed width: count in i64 instead, which the
+    // value-preserving cast zero-extends into, so the bit length comes out
+    // the same for any narrower lowering of index.
+    bool ivIsIndex = isa<IndexType>(ivTy);
+    Type lenTy = ivIsIndex ? (Type)rewriter.getI64Type() : ivTy;
+    unsigned width = lenTy.getIntOrFloatBitWidth();
 
     // Trips: max(bitwidth - ctlz(start), 1); ctlz(0) is the bitwidth, so a
     // zero start still runs the body once, matching the do-while.
-    Value lz = math::CountLeadingZerosOp::create(rewriter, loc, start);
-    Value wC = ConstantIntOp::create(rewriter, loc, ivTy, width);
+    Value cstart = start;
+    if (ivIsIndex)
+      cstart = arith::IndexCastUIOp::create(rewriter, loc, lenTy, start);
+    Value lz = math::CountLeadingZerosOp::create(rewriter, loc, cstart);
+    Value wC = ConstantIntOp::create(rewriter, loc, lenTy, width);
     Value len = SubIOp::create(rewriter, loc, wC, lz);
-    Value oneC = ConstantIntOp::create(rewriter, loc, ivTy, 1);
+    Value oneC = ConstantIntOp::create(rewriter, loc, lenTy, 1);
     Value trips = MaxUIOp::create(rewriter, loc, len, oneC);
     Value ub = arith::IndexCastUIOp::create(rewriter, loc,
                                             rewriter.getIndexType(), trips);
@@ -3082,8 +3090,9 @@ struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
     if (!forOp.getBody()->empty())
       rewriter.eraseOp(&forOp.getBody()->back());
     rewriter.setInsertionPointToStart(forOp.getBody());
-    Value k = arith::IndexCastUIOp::create(rewriter, loc, ivTy,
-                                           forOp.getInductionVar());
+    Value k = forOp.getInductionVar();
+    if (!ivIsIndex)
+      k = arith::IndexCastUIOp::create(rewriter, loc, ivTy, k);
     Value curIv = ShRUIOp::create(rewriter, loc, start, k);
 
     IRMapping map;
@@ -3106,12 +3115,13 @@ struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
 
     // At the exit the forwarded shift result is zero; other results carry.
     rewriter.setInsertionPoint(loop);
+    Value exitZero = ivIsIndex
+                         ? (Value)ConstantIndexOp::create(rewriter, loc, 0)
+                         : (Value)ConstantIntOp::create(rewriter, loc, ivTy, 0);
     SmallVector<Value> repl;
     for (auto [i, res] : llvm::enumerate(loop.getResults()))
-      repl.push_back(
-          i == afterIvIdx
-              ? ConstantIntOp::create(rewriter, loc, ivTy, 0).getResult()
-              : forOp.getResult(resultSlot[i]));
+      repl.push_back(i == afterIvIdx ? exitZero
+                                     : forOp.getResult(resultSlot[i]));
     rewriter.replaceOp(loop, repl);
     return success();
   }

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -2992,6 +2992,104 @@ struct SelectTruncToTruncSelect : public OpRewritePattern<TruncIOp> {
   }
 };
 
+// The do-while form of a halving loop: the whole body sits in the before
+// region, and the condition forwards i >> 1, continuing while it is nonzero.
+// The iteration space is logarithmic: k in [0, max(bitwidth - ctlz(start),
+// 1)) with i = start >> k, and the value forwarded out at the exit is always
+// zero. Rewriting to an scf.for gives the loop a linear induction variable
+// downstream analyses can reason about.
+struct DoWhileShiftToFor : public OpRewritePattern<WhileOp> {
+  using OpRewritePattern<WhileOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(WhileOp loop,
+                                PatternRewriter &rewriter) const override {
+    // The after region must be a pure passthrough.
+    Block &after = loop.getAfter().front();
+    auto afterYield = cast<scf::YieldOp>(after.getTerminator());
+    for (auto [i, o] : llvm::enumerate(afterYield.getOperands())) {
+      auto ba = dyn_cast<BlockArgument>(o);
+      if (!ba || ba.getOwner() != &after || ba.getArgNumber() != i)
+        return failure();
+    }
+
+    auto condOp = loop.getConditionOp();
+    auto cmp = condOp.getCondition().getDefiningOp<CmpIOp>();
+    if (!cmp)
+      return failure();
+    if (!(cmp.getPredicate() == CmpIPredicate::ne ||
+          cmp.getPredicate() == CmpIPredicate::ugt) ||
+        !matchPattern(cmp.getRhs(), m_Zero()))
+      return failure();
+    auto shift = cmp.getLhs().getDefiningOp<ShRUIOp>();
+    if (!shift || !matchPattern(shift.getRhs(), m_One()))
+      return failure();
+    auto iv = dyn_cast<BlockArgument>(shift.getLhs());
+    if (!iv || iv.getOwner() != &loop.getBefore().front())
+      return failure();
+    unsigned ivIdx = iv.getArgNumber();
+    if (condOp.getArgs()[ivIdx] != shift.getResult())
+      return failure();
+
+    Location loc = loop.getLoc();
+    Value start = loop.getInits()[ivIdx];
+    Type ivTy = iv.getType();
+    unsigned width = ivTy.getIntOrFloatBitWidth();
+
+    // Trips: max(bitwidth - ctlz(start), 1); ctlz(0) is the bitwidth, so a
+    // zero start still runs the body once, matching the do-while.
+    Value lz = math::CountLeadingZerosOp::create(rewriter, loc, start);
+    Value wC = ConstantIntOp::create(rewriter, loc, ivTy, width);
+    Value len = SubIOp::create(rewriter, loc, wC, lz);
+    Value oneC = ConstantIntOp::create(rewriter, loc, ivTy, 1);
+    Value trips = MaxUIOp::create(rewriter, loc, len, oneC);
+    Value ub = arith::IndexCastUIOp::create(rewriter, loc,
+                                            rewriter.getIndexType(), trips);
+    Value lb = ConstantIndexOp::create(rewriter, loc, 0);
+    Value step = ConstantIndexOp::create(rewriter, loc, 1);
+
+    SmallVector<Value> inits;
+    for (auto [i, init] : llvm::enumerate(loop.getInits()))
+      if (i != ivIdx)
+        inits.push_back(init);
+
+    auto forOp = ForOp::create(rewriter, loc, lb, ub, step, inits);
+    if (auto *autoTerm = forOp.getBody()->getTerminator())
+      rewriter.eraseOp(autoTerm);
+    rewriter.setInsertionPointToStart(forOp.getBody());
+    Value k = arith::IndexCastUIOp::create(rewriter, loc, ivTy,
+                                           forOp.getInductionVar());
+    Value curIv = ShRUIOp::create(rewriter, loc, start, k);
+
+    IRMapping map;
+    unsigned fi = 0;
+    for (auto [i, arg] :
+         llvm::enumerate(loop.getBefore().front().getArguments())) {
+      if (i == ivIdx)
+        map.map(arg, curIv);
+      else
+        map.map(arg, forOp.getRegionIterArgs()[fi++]);
+    }
+    for (Operation &op : loop.getBefore().front().without_terminator())
+      rewriter.clone(op, map);
+    SmallVector<Value> yields;
+    for (auto [i, v] : llvm::enumerate(condOp.getArgs()))
+      if (i != ivIdx)
+        yields.push_back(map.lookupOrDefault(v));
+    scf::YieldOp::create(rewriter, loc, yields);
+
+    // At the exit the forwarded shift result is zero; other results carry.
+    rewriter.setInsertionPoint(loop);
+    SmallVector<Value> repl;
+    fi = 0;
+    for (auto [i, res] : llvm::enumerate(loop.getResults()))
+      repl.push_back(
+          i == ivIdx ? ConstantIntOp::create(rewriter, loc, ivTy, 0).getResult()
+                     : forOp.getResult(fi++));
+    rewriter.replaceOp(loop, repl);
+    return success();
+  }
+};
+
 // If and and with something is preventing creating a for
 // move the and into the after body guarded by an if
 struct WhileShiftToInduction : public OpRewritePattern<WhileOp> {
@@ -3655,7 +3753,7 @@ void CanonicalizeFor::runOnOperation() {
 
           ReplaceRedundantArgs,
 
-          WhileShiftToInduction,
+          WhileShiftToInduction, DoWhileShiftToFor,
 
           ForBreakAddUpgrade, RemoveUnusedResults,
 

--- a/test/lit_tests/dowhile_shift_log.mlir
+++ b/test/lit_tests/dowhile_shift_log.mlir
@@ -58,3 +58,38 @@ func.func @treereduce(%bs: i32, %tid: i32, %buf: memref<?xf64>) {
 // CHECK-NEXT: }
 // CHECK-NEXT: return
 // CHECK-NEXT: }
+
+// The same rotated shape with a carried counter, where the condition forwards
+// its operands in a different order than the before arguments and the after
+// region's yield permutes them back: the shifted variable is condition
+// operand 1 but before argument 0, so the before and after index spaces must
+// be translated through the after yield.
+func.func @treereduce_swap(%bs: i32) -> (i32, i32) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %start = arith.shrui %bs, %c1_i32 : i32
+  %r:2 = scf.while (%i = %start, %count = %c0_i32) : (i32, i32) -> (i32, i32) {
+    %c2 = arith.addi %count, %c1_i32 : i32
+    %next = arith.shrui %i, %c1_i32 : i32
+    %nz = arith.cmpi ne, %next, %c0_i32 : i32
+    scf.condition(%nz) %c2, %next : i32, i32
+  } do {
+  ^bb0(%cc: i32, %a: i32):
+    scf.yield %a, %cc : i32, i32
+  }
+  return %r#0, %r#1 : i32, i32
+}
+
+// CHECK-LABEL: func.func @treereduce_swap(
+// CHECK-SAME: %[[SBS:.+]]: i32
+// CHECK-NEXT: %[[S0:.+]] = arith.constant 0 : i32
+// CHECK-NEXT: %[[S32:.+]] = arith.constant 32 : i32
+// CHECK-NEXT: %[[S1:.+]] = arith.constant 1 : i32
+// CHECK-NEXT: %[[SV0:.+]] = arith.shrui %[[SBS]], %[[S1]] : i32
+// CHECK-NEXT: %[[SV1:.+]] = math.ctlz %[[SV0]] : i32
+// CHECK-NEXT: %[[SV2:.+]] = arith.subi %[[S32]], %[[SV1]] : i32
+// CHECK-NEXT: %[[SV3:.+]] = arith.maxui %[[SV2]], %[[S1]] : i32
+// CHECK-NEXT: %[[SV4:.+]] = arith.index_castui %[[SV3]] : i32 to index
+// CHECK-NEXT: %[[SV5:.+]] = arith.index_cast %[[SV4]] : index to i32
+// CHECK-NEXT: return %[[SV5]], %[[S0]] : i32, i32
+// CHECK-NEXT: }

--- a/test/lit_tests/dowhile_shift_log.mlir
+++ b/test/lit_tests/dowhile_shift_log.mlir
@@ -1,0 +1,60 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for | FileCheck %s
+
+// The rotated (do-while) halving loop of a block tree reduction: the body,
+// the shift, and the nonzero test all sit in the before region, with the
+// shifted value forwarded as the carried state. WhileShiftToInduction only
+// matches the canonical body-in-after form, so this shape converts here: a
+// log-space scf.for over max(bitwidth - ctlz(start), 1) trips with
+// i = start >> k, running the body once even for a zero start.
+func.func @treereduce(%bs: i32, %tid: i32, %buf: memref<?xf64>) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %start = arith.shrui %bs, %c1_i32 : i32
+  %r = scf.while (%i = %start) : (i32) -> i32 {
+    %active = arith.cmpi ult, %tid, %i : i32
+    scf.if %active {
+      %pos = arith.addi %i, %tid overflow<nsw, nuw> : i32
+      %pi = arith.index_cast %pos : i32 to index
+      %ti = arith.index_cast %tid : i32 to index
+      %a = memref.load %buf[%ti] : memref<?xf64>
+      %b = memref.load %buf[%pi] : memref<?xf64>
+      %s = arith.addf %a, %b : f64
+      memref.store %s, %buf[%ti] : memref<?xf64>
+    }
+    %next = arith.shrui %i, %c1_i32 : i32
+    %nz = arith.cmpi ne, %next, %c0_i32 : i32
+    scf.condition(%nz) %next : i32
+  } do {
+  ^bb0(%a: i32):
+    scf.yield %a : i32
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @treereduce(
+// CHECK-SAME: %[[BS:.+]]: i32, %[[TID:.+]]: i32, %[[BUF:.+]]: memref<?xf64>
+// CHECK-NEXT: %[[V0:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[V1:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[V2:.+]] = arith.constant 32 : i32
+// CHECK-NEXT: %[[V3:.+]] = arith.constant 1 : i32
+// CHECK-NEXT: %[[V4:.+]] = arith.shrui %[[BS]], %[[V3]] : i32
+// CHECK-NEXT: %[[V5:.+]] = math.ctlz %[[V4]] : i32
+// CHECK-NEXT: %[[V6:.+]] = arith.subi %[[V2]], %[[V5]] : i32
+// CHECK-NEXT: %[[V7:.+]] = arith.maxui %[[V6]], %[[V3]] : i32
+// CHECK-NEXT: %[[V8:.+]] = arith.index_castui %[[V7]] : i32 to index
+// CHECK-NEXT: scf.for %[[V9:.+]] = %[[V1]] to %[[V8]] step %[[V0]] {
+// CHECK-NEXT: %[[V10:.+]] = arith.index_castui %[[V9]] : index to i32
+// CHECK-NEXT: %[[V11:.+]] = arith.shrui %[[V4]], %[[V10]] : i32
+// CHECK-NEXT: %[[V12:.+]] = arith.cmpi ult, %[[TID]], %[[V11]] : i32
+// CHECK-NEXT: scf.if %[[V12]] {
+// CHECK-NEXT: %[[V13:.+]] = arith.addi %[[V11]], %[[TID]] overflow<nsw, nuw> : i32
+// CHECK-NEXT: %[[V14:.+]] = arith.index_cast %[[V13]] : i32 to index
+// CHECK-NEXT: %[[V15:.+]] = arith.index_cast %[[TID]] : i32 to index
+// CHECK-NEXT: %[[V16:.+]] = memref.load %[[BUF]][%[[V15]]] : memref<?xf64>
+// CHECK-NEXT: %[[V17:.+]] = memref.load %[[BUF]][%[[V14]]] : memref<?xf64>
+// CHECK-NEXT: %[[V18:.+]] = arith.addf %[[V16]], %[[V17]] : f64
+// CHECK-NEXT: memref.store %[[V18]], %[[BUF]][%[[V15]]] : memref<?xf64>
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+// CHECK-NEXT: return
+// CHECK-NEXT: }

--- a/test/lit_tests/dowhile_shift_log.mlir
+++ b/test/lit_tests/dowhile_shift_log.mlir
@@ -93,3 +93,45 @@ func.func @treereduce_swap(%bs: i32) -> (i32, i32) {
 // CHECK-NEXT: %[[SV5:.+]] = arith.index_cast %[[SV4]] : index to i32
 // CHECK-NEXT: return %[[SV5]], %[[S0]] : i32, i32
 // CHECK-NEXT: }
+
+// An index-typed halving loop: index has no fixed bit width, so the trip
+// count is computed in i64 (which index_castui zero-extends into, keeping the
+// bit length right for any narrower index lowering), the for's induction
+// variable feeds the shift without a cast, and the exit value is a constant
+// index zero.
+func.func @treereduce_index(%bs: index, %buf: memref<?xf64>) -> index {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cf = arith.constant 1.000000e+00 : f64
+  %start = arith.shrui %bs, %c1 : index
+  %r = scf.while (%i = %start) : (index) -> index {
+    memref.store %cf, %buf[%i] : memref<?xf64>
+    %next = arith.shrui %i, %c1 : index
+    %nz = arith.cmpi ne, %next, %c0 : index
+    scf.condition(%nz) %next : index
+  } do {
+  ^bb0(%a: index):
+    scf.yield %a : index
+  }
+  return %r : index
+}
+
+// CHECK-LABEL: func.func @treereduce_index(
+// CHECK-SAME: %[[IBS:.+]]: index, %[[IBUF:.+]]: memref<?xf64>
+// CHECK-NEXT: %[[I0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[I1I64:.+]] = arith.constant 1 : i64
+// CHECK-NEXT: %[[I64C:.+]] = arith.constant 64 : i64
+// CHECK-NEXT: %[[I1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[ICF:.+]] = arith.constant 1.000000e+00 : f64
+// CHECK-NEXT: %[[IV0:.+]] = arith.shrui %[[IBS]], %[[I1]] : index
+// CHECK-NEXT: %[[IV1:.+]] = arith.index_castui %[[IV0]] : index to i64
+// CHECK-NEXT: %[[IV2:.+]] = math.ctlz %[[IV1]] : i64
+// CHECK-NEXT: %[[IV3:.+]] = arith.subi %[[I64C]], %[[IV2]] : i64
+// CHECK-NEXT: %[[IV4:.+]] = arith.maxui %[[IV3]], %[[I1I64]] : i64
+// CHECK-NEXT: %[[IV5:.+]] = arith.index_castui %[[IV4]] : i64 to index
+// CHECK-NEXT: scf.for %[[IK:.+]] = %[[I0]] to %[[IV5]] step %[[I1]] {
+// CHECK-NEXT: %[[IV6:.+]] = arith.shrui %[[IV0]], %[[IK]] : index
+// CHECK-NEXT: memref.store %[[ICF]], %[[IBUF]][%[[IV6]]] : memref<?xf64>
+// CHECK-NEXT: }
+// CHECK-NEXT: return %[[I0]] : index
+// CHECK-NEXT: }


### PR DESCRIPTION
The last raising blocker in MFEM's `reducers.hpp` kernels: the block tree reduction `for (i = bs>>1; i > 0; i >>= 1)` arrives do-while rotated — body, shift, and nonzero test all in the before region with the shifted value forwarded as carried state. `WhileShiftToInduction` (the existing Polygeist-heritage support for these) only matches the canonical body-in-after shape with a bare `ugt iv, 0` guard, so it never fires on this form.

`DoWhileShiftToFor` converts the rotated shape directly to a linear loop: `scf.for k in [0, max(bitwidth - ctlz(start), 1))` with `i = start >> k` — a zero start still runs the body once, matching do-while semantics, and the forwarded exit value is the constant zero. Test carries the full converted output; the canonicalize-scf-for corpus is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD