### PR TITLE
CuDNNHLOOpt: give every fusion function an unused symbol name

### DIFF
--- a/src/enzyme_ad/jax/Passes/CuDNNHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/CuDNNHLOOpt.cpp
@@ -86,11 +86,18 @@ struct DotGeneralElementwiseToCuDNNFusion
     if (!mod)
       return rewriter.notifyMatchFailure(elemOp, "No module found");
 
-    static int fusionCounter = 0;
-    std::string fnName =
-        (kCuDNNFusionFuncPrefix + std::to_string(fusionCounter)).str();
+    // Pick a name that is unused in this module. A counter local to the pattern
+    // is not enough: it is `static` inside a class template, so every
+    // ElementwiseOpTy instantiation gets its own and they all restart at 0,
+    // redefining each other's symbols.
+    SymbolTable symbolTable(mod);
+    std::string fnName;
+    for (unsigned i = 0;; ++i) {
+      fnName = (kCuDNNFusionFuncPrefix + std::to_string(i)).str();
+      if (!symbolTable.lookup(fnName))
+        break;
+    }
     auto fnSym = rewriter.getStringAttr(fnName);
-    fusionCounter++;
 
     // Input Types
     auto dotGeneralLhsTy = dotGeneral.getLhs().getType();

--- a/src/enzyme_ad/jax/Passes/CuDNNHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/CuDNNHLOOpt.cpp
@@ -90,13 +90,19 @@ struct DotGeneralElementwiseToCuDNNFusion
     // is not enough: it is `static` inside a class template, so every
     // ElementwiseOpTy instantiation gets its own and they all restart at 0,
     // redefining each other's symbols.
+    //
+    // generateSymbolName appends "_<n>", so it gets the prefix without its
+    // trailing underscore and keeps the existing _0, _1, ... names. Trimming
+    // the underscore from kCuDNNFusionFuncPrefix itself would instead break the
+    // starts_with() guard above.
     SymbolTable symbolTable(mod);
-    std::string fnName;
-    for (unsigned i = 0;; ++i) {
-      fnName = (kCuDNNFusionFuncPrefix + std::to_string(i)).str();
-      if (!symbolTable.lookup(fnName))
-        break;
-    }
+    unsigned uniquingCounter = 0;
+    SmallString<128> fnName = SymbolTable::generateSymbolName<128>(
+        kCuDNNFusionFuncPrefix.drop_back(),
+        [&](llvm::StringRef candidate) {
+          return symbolTable.lookup(candidate) != nullptr;
+        },
+        uniquingCounter);
     auto fnSym = rewriter.getStringAttr(fnName);
 
     // Input Types

--- a/test/lit_tests/cudnn/fusion.mlir
+++ b/test/lit_tests/cudnn/fusion.mlir
@@ -51,8 +51,18 @@ module {
     }
 }
 
-// CHECK-DAG: func.func private @__cudnn_fused_elementwise_dot_0(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> attributes {no_inline} {
-// CHECK-DAG: func.func private @__cudnn_fused_elementwise_dot_1(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> attributes {no_inline} {
-// CHECK:     func.func @dense3
-// CHECK:       stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_{{[0-9]+}}]}
-// CHECK:       stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_{{[0-9]+}}]}
+// CHECK: func.func private @__cudnn_fused_elementwise_dot_1(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> attributes {no_inline} {
+// CHECK-NEXT:    %0 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %arg2 : tensor<4x16x16xbf16>
+// CHECK-NEXT:    return %1 : tensor<4x16x16xbf16>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @__cudnn_fused_elementwise_dot_0(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> attributes {no_inline} {
+// CHECK-NEXT:    %0 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+// CHECK-NEXT:    %1 = stablehlo.multiply %0, %arg2 : tensor<4x16x16xbf16>
+// CHECK-NEXT:    return %1 : tensor<4x16x16xbf16>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @dense3(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) {
+// CHECK-NEXT:    %0 = stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_1]} : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+// CHECK-NEXT:    %1 = stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_0]} : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+// CHECK-NEXT:    return %0, %1 : tensor<4x16x16xbf16>, tensor<4x16x16xbf16>
+// CHECK-NEXT:  }

--- a/test/lit_tests/cudnn/fusion.mlir
+++ b/test/lit_tests/cudnn/fusion.mlir
@@ -36,3 +36,23 @@ module {
 // CHECK-NEXT:    %0 = stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_0]} : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
 // CHECK-NEXT:    return %0 : tensor<4x16x16xbf16>
 // CHECK-NEXT:  }
+
+// Two fusions in the same module must get distinct symbols. The counter used to
+// be a `static` inside the class template, so the add and multiply
+// instantiations both handed out `__cudnn_fused_elementwise_dot_0` and the
+// module failed to verify with "redefinition of symbol named ...".
+module {
+    func.func @dense3(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) {
+        %1 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+        %2 = stablehlo.add %1, %arg2 : tensor<4x16x16xbf16>
+        %3 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [2] x [1], precision = [DEFAULT, DEFAULT] : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
+        %4 = stablehlo.multiply %3, %arg2 : tensor<4x16x16xbf16>
+        return %2, %4 : tensor<4x16x16xbf16>, tensor<4x16x16xbf16>
+    }
+}
+
+// CHECK-DAG: func.func private @__cudnn_fused_elementwise_dot_0(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> attributes {no_inline} {
+// CHECK-DAG: func.func private @__cudnn_fused_elementwise_dot_1(%arg0: tensor<4x16x16xbf16>, %arg1: tensor<4x16x16xbf16>, %arg2: tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16> attributes {no_inline} {
+// CHECK:     func.func @dense3
+// CHECK:       stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_{{[0-9]+}}]}
+// CHECK:       stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_{{[0-9]+}}]}


### PR DESCRIPTION
Fixes #2985.

The outlined `__cudnn_fused_elementwise_dot_N` function got its name from a `static int
fusionCounter` inside `DotGeneralElementwiseToCuDNNFusion`. That is a class template, so
each `ElementwiseOpTy` instantiation has its own counter and they all start at 0: as soon as
one module contains, say, an add-of-dot and a multiply-of-dot, both fusions are named
`__cudnn_fused_elementwise_dot_0` and the pass fails with

```
error: redefinition of symbol named '__cudnn_fused_elementwise_dot_0'
```

Look the candidate name up in the module's `SymbolTable` and take the first free one. That
fixes the collision, drops the process-global state (the old counter also made the names
depend on how many fusions had run earlier in the process), and makes the pass robust
against a name already present in the input module.

Lit test appended to `test/lit_tests/cudnn/fusion.mlir`. The existing `@dense1` / `@dense2`
cases are unaffected: they live in separate nested modules, so each still starts from `_0`.

### Testing

The C++ is **not built or run here** -- no bazel in this environment. The reproducer and the
error message come from running the shipped pass (`Reactant_jll` v0.0.405) on the module in
the issue. The lit test is written against the current sources but has not been executed;
please let CI have it, and tell me if the CHECK lines need adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k6KZhhCNSCvZFKzErHaHH
