### PR TITLE
Distribute barriers under serialized parallel axes before raising

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3398,9 +3398,63 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     // it, which is exactly what materializing its initial value where the
     // alloca sits gives. Reads before any write see zeros.
     auto MT = alloca.getType();
-    if (!MT.hasStaticShape() || !isXLACompatiblePrimitive(MT.getElementType()))
+    if (!isXLACompatiblePrimitive(MT.getElementType()))
       return op->emitError("cannot raise dynamic or non-primitive alloca")
              << *op;
+    if (!MT.hasStaticShape()) {
+      // A scratch of runtime extent: a dynamic broadcast of the zero makes
+      // the buffer, its shape assembled from the mapped extents.
+      auto loc = rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo);
+      SmallVector<Value> dims;
+      unsigned dynIdx = 0;
+      auto i64Ty = RankedTensorType::get({}, builder.getI64Type());
+      auto i64x1Ty = RankedTensorType::get({1}, builder.getI64Type());
+      for (int64_t d = 0; d < MT.getRank(); ++d) {
+        Value dv;
+        if (MT.isDynamicDim(d)) {
+          if (dynIdx >= alloca.getDynamicSizes().size())
+            return op->emitError("cannot raise dynamic or non-primitive "
+                                 "alloca")
+                   << *op;
+          Value szv = mapping.lookupOrNull(alloca.getDynamicSizes()[dynIdx++]);
+          if (!szv || cast<RankedTensorType>(szv.getType()).getRank() != 0)
+            return op->emitError("cannot raise dynamic or non-primitive "
+                                 "alloca")
+                   << *op;
+          if (!cast<RankedTensorType>(szv.getType())
+                   .getElementType()
+                   .isInteger(64))
+            szv = stablehlo::ConvertOp::create(builder, loc, i64Ty, szv);
+          dv = szv;
+        } else {
+          dv = stablehlo::ConstantOp::create(
+              builder, loc, i64Ty,
+              SplatElementsAttr::get(
+                  i64Ty, builder.getI64IntegerAttr(MT.getDimSize(d))));
+        }
+        dims.push_back(stablehlo::ReshapeOp::create(builder, loc, i64x1Ty, dv));
+      }
+      Value shape =
+          dims.size() == 1
+              ? dims[0]
+              : stablehlo::ConcatenateOp::create(builder, loc, dims, 0)
+                    .getResult();
+      auto ST = RankedTensorType::get({}, MT.getElementType());
+      Value zeroScalar = stablehlo::ConstantOp::create(
+          builder, loc, ST,
+          SplatElementsAttr::get(ST, builder.getZeroAttr(MT.getElementType())));
+      SmallVector<int64_t> dynShape(MT.getRank(), ShapedType::kDynamic);
+      for (int64_t d = 0; d < MT.getRank(); ++d)
+        if (!MT.isDynamicDim(d))
+          dynShape[d] = MT.getDimSize(d);
+      auto TT = RankedTensorType::get(dynShape, MT.getElementType());
+      Value dyn = stablehlo::DynamicBroadcastInDimOp::create(
+          builder, loc, TT, zeroScalar, shape,
+          builder.getDenseI64ArrayAttr({}));
+      mapping.map(alloca.getResult(), dyn);
+      maps[dyn] = affine::AffineValueMap(AffineMap::get(op->getContext()), {});
+      return success();
+    }
     auto TT = RankedTensorType::get(MT.getShape(), MT.getElementType());
     Value zero = stablehlo::ConstantOp::create(
         builder, rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
@@ -3419,6 +3473,13 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
   // thread axis completes for the entire axis before the next op runs, which
   // is exactly what the barrier guaranteed.
   if (isa<enzymexla::BarrierOp>(op)) {
+    // A serialized (dynamic-extent) axis has no whole-tensor ordering, and
+    // should have been distributed away before raising.
+    for (Operation *p = op->getParentOp(); p; p = p->getParentOp())
+      if (auto ap = dyn_cast<affine::AffineParallelOp>(p))
+        if (!ap.getConstantRanges())
+          return op->emitError(
+              "barrier under a serialized parallel axis was not distributed");
     return success();
   }
 
@@ -3576,6 +3637,38 @@ struct AffineToStableHLORaisingPass
   // raising identifies buffers by SSA root: a memory_space_cast view would
   // split one buffer into two roots and lose store propagation. Retarget the
   // accesses to the source and drop the cast.
+  // An alloca scope only delimits stack lifetime, which the raised value
+  // semantics make meaningless: splice its body into the parent.
+  static void inlineAllocaScopes(Operation *g) {
+    SmallVector<memref::AllocaScopeOp> scopes;
+    g->walk([&](memref::AllocaScopeOp sc) { scopes.push_back(sc); });
+    for (auto sc : scopes) {
+      if (sc->getNumResults() != 0)
+        continue;
+      Block *body = &sc.getBodyRegion().front();
+      body->getTerminator()->erase();
+      sc->getBlock()->getOperations().splice(sc->getIterator(),
+                                             body->getOperations());
+      sc.erase();
+    }
+  }
+
+  // A barrier under a parallel axis of dynamic extent raises serialized, so
+  // it cannot be dropped as a no-op: distribute the loops around it first,
+  // cpuify-style, so every pre-barrier phase completes for the whole axis
+  // before the next phase starts.
+  static void distributeSerializedBarriers(Operation *g) {
+    bool need = false;
+    g->walk([&](enzymexla::BarrierOp b) {
+      for (Operation *p = b->getParentOp(); p && p != g; p = p->getParentOp())
+        if (auto ap = dyn_cast<affine::AffineParallelOp>(p))
+          if (!ap.getConstantRanges())
+            need = true;
+    });
+    if (need)
+      (void)enzymexla::distributeAroundBarriers(g);
+  }
+
   static void stripAccessMemorySpaceCasts(Operation *root) {
     SmallVector<memref::MemorySpaceCastOp> casts;
     root->walk([&](memref::MemorySpaceCastOp c) { casts.push_back(c); });
@@ -3715,6 +3808,8 @@ struct AffineToStableHLORaisingPass
     // actually raises.
     for (auto func : funcs) {
       stripAccessMemorySpaceCasts(func);
+      distributeSerializedBarriers(func);
+      inlineAllocaScopes(func);
       peelDynamicParallelDims(func);
     }
 
@@ -3737,6 +3832,8 @@ struct AffineToStableHLORaisingPass
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
       stripAccessMemorySpaceCasts(g);
+      distributeSerializedBarriers(g);
+      inlineAllocaScopes(g);
       peelDynamicParallelDims(g);
     }
     size_t raised_count = 0;

--- a/src/enzyme_ad/jax/Passes/ParallelLoopDistribute.cpp
+++ b/src/enzyme_ad/jax/Passes/ParallelLoopDistribute.cpp
@@ -2861,7 +2861,8 @@ struct LowerCacheLoad : public OpRewritePattern<enzymexla::CacheLoadOp> {
 
 struct SCFCPUifyPass : public enzyme::impl::SCFCPUifyBase<SCFCPUifyPass> {
   template <bool UseMinCut>
-  void addPatterns(RewritePatternSet &patterns, StringRef method) {
+  static void addPatterns(RewritePatternSet &patterns, StringRef method,
+                          MLIRContext *ctx) {
     patterns.insert<
         mlir::enzymexla::BarrierElim</*TopLevelOnly*/ false>, Reg2MemWhile,
         Reg2MemFor<scf::ForOp, UseMinCut>,
@@ -2879,14 +2880,14 @@ struct SCFCPUifyPass : public enzyme::impl::SCFCPUifyBase<SCFCPUifyPass> {
         InterchangeForIfPFor<affine::AffineParallelOp, scf::IfOp>,
         InterchangeForIfPFor<scf::ParallelOp, affine::AffineIfOp>,
         InterchangeForIfPFor<affine::AffineParallelOp, affine::AffineIfOp>>(
-        &getContext());
+        ctx);
     if (method.contains("ifhoist")) {
       patterns
           .insert<HoistBarrierIf<scf::ParallelOp, scf::IfOp>,
                   HoistBarrierIf<scf::ParallelOp, affine::AffineIfOp>,
                   HoistBarrierIf<affine::AffineParallelOp, scf::IfOp>,
                   HoistBarrierIf<affine::AffineParallelOp, affine::AffineIfOp>>(
-              &getContext());
+              ctx);
     } else {
       if (method.contains("ifsplit")) {
         patterns.insert<
@@ -2896,11 +2897,10 @@ struct SCFCPUifyPass : public enzyme::impl::SCFCPUifyBase<SCFCPUifyPass> {
                                       affine::AffineParallelOp, UseMinCut>,
             DistributeIfAroundBarrier<scf::IfOp, scf::ParallelOp, UseMinCut>,
             DistributeIfAroundBarrier<affine::AffineIfOp, scf::ParallelOp,
-                                      UseMinCut>>(&getContext());
+                                      UseMinCut>>(ctx);
       }
       patterns.insert<WrapIfWithBarrier<scf::IfOp, UseMinCut>,
-                      WrapIfWithBarrier<affine::AffineIfOp, UseMinCut>>(
-          &getContext());
+                      WrapIfWithBarrier<affine::AffineIfOp, UseMinCut>>(ctx);
     }
 
     patterns.insert<
@@ -2909,8 +2909,7 @@ struct SCFCPUifyPass : public enzyme::impl::SCFCPUifyBase<SCFCPUifyPass> {
         // RotateWhile,
 
         DistributeAroundBarrier<scf::ParallelOp, UseMinCut>,
-        DistributeAroundBarrier<affine::AffineParallelOp, UseMinCut>>(
-        &getContext());
+        DistributeAroundBarrier<affine::AffineParallelOp, UseMinCut>>(ctx);
   }
   // CPUifyPass() = default;
   // CPUifyPass(StringRef method) { this->method.setValue(method.str()); }
@@ -2921,9 +2920,9 @@ struct SCFCPUifyPass : public enzyme::impl::SCFCPUifyBase<SCFCPUifyPass> {
       {
         RewritePatternSet patterns(&getContext());
         if (method.contains("mincut"))
-          addPatterns<true>(patterns, method);
+          addPatterns<true>(patterns, method, &getContext());
         else
-          addPatterns<false>(patterns, method);
+          addPatterns<false>(patterns, method, &getContext());
         // GreedyRewriteConfig config;
         //  config.maxIterations = 142;
         mlir::GreedyRewriteConfig config;
@@ -2963,5 +2962,38 @@ struct SCFCPUifyPass : public enzyme::impl::SCFCPUifyBase<SCFCPUifyPass> {
 };
 
 } // end namespace
+
+// Distribute loops around barriers in `root`, cpuify-style, without running
+// the whole pass: the raising uses this for wrappers whose barrier sits
+// under a serialized parallel axis. The mincut variant recomputes values
+// crossing a barrier where it can, keeping the cache buffers away.
+namespace mlir {
+namespace enzymexla {
+LogicalResult distributeAroundBarriers(Operation *root) {
+  MLIRContext *ctx = root->getContext();
+  {
+    RewritePatternSet patterns(ctx);
+    SCFCPUifyPass::addPatterns<true>(patterns, "distribute.mincut", ctx);
+    GreedyRewriteConfig config;
+    config.setMaxIterations(142);
+    config.enableFolding();
+    if (failed(applyPatternsGreedily(root, std::move(patterns), config)))
+      return failure();
+  }
+  {
+    RewritePatternSet patterns(ctx);
+    patterns.insert<LowerCacheLoad>(ctx);
+    // The cache buffers arrive behind subindex views; fold them into the
+    // accesses so the raising sees plain multi-dimensional indexing.
+    enzymexla::SubIndexOp::getCanonicalizationPatterns(patterns, ctx);
+    GreedyRewriteConfig config;
+    config.enableFolding();
+    if (failed(applyPatternsGreedily(root, std::move(patterns), config)))
+      return failure();
+  }
+  return success();
+}
+} // namespace enzymexla
+} // namespace mlir
 
 // } // namespace mlir

--- a/src/enzyme_ad/jax/Passes/Passes.h
+++ b/src/enzyme_ad/jax/Passes/Passes.h
@@ -54,6 +54,10 @@ namespace cf {
 void populateLLVMToControlFlowConversionPatterns(RewritePatternSet &patterns);
 } // namespace cf
 
+namespace enzymexla {
+// Distribute loops around enzymexla.barrier ops in `root`, cpuify-style.
+LogicalResult distributeAroundBarriers(Operation *root);
+} // namespace enzymexla
 } // end namespace mlir
 
 void fully2ComposeAffineMapAndOperands(


### PR DESCRIPTION
The raiser drops `enzymexla.barrier` as a no-op on the grounds that whole-tensor updates over a batched thread axis are already ordered — but that only holds when the axis is actually batched. A parallel axis of **dynamic extent** raises as a sequential loop, and dropping the barrier then runs each thread's entire body (tree reduction included) before the next thread ever stores its partial. MFEM's block reductions (`Vector::Sum`/`Min`/`Max`/norms, `reducers.hpp`) returned a single lane's value this way.

This distributes loops around such barriers before raising, reusing the cpuify machinery (`SCFCPUifyPass`'s pattern set exported as a scoped `distributeAroundBarriers` helper; the mincut variant recomputes barrier-crossing values, which keeps the crossing caches away entirely for these kernels). Downstream needs three companions, included here: `memref.alloca_scope` ops the distribution introduces are spliced away (they only delimit stack lifetime, meaningless under value semantics); one-dimensional dynamic-extent allocas raise as dynamic zero broadcasts; and a barrier still found under a serialized axis is now a hard error instead of a silent drop.

Together with #2978, MFEM's `Vector Sum` GPU test passes exactly through the raised XLA path (per-block partials verified against numpy under a PJRT harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD