### PR TITLE
Derive parallel-axis bounds from dominating guards

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -5388,11 +5388,91 @@ struct AffineToStableHLORaisingPass
   // raising then iterates, leaving the constant-extent dimensions to raise as
   // axes. The tag rides onto the stablehlo.while so downstream passes know
   // the iterations commute.
+  // The bound the relation `v REL C` puts on v when it holds, or when its
+  // negation holds.
+  static std::optional<int64_t> relationBound(arith::CmpIOp cmp, Value v,
+                                              bool holds) {
+    APInt cst;
+    bool onLhs =
+        cmp.getLhs() == v && matchPattern(cmp.getRhs(), m_ConstantInt(&cst));
+    if (!onLhs &&
+        !(cmp.getRhs() == v && matchPattern(cmp.getLhs(), m_ConstantInt(&cst))))
+      return std::nullopt;
+    arith::CmpIPredicate pred =
+        onLhs ? cmp.getPredicate() : swapPredicate(cmp.getPredicate());
+    if (!holds)
+      pred = arith::invertPredicate(pred);
+    int64_t c = cst.getSExtValue();
+    switch (pred) {
+    case arith::CmpIPredicate::eq:
+    case arith::CmpIPredicate::sle:
+    case arith::CmpIPredicate::ule:
+      return c;
+    case arith::CmpIPredicate::slt:
+    case arith::CmpIPredicate::ult:
+      return c - 1;
+    default:
+      return std::nullopt;
+    }
+  }
+
+  // Upper bound on `v` from the guards dominating `anchor`: a verify
+  // `if (v REL C) <noreturn>` leaves the complementary relation holding on
+  // every path that reaches the anchor, and inside the surviving branch of an
+  // enclosing `if (v REL C)` the relation holds.
+  static std::optional<int64_t> guardBound(Value v, Operation *anchor) {
+    if (!anchor)
+      return std::nullopt;
+    std::optional<int64_t> bound;
+    auto aborts = [](Region &region) {
+      return region
+          .walk([](LLVM::UnreachableOp) { return WalkResult::interrupt(); })
+          .wasInterrupted();
+    };
+    for (Operation *user : v.getUsers()) {
+      auto cmp = dyn_cast<arith::CmpIOp>(user);
+      if (!cmp)
+        continue;
+      for (Operation *condUser : cmp->getUsers()) {
+        auto ifOp = dyn_cast<scf::IfOp>(condUser);
+        if (!ifOp || ifOp.getCondition() != cmp.getResult())
+          continue;
+        bool thenAborts = aborts(ifOp.getThenRegion());
+        bool elseAborts =
+            !ifOp.getElseRegion().empty() && aborts(ifOp.getElseRegion());
+        if (thenAborts == elseAborts)
+          continue;
+        Operation *a = anchor;
+        while (a && a->getBlock() != ifOp->getBlock())
+          a = a->getParentOp();
+        if (!a || a == ifOp || !ifOp->isBeforeInBlock(a))
+          continue;
+        if (auto b = relationBound(cmp, v, /*holds=*/elseAborts))
+          bound = std::min(bound.value_or(*b), *b);
+      }
+    }
+    for (Operation *cur = anchor; cur->getParentOp();
+         cur = cur->getParentOp()) {
+      auto ifOp = dyn_cast<scf::IfOp>(cur->getParentOp());
+      if (!ifOp)
+        continue;
+      auto cmp = ifOp.getCondition().getDefiningOp<arith::CmpIOp>();
+      if (!cmp)
+        continue;
+      bool inThen = cur->getParentRegion() == &ifOp.getThenRegion();
+      if (auto b = relationBound(cmp, v, /*holds=*/inThen))
+        bound = std::min(bound.value_or(*b), *b);
+    }
+    return bound;
+  }
+
   // The constant upper bound of an extent value, where one can be derived:
-  // the value itself when constant, or the constant side of a min it is
-  // clamped by (MFEM's block sizes arrive as min(1 << log2(N), 256)).
-  static std::optional<int64_t> derivedExtentBound(Value v,
-                                                   unsigned depth = 0) {
+  // the value itself when constant, the constant side of a min it is
+  // clamped by (MFEM's block sizes arrive as min(1 << log2(N), 256)), the
+  // arithmetic the launch plumbing wraps it in, or a guard dominating
+  // `anchor`.
+  static std::optional<int64_t>
+  derivedExtentBound(Value v, unsigned depth = 0, Operation *anchor = nullptr) {
     if (depth > 8)
       return std::nullopt;
     while (true) {
@@ -5409,28 +5489,93 @@ struct AffineToStableHLORaisingPass
     APInt cst;
     if (matchPattern(v, m_ConstantInt(&cst)))
       return cst.getSExtValue();
-    if (auto mn = v.getDefiningOp<arith::MinSIOp>()) {
-      auto l = derivedExtentBound(mn.getLhs(), depth + 1);
-      auto r = derivedExtentBound(mn.getRhs(), depth + 1);
+    Operation *def = v.getDefiningOp();
+    auto operandBound = [&](unsigned i) {
+      return derivedExtentBound(def->getOperand(i), depth + 1, anchor);
+    };
+    // A min is bounded by either bounded side; a max or a select needs both.
+    if (isa_and_nonnull<arith::MinSIOp, arith::MinUIOp, LLVM::SMinOp,
+                        LLVM::UMinOp>(def)) {
+      auto l = operandBound(0), r = operandBound(1);
       if (l && r)
         return std::min(*l, *r);
       return l ? l : r;
     }
-    if (auto mn = v.getDefiningOp<arith::MinUIOp>()) {
-      auto l = derivedExtentBound(mn.getLhs(), depth + 1);
-      auto r = derivedExtentBound(mn.getRhs(), depth + 1);
+    if (isa_and_nonnull<arith::MaxSIOp, arith::MaxUIOp, LLVM::SMaxOp,
+                        LLVM::UMaxOp, arith::SelectOp>(def)) {
+      unsigned first = isa<arith::SelectOp>(def);
+      auto l = operandBound(first), r = operandBound(first + 1);
       if (l && r)
-        return std::min(*l, *r);
-      return l ? l : r;
+        return std::max(*l, *r);
+      return std::nullopt;
     }
-    return std::nullopt;
+    if (isa_and_nonnull<arith::ExtUIOp, arith::ExtSIOp>(def))
+      return operandBound(0);
+    APInt k;
+    if (auto t = dyn_cast_or_null<arith::TruncIOp>(def)) {
+      // dim3 packing replicates a 32-bit dim into both halves of an i64 as
+      // x * 0x100000001; either half recovers the dim.
+      if (auto mul = t.getIn().getDefiningOp<arith::MulIOp>())
+        if (matchPattern(mul.getRhs(), m_ConstantInt(&k)) &&
+            k.getZExtValue() == 0x100000001ULL)
+          return derivedExtentBound(mul.getLhs(), depth + 1, anchor);
+      auto b = operandBound(0);
+      unsigned w = t.getType().getIntOrFloatBitWidth();
+      if (b && *b >= 0 && (w >= 63 || *b < (int64_t(1) << w)))
+        return b;
+      return std::nullopt;
+    }
+    if (auto sh = dyn_cast_or_null<arith::ShRUIOp>(def)) {
+      if (matchPattern(sh.getRhs(), m_ConstantInt(&k)) &&
+          k.getZExtValue() < 63) {
+        auto b = operandBound(0);
+        if (b && *b >= 0)
+          return *b >> k.getZExtValue();
+      }
+      return std::nullopt;
+    }
+    // dim3 packing with a constant second half arrives as a disjoint or:
+    // either half of (a | c) recovers its own dim. a <= b does not order
+    // a|c against b|c bitwise; a|c <= a+c <= b+c.
+    if (auto orOp = dyn_cast_or_null<arith::OrIOp>(def)) {
+      if (matchPattern(orOp.getRhs(), m_ConstantInt(&k)) &&
+          k.getSExtValue() >= 0) {
+        auto b = operandBound(0);
+        if (b && *b >= 0)
+          return *b + k.getSExtValue();
+      }
+      return std::nullopt;
+    }
+    // Launch dims are non-negative by construction, so a product of two
+    // bounded dims (a dof count like 2*(D1D-1)*D1D) stays under the product
+    // of the bounds.
+    if (auto mul = dyn_cast_or_null<arith::MulIOp>(def)) {
+      auto l = operandBound(0);
+      auto r = matchPattern(mul.getRhs(), m_ConstantInt(&k))
+                   ? std::optional<int64_t>(k.getSExtValue())
+                   : operandBound(1);
+      if (l && r && *l >= 0 && *r >= 0 && (*l == 0 || *r <= INT64_MAX / *l))
+        return *l * *r;
+      return std::nullopt;
+    }
+    if (isa_and_nonnull<arith::AddIOp, arith::SubIOp>(def)) {
+      if (!matchPattern(def->getOperand(1), m_ConstantInt(&k)))
+        return std::nullopt;
+      auto b = operandBound(0);
+      if (!b)
+        return std::nullopt;
+      return isa<arith::AddIOp>(def) ? *b + k.getSExtValue()
+                                     : *b - k.getSExtValue();
+    }
+    return guardBound(v, anchor);
   }
 
   // A parallel axis whose extent is dynamic but provably bounded (a block
-  // size clamped by a min against a constant) batches at the bound instead
-  // of peeling to a serial loop: the axis becomes constant-extent and the
-  // body sits behind an `iv < extent` guard, which the masking machinery
-  // already understands. Barriers over the axis then stay batched no-ops.
+  // size clamped by a min against a constant, or capped by a guard) batches
+  // at the bound instead of peeling to a serial loop: the axis becomes
+  // constant-extent and the body sits behind an `iv < extent` guard, which
+  // the masking machinery already understands. Barriers over the axis then
+  // stay batched no-ops.
   static void boundParallelAxes(Operation *root) {
     SmallVector<affine::AffineParallelOp> worklist;
     root->walk([&](affine::AffineParallelOp par) { worklist.push_back(par); });
@@ -5453,13 +5598,15 @@ struct AffineToStableHLORaisingPass
         auto um = par.getUpperBoundMap(i);
         if (um.getNumResults() != 1)
           continue;
-        auto se = dyn_cast<AffineSymbolExpr>(um.getResult(0));
-        if (!se)
+        Value ext;
+        if (auto sym = dyn_cast<AffineSymbolExpr>(um.getResult(0)))
+          ext =
+              par.getUpperBoundsOperands()[um.getNumDims() + sym.getPosition()];
+        else if (auto dim = dyn_cast<AffineDimExpr>(um.getResult(0)))
+          ext = par.getUpperBoundsOperands()[dim.getPosition()];
+        else
           continue;
-        Value ext =
-            par.getUpperBoundsOperands()[par.getUpperBoundsMap().getNumDims() +
-                                         se.getPosition()];
-        if (auto c = derivedExtentBound(ext))
+        if (auto c = derivedExtentBound(ext, 0, par))
           bounded.push_back({i, *c, ext});
       }
       if (bounded.empty())

--- a/test/lit_tests/raising/raise_guard_bounded.mlir
+++ b/test/lit_tests/raising/raise_guard_bounded.mlir
@@ -1,0 +1,107 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// The extent has no clamp of its own, but the launch sits inside the
+// surviving branch of a dispatcher check (MFEM_VERIFY-style): inside
+// `if (d < 25)` the axis is bounded by 24 and batches behind a guard.
+func.func @guarded(%out: memref<32xf64, 1>, %in: memref<32xf64, 1>, %dbuf: memref<i32, 1>, %unused: index) {
+  %c1 = arith.constant 1 : index
+  %c25 = arith.constant 25 : i32
+  %d = affine.load %dbuf[] : memref<i32, 1>
+  %ok = arith.cmpi slt, %d, %c25 : i32
+  scf.if %ok {
+    %di = arith.index_cast %d : i32 to index
+    %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %di, %c1, %c1) ({
+      affine.parallel (%e) = (0) to (1) {
+        %scr = memref.alloca() : memref<32xf64>
+        affine.parallel (%t) = (0) to (symbol(%di)) {
+          %v = affine.load %in[%t] : memref<32xf64, 1>
+          affine.store %v, %scr[%t] : memref<32xf64>
+          "enzymexla.barrier"(%t, %c1, %c1) : (index, index, index) -> ()
+          %w = affine.load %scr[0] : memref<32xf64>
+          affine.store %w, %out[%t] : memref<32xf64, 1>
+        }
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+  }
+  return
+}
+
+// CHECK:    func.func @guarded(%arg0: memref<32xf64, 1>, %arg1: memref<32xf64, 1>, %arg2: memref<i32, 1>, %arg3: index) {
+// CHECK-NEXT:    %alloca = memref.alloca() : memref<i32>
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c25_i32 = arith.constant 25 : i32
+// CHECK-NEXT:    %0 = affine.load %arg2[] : memref<i32, 1>
+// CHECK-NEXT:    %1 = arith.cmpi slt, %0, %c25_i32 : i32
+// CHECK-NEXT:    scf.if %1 {
+// CHECK-NEXT:      %2 = arith.index_cast %0 : i32 to index
+// CHECK-NEXT:      %memref = gpu.alloc  () : memref<i32, 1>
+// CHECK-NEXT:      affine.store %0, %alloca[] : memref<i32>
+// CHECK-NEXT:      %c4 = arith.constant 4 : index
+// CHECK-NEXT:      enzymexla.memcpy  %memref, %alloca, %c4 : memref<i32, 1>, memref<i32>
+// CHECK-NEXT:      enzymexla.xla_wrapper @rxla$raised_0 (%arg1, %arg0, %memref) : (memref<32xf64, 1>, memref<32xf64, 1>, memref<i32, 1>) -> ()
+// CHECK-NEXT:      %c0 = arith.constant 0 : index
+// CHECK-NEXT:      gpu.dealloc  %memref : memref<i32, 1>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @rxla$raised_0(%arg0: tensor<32xf64>, %arg1: tensor<32xf64>, %arg2: tensor<i32>) -> (tensor<32xf64>, tensor<32xf64>, tensor<i32>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %0 = stablehlo.convert %arg2 : (tensor<i32>) -> tensor<i64>
+// CHECK-NEXT:    %1 = stablehlo.iota dim = 0 : tensor<1xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %2 = stablehlo.add %1, %c_0 : tensor<1xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<1xi64>
+// CHECK-NEXT:    %3 = stablehlo.multiply %2, %c_1 : tensor<1xi64>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<1x32xf64>
+// CHECK-NEXT:    %4 = stablehlo.iota dim = 0 : tensor<24xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<24xi64>
+// CHECK-NEXT:    %5 = stablehlo.add %4, %c_2 : tensor<24xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<1> : tensor<24xi64>
+// CHECK-NEXT:    %6 = stablehlo.multiply %5, %c_3 : tensor<24xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<-1> : tensor<i64>
+// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %c_4, dims = [] : (tensor<i64>) -> tensor<24xi64>
+// CHECK-NEXT:    %8 = stablehlo.multiply %6, %7 : tensor<24xi64>
+// CHECK-NEXT:    %9 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<i64>) -> tensor<24xi64>
+// CHECK-NEXT:    %10 = stablehlo.add %8, %9 : tensor<24xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<-1> : tensor<i64>
+// CHECK-NEXT:    %11 = stablehlo.broadcast_in_dim %c_5, dims = [] : (tensor<i64>) -> tensor<24xi64>
+// CHECK-NEXT:    %12 = stablehlo.add %10, %11 : tensor<24xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<24xi64>
+// CHECK-NEXT:    %13 = stablehlo.compare GE, %12, %c_6 : (tensor<24xi64>, tensor<24xi64>) -> tensor<24xi1>
+// CHECK-NEXT:    %14 = stablehlo.slice %arg0 [0:24] : (tensor<32xf64>) -> tensor<24xf64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_8 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_9 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_10 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_11 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_12 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_13 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_14 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_15 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_16 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_17 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_18 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %15 = stablehlo.broadcast_in_dim %14, dims = [1] : (tensor<24xf64>) -> tensor<1x24xf64>
+// CHECK-NEXT:    %16 = stablehlo.slice %cst [0:1, 0:24] : (tensor<1x32xf64>) -> tensor<1x24xf64>
+// CHECK-NEXT:    %17 = stablehlo.broadcast_in_dim %13, dims = [0] : (tensor<24xi1>) -> tensor<24x1xi1>
+// CHECK-NEXT:    %18 = stablehlo.broadcast_in_dim %15, dims = [1, 0] : (tensor<1x24xf64>) -> tensor<24x1xf64>
+// CHECK-NEXT:    %19 = stablehlo.broadcast_in_dim %16, dims = [1, 0] : (tensor<1x24xf64>) -> tensor<24x1xf64>
+// CHECK-NEXT:    %20 = stablehlo.select %17, %18, %19 : tensor<24x1xi1>, tensor<24x1xf64>
+// CHECK-NEXT:    %21 = stablehlo.broadcast_in_dim %20, dims = [1, 0] : (tensor<24x1xf64>) -> tensor<1x24xf64>
+// CHECK-NEXT:    %22 = stablehlo.dynamic_update_slice %cst, %21, %c_12, %c_18 : (tensor<1x32xf64>, tensor<1x24xf64>, tensor<i64>, tensor<i64>) -> tensor<1x32xf64>
+// CHECK-NEXT:    %23 = stablehlo.slice %22 [0:1, 0:1] : (tensor<1x32xf64>) -> tensor<1x1xf64>
+// CHECK-NEXT:    %24 = stablehlo.reshape %23 : (tensor<1x1xf64>) -> tensor<1xf64>
+// CHECK-NEXT:    %c_19 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_20 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_21 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_22 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_23 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_24 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %25 = stablehlo.reshape %24 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %26 = stablehlo.broadcast_in_dim %25, dims = [] : (tensor<f64>) -> tensor<24xf64>
+// CHECK-NEXT:    %27 = stablehlo.slice %arg1 [0:24] : (tensor<32xf64>) -> tensor<24xf64>
+// CHECK-NEXT:    %28 = stablehlo.select %13, %26, %27 : tensor<24xi1>, tensor<24xf64>
+// CHECK-NEXT:    %29 = stablehlo.dynamic_update_slice %arg1, %28, %c_24 : (tensor<32xf64>, tensor<24xf64>, tensor<i64>) -> tensor<32xf64>
+// CHECK-NEXT:    return %arg0, %29, %arg2 : tensor<32xf64>, tensor<32xf64>, tensor<i32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Follow-up to #2981. The bounded-axis batching only helped kernels whose clamp is in the same function as the launch. MFEM's runtime-dispatch fallback families (quadinterpolator, lininteg, restriction, the `_ea` and `_pa` integrators) break that assumption: the ceiling lives in a dispatcher `MFEM_VERIFY` rather than a min, and LLVM deletes source-level clamps it can prove redundant from those very verifies (adding `min(q1d, MAX_Q1D)` at the launch literally compiles away). Since #3165 and Reactant #98 the launch stubs inline into the dispatcher, so the verify and the launch sit in one function.

`derivedExtentBound` therefore learns to:
- **read dominating guards**: a `cmp`+noreturn verify arm, or the surviving branch of an enclosing `scf.if`, pins the complementary relation (`if (d < 25)` bounds the axis at 24);
- **see through the plumbing**: dim3 packing (`x * 0x100000001` replication, disjoint-or with a constant, trunc/shrui halves), `llvm.intr.smin/smax`, extension, bounded sums/products (dof counts like `2*(D1D-1)*D1D`), and selects.

Without this (and #3134, which builds on it) 25 MFEM TUs fail with `barrier over a dynamically sized parallel axis`; with it the whole 145-TU sweep compiles and the GPU suite is 74/74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
