### PR TITLE
Raising: fold null-guarded pointer selects

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3592,6 +3592,65 @@ struct AffineToStableHLORaisingPass
           AffineToStableHLORaisingPass> {
   using AffineToStableHLORaisingBase::AffineToStableHLORaisingBase;
 
+  // Whether the pointer's value is only ever consumed as an address of a
+  // memory access (through geps, casts, further selects, or memref views):
+  // anything that observes the value itself — a comparison, an int cast, a
+  // call, a store of the pointer as data — disqualifies it.
+  static bool onlyAddressesMemory(Value v) {
+    for (OpOperand &use : v.getUses()) {
+      Operation *u = use.getOwner();
+      if (auto gep = dyn_cast<LLVM::GEPOp>(u)) {
+        if (use.get() != gep.getBase() || !onlyAddressesMemory(gep.getResult()))
+          return false;
+      } else if (isa<LLVM::AddrSpaceCastOp>(u)) {
+        if (!onlyAddressesMemory(u->getResult(0)))
+          return false;
+      } else if (auto sel = dyn_cast<arith::SelectOp>(u)) {
+        if (use.get() == sel.getCondition() ||
+            !onlyAddressesMemory(sel.getResult()))
+          return false;
+      } else if (auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(u)) {
+        for (Operation *mu : p2m->getUsers())
+          if (!isa<affine::AffineLoadOp, affine::AffineStoreOp, memref::LoadOp,
+                   memref::StoreOp, memref::AtomicRMWOp>(mu))
+            return false;
+      } else if (isa<LLVM::LoadOp>(u)) {
+      } else if (auto store = dyn_cast<LLVM::StoreOp>(u)) {
+        if (use.get() == store.getValue())
+          return false;
+      } else if (auto rmw = dyn_cast<LLVM::AtomicRMWOp>(u)) {
+        if (use.get() != rmw.getPtr())
+          return false;
+      } else {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // mfem's Read/Write staging helpers return null for empty buffers, so a
+  // captured device pointer arrives as `select(size > 0, ptr, null)`. When
+  // the pointer is only dereferenced, the null arm can only fault, so the
+  // select collapses to the real pointer.
+  static void dropNullPointerSelects(Operation *root) {
+    SmallVector<arith::SelectOp> sels;
+    root->walk([&](arith::SelectOp s) {
+      if (isa<LLVM::LLVMPointerType>(s.getType()))
+        sels.push_back(s);
+    });
+    for (auto s : sels) {
+      Value tv = s.getTrueValue(), fv = s.getFalseValue();
+      bool tNull = tv.getDefiningOp<LLVM::ZeroOp>() != nullptr;
+      bool fNull = fv.getDefiningOp<LLVM::ZeroOp>() != nullptr;
+      if (tNull == fNull)
+        continue;
+      if (!onlyAddressesMemory(s.getResult()))
+        continue;
+      s.getResult().replaceAllUsesWith(tNull ? fv : tv);
+      s.erase();
+    }
+  }
+
   // An access does not care about the address space of its base, but the
   // raising identifies buffers by SSA root: a memory_space_cast view would
   // split one buffer into two roots and lose store propagation. Retarget the
@@ -3899,6 +3958,7 @@ struct AffineToStableHLORaisingPass
     // Peeling rewrites loops, so it stays scoped to the regions this pass
     // actually raises.
     for (auto func : funcs) {
+      dropNullPointerSelects(func);
       stripAccessMemorySpaceCasts(func);
       boundParallelAxes(func);
       peelDynamicParallelDims(func);
@@ -3922,6 +3982,7 @@ struct AffineToStableHLORaisingPass
     std::vector<enzymexla::GPUWrapperOp> gwrap;
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
+      dropNullPointerSelects(g);
       stripAccessMemorySpaceCasts(g);
       boundParallelAxes(g);
       peelDynamicParallelDims(g);

--- a/test/lit_tests/raising/raise_null_select.mlir
+++ b/test/lit_tests/raising/raise_null_select.mlir
@@ -1,0 +1,27 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// Staging helpers return null for empty buffers, so a captured device
+// pointer arrives as `select(size > 0, ptr, null)`; the pointer is only
+// dereferenced, so the select collapses to the real pointer and the kernel
+// raises.
+llvm.func @kern(%out: !llvm.ptr, %in: !llvm.ptr, %n: i32) {
+  %c1 = arith.constant 1 : index
+  %c0_i32 = arith.constant 0 : i32
+  %null = llvm.mlir.zero : !llvm.ptr
+  %ok = arith.cmpi sgt, %n, %c0_i32 : i32
+  %p = arith.select %ok, %out, %null : !llvm.ptr
+  %om = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+  %im = "enzymexla.pointer2memref"(%in) : (!llvm.ptr) -> memref<?xf64>
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+    affine.parallel (%i) = (0) to (16) {
+      %v = affine.load %im[%i] : memref<?xf64>
+      affine.store %v, %om[%i] : memref<?xf64>
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @kern(
+// CHECK-NOT: arith.select
+// CHECK: enzymexla.xla_wrapper @rxla$raised


### PR DESCRIPTION
mfem's staging helpers (`Read()`/`Write()` in device.hpp) return null for empty buffers, so a captured device pointer reaches the kernel as `select(size > 0, ptr, null)`, and raising fails on the select (hit by `EABilinearFormExtension::GetElementMatrices` and other assembly paths in the MFEM CUDA campaign, #2968).

When the pointer's value is only ever consumed as the address of a memory access (through geps, casts, further selects, or `pointer2memref` views feeding loads/stores/atomics), the null arm can only fault, so the select collapses to the real pointer. Pointers whose value is observed directly — compared, cast to int, stored as data, passed to a call — are left alone.

Includes a lit test where the folded kernel then raises end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD