### PR TITLE
Size the captured-scalar staging copy in bytes

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3930,12 +3930,19 @@ struct AffineToStableHLORaisingPass
             affine::AffineStoreOp::create(
                 b, rewriteLocation(g.getLoc(), options.strip_llvm_debuginfo),
                 storeVal, res0, b.getMultiDimIdentityMap(0), ValueRange());
-            auto c1 = arith::ConstantIndexOp::create(
+            // The memcpy size is in bytes: a count of one only copies the
+            // low byte of the scalar.
+            int64_t elemBytes = (cast<MemRefType>(res0.getType())
+                                     .getElementType()
+                                     .getIntOrFloatBitWidth() +
+                                 7) /
+                                8;
+            auto csz = arith::ConstantIndexOp::create(
                 b, rewriteLocation(g.getLoc(), options.strip_llvm_debuginfo),
-                1);
+                elemBytes);
             enzymexla::MemcpyOp::create(
                 b, rewriteLocation(g.getLoc(), options.strip_llvm_debuginfo),
-                (mlir::Type) nullptr, ValueRange(), res, res0, c1);
+                (mlir::Type) nullptr, ValueRange(), res, res0, csz);
             b.setInsertionPointToStart(body);
             auto ld = affine::AffineLoadOp::create(
                 b, rewriteLocation(g.getLoc(), options.strip_llvm_debuginfo),

--- a/test/lit_tests/raising/raise_scalar_capture_bytes.mlir
+++ b/test/lit_tests/raising/raise_scalar_capture_bytes.mlir
@@ -1,0 +1,24 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// A captured scalar ships to the kernel through a one-element staging
+// buffer; the copy is sized in bytes, not elements: a count of one only
+// moved the low byte, so any captured value past 255 arrived as zero.
+func.func @capture(%out: memref<1024xf64, 1>, %n: index) {
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c32, %c1, %c1) ({
+    affine.parallel (%t) = (0) to (32) {
+      %v = arith.index_cast %n : index to i64
+      %tv = arith.index_cast %t : index to i64
+      %s = arith.addi %v, %tv : i64
+      %f = arith.sitofp %s : i64 to f64
+      affine.store %f, %out[%t] : memref<1024xf64, 1>
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK-LABEL: func.func @capture(
+// CHECK: %[[C8:.+]] = arith.constant 8 : index
+// CHECK: enzymexla.memcpy %{{.+}}, %{{.+}}, %[[C8]] : memref<i64, 1>, memref<i64>


### PR DESCRIPTION
A scalar captured by a raised kernel ships through a one-element staging buffer plus `enzymexla.memcpy`, whose size operand is in **bytes** — but the emission passed a constant count of one. Only the low byte of each captured scalar arrived on device: every value ≤ 255 (small block dims, tiny test sizes) worked by luck, while anything larger read as zero. On MFEM this made `Vector::Sum` receive N=0 and a zero thread-loop bound, silently returning 0 from an otherwise perfectly raised reduction kernel (root-caused by dumping exec inputs: `s32[] 0` for exactly the >255 scalars).

Size the copy by the element's byte width. With this (and the barrier-distribution fix in the companion PR), MFEM's `Vector Sum` GPU test passes with exact results through the raised XLA path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD