### PR TITLE
Hoist wrapper-invariant pointer compares to the host

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -4772,6 +4772,29 @@ struct AffineToStableHLORaisingPass
           AffineToStableHLORaisingPass> {
   using AffineToStableHLORaisingBase::AffineToStableHLORaisingBase;
 
+  // A pointer comparison has no tensor form, so a null check of an optional
+  // buffer computed inside the kernel blocks capturing the pointer. When
+  // both pointers are defined outside the wrapper the comparison is the
+  // host's to compute: hoist it out, so the kernel captures the resulting
+  // flag instead.
+  static void hoistWrapperInvariantPointerCompares(Operation *g) {
+    auto definedOutside = [&](Value v) {
+      if (auto ba = dyn_cast<BlockArgument>(v))
+        return !g->isProperAncestor(ba.getOwner()->getParentOp()) &&
+               ba.getOwner()->getParentOp() != g;
+      return !g->isProperAncestor(v.getDefiningOp());
+    };
+    SmallVector<LLVM::ICmpOp> toHoist;
+    g->walk([&](LLVM::ICmpOp cmp) {
+      if (!isa<LLVM::LLVMPointerType>(cmp.getLhs().getType()))
+        return;
+      if (definedOutside(cmp.getLhs()) && definedOutside(cmp.getRhs()))
+        toHoist.push_back(cmp);
+    });
+    for (auto cmp : toHoist)
+      cmp->moveBefore(g);
+  }
+
   // An access does not care about the address space of its base, but the
   // raising identifies buffers by SSA root: a memory_space_cast view would
   // split one buffer into two roots and lose store propagation. Retarget the
@@ -5103,6 +5126,7 @@ struct AffineToStableHLORaisingPass
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
       stripAccessMemorySpaceCasts(g);
+      hoistWrapperInvariantPointerCompares(g);
       boundParallelAxes(g);
       peelDynamicParallelDims(g);
     }

--- a/test/lit_tests/raising/raise_hoist_nullcheck.mlir
+++ b/test/lit_tests/raising/raise_hoist_nullcheck.mlir
@@ -1,0 +1,30 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// The guard flag of an optional buffer is computed inside the kernel as a
+// null check of a captured pointer. Both pointers are defined outside the
+// wrapper, so the comparison hoists to the host and the kernel captures the
+// resulting flag instead of pointers no tensor can stand for; the arithmetic
+// on the flag stays in the kernel.
+func.func @nullguard(%out: memref<32xf64, 1>, %opt: !llvm.ptr<1>) {
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  %null = llvm.mlir.zero : !llvm.ptr<1>
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c32, %c1, %c1) ({
+    %has = llvm.icmp "ne" %opt, %null : !llvm.ptr<1>
+    affine.parallel (%t) = (0) to (32) {
+      %v = arith.uitofp %has : i1 to f64
+      affine.store %v, %out[%t] : memref<32xf64, 1>
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK-LABEL: func.func @nullguard(
+// CHECK-SAME: %[[OUT:.+]]: memref<32xf64, 1>, %[[OPT:.+]]: !llvm.ptr<1>
+// CHECK: %[[NULL:.+]] = llvm.mlir.zero : !llvm.ptr<1>
+// CHECK-NEXT: %[[CMP:.+]] = llvm.icmp "ne" %[[OPT]], %[[NULL]] : !llvm.ptr<1>
+// CHECK: affine.store %[[CMP]], %{{.+}}[] : memref<i1>
+// CHECK: enzymexla.xla_wrapper @rxla$raised_0 (%{{.+}}, %[[OUT]]) : (memref<i1, 1>, memref<32xf64, 1>) -> ()
+// CHECK: func.func private @rxla$raised_0(%{{.+}}: tensor<i1>, %{{.+}}: tensor<32xf64>) -> (tensor<i1>, tensor<32xf64>)
+// CHECK: arith.uitofp %{{.+}} : tensor<i1> to tensor<f64>


### PR DESCRIPTION
Several MFEM TUs (hybridization_ext, bilinearform_ext, trace_jump_ea, batchitrans, ...) compute the guard flag of an optional buffer inside the kernel, as `llvm.icmp ne %captured, %null` — and pointer comparisons have no tensor form, so the wrapper-operand classifier rejects the captured pointers.

When both sides of an `llvm.icmp` on pointers are defined outside the `gpu_wrapper`, the comparison is the host's to compute: hoist it out of the region before raising. The kernel then captures the resulting flag, which the existing buffered-scalar path ships in as a `tensor<i1>` operand; the arithmetic on the flag stays in the kernel. Only pointer compares are hoisted — a pointer constant observed through other ops (`raise_ptr_constant_operand.mlir`) is still reported as an unraised operand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
