### PR TITLE
Batch bounded-extent parallel axes behind a guard

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3617,6 +3617,171 @@ struct AffineToStableHLORaisingPass
   // raising then iterates, leaving the constant-extent dimensions to raise as
   // axes. The tag rides onto the stablehlo.while so downstream passes know
   // the iterations commute.
+  // The constant upper bound of an extent value, where one can be derived:
+  // the value itself when constant, or the constant side of a min it is
+  // clamped by (MFEM's block sizes arrive as min(1 << log2(N), 256)).
+  static std::optional<int64_t> derivedExtentBound(Value v,
+                                                   unsigned depth = 0) {
+    if (depth > 8)
+      return std::nullopt;
+    while (true) {
+      if (auto c = v.getDefiningOp<arith::IndexCastOp>()) {
+        v = c.getIn();
+        continue;
+      }
+      if (auto c = v.getDefiningOp<arith::IndexCastUIOp>()) {
+        v = c.getIn();
+        continue;
+      }
+      break;
+    }
+    APInt cst;
+    if (matchPattern(v, m_ConstantInt(&cst)))
+      return cst.getSExtValue();
+    if (auto mn = v.getDefiningOp<arith::MinSIOp>()) {
+      auto l = derivedExtentBound(mn.getLhs(), depth + 1);
+      auto r = derivedExtentBound(mn.getRhs(), depth + 1);
+      if (l && r)
+        return std::min(*l, *r);
+      return l ? l : r;
+    }
+    if (auto mn = v.getDefiningOp<arith::MinUIOp>()) {
+      auto l = derivedExtentBound(mn.getLhs(), depth + 1);
+      auto r = derivedExtentBound(mn.getRhs(), depth + 1);
+      if (l && r)
+        return std::min(*l, *r);
+      return l ? l : r;
+    }
+    return std::nullopt;
+  }
+
+  // A parallel axis whose extent is dynamic but provably bounded (a block
+  // size clamped by a min against a constant) batches at the bound instead
+  // of peeling to a serial loop: the axis becomes constant-extent and the
+  // body sits behind an `iv < extent` guard, which the masking machinery
+  // already understands. Barriers over the axis then stay batched no-ops.
+  static void boundParallelAxes(Operation *root) {
+    SmallVector<affine::AffineParallelOp> worklist;
+    root->walk([&](affine::AffineParallelOp par) { worklist.push_back(par); });
+    for (auto par : worklist) {
+      if (!par.getReductions().empty())
+        continue;
+      unsigned n = par.getNumDims();
+      struct BoundedDim {
+        unsigned dim;
+        int64_t bound;
+        Value extent;
+      };
+      SmallVector<BoundedDim> bounded;
+      for (unsigned i = 0; i < n; ++i) {
+        auto lb = getConstant(par.getLowerBoundMap(i));
+        if (!lb || *lb != 0 || par.getSteps()[i] != 1)
+          continue;
+        if (getConstant(par.getUpperBoundMap(i)))
+          continue;
+        auto um = par.getUpperBoundMap(i);
+        if (um.getNumResults() != 1)
+          continue;
+        auto se = dyn_cast<AffineSymbolExpr>(um.getResult(0));
+        if (!se)
+          continue;
+        Value ext =
+            par.getUpperBoundsOperands()[par.getUpperBoundsMap().getNumDims() +
+                                         se.getPosition()];
+        if (auto c = derivedExtentBound(ext))
+          bounded.push_back({i, *c, ext});
+      }
+      if (bounded.empty())
+        continue;
+
+      OpBuilder b(par);
+      Location loc = par.getLoc();
+      SmallVector<AffineExpr> lbounds, ubounds;
+      SmallVector<int32_t> lboundGroup, uboundGroup;
+      SmallVector<int64_t> steps;
+      for (unsigned i = 0; i < n; ++i) {
+        auto lm = par.getLowerBoundMap(i);
+        lbounds.append(lm.getResults().begin(), lm.getResults().end());
+        lboundGroup.push_back(lm.getNumResults());
+        auto um = par.getUpperBoundMap(i);
+        auto bit = llvm::find_if(
+            bounded, [&](const BoundedDim &bd) { return bd.dim == i; });
+        if (bit != bounded.end()) {
+          ubounds.push_back(
+              getAffineConstantExpr(bit->bound, par.getContext()));
+          uboundGroup.push_back(1);
+        } else {
+          ubounds.append(um.getResults().begin(), um.getResults().end());
+          uboundGroup.push_back(um.getNumResults());
+        }
+        steps.push_back(par.getSteps()[i]);
+      }
+      // When every bound came out constant, drop the stale symbols and
+      // operands entirely: downstream batching expects clean constant maps.
+      bool allConstant = llvm::all_of(lbounds,
+                                      [](AffineExpr e) {
+                                        return isa<AffineConstantExpr>(e);
+                                      }) &&
+                         llvm::all_of(ubounds, [](AffineExpr e) {
+                           return isa<AffineConstantExpr>(e);
+                         });
+      unsigned lbDims = par.getLowerBoundsMap().getNumDims(),
+               lbSyms = par.getLowerBoundsMap().getNumSymbols(),
+               ubDims = par.getUpperBoundsMap().getNumDims(),
+               ubSyms = par.getUpperBoundsMap().getNumSymbols();
+      SmallVector<Value> mapOperands(par.getOperands());
+      if (allConstant) {
+        lbDims = lbSyms = ubDims = ubSyms = 0;
+        mapOperands.clear();
+      }
+      auto newPar = affine::AffineParallelOp::create(
+          b, loc, TypeRange(), b.getArrayAttr({}),
+          AffineMapAttr::get(
+              AffineMap::get(lbDims, lbSyms, lbounds, par.getContext())),
+          b.getI32TensorAttr(lboundGroup),
+          AffineMapAttr::get(
+              AffineMap::get(ubDims, ubSyms, ubounds, par.getContext())),
+          b.getI32TensorAttr(uboundGroup), b.getI64ArrayAttr(steps),
+          mapOperands);
+      Block *blk = new Block();
+      SmallVector<Value> ivRepl;
+      for (unsigned i = 0; i < n; ++i)
+        ivRepl.push_back(blk->addArgument(b.getIndexType(), loc));
+      newPar.getRegion().push_back(blk);
+      b.setInsertionPointToEnd(blk);
+      auto yield = affine::AffineYieldOp::create(b, loc);
+
+      // Guard: every bounded axis only runs its true extent.
+      SmallVector<AffineExpr> constraints;
+      SmallVector<bool> eqs;
+      SmallVector<Value> setOperands;
+      for (auto [k, bd] : llvm::enumerate(bounded)) {
+        constraints.push_back(getAffineSymbolExpr(k, par.getContext()) -
+                              getAffineDimExpr(k, par.getContext()) - 1);
+        eqs.push_back(false);
+      }
+      auto iset =
+          IntegerSet::get(bounded.size(), bounded.size(), constraints, eqs);
+      for (auto &bd : bounded)
+        setOperands.push_back(ivRepl[bd.dim]);
+      for (auto &bd : bounded)
+        setOperands.push_back(bd.extent);
+      b.setInsertionPoint(yield);
+      auto ifOp =
+          affine::AffineIfOp::create(b, loc, TypeRange(), iset, setOperands,
+                                     /*withElseRegion=*/false);
+      Block *oldBody = par.getBody();
+      for (unsigned i = 0; i < n; ++i)
+        oldBody->getArgument(i).replaceAllUsesWith(ivRepl[i]);
+      Block *thenBlk = ifOp.getThenBlock();
+      thenBlk->getOperations().splice(
+          std::prev(thenBlk->getOperations().end()), oldBody->getOperations(),
+          oldBody->getOperations().begin(),
+          std::prev(oldBody->getOperations().end()));
+      par.erase();
+    }
+  }
+
   static void peelDynamicParallelDims(Operation *root) {
     SmallVector<affine::AffineParallelOp> worklist;
     root->walk([&](affine::AffineParallelOp par) { worklist.push_back(par); });
@@ -3735,6 +3900,7 @@ struct AffineToStableHLORaisingPass
     // actually raises.
     for (auto func : funcs) {
       stripAccessMemorySpaceCasts(func);
+      boundParallelAxes(func);
       peelDynamicParallelDims(func);
     }
 
@@ -3757,6 +3923,7 @@ struct AffineToStableHLORaisingPass
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
       stripAccessMemorySpaceCasts(g);
+      boundParallelAxes(g);
       peelDynamicParallelDims(g);
     }
     size_t raised_count = 0;

--- a/test/lit_tests/raising/raise_bounded_parallel.mlir
+++ b/test/lit_tests/raising/raise_bounded_parallel.mlir
@@ -1,0 +1,31 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// A thread axis whose extent is dynamic but clamped by a min against a
+// constant (MFEM block sizes arrive as min(1 << log2(N), 256)) batches at
+// the bound behind an `iv < extent` guard instead of peeling to a serial
+// loop; the barrier over it stays a batched no-op.
+func.func @bounded(%out: memref<256xf64, 1>, %in: memref<256xf64, 1>, %nbuf: memref<i32, 1>, %unused: index) {
+  %c1 = arith.constant 1 : index
+  %c256_i32 = arith.constant 256 : i32
+  %n = affine.load %nbuf[] : memref<i32, 1>
+  %b = arith.minsi %n, %c256_i32 : i32
+  %bi = arith.index_cast %b : i32 to index
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %bi, %c1, %c1) ({
+    affine.parallel (%e) = (0) to (1) {
+      %scr = memref.alloca() : memref<256xf64>
+      affine.parallel (%t) = (0) to (symbol(%bi)) {
+        %v = affine.load %in[%t] : memref<256xf64, 1>
+        affine.store %v, %scr[%t] : memref<256xf64>
+        "enzymexla.barrier"(%t, %c1, %c1) : (index, index, index) -> ()
+        %w = affine.load %scr[0] : memref<256xf64>
+        affine.store %w, %out[%t] : memref<256xf64, 1>
+      }
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK-LABEL: func.func private @rxla$raised_0(
+// CHECK-NOT: stablehlo.while
+// CHECK: stablehlo.select


### PR DESCRIPTION
Follow-up to #2980, replacing #2979's distribution approach per review. A parallel axis whose extent is dynamic but **provably bounded** batches at the bound instead of peeling to a serial loop. The bound is derived straight from the IR: MFEM's block sizes arrive as `min(1 << log2(N), 256)` (`reducers.hpp: max_blocksize() = 256`), i.e. `arith.minsi(..., c256)` feeding the extent symbol — `derivedExtentBound` walks index casts and min chains to the constant. The axis is rewritten to constant extent with the body behind an `iv < extent` `affine.if`, exactly the guard shape the masking machinery already handles, so barriers over the axis stay batched no-ops (satisfying #2980's check) and the kernel raises in its performant batched form rather than serialized.

Validated numerically: MFEM's `Vector::Sum` reduction kernel raised this way computes per-block partials exactly (including a masked non-power-of-two N=1000 case, verified against numpy through a PJRT harness). The extents that stay underivable (e.g. quadinterpolator's runtime-`q1d` fallbacks, plain loads with no clamp) keep failing cleanly under #2980's guard; deriving those bounds (`q1d ≤ MAX_Q1D`, also visible as the shared-array extents) is a natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD