### PR TITLE
Embed one module string per distinct kernel body

### DIFF
--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -15,6 +15,7 @@
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/MD5.h"
 
 #include "mlir/Analysis/DataLayoutAnalysis.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
@@ -3490,19 +3491,40 @@ private:
 
     auto loc = wrap.getLoc();
 
-    std::string str;
-    llvm::raw_string_ostream stream(str);
-
     auto i64 = rewriter.getIntegerType(64);
 
     auto fn = cast<FunctionOpInterface>(
         SymbolTable::lookupNearestSymbolFrom(wrap, wrap.getFn()));
-    stream << fn << "\n" << '\0';
 
-    auto stringval = mlir::LLVM::createGlobalString(
-        loc, rewriter,
-        "xlamod$" + cast<FlatSymbolRefAttr>(wrap.getFn()).getValue().str(), str,
-        LLVM::Linkage::Internal);
+    // Every launch site of a kernel lowers through here, and separate
+    // instantiations often raise to identical functions. The runtime renames
+    // the parsed function to `main` anyway, so print under a fixed name and
+    // key the embedded module by its content: every site of every identical
+    // kernel shares one copy (and one runtime executable-cache entry).
+    std::string str;
+    {
+      Operation *cloned = fn->clone();
+      cloned->setAttr(SymbolTable::getSymbolAttrName(),
+                      rewriter.getStringAttr("reactant_kernel"));
+      llvm::raw_string_ostream stream(str);
+      stream << *cloned << "\n" << '\0';
+      cloned->erase();
+    }
+    llvm::MD5 md5;
+    md5.update(str);
+    llvm::MD5::MD5Result res;
+    md5.final(res);
+    SmallString<32> hex;
+    llvm::MD5::stringifyResult(res, hex);
+    std::string modName = ("xlamod$" + hex).str();
+    Value stringval;
+    if (auto existing = SymbolTable::lookupNearestSymbolFrom<LLVM::GlobalOp>(
+            wrap, rewriter.getStringAttr(modName))) {
+      stringval = LLVM::AddressOfOp::create(rewriter, loc, existing);
+    } else {
+      stringval = mlir::LLVM::createGlobalString(loc, rewriter, modName, str,
+                                                 LLVM::Linkage::Internal);
+    }
 
     auto ptrty = LLVM::LLVMPointerType::get(rewriter.getContext());
 

--- a/test/lit_tests/lowering/xla.mlir
+++ b/test/lit_tests/lowering/xla.mlir
@@ -56,7 +56,7 @@ module {
 // CHECK:   llvm.func local_unnamed_addr @main() -> (i32 {llvm.noundef}) attributes {dso_local, passthrough = ["mustprogress", "norecurse", ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic", uwtable_kind = #llvm.uwtableKind<async>} {
 // CHECK-NEXT:      %0 = llvm.mlir.constant(2 : i32) : i32
 // CHECK-NEXT:      %1 = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:      %2 = llvm.mlir.addressof @xlamod$raised : !llvm.ptr
+// CHECK-NEXT:      %2 = llvm.mlir.addressof @[[MOD:xlamod\$[0-9a-f]+]] : !llvm.ptr
 // CHECK-NEXT:      %3 = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT:      %4 = llvm.mlir.addressof @__reactant_xla_data : !llvm.ptr
 // CHECK-NEXT:      %5 = llvm.mlir.constant(12 : i64) : i64
@@ -101,7 +101,7 @@ module {
 // CHECK-NEXT:      llvm.call @reactantXLAMemcpy(%4, %29, %22, %14, %3) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i32) -> ()
 // CHECK-NEXT:      llvm.call @reactantXLAMemcpy(%4, %31, %23, %14, %3) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i32) -> ()
 // CHECK-NEXT:      llvm.call @reactantXLAMemcpy(%4, %34, %24, %14, %3) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i32) -> ()
-// CHECK-NEXT:      %35 = llvm.getelementptr %2[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<574 x i8>
+// CHECK-NEXT:      %35 = llvm.getelementptr %2[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<583 x i8>
 // CHECK-NEXT:      %36 = llvm.getelementptr %16[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<2 x i64>
 // CHECK-NEXT:      llvm.store %27, %36 : !llvm.ptr<1>, !llvm.ptr
 // CHECK-NEXT:      %37 = llvm.getelementptr %16[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<2 x i64>

--- a/test/lit_tests/lowering/xla_dedup.mlir
+++ b/test/lit_tests/lowering/xla_dedup.mlir
@@ -1,0 +1,33 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=xla-gpu})" | FileCheck %s
+
+// Three launch sites, two structurally identical kernels under different
+// names: the embedded module is printed under a fixed function name and
+// keyed by content, so exactly one copy is emitted and every site loads it.
+module {
+  llvm.func @caller() {
+    %memref = gpu.alloc () : memref<4xf64, 1>
+    %memref_1 = gpu.alloc () : memref<4xf64, 1>
+    enzymexla.xla_wrapper @k1 (%memref, %memref_1) : (memref<4xf64, 1>, memref<4xf64, 1>) -> ()
+    enzymexla.xla_wrapper @k1 (%memref_1, %memref) : (memref<4xf64, 1>, memref<4xf64, 1>) -> ()
+    enzymexla.xla_wrapper @k2 (%memref, %memref_1) : (memref<4xf64, 1>, memref<4xf64, 1>) -> ()
+    llvm.return
+  }
+  func.func private @k1(%arg0: tensor<4xf64>, %arg1: tensor<4xf64>) -> (tensor<4xf64>, tensor<4xf64>) {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<4xf64>
+    return %arg0, %0 : tensor<4xf64>, tensor<4xf64>
+  }
+  func.func private @k2(%arg0: tensor<4xf64>, %arg1: tensor<4xf64>) -> (tensor<4xf64>, tensor<4xf64>) {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<4xf64>
+    return %arg0, %0 : tensor<4xf64>, tensor<4xf64>
+  }
+}
+
+// Exactly one embedded module, printed under the fixed name; its single
+// materialized address serves all three launch sites.
+// CHECK-COUNT-1: llvm.mlir.global internal constant @[[MOD:xlamod\$[0-9a-f]+]]("func.func private @reactant_kernel
+// CHECK-NOT: llvm.mlir.global internal constant @xlamod
+// CHECK: llvm.func @caller()
+// CHECK: llvm.mlir.addressof @[[MOD]] : !llvm.ptr
+// CHECK-NOT: llvm.mlir.addressof @xlamod
+// CHECK-COUNT-3: llvm.call @reactantXLAExec(
+// CHECK-NOT: llvm.call @reactantXLAExec(


### PR DESCRIPTION
Every `enzymexla.xla_wrapper` lowering embedded its own copy of the printed kernel module — one global per launch site — and structurally identical kernels (separate template instantiations that raise to the same function) each embedded yet another. On MFEM's `bilininteg_diffusion_ea.cpp` the duplicated strings grew the object to 2.6GB, overflowing PC32 relocations at link time.

The runtime renames the parsed function to `main` regardless of its symbol, so the kernel is now printed under a fixed name and the embedded global is keyed by an MD5 of the content: every launch site of every identical kernel body shares one string (and, since the runtime caches executables by the module pointer, one executable-cache entry). Includes a lit test with two identical kernels and three launch sites lowering to a single global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD