### PR TITLE
Differentiate before the backends diverge; raise __enzyme calls before launch recognition

### DIFF
--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -120,11 +120,12 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       "inline{default-pipeline=canonicalize "
       "max-iterations=4},sroa-wrappers{set_private=false attributor=false},"
       "lift-tessera-annotations,parse-optimization-rules,"
+      "libdevice-funcs-raise,"
       "gpu-launch-recognition{backend=";
   pass_pipeline += backend;
   pass_pipeline += "}";
   pass_pipeline += ","
-      "" + canonicalize + ",libdevice-funcs-raise,restore-preserve-nvvm," + canonicalize + ","
+      "" + canonicalize + ",restore-preserve-nvvm," + canonicalize + ","
       "inline-enzyme-regions,symbol-dce,";
   
   if (backend == "cpu")
@@ -146,7 +147,56 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       "affine-cfg," + canonicalize + ",llvm-to-affine-access," + canonicalize + ","
       "func.func(affine-loop-invariant-code-motion),"
       "" + canonicalize + ",sort-memory,llvm-to-tessera,tessera-apply-pdl,tessera-to-llvm,";
+  // Differentiation runs before the backends diverge, so on xla the
+  // generated derivative launches raise to stablehlo like any other kernel.
+  if (outfile.size() && getenv("EXPORT_REACTANT")) {
+    pass_pipeline += "print{filename="+outfile+".mlir},";
+  }
+  pass_pipeline += "symbol-dce,raise-llvm-ext,outline-enzyme-regions,";
+  if (options->preADLowerAffine)
+    pass_pipeline += "lower-aligned-affine-accesses,lower-affine,";
+
+  // A checkpointed loop must not capture both a value and a view of it:
+  // it would snapshot the same buffer twice. Has to precede `enzyme`,
+  // which is what reads the captures.
+  pass_pipeline += "sink-checkpoint-views,";
+
+  pass_pipeline += "enzyme{";
+  if (options->dataflow)
+    pass_pipeline += "dataflow ";
+  if (options->markReadonly)
+    pass_pipeline += "markReadonly ";
+  // Each generated derivative function is cleaned of enzyme cache ops
+  // the moment it is created: nested differentiation hands the outer AD
+  // the inner function as input, and enzyme.push/pop have no derivative
+  // of their own.
+  pass_pipeline += "postpasses=\"canonicalize,";
+  if (options->splitMultiResults)
+    pass_pipeline += "split-multi-results,";
+  pass_pipeline += "remove-unnecessary-enzyme-ops,"
+    // binomial checkpointing leaves enzyme.binomial_progress behind; it has
+    // no lowering of its own further down, so expand it here.
+    "flatten-enzyme-caches,lower-enzyme-binomial-progress,";
+  if (options->hoistLoopAllocations)
+    pass_pipeline += "hoist-loop-allocations,";
+  pass_pipeline += "enzyme-simplify-math\"";
+  pass_pipeline += "},"
+    // The one module-level survivor: llvm_ext ops also live outside the
+    // generated functions the postpasses clean -- a ptr_size_hint sits in
+    // the primal that carries the user's marker -- and any left behind
+    // fail translation to LLVM IR.
+    "lower-llvm-ext,"
+    "inline{default-pipeline=canonicalize max-iterations=4},"
+    "polygeist-mem2reg," + canonicalize + ",symbol-dce,"
+    // canonicalize-parallel here folds away memref.subview ops before gpu-kernel-outlining
+    "" + canonicalize + ",cse";
+  if (options->removeAtomics)
+    pass_pipeline += ",affine-cfg,remove-atomics";
   if (StringRef(backend).starts_with("xla")) {
+      // Differentiation and its cleanups disturb the affine structure the
+      // raiser wants; rebuild it the way the shared prefix does.
+      pass_pipeline += ",affine-cfg," + canonicalize +
+                       ",llvm-to-affine-access," + canonicalize + ",";
       pass_pipeline += "func.func(kernelcast),raise-affine-to-stablehlo{prefer_while_raising=false "
       "dump_failed_lockstep=true}," + canonicalize + ",arith-raise{stablehlo=true},"
       "symbol-dce";
@@ -163,49 +213,6 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       pass_pipeline += backend;
       pass_pipeline += "}";
   } else {
-      if (outfile.size() && getenv("EXPORT_REACTANT")) {
-        pass_pipeline += "print{filename="+outfile+".mlir},";
-      }
-      pass_pipeline += "symbol-dce,raise-llvm-ext,outline-enzyme-regions,";
-      if (options->preADLowerAffine)
-        pass_pipeline += "lower-aligned-affine-accesses,lower-affine,";
-
-      // A checkpointed loop must not capture both a value and a view of it:
-      // it would snapshot the same buffer twice. Has to precede `enzyme`,
-      // which is what reads the captures.
-      pass_pipeline += "sink-checkpoint-views,";
-
-      pass_pipeline += "enzyme{";
-      if (options->dataflow)
-        pass_pipeline += "dataflow ";
-      if (options->markReadonly)
-        pass_pipeline += "markReadonly ";
-      // Each generated derivative function is cleaned of enzyme cache ops
-      // the moment it is created: nested differentiation hands the outer AD
-      // the inner function as input, and enzyme.push/pop have no derivative
-      // of their own.
-      pass_pipeline += "postpasses=\"canonicalize,";
-      if (options->splitMultiResults)
-        pass_pipeline += "split-multi-results,";
-      pass_pipeline += "remove-unnecessary-enzyme-ops,"
-        // binomial checkpointing leaves enzyme.binomial_progress behind; it has
-        // no lowering of its own further down, so expand it here.
-        "flatten-enzyme-caches,lower-enzyme-binomial-progress,";
-      if (options->hoistLoopAllocations)
-        pass_pipeline += "hoist-loop-allocations,";
-      pass_pipeline += "enzyme-simplify-math\"";
-      pass_pipeline += "},"
-        // The one module-level survivor: llvm_ext ops also live outside the
-        // generated functions the postpasses clean -- a ptr_size_hint sits in
-        // the primal that carries the user's marker -- and any left behind
-        // fail translation to LLVM IR.
-        "lower-llvm-ext,"
-        "inline{default-pipeline=canonicalize max-iterations=4},"
-        "polygeist-mem2reg," + canonicalize + ",symbol-dce,"
-        // canonicalize-parallel here folds away memref.subview ops before gpu-kernel-outlining
-        "" + canonicalize + ",cse";
-      if (options->removeAtomics)
-        pass_pipeline += ",affine-cfg,remove-atomics";
       if (options->sortBlockMemory)
         pass_pipeline += ",sort-block-memory";
       pass_pipeline += ",lower-aligned-affine-accesses,lower-affine,"


### PR DESCRIPTION
Per review: the AD section (EXPORT print, outline-enzyme-regions, enzyme{...} with its postpasses, lower-llvm-ext/inline/mem2reg/cse, remove-atomics) is **moved** out of the non-xla branch to run before the backends diverge — one copy, shared by both paths. Host-side __enzyme_fwddiff/__enzyme_autodiff calls previously became enzyme.fwddiff_region ops the xla branch never differentiated, dying at LLVM translation with a missing dialect interface. The xla branch then rebuilds the affine structure the differentiation cleanups disturb (affine-cfg + llvm-to-affine-access + canonicalize, matching the shared prefix) before kernelcast/raising — plain affine-cfg alone regressed quadinterpolator.

Also per review, no capture special-case in gpu-launch-recognition: libdevice-funcs-raise moves **before** gpu-launch-recognition, so __enzyme_* calls raise to enzyme ops (resolving the kernel-stub pointer they hold into a symbol) before the capture scan runs — the stub address is no longer escaped and the kernel keeps the region-launch form instead of falling back to launch_func.

Validated on MFEM through xla-gpu: enzyme/compatibility.cpp and both test_enzyme_scratch TUs compile; quadinterpolator/vector/test_reduction/pfespace/lininteg_domain/dfem gates unchanged; all 8 [Enzyme] unit-test cases (1441 assertions) pass on GPU through raised XLA kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD