### PR TITLE
Pointer2MemrefOp: an access through a view of null folds

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -1196,19 +1196,55 @@ struct HoistSelectConversion : public OpRewritePattern<arith::SelectOp> {
   }
 };
 
+// An access through a view of the null pointer can only execute as undefined
+// behavior (an optional buffer a kernel receives as null sits behind a runtime
+// flag), so it is dynamically dead: an access with a result (a load) reads as
+// a zero of its type, one without (a store) drops. Offsets off the null have
+// already folded into the index.
+template <typename T>
+class NullPointer2MemrefAccess final : public OpRewritePattern<T> {
+public:
+  using OpRewritePattern<T>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(T op,
+                                PatternRewriter &rewriter) const override {
+    auto view =
+        op.getMemref().template getDefiningOp<enzymexla::Pointer2MemrefOp>();
+    if (!view || !view.getSource().template getDefiningOp<LLVM::ZeroOp>())
+      return failure();
+    if (op->getNumResults() == 0) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+    Type t = op->getResult(0).getType();
+    if (t.isIntOrFloat())
+      rewriter.replaceOpWithNewOp<arith::ConstantOp>(op, t,
+                                                     rewriter.getZeroAttr(t));
+    else if (LLVM::isCompatibleType(t))
+      rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, t);
+    else
+      return failure();
+    return success();
+  }
+};
+
 void Pointer2MemrefOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                    MLIRContext *context) {
-  results.insert<Pointer2MemrefCast, Pointer2Memref2PointerCast,
-                 LoadStorePointer2MemrefGEP<memref::LoadOp>,
-                 LoadStorePointer2MemrefGEP<affine::AffineLoadOp>,
-                 LoadStorePointer2MemrefGEP<memref::StoreOp>,
-                 LoadStorePointer2MemrefGEP<affine::AffineStoreOp>,
-                 LoadStorePointer2MemrefGEP<enzyme::AtomicRMWOp>,
-                 LoadStorePointer2MemrefGEP<memref::AtomicRMWOp>,
-                 LoadStorePointer2MemrefGEP<enzyme::AffineAtomicRMWOp>,
-                 HoistIfYieldConversion<scf::IfOp>,
-                 HoistIfYieldConversion<affine::AffineIfOp>,
-                 HoistSelectConversion>(context);
+  results
+      .insert<Pointer2MemrefCast, Pointer2Memref2PointerCast,
+              LoadStorePointer2MemrefGEP<memref::LoadOp>,
+              LoadStorePointer2MemrefGEP<affine::AffineLoadOp>,
+              LoadStorePointer2MemrefGEP<memref::StoreOp>,
+              LoadStorePointer2MemrefGEP<affine::AffineStoreOp>,
+              LoadStorePointer2MemrefGEP<enzyme::AtomicRMWOp>,
+              LoadStorePointer2MemrefGEP<memref::AtomicRMWOp>,
+              LoadStorePointer2MemrefGEP<enzyme::AffineAtomicRMWOp>,
+              HoistIfYieldConversion<scf::IfOp>,
+              HoistIfYieldConversion<affine::AffineIfOp>, HoistSelectConversion,
+              NullPointer2MemrefAccess<memref::LoadOp>,
+              NullPointer2MemrefAccess<affine::AffineLoadOp>,
+              NullPointer2MemrefAccess<memref::StoreOp>,
+              NullPointer2MemrefAccess<affine::AffineStoreOp>>(context);
   /*
   results.insert<Pointer2MemrefCast, Pointer2Memref2PointerCast,
                  MetaPointer2Memref<memref::LoadOp>,

--- a/test/lit_tests/null_view_access.mlir
+++ b/test/lit_tests/null_view_access.mlir
@@ -1,0 +1,71 @@
+// RUN: enzymexlamlir-opt %s --canonicalize --split-input-file | FileCheck %s
+
+// An optional buffer arriving as null: its accesses sit behind a runtime
+// flag, so they can only execute as undefined behavior. Loads through the
+// null view read as zero, stores through it drop, and the view dies.
+
+func.func @optional(%out: memref<?xf64>, %flag: i1, %v: f64) {
+  %null = llvm.mlir.zero : !llvm.ptr
+  %fview = "enzymexla.pointer2memref"(%null) : (!llvm.ptr) -> memref<?xf64>
+  %iview = "enzymexla.pointer2memref"(%null) : (!llvm.ptr) -> memref<?xi32>
+  scf.if %flag {
+    %m = affine.load %fview[3] : memref<?xf64>
+    %i = affine.load %iview[1] : memref<?xi32>
+    %fi = arith.sitofp %i : i32 to f64
+    %s = arith.addf %m, %fi : f64
+    affine.store %s, %out[0] : memref<?xf64>
+    affine.store %v, %fview[2] : memref<?xf64>
+  }
+  return
+}
+
+// CHECK:  module {
+// CHECK-NEXT:  func.func @optional(%arg0: memref<?xf64>, %arg1: i1, %arg2: f64) {
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    scf.if %arg1 {
+// CHECK-NEXT:      affine.store %cst, %arg0[0] : memref<?xf64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+// -----
+
+// A pointer loaded through a null view has no arith zero; it reads as llvm
+// null. memref accesses fold the same way as affine ones.
+
+func.func @optionalptr(%i: index, %v: i64) -> !llvm.ptr {
+  %null = llvm.mlir.zero : !llvm.ptr
+  %view = "enzymexla.pointer2memref"(%null) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+  %iview = "enzymexla.pointer2memref"(%null) : (!llvm.ptr) -> memref<?xi64>
+  %p = memref.load %view[%i] : memref<?x!llvm.ptr>
+  memref.store %v, %iview[%i] : memref<?xi64>
+  return %p : !llvm.ptr
+}
+
+// CHECK:  module {
+// CHECK-NEXT:  func.func @optionalptr(%arg0: index, %arg1: i64) -> !llvm.ptr {
+// CHECK-NEXT:    %0 = llvm.mlir.zero : !llvm.ptr
+// CHECK-NEXT:    return %0 : !llvm.ptr
+// CHECK-NEXT:  }
+
+// -----
+
+// An offset off the null folds into the view's index first, then the access
+// through the null view folds.
+
+func.func @offset(%out: memref<?xf64>, %v: f64) {
+  %null = llvm.mlir.zero : !llvm.ptr
+  %p = llvm.getelementptr %null[3] : (!llvm.ptr) -> !llvm.ptr, f64
+  %view = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+  %m = affine.load %view[1] : memref<?xf64>
+  affine.store %m, %out[0] : memref<?xf64>
+  affine.store %v, %view[0] : memref<?xf64>
+  return
+}
+
+// CHECK:  module {
+// CHECK-NEXT:  func.func @offset(%arg0: memref<?xf64>, %arg1: f64) {
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    affine.store %cst, %arg0[0] : memref<?xf64>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }


### PR DESCRIPTION
mfem's `hybridization_ext` passes a null for an absent optional array; the kernel's accesses through it sit behind a runtime flag, so they can only execute as undefined behavior, yet the raised kernel was left with an untypable null operand.

A null chosen against a real pointer is already the real pointer (canonicalize-parallel's select-of-null / if-of-null), and an offset off the null already folds into the view's index (`LoadStorePointer2MemrefGEP`). The remaining shape is the direct `pointer2memref` of `llvm.mlir.zero`, which this adds as a canonicalizer on `Pointer2MemrefOp`: a memref/affine load through such a view reads as a zero of its type (llvm null for pointer elements), and a store through it drops. The view then dies with its last access.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
