### PR TITLE
Expand small homogeneous-struct memcpy/memset into typed accesses

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -620,7 +620,7 @@ struct ExpandStructMemcpy : public OpRewritePattern<LLVM::MemcpyOp> {
     Type elt = tracedElementType(op.getSrc());
     if (!elt)
       elt = tracedElementType(op.getDst());
-    if (!elt)
+    if (!elt || !elt.isIntOrFloat())
       return failure();
     uint64_t eltBytes = elt.getIntOrFloatBitWidth() / 8;
     if (!eltBytes || len % eltBytes)
@@ -661,7 +661,7 @@ struct ExpandStructMemsetZero : public OpRewritePattern<LLVM::MemsetOp> {
     if (!len || len > 64)
       return failure();
     Type elt = ExpandStructMemcpy::tracedElementType(op.getDst());
-    if (!elt)
+    if (!elt || !elt.isIntOrFloat())
       return failure();
     uint64_t eltBytes = elt.getIntOrFloatBitWidth() / 8;
     if (!eltBytes || len % eltBytes)

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -551,6 +551,127 @@ static Value convertToIndex(Value v) {
       .getResult();
 }
 
+// A small constant-length llvm.intr.memcpy of struct data (MFEM's
+// work[work_idx] = buffer[0] tail writing a DevicePair) is opaque to both
+// mem2reg (no promotable slot: the shared source is dynamically indexed) and
+// the access raising. When either end traces to a memref of a homogeneous
+// struct -- every field the same scalar -- the copy is just n typed
+// load/store pairs, which the affine raising handles like any other access.
+struct ExpandStructMemcpy : public OpRewritePattern<LLVM::MemcpyOp> {
+  using OpRewritePattern<LLVM::MemcpyOp>::OpRewritePattern;
+
+  static Type tracedElementType(Value ptr, unsigned depth = 0) {
+    if (depth > 6)
+      return nullptr;
+    if (auto cast = ptr.getDefiningOp<LLVM::AddrSpaceCastOp>())
+      return tracedElementType(cast.getArg(), depth + 1);
+    if (auto gep = ptr.getDefiningOp<LLVM::GEPOp>())
+      return tracedElementType(gep.getBase(), depth + 1);
+    if (auto m2p = ptr.getDefiningOp<enzymexla::Memref2PointerOp>()) {
+      Type elt = cast<MemRefType>(m2p.getSource().getType()).getElementType();
+      if (auto st = dyn_cast<LLVM::LLVMStructType>(elt)) {
+        ArrayRef<Type> body = st.getBody();
+        if (body.empty() || !llvm::all_equal(body) ||
+            !body.front().isIntOrFloat())
+          return nullptr;
+        return body.front();
+      }
+      if (elt.isIntOrFloat())
+        return elt;
+      return nullptr;
+    }
+    return nullptr;
+  }
+
+  static unsigned argAlignment(Operation *op, unsigned arg) {
+    auto argAttrs = op->getAttrOfType<ArrayAttr>("arg_attrs");
+    if (!argAttrs || argAttrs.size() <= arg)
+      return 1;
+    auto dict = dyn_cast<DictionaryAttr>(argAttrs[arg]);
+    if (!dict)
+      return 1;
+    if (auto align =
+            dict.getAs<IntegerAttr>(LLVM::LLVMDialect::getAlignAttrName()))
+      return align.getInt();
+    return 1;
+  }
+
+  LogicalResult matchAndRewrite(LLVM::MemcpyOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getIsVolatile())
+      return failure();
+    APInt lenCst;
+    if (!matchPattern(op.getLen(), m_ConstantInt(&lenCst)))
+      return failure();
+    uint64_t len = lenCst.getZExtValue();
+    if (!len || len > 64)
+      return failure();
+    Type elt = tracedElementType(op.getSrc());
+    if (!elt)
+      elt = tracedElementType(op.getDst());
+    if (!elt)
+      return failure();
+    uint64_t eltBytes = elt.getIntOrFloatBitWidth() / 8;
+    if (!eltBytes || len % eltBytes)
+      return failure();
+    if (argAlignment(op, 0) < eltBytes || argAlignment(op, 1) < eltBytes)
+      return failure();
+
+    Location loc = op.getLoc();
+    for (uint64_t k = 0; k * eltBytes < len; ++k) {
+      Value sgep = LLVM::GEPOp::create(
+          rewriter, loc, op.getSrc().getType(), elt, op.getSrc(),
+          ArrayRef<LLVM::GEPArg>{LLVM::GEPArg((int32_t)k)});
+      Value dgep = LLVM::GEPOp::create(
+          rewriter, loc, op.getDst().getType(), elt, op.getDst(),
+          ArrayRef<LLVM::GEPArg>{LLVM::GEPArg((int32_t)k)});
+      Value v = LLVM::LoadOp::create(rewriter, loc, elt, sgep, eltBytes);
+      LLVM::StoreOp::create(rewriter, loc, v, dgep, eltBytes);
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// The zero-memset sibling: SetInitialValue zeroes the struct slot with a
+// 16-byte llvm.intr.memset, which expands to typed zero stores the same way.
+struct ExpandStructMemsetZero : public OpRewritePattern<LLVM::MemsetOp> {
+  using OpRewritePattern<LLVM::MemsetOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::MemsetOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getIsVolatile())
+      return failure();
+    APInt lenCst, valCst;
+    if (!matchPattern(op.getLen(), m_ConstantInt(&lenCst)) ||
+        !matchPattern(op.getVal(), m_ConstantInt(&valCst)) || !valCst.isZero())
+      return failure();
+    uint64_t len = lenCst.getZExtValue();
+    if (!len || len > 64)
+      return failure();
+    Type elt = ExpandStructMemcpy::tracedElementType(op.getDst());
+    if (!elt)
+      return failure();
+    uint64_t eltBytes = elt.getIntOrFloatBitWidth() / 8;
+    if (!eltBytes || len % eltBytes)
+      return failure();
+    if (ExpandStructMemcpy::argAlignment(op, 0) < eltBytes)
+      return failure();
+
+    Location loc = op.getLoc();
+    Value zero = arith::ConstantOp::create(rewriter, loc, elt,
+                                           rewriter.getZeroAttr(elt));
+    for (uint64_t k = 0; k * eltBytes < len; ++k) {
+      Value dgep = LLVM::GEPOp::create(
+          rewriter, loc, op.getDst().getType(), elt, op.getDst(),
+          ArrayRef<LLVM::GEPArg>{LLVM::GEPArg((int32_t)k)});
+      LLVM::StoreOp::create(rewriter, loc, zero, dgep, eltBytes);
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct GEPOfMemRefLoad : public OpRewritePattern<memref::LoadOp> {
   using OpRewritePattern<memref::LoadOp>::OpRewritePattern;
   const DataLayoutAnalysis &dl;
@@ -2171,7 +2292,8 @@ convertLLVMToAffineAccess(Operation *op,
                     SimplifyInPlaceAlloc<gpu::AllocOp>>(context,
                                                         dataLayoutAnalysis);
     patterns.insert<IndexCastAddSub, MemrefLoadAffineApply, SelectCSE,
-                    SelectAddrCast>(context);
+                    SelectAddrCast, ExpandStructMemcpy, ExpandStructMemsetZero>(
+        context);
     patterns.insert<SimplifyAllocConst<memref::AllocOp>,
                     SimplifyAllocConst<memref::AllocaOp>,
                     SimplifyAllocConst<gpu::AllocOp, true>>(context);

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -569,17 +569,28 @@ struct ExpandStructMemcpy : public OpRewritePattern<LLVM::MemcpyOp> {
       return tracedElementType(gep.getBase(), depth + 1);
     if (auto m2p = ptr.getDefiningOp<enzymexla::Memref2PointerOp>()) {
       Type elt = cast<MemRefType>(m2p.getSource().getType()).getElementType();
-      if (auto st = dyn_cast<LLVM::LLVMStructType>(elt)) {
-        ArrayRef<Type> body = st.getBody();
-        if (body.empty() || !llvm::all_equal(body) ||
-            !body.front().isIntOrFloat())
-          return nullptr;
-        return body.front();
-      }
-      if (elt.isIntOrFloat())
-        return elt;
-      return nullptr;
+      return homogeneousScalar(elt);
     }
+    if (auto alloca = ptr.getDefiningOp<LLVM::AllocaOp>())
+      return homogeneousScalar(alloca.getElemType());
+    return nullptr;
+  }
+
+  // The scalar a type is homogeneously made of: itself for a scalar, the
+  // field type for a struct or array of one scalar.
+  static Type homogeneousScalar(Type elt, unsigned depth = 0) {
+    if (depth > 4)
+      return nullptr;
+    if (auto st = dyn_cast<LLVM::LLVMStructType>(elt)) {
+      ArrayRef<Type> body = st.getBody();
+      if (body.empty() || !llvm::all_equal(body))
+        return nullptr;
+      return homogeneousScalar(body.front(), depth + 1);
+    }
+    if (auto at = dyn_cast<LLVM::LLVMArrayType>(elt))
+      return homogeneousScalar(at.getElementType(), depth + 1);
+    if (elt.isIntOrFloat())
+      return elt;
     return nullptr;
   }
 

--- a/test/lit_tests/expand_struct_memcpy.mlir
+++ b/test/lit_tests/expand_struct_memcpy.mlir
@@ -48,3 +48,20 @@ func.func @arrayinit() -> f64 {
 
 // CHECK-LABEL: func.func @arrayinit(
 // CHECK-NOT: llvm.intr.memset
+
+// -----
+
+// A pointer-element struct has no int-or-float width to expand with; the
+// memset stays a memset instead of producing a typeless zero constant.
+// CHECK-LABEL: llvm.func @ptrelems(
+// CHECK: "llvm.intr.memset"
+func.func private @use(!llvm.ptr)
+llvm.func @ptrelems() {
+  %c1 = llvm.mlir.constant(1 : i64) : i64
+  %len = llvm.mlir.constant(16 : i64) : i64
+  %zero = llvm.mlir.constant(0 : i8) : i8
+  %slot = llvm.alloca %c1 x !llvm.struct<(ptr, ptr)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+  "llvm.intr.memset"(%slot, %zero, %len) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  func.call @use(%slot) : (!llvm.ptr) -> ()
+  llvm.return
+}

--- a/test/lit_tests/expand_struct_memcpy.mlir
+++ b/test/lit_tests/expand_struct_memcpy.mlir
@@ -1,0 +1,32 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+// A small constant-length memcpy/memset of homogeneous-struct data (MFEM's
+// DevicePair reductions writing work[i] = buffer[0]) expands into typed
+// load/store pairs the affine access raising handles.
+func.func @structcopy(%dst: !llvm.ptr, %idx: i64) {
+  %buf = memref.alloca() : memref<256x!llvm.struct<"struct.mfem::DevicePair", (f64, f64)>>
+  %src = "enzymexla.memref2pointer"(%buf) : (memref<256x!llvm.struct<"struct.mfem::DevicePair", (f64, f64)>>) -> !llvm.ptr
+  %c0 = llvm.mlir.constant(0 : i8) : i8
+  %c16 = llvm.mlir.constant(16 : i64) : i64
+  "llvm.intr.memset"(%src, %c0, %c16) <{arg_attrs = [{llvm.align = 8 : i64}, {}, {}], isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %gep = llvm.getelementptr inbounds %dst[%idx] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<16 x i8>
+  "llvm.intr.memcpy"(%gep, %src, %c16) <{arg_attrs = [{llvm.align = 8 : i64}, {llvm.align = 8 : i64}, {}], isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @structcopy(
+// CHECK-SAME: %[[DST:.+]]: !llvm.ptr, %[[IDX:.+]]: i64
+// CHECK-NEXT: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT: %[[BUF:.+]] = memref.alloca() : memref<256x!llvm.struct<"struct.mfem::DevicePair", (f64, f64)>>
+// CHECK-NEXT: %[[SRC:.+]] = "enzymexla.memref2pointer"(%[[BUF]]) : (memref<256x!llvm.struct<"struct.mfem::DevicePair", (f64, f64)>>) -> !llvm.ptr
+// CHECK-NEXT: llvm.store %[[ZERO]], %[[SRC]] {alignment = 8 : i64} : f64, !llvm.ptr
+// CHECK-NEXT: %[[SF1:.+]] = llvm.getelementptr %[[SRC]][1] : (!llvm.ptr) -> !llvm.ptr, f64
+// CHECK-NEXT: llvm.store %[[ZERO]], %[[SF1]] {alignment = 8 : i64} : f64, !llvm.ptr
+// CHECK-NEXT: %[[DGEP:.+]] = llvm.getelementptr inbounds %[[DST]][%[[IDX]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<16 x i8>
+// CHECK-NEXT: %[[V0:.+]] = llvm.load %[[SRC]] {alignment = 8 : i64} : !llvm.ptr -> f64
+// CHECK-NEXT: llvm.store %[[V0]], %[[DGEP]] {alignment = 8 : i64} : f64, !llvm.ptr
+// CHECK-NEXT: %[[SF1B:.+]] = llvm.getelementptr %[[SRC]][1] : (!llvm.ptr) -> !llvm.ptr, f64
+// CHECK-NEXT: %[[DF1:.+]] = llvm.getelementptr %[[DGEP]][1] : (!llvm.ptr) -> !llvm.ptr, f64
+// CHECK-NEXT: %[[V1:.+]] = llvm.load %[[SF1B]] {alignment = 8 : i64} : !llvm.ptr -> f64
+// CHECK-NEXT: llvm.store %[[V1]], %[[DF1]] {alignment = 8 : i64} : f64, !llvm.ptr
+// CHECK-NEXT: return

--- a/test/lit_tests/expand_struct_memcpy.mlir
+++ b/test/lit_tests/expand_struct_memcpy.mlir
@@ -1,4 +1,4 @@
-// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access --split-input-file | FileCheck %s
 
 // A small constant-length memcpy/memset of homogeneous-struct data (MFEM's
 // DevicePair reductions writing work[i] = buffer[0]) expands into typed
@@ -30,3 +30,21 @@ func.func @structcopy(%dst: !llvm.ptr, %idx: i64) {
 // CHECK-NEXT: %[[V1:.+]] = llvm.load %[[SF1B]] {alignment = 8 : i64} : !llvm.ptr -> f64
 // CHECK-NEXT: llvm.store %[[V1]], %[[DF1]] {alignment = 8 : i64} : f64, !llvm.ptr
 // CHECK-NEXT: return
+
+// -----
+
+// The zero initializer of a small stack array (real_t du[3] = {0,0,0} in
+// MFEM's quadrature interpolator fallbacks) is a memset whose root is the
+// llvm.alloca itself; it expands the same way, letting the alloca convert.
+func.func @arrayinit() -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %c0_i8 = llvm.mlir.constant(0 : i8) : i8
+  %c24 = llvm.mlir.constant(24 : i64) : i64
+  %du = llvm.alloca %c1 x !llvm.array<3 x f64> {alignment = 16 : i64} : (i32) -> !llvm.ptr
+  "llvm.intr.memset"(%du, %c0_i8, %c24) <{arg_attrs = [{llvm.align = 16 : i64}, {}, {}], isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+  %v = llvm.load %du : !llvm.ptr -> f64
+  return %v : f64
+}
+
+// CHECK-LABEL: func.func @arrayinit(
+// CHECK-NOT: llvm.intr.memset


### PR DESCRIPTION
The last `vector.cpp` blocker class (#2968): MFEM's `DevicePair` reductions end with `work[work_idx] = buffer[0]`, a 16-byte struct copy arriving as `llvm.intr.memcpy` (plus a zero `llvm.intr.memset` from `SetInitialValue`). Neither mem2reg (no promotable slot — the shared source is dynamically indexed across barriers) nor the access raising can see through them.

When either end traces through casts/GEPs to a memref of a homogeneous struct — every field the same scalar — the transfer is just n typed load/store pairs (alignment permitting), which llvm-to-affine-access then raises like any other access. With this (and the strip of access-only `memory_space_cast`s), `vector.cpp` raises 49/49 kernels under the open PR set; the mass TUs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD