### PR TITLE
Strip access-only memory_space_cast views before raising

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3572,6 +3572,25 @@ struct AffineToStableHLORaisingPass
           AffineToStableHLORaisingPass> {
   using AffineToStableHLORaisingBase::AffineToStableHLORaisingBase;
 
+  // An access does not care about the address space of its base, but the
+  // raising identifies buffers by SSA root: a memory_space_cast view would
+  // split one buffer into two roots and lose store propagation. Retarget the
+  // accesses to the source and drop the cast.
+  static void stripAccessMemorySpaceCasts(Operation *root) {
+    SmallVector<memref::MemorySpaceCastOp> casts;
+    root->walk([&](memref::MemorySpaceCastOp c) { casts.push_back(c); });
+    for (auto c : casts) {
+      if (!llvm::all_of(c->getUsers(), [](Operation *u) {
+            return isa<affine::AffineLoadOp, affine::AffineStoreOp,
+                       memref::LoadOp, memref::StoreOp>(u);
+          }))
+        continue;
+      for (Operation *u : llvm::make_early_inc_range(c->getUsers()))
+        u->replaceUsesOfWith(c.getResult(), c.getSource());
+      c.erase();
+    }
+  }
+
   // A parallel dimension whose extent is only known at runtime cannot become
   // a tensor axis, but its iterations are still independent: peel each such
   // dimension into an affine.for tagged enzymexla.parallel, which the while
@@ -3694,8 +3713,10 @@ struct AffineToStableHLORaisingPass
 
     // Peeling rewrites loops, so it stays scoped to the regions this pass
     // actually raises.
-    for (auto func : funcs)
+    for (auto func : funcs) {
+      stripAccessMemorySpaceCasts(func);
       peelDynamicParallelDims(func);
+    }
 
     SymbolTableCollection symbolTable;
     SymbolUserMap userMap(symbolTable, op);
@@ -3714,8 +3735,10 @@ struct AffineToStableHLORaisingPass
     }
     std::vector<enzymexla::GPUWrapperOp> gwrap;
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
-    for (auto g : gwrap)
+    for (auto g : gwrap) {
+      stripAccessMemorySpaceCasts(g);
       peelDynamicParallelDims(g);
+    }
     size_t raised_count = 0;
     for (auto g : gwrap) {
       auto modOp = g->getParentOfType<ModuleOp>();

--- a/test/lit_tests/raising/raise_space_cast.mlir
+++ b/test/lit_tests/raising/raise_space_cast.mlir
@@ -1,0 +1,22 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// A memory_space_cast view of scratch would split one buffer into two SSA
+// roots; accesses do not care about the address space, so they retarget to
+// the source and the cast drops, letting the scratch raise as usual.
+func.func @spacecast(%out: memref<10xf64, 1>) {
+  %tmp = memref.alloca() : memref<10xf64>
+  %view = memref.memory_space_cast %tmp : memref<10xf64> to memref<10xf64, 3>
+  affine.parallel (%i) = (0) to (10) {
+    %c = arith.constant 2.0 : f64
+    affine.store %c, %view[%i] : memref<10xf64, 3>
+    %v = affine.load %view[9 - %i] : memref<10xf64, 3>
+    affine.store %v, %out[%i] : memref<10xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @spacecast_raised(
+// CHECK-NOT: memory_space_cast
+// CHECK-DAG: stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-DAG: stablehlo.constant dense<0.000000e+00> : tensor<10xf64>
+// CHECK: stablehlo.reverse


### PR DESCRIPTION
Companion to #2969 (together they close the last `vector.cpp` blocker in #2968): once the struct memcpy/memset expands, llvm-to-affine-access flattens the `DevicePair` scratch alloca itself — but its addrspace(3) views become `memref.memory_space_cast` ops, and the raising identifies buffers by SSA root, so the cast would split one buffer into two roots and lose store propagation (and `memory_space_cast` itself had no raising rule).

Accesses do not care about the address space: a pre-raise sweep (scoped to raise targets, like the peel) retargets load/store users to the cast's source and drops the cast. With #2969 + this + the open PR set, `vector.cpp` raises 49/49 kernels (73 whiles); pa/mk outputs are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD