### PR TITLE
Error on a barrier over a dynamically sized parallel axis

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3419,6 +3419,26 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
   // thread axis completes for the entire axis before the next op runs, which
   // is exactly what the barrier guaranteed.
   if (isa<enzymexla::BarrierOp>(op)) {
+    // Raised execution is ordered over whole tensors, so a barrier over
+    // batched axes is a no-op. That is only sound for the axes the barrier
+    // spans when they are batched: an induction variable of a dynamically
+    // sized loop raises serialized, with no whole-tensor ordering to lean
+    // on, and dropping the barrier would let one lane run ahead of the
+    // others' stores.
+    for (Value iv : op->getOperands()) {
+      auto ba = dyn_cast<BlockArgument>(iv);
+      if (!ba)
+        continue;
+      Operation *owner = ba.getOwner()->getParentOp();
+      if (auto par = dyn_cast<affine::AffineParallelOp>(owner)) {
+        if (!par.getConstantRanges())
+          return op->emitError(
+              "barrier over a dynamically sized parallel axis");
+        continue;
+      }
+      if (isa<affine::AffineForOp, scf::ForOp, scf::WhileOp>(owner))
+        return op->emitError("barrier over a dynamically sized parallel axis");
+    }
     return success();
   }
 

--- a/test/lit_tests/raising/raise_barrier_dynamic_error.mlir
+++ b/test/lit_tests/raising/raise_barrier_dynamic_error.mlir
@@ -1,0 +1,21 @@
+// RUN: not enzymexlamlir-opt %s --raise-affine-to-stablehlo 2>&1 | FileCheck %s
+
+// A barrier over a statically sized thread axis batches away; over a
+// dynamically sized axis the loop raises serialized, where dropping the
+// barrier would let one lane run ahead of the others' stores: report it
+// instead of miscompiling.
+func.func @dynbarrier(%out: memref<?xf64, 1>, %in: memref<?xf64, 1>, %nbuf: memref<i64, 1>) {
+  %n = affine.load %nbuf[] : memref<i64, 1>
+  %ni = arith.index_cast %n : i64 to index
+  %c0 = arith.constant 0 : index
+  affine.parallel (%t) = (0) to (symbol(%ni)) {
+    %v = affine.load %in[%t] : memref<?xf64, 1>
+    affine.store %v, %out[%t] : memref<?xf64, 1>
+    "enzymexla.barrier"(%t, %c0, %c0) : (index, index, index) -> ()
+    %w = affine.load %out[%t] : memref<?xf64, 1>
+    affine.store %w, %in[%t] : memref<?xf64, 1>
+  }
+  return
+}
+
+// CHECK: barrier over a dynamically sized parallel axis


### PR DESCRIPTION
The raiser drops `enzymexla.barrier` as a no-op on the grounds that whole-tensor updates over a batched thread axis are already ordered. That's only sound for the axes the barrier spans when they're batched: an induction variable of a **dynamically sized** loop raises serialized, and dropping the barrier then lets one lane run its whole body — tree reduction included — before the other lanes store their partials. MFEM's block reductions (`Vector::Sum`/norms, reducers.hpp) silently returned a single lane's value this way.

Per review on #2979, this is the minimal guard first: check the induction variables actually passed to the barrier, and error when one belongs to a dynamically sized `affine.parallel` (or to a sequential loop after peeling) instead of miscompiling. Static-axis barriers are untouched.

Survey of who actually hits this on MFEM (block sizes are usually compile-time constants, so the reach is narrower than feared, but non-empty): the `reduce()` family in linalg/vector.cpp computes `block_size = min(256, 1 << log2(N))` at runtime, and fem/quadinterpolator.cpp's runtime-dispatch fallback kernels launch `MFEM_FORALL_2D(e, NE, q1d, q1d, 1)` with runtime `q1d` — full per-TU list to follow on the tracking issue once the sweep completes. #2979 (distribution) remains the candidate fix for actually raising those kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD