### PR TITLE
Split struct-element kernel scratch into per-field buffers

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -6006,6 +6006,463 @@ struct AffineToStableHLORaisingPass
     }
   }
 
+  // Residue of an integer/index value modulo m, when the defining arith
+  // chain pins it down. Extension and truncation preserve residues for the
+  // power-of-two moduli struct layouts produce.
+  static std::optional<int64_t> staticResidue(Value v, int64_t m,
+                                              unsigned depth = 0) {
+    if (m == 1)
+      return 0;
+    if (depth > 16)
+      return std::nullopt;
+    APInt cst;
+    if (matchPattern(v, m_ConstantInt(&cst)))
+      return ((cst.getSExtValue() % m) + m) % m;
+    Operation *op = v.getDefiningOp();
+    if (!op)
+      return std::nullopt;
+    if (isa<arith::IndexCastOp, arith::IndexCastUIOp, arith::ExtSIOp,
+            arith::ExtUIOp>(op) ||
+        (isa<arith::TruncIOp>(op) && llvm::isPowerOf2_64(m)))
+      return staticResidue(op->getOperand(0), m, depth + 1);
+    if (auto add = dyn_cast<arith::AddIOp>(op)) {
+      auto a = staticResidue(add.getLhs(), m, depth + 1);
+      auto b = staticResidue(add.getRhs(), m, depth + 1);
+      if (a && b)
+        return (*a + *b) % m;
+      return std::nullopt;
+    }
+    if (auto mul = dyn_cast<arith::MulIOp>(op)) {
+      auto a = staticResidue(mul.getLhs(), m, depth + 1);
+      auto b = staticResidue(mul.getRhs(), m, depth + 1);
+      if (a && b)
+        return (*a * *b) % m;
+      if ((a && *a == 0) || (b && *b == 0))
+        return 0;
+      return std::nullopt;
+    }
+    if (auto shl = dyn_cast<arith::ShLIOp>(op)) {
+      APInt sh;
+      if (matchPattern(shl.getRhs(), m_ConstantInt(&sh)) &&
+          sh.getZExtValue() < 63) {
+        int64_t f = (int64_t(1) << sh.getZExtValue()) % m;
+        if (f == 0)
+          return 0;
+        auto a = staticResidue(shl.getLhs(), m, depth + 1);
+        if (a)
+          return (*a * f) % m;
+      }
+      return std::nullopt;
+    }
+    return std::nullopt;
+  }
+
+  // Struct-element scratch (e.g. reduce-with-location value/index pairs)
+  // cannot become a tensor whole. Every access reaches it through a flat
+  // primitive view whose affine index resolves to a fixed byte offset within
+  // the struct, so the array-of-structs splits into one primitive scratch
+  // per field, with whole-struct integer moves split into their fields.
+  static void splitStructScratch(Operation *root) {
+    SmallVector<memref::AllocaOp> allocas;
+    root->walk([&](memref::AllocaOp a) { allocas.push_back(a); });
+    for (auto alloca : allocas) {
+      auto MT = alloca.getType();
+      if (!MT.hasStaticShape())
+        continue;
+      auto ST = dyn_cast<LLVM::LLVMStructType>(MT.getElementType());
+      if (!ST)
+        continue;
+      DataLayout dl = DataLayout::closest(alloca);
+      struct Field {
+        uint64_t off, size;
+        Type ty;
+      };
+      SmallVector<Field> fields;
+      uint64_t byte = 0;
+      bool ok = true;
+      for (Type member : ST.getBody()) {
+        if (!member.isIntOrFloat()) {
+          ok = false;
+          break;
+        }
+        if (!ST.isPacked())
+          byte = llvm::alignTo(byte, dl.getTypeABIAlignment(member));
+        fields.push_back({byte, dl.getTypeSize(member), member});
+        byte += dl.getTypeSize(member);
+      }
+      if (!ok)
+        continue;
+      int64_t pairSize = dl.getTypeSize(ST);
+
+      struct FieldAccess {
+        Operation *op;
+        unsigned field;
+        AffineMap pairMap;
+        bool bitcast;
+      };
+      struct WideAccess {
+        Operation *op;
+        SmallVector<unsigned> covered;
+        uint64_t base;
+        AffineMap pairMap;
+      };
+      struct DynAccess {
+        Operation *op;
+        unsigned field;
+        int64_t q;
+        bool bitcast;
+      };
+      SmallVector<FieldAccess> fieldAccesses;
+      SmallVector<WideAccess> wideAccesses;
+      SmallVector<DynAccess> dynAccesses;
+      SmallVector<enzymexla::Pointer2MemrefOp> views;
+      SmallVector<enzymexla::Memref2PointerOp> casts;
+
+      auto classify = [&](Operation *op, Type elemTy, AffineMap map) -> bool {
+        if (map.getNumResults() != 1)
+          return false;
+        int64_t s = dl.getTypeSize(elemTy);
+        AffineExpr byteExpr = map.getResult(0) * s;
+        AffineExpr rem = simplifyAffineExpr(
+            byteExpr % pairSize, map.getNumDims(), map.getNumSymbols());
+        auto remCst = dyn_cast<AffineConstantExpr>(rem);
+        if (!remCst)
+          return false;
+        uint64_t off = remCst.getValue();
+        AffineMap pairMap = AffineMap::get(
+            map.getNumDims(), map.getNumSymbols(),
+            simplifyAffineExpr(byteExpr.floorDiv(pairSize), map.getNumDims(),
+                               map.getNumSymbols()));
+        for (auto &&[i, f] : llvm::enumerate(fields))
+          if (f.off == off && f.size == (uint64_t)s) {
+            fieldAccesses.push_back({op, (unsigned)i, pairMap,
+                                     /*bitcast=*/f.ty != elemTy});
+            return true;
+          }
+        // A wider integer move covering whole fields splits into them.
+        if (!isa<IntegerType>(elemTy))
+          return false;
+        SmallVector<unsigned> covered;
+        for (auto &&[i, f] : llvm::enumerate(fields)) {
+          if (f.off + f.size <= off || f.off >= off + s)
+            continue;
+          if (f.off < off || f.off + f.size > off + s ||
+              !isa<IntegerType>(f.ty))
+            return false;
+          covered.push_back(i);
+        }
+        if (covered.empty())
+          return false;
+        wideAccesses.push_back({op, covered, off, pairMap});
+        return true;
+      };
+
+      // The same classification for accesses whose index arrives through
+      // plain arithmetic instead of an affine map: the field is fixed when
+      // the index has a static residue modulo the per-struct element count.
+      auto classifyDyn = [&](Operation *op, Type elemTy, Value idx) -> bool {
+        int64_t s = dl.getTypeSize(elemTy);
+        if (!s || pairSize % s)
+          return false;
+        int64_t q = pairSize / s;
+        auto r = staticResidue(idx, q);
+        if (!r)
+          return false;
+        uint64_t off = (uint64_t)*r * s;
+        for (auto &&[i, f] : llvm::enumerate(fields))
+          if (f.off == off && f.size == (uint64_t)s) {
+            dynAccesses.push_back({op, (unsigned)i, q,
+                                   /*bitcast=*/f.ty != elemTy});
+            return true;
+          }
+        return false;
+      };
+
+      SmallVector<Operation *> spaceCasts;
+      llvm::MapVector<Operation *, Value> pairGeps;
+      llvm::SetVector<Operation *> pairCopies;
+      DenseSet<Value> basePtrs;
+      bool viewedOnly = true;
+      for (Operation *user : alloca->getUsers()) {
+        auto m2p = dyn_cast<enzymexla::Memref2PointerOp>(user);
+        if (!m2p) {
+          viewedOnly = false;
+          break;
+        }
+        casts.push_back(m2p);
+        basePtrs.insert(m2p.getResult());
+        SmallVector<Operation *> viewUsers(m2p->getUsers());
+        for (unsigned vi = 0; vi < viewUsers.size() && viewedOnly; ++vi) {
+          Operation *viewUser = viewUsers[vi];
+          if (isa<LLVM::AddrSpaceCastOp>(viewUser)) {
+            spaceCasts.push_back(viewUser);
+            basePtrs.insert(viewUser->getResult(0));
+            viewUsers.append(viewUser->getUsers().begin(),
+                             viewUser->getUsers().end());
+            continue;
+          }
+          // A copy of pair zero addresses the scratch base directly.
+          if (auto mc = dyn_cast<LLVM::MemcpyOp>(viewUser)) {
+            APInt len;
+            if (mc.getIsVolatile() ||
+                !matchPattern(mc.getLen(), m_ConstantInt(&len)) ||
+                len.getSExtValue() != pairSize) {
+              viewedOnly = false;
+              break;
+            }
+            pairCopies.insert(mc);
+            continue;
+          }
+          // A whole-struct move arrives as a fixed-size memcpy between
+          // struct-strided geps into the scratch: split it per field.
+          if (auto gep = dyn_cast<LLVM::GEPOp>(viewUser)) {
+            auto idxs = gep.getIndices();
+            if (idxs.size() != 1 ||
+                (int64_t)dl.getTypeSize(gep.getElemType()) != pairSize) {
+              viewedOnly = false;
+              break;
+            }
+            // The copy may address the gep through an address-space cast
+            // (canonicalize-parallel sinks the shared-to-generic cast below
+            // the gep); the cast stands for the gep's pair index.
+            bool copiesOnly = true;
+            SmallVector<Operation *> gepUsers(gep->getUsers());
+            SmallVector<Operation *> gepCasts;
+            for (unsigned ui = 0; ui < gepUsers.size(); ++ui) {
+              Operation *gu = gepUsers[ui];
+              if (isa<LLVM::AddrSpaceCastOp>(gu)) {
+                gepCasts.push_back(gu);
+                gepUsers.append(gu->getUsers().begin(), gu->getUsers().end());
+                continue;
+              }
+              auto mc = dyn_cast<LLVM::MemcpyOp>(gu);
+              APInt len;
+              if (!mc || mc.getIsVolatile() ||
+                  !matchPattern(mc.getLen(), m_ConstantInt(&len)) ||
+                  len.getSExtValue() != pairSize) {
+                copiesOnly = false;
+                break;
+              }
+              pairCopies.insert(mc);
+            }
+            if (!copiesOnly) {
+              viewedOnly = false;
+              break;
+            }
+            Value gepIdx;
+            if (!gep.getDynamicIndices().empty()) {
+              gepIdx = gep.getDynamicIndices()[0];
+            } else {
+              OpBuilder gb(gep);
+              gepIdx = arith::ConstantIndexOp::create(
+                  gb, gep.getLoc(), cast<IntegerAttr>(idxs[0]).getInt());
+            }
+            pairGeps.insert({gep, gepIdx});
+            for (Operation *sc : gepCasts)
+              pairGeps.insert({sc, gepIdx});
+            continue;
+          }
+          auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(viewUser);
+          if (!p2m || p2m.getType().getRank() != 1 ||
+              !p2m.getType().getElementType().isIntOrFloat()) {
+            viewedOnly = false;
+            break;
+          }
+          for (Operation *access : p2m->getUsers()) {
+            if (auto ld = dyn_cast<affine::AffineLoadOp>(access)) {
+              if (classify(ld, ld.getType(), ld.getMap()))
+                continue;
+            } else if (auto st = dyn_cast<affine::AffineStoreOp>(access)) {
+              if (st.getValueToStore() != p2m.getResult() &&
+                  classify(st, st.getValueToStore().getType(), st.getMap()))
+                continue;
+            } else if (auto mld = dyn_cast<memref::LoadOp>(access)) {
+              if (mld.getIndices().size() == 1 &&
+                  classifyDyn(mld, mld.getType(), mld.getIndices()[0]))
+                continue;
+            } else if (auto mst = dyn_cast<memref::StoreOp>(access)) {
+              if (mst.getMemRef() == p2m.getResult() &&
+                  mst.getValueToStore() != p2m.getResult() &&
+                  mst.getIndices().size() == 1 &&
+                  classifyDyn(mst, mst.getValueToStore().getType(),
+                              mst.getIndices()[0]))
+                continue;
+            }
+            viewedOnly = false;
+            break;
+          }
+          if (!viewedOnly)
+            break;
+          views.push_back(p2m);
+        }
+        if (!viewedOnly)
+          break;
+      }
+      // Every pair copy must connect two classified geps or scratch bases.
+      auto copyEnd = [&](Value p) {
+        return basePtrs.contains(p) ||
+               (p.getDefiningOp() && pairGeps.count(p.getDefiningOp()));
+      };
+      for (Operation *mc : pairCopies) {
+        auto cp = cast<LLVM::MemcpyOp>(mc);
+        if (!copyEnd(cp.getDst()) || !copyEnd(cp.getSrc()))
+          viewedOnly = false;
+      }
+      if (!viewedOnly || (fieldAccesses.empty() && wideAccesses.empty()))
+        continue;
+
+      OpBuilder b(alloca);
+      SmallVector<Value> fieldBufs;
+      for (auto &f : fields)
+        fieldBufs.push_back(memref::AllocaOp::create(
+            b, alloca.getLoc(), MemRefType::get({MT.getNumElements()}, f.ty)));
+
+      for (auto &fa : fieldAccesses) {
+        if (auto ld = dyn_cast<affine::AffineLoadOp>(fa.op)) {
+          OpBuilder ab(ld);
+          Value newLd =
+              affine::AffineLoadOp::create(ab, ld.getLoc(), fieldBufs[fa.field],
+                                           fa.pairMap, ld.getMapOperands());
+          if (fa.bitcast)
+            newLd =
+                arith::BitcastOp::create(ab, ld.getLoc(), ld.getType(), newLd);
+          ld.getResult().replaceAllUsesWith(newLd);
+          ld.erase();
+        } else {
+          auto st = cast<affine::AffineStoreOp>(fa.op);
+          OpBuilder ab(st);
+          Value val = st.getValueToStore();
+          if (fa.bitcast)
+            val = arith::BitcastOp::create(ab, st.getLoc(), fields[fa.field].ty,
+                                           val);
+          affine::AffineStoreOp::create(ab, st.getLoc(), val,
+                                        fieldBufs[fa.field], fa.pairMap,
+                                        st.getMapOperands());
+          st.erase();
+        }
+      }
+      for (auto &wa : wideAccesses) {
+        if (auto ld = dyn_cast<affine::AffineLoadOp>(wa.op)) {
+          OpBuilder ab(ld);
+          Location loc = ld.getLoc();
+          Type wideTy = ld.getType();
+          Value acc = arith::ConstantOp::create(ab, loc, wideTy,
+                                                ab.getIntegerAttr(wideTy, 0));
+          for (unsigned i : wa.covered) {
+            Value v = affine::AffineLoadOp::create(
+                ab, loc, fieldBufs[i], wa.pairMap, ld.getMapOperands());
+            Value z = arith::ExtUIOp::create(ab, loc, wideTy, v);
+            uint64_t sh = (fields[i].off - wa.base) * 8;
+            if (sh) {
+              Value shv = arith::ConstantOp::create(
+                  ab, loc, wideTy, ab.getIntegerAttr(wideTy, sh));
+              z = arith::ShLIOp::create(ab, loc, z, shv);
+            }
+            acc = arith::OrIOp::create(ab, loc, acc, z);
+          }
+          ld.getResult().replaceAllUsesWith(acc);
+          ld.erase();
+        } else {
+          auto st = cast<affine::AffineStoreOp>(wa.op);
+          OpBuilder ab(st);
+          Location loc = st.getLoc();
+          Value val = st.getValueToStore();
+          Type wideTy = val.getType();
+          for (unsigned i : wa.covered) {
+            Value part = val;
+            uint64_t sh = (fields[i].off - wa.base) * 8;
+            if (sh) {
+              Value shv = arith::ConstantOp::create(
+                  ab, loc, wideTy, ab.getIntegerAttr(wideTy, sh));
+              part = arith::ShRUIOp::create(ab, loc, part, shv);
+            }
+            part = arith::TruncIOp::create(ab, loc, fields[i].ty, part);
+            affine::AffineStoreOp::create(ab, loc, part, fieldBufs[i],
+                                          wa.pairMap, st.getMapOperands());
+          }
+          st.erase();
+        }
+      }
+      for (auto &da : dynAccesses) {
+        OpBuilder ab(da.op);
+        Location loc = da.op->getLoc();
+        Value idx = isa<memref::LoadOp>(da.op)
+                        ? cast<memref::LoadOp>(da.op).getIndices()[0]
+                        : cast<memref::StoreOp>(da.op).getIndices()[0];
+        Value pairIdx = idx;
+        if (da.q != 1) {
+          Value qc = arith::ConstantIndexOp::create(ab, loc, da.q);
+          pairIdx = arith::DivUIOp::create(ab, loc, idx, qc);
+        }
+        if (auto mld = dyn_cast<memref::LoadOp>(da.op)) {
+          Value newLd = memref::LoadOp::create(ab, loc, fieldBufs[da.field],
+                                               ValueRange{pairIdx});
+          if (da.bitcast)
+            newLd = arith::BitcastOp::create(ab, loc, mld.getType(), newLd);
+          mld.getResult().replaceAllUsesWith(newLd);
+          mld.erase();
+        } else {
+          auto mst = cast<memref::StoreOp>(da.op);
+          Value val = mst.getValueToStore();
+          if (da.bitcast)
+            val = arith::BitcastOp::create(ab, loc, fields[da.field].ty, val);
+          memref::StoreOp::create(ab, loc, val, fieldBufs[da.field],
+                                  ValueRange{pairIdx});
+          mst.erase();
+        }
+      }
+      for (Operation *mc : pairCopies) {
+        auto cp = cast<LLVM::MemcpyOp>(mc);
+        OpBuilder ab(cp);
+        Location loc = cp.getLoc();
+        // Constant pair indices stay affine so the accesses raise directly.
+        auto toIdx = [&](Value p) -> std::pair<Value, std::optional<int64_t>> {
+          if (basePtrs.contains(p))
+            return {Value(), 0};
+          Value v = pairGeps.find(p.getDefiningOp())->second;
+          APInt c;
+          if (matchPattern(v, m_ConstantInt(&c)))
+            return {Value(), c.getSExtValue()};
+          if (!isa<IndexType>(v.getType()))
+            v = arith::IndexCastUIOp::create(ab, loc, ab.getIndexType(), v);
+          return {v, std::nullopt};
+        };
+        auto [dstIdx, dstC] = toIdx(cp.getDst());
+        auto [srcIdx, srcC] = toIdx(cp.getSrc());
+        for (auto &&[i, f] : llvm::enumerate(fields)) {
+          Value v;
+          if (srcC)
+            v = affine::AffineLoadOp::create(
+                ab, loc, fieldBufs[i],
+                AffineMap::getConstantMap(*srcC, ab.getContext()),
+                ValueRange());
+          else
+            v = memref::LoadOp::create(ab, loc, fieldBufs[i],
+                                       ValueRange{srcIdx});
+          if (dstC)
+            affine::AffineStoreOp::create(
+                ab, loc, v, fieldBufs[i],
+                AffineMap::getConstantMap(*dstC, ab.getContext()),
+                ValueRange());
+          else
+            memref::StoreOp::create(ab, loc, v, fieldBufs[i],
+                                    ValueRange{dstIdx});
+        }
+        cp.erase();
+      }
+      // Casts of a gep were recorded after it: erase users first.
+      for (auto &g : llvm::reverse(pairGeps))
+        g.first->erase();
+      for (auto p2m : views)
+        p2m.erase();
+      for (Operation *sc : llvm::reverse(spaceCasts))
+        sc->erase();
+      for (auto m2p : casts)
+        m2p.erase();
+      alloca.erase();
+    }
+  }
+
   void runOnOperation() override {
     ParallelContext::Options options{enable_lockstep_for, dump_failed_lockstep,
                                      prefer_while_raising, strip_llvm_debuginfo,
@@ -6048,6 +6505,7 @@ struct AffineToStableHLORaisingPass
     // actually raises.
     for (auto func : funcs) {
       stripAccessMemorySpaceCasts(func);
+      splitStructScratch(func);
       boundParallelAxes(func);
       peelDynamicParallelDims(func);
     }
@@ -6071,6 +6529,7 @@ struct AffineToStableHLORaisingPass
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
       stripAccessMemorySpaceCasts(g);
+      splitStructScratch(g);
       hoistWrapperInvariantPointerCompares(g);
       boundParallelAxes(g);
       peelDynamicParallelDims(g);

--- a/test/lit_tests/raising/raise_struct_scratch.mlir
+++ b/test/lit_tests/raising/raise_struct_scratch.mlir
@@ -1,0 +1,105 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// Struct-element scratch splits into one primitive scratch per field: the
+// i32 views address the fields at even/odd offsets, and the whole-pair i64
+// load reads both fields of pair zero at once.
+func.func @intpair(%out: memref<256xi32, 1>, %in: memref<256xi32, 1>) {
+  %scr = memref.alloca() {alignment = 4 : i64} : memref<256x!llvm.struct<"struct.mfem::DevicePair", (i32, i32)>>
+  %ptr = "enzymexla.memref2pointer"(%scr) : (memref<256x!llvm.struct<"struct.mfem::DevicePair", (i32, i32)>>) -> !llvm.ptr<3>
+  %c2 = arith.constant 2 : index
+  affine.parallel (%t) = (0) to (256) {
+    %view = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr<3>) -> memref<?xi32, 3>
+    %v = affine.load %in[%t] : memref<256xi32, 1>
+    affine.store %v, %view[%t * 2] : memref<?xi32, 3>
+    %ti = arith.index_castui %t : index to i32
+    affine.store %ti, %view[%t * 2 + 1] : memref<?xi32, 3>
+    "enzymexla.barrier"(%t) : (index) -> ()
+    %wide = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr<3>) -> memref<?xi64, 3>
+    %pair0 = affine.load %wide[0] : memref<?xi64, 3>
+    %lo = arith.trunci %pair0 : i64 to i32
+    %t2 = arith.muli %t, %c2 : index
+    %e = memref.load %view[%t2] : memref<?xi32, 3>
+    %r = arith.addi %lo, %e : i32
+    affine.store %r, %out[%t] : memref<256xi32, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @intpair_raised(
+// CHECK-NOT: llvm.struct
+// CHECK: stablehlo.slice
+
+// -----
+
+// Mixed-type pairs keep each field in its own scratch, and the whole-pair
+// memcpy between struct-strided geps becomes per-field moves.
+func.func @mixedpair(%out: memref<256xf64, 1>, %in: memref<256xf64, 1>) {
+  %scr = memref.alloca() {alignment = 8 : i64} : memref<256x!llvm.struct<"struct.mfem::DevicePair.0", (f64, i32)>>
+  %ptr = "enzymexla.memref2pointer"(%scr) : (memref<256x!llvm.struct<"struct.mfem::DevicePair.0", (f64, i32)>>) -> !llvm.ptr<3>
+  %gp = llvm.addrspacecast %ptr : !llvm.ptr<3> to !llvm.ptr
+  %c16_i64 = arith.constant 16 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c255_i64 = arith.constant 255 : i64
+  affine.parallel (%t) = (0) to (256) {
+    %fview = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr<3>) -> memref<?xf64, 3>
+    %iview = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr<3>) -> memref<?xi32, 3>
+    %v = affine.load %in[%t] : memref<256xf64, 1>
+    affine.store %v, %fview[%t * 2] : memref<?xf64, 3>
+    %ti = arith.index_castui %t : index to i32
+    affine.store %ti, %iview[%t * 4 + 2] : memref<?xi32, 3>
+    "enzymexla.barrier"(%t) : (index) -> ()
+    %tl = arith.index_castui %t : index to i64
+    %tn = arith.addi %tl, %c1_i64 : i64
+    %ts = arith.andi %tn, %c255_i64 : i64
+    %dst = llvm.getelementptr inbounds %gp[%tl] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<16 x i8>
+    %src = llvm.getelementptr inbounds %gp[%ts] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<16 x i8>
+    "llvm.intr.memcpy"(%dst, %src, %c16_i64) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    "enzymexla.barrier"(%t) : (index) -> ()
+    %r = affine.load %fview[%t * 2] : memref<?xf64, 3>
+    affine.store %r, %out[%t] : memref<256xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @mixedpair_raised(
+// CHECK-NOT: llvm.struct
+// CHECK: stablehlo.gather
+// CHECK: stablehlo.scatter
+
+// -----
+
+// The same pair copy with the shared-to-generic cast sunk below the geps,
+// as canonicalize-parallel leaves it: the cast stands for the gep's index.
+func.func @castpair(%out: memref<256xf64, 1>, %in: memref<256xf64, 1>) {
+  %scr = memref.alloca() : memref<256x!llvm.struct<"struct.mfem::DevicePair.1", (f64, i32)>>
+  %ptr = "enzymexla.memref2pointer"(%scr) : (memref<256x!llvm.struct<"struct.mfem::DevicePair.1", (f64, i32)>>) -> !llvm.ptr<3>
+  %c16_i64 = arith.constant 16 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c255_i64 = arith.constant 255 : i64
+  affine.parallel (%t) = (0) to (256) {
+    %fview = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr<3>) -> memref<?xf64, 3>
+    %iview = "enzymexla.pointer2memref"(%ptr) : (!llvm.ptr<3>) -> memref<?xi32, 3>
+    %v = affine.load %in[%t] : memref<256xf64, 1>
+    affine.store %v, %fview[%t * 2] : memref<?xf64, 3>
+    %ti = arith.index_castui %t : index to i32
+    affine.store %ti, %iview[%t * 4 + 2] : memref<?xi32, 3>
+    "enzymexla.barrier"(%t) : (index) -> ()
+    %tl = arith.index_castui %t : index to i64
+    %tn = arith.addi %tl, %c1_i64 : i64
+    %ts = arith.andi %tn, %c255_i64 : i64
+    %dst3 = llvm.getelementptr inbounds %ptr[%tl] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<16 x i8>
+    %src3 = llvm.getelementptr inbounds %ptr[%ts] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<16 x i8>
+    %dst = llvm.addrspacecast %dst3 : !llvm.ptr<3> to !llvm.ptr
+    %src = llvm.addrspacecast %src3 : !llvm.ptr<3> to !llvm.ptr
+    "llvm.intr.memcpy"(%dst, %src, %c16_i64) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    "enzymexla.barrier"(%t) : (index) -> ()
+    %r = affine.load %fview[%t * 2] : memref<?xf64, 3>
+    affine.store %r, %out[%t] : memref<256xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @castpair_raised(
+// CHECK-NOT: llvm.struct
+// CHECK: stablehlo.gather
+// CHECK: stablehlo.scatter


### PR DESCRIPTION
MFEM's reduce-with-location kernels (`ArgMin`/`ArgMax`/`MinMaxLoc` reducers, exercised by the GPU unit-test suite's `Reduce *` cases) keep their block partials in __shared__ scratch of struct type — `memref<256 x !llvm.struct<(f64, i32)>>` — which the raiser rejects as a non-primitive alloca.

Every access reaches such scratch through a flat primitive view with a statically determined byte offset inside the struct, so the array-of-structs splits into one primitive scratch per field:

- `affine.load/store` through `pointer2memref` views: the map's byte expression has a constant residue mod the struct size, picking the field (`[t*4+2]` on an i32 view of an `(f64,i32)` pair → the i32 field of pair `t`).
- plain `memref.load/store` whose index is an arith chain: a small residue analysis (constants, sums, products, shifts, casts) derives the same field pinning for the tree-reduction phase's computed indices.
- same-size accesses of a differently-typed field (an `i64` move of the `f64` half) become `arith.bitcast`s.
- wider integer moves covering whole fields (the `i64` whole-pair move of an `(i32,i32)` pair) split into per-field accesses recomposed with shifts.
- whole-struct `llvm.intr.memcpy` between struct-strided geps (16-byte pair copies) becomes per-field moves, including geps folded to constant indices or to the scratch base.

Validated end to end on MFEM: `general/test_reduction.cpp` fully raises and the whole reduction battery (Sum/Mult/BAnd/BOr/Min/Max/MinMax/ArgMin/ArgMax) passes on GPU through raised XLA kernels, exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD