### PR TITLE
Raising: dead lanes must not scatter at all

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -1472,21 +1472,6 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
                                              broadcastDims);
 
   if (pc.mask) {
-    SmallVector<int64_t> collapsedDims(scatterDimsToOperandDims.begin(),
-                                       scatterDimsToOperandDims.end());
-    SmallVector<int64_t> sliceSizes(collapsedDims.size(), 1);
-    Value orig = stablehlo::GatherOp::create(
-        builder, loc, input, indices,
-        stablehlo::GatherDimensionNumbersAttr::get(
-            loc.getContext(),
-            /*offsetDims*/ {},
-            /*collapsedSliceDims*/ collapsedDims,
-            /*operandBatchingDims*/ {},
-            /*startIndicesBatchingDims*/ {},
-            /*startIndexMap*/ collapsedDims,
-            /*indexVectorDim*/ (int64_t)gridShape.size()),
-        sliceSizes);
-
     // Broadcast the mask from its IV-space to the update's grid shape. A
     // mask axis over an IV the store does not index or-reduces away first:
     // the update is already known invariant along it (a variant update
@@ -1535,8 +1520,24 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
     Value broadcastedMask = stablehlo::BroadcastInDimOpCreate(
         builder, loc, mask, maskGridTy.getShape(), maskBroadcastDims);
 
-    update = stablehlo::SelectOp::create(builder, loc, broadcastedMask, update,
-                                         orig);
+    // A masked-out lane must not write at all: its index expression is
+    // unconstrained and can collide with a live lane's slot, and scatter
+    // applies duplicate indices in unspecified order. Send dead lanes out
+    // of bounds — the scatter drops those updates.
+    auto idxTy = cast<RankedTensorType>(indices.getType());
+    Value minusOne = stablehlo::ConstantOp::create(
+        builder, loc, idxTy,
+        SplatElementsAttr::get(
+            idxTy, builder.getIntegerAttr(idxTy.getElementType(), -1)));
+    auto idxMaskTy =
+        RankedTensorType::get(idxTy.getShape(), builder.getI1Type());
+    SmallVector<int64_t> idxMaskDims;
+    for (int64_t k = 0, e = (int64_t)gridShape.size(); k < e; ++k)
+      idxMaskDims.push_back(k);
+    Value idxMask = stablehlo::BroadcastInDimOp::create(
+        builder, loc, idxMaskTy, broadcastedMask, idxMaskDims);
+    indices =
+        stablehlo::SelectOp::create(builder, loc, idxMask, indices, minusOne);
   }
 
   auto Ty = cast<RankedTensorType>(input.getType());

--- a/test/lit_tests/raising/affine_to_stablehlo_masked_scatter.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_masked_scatter.mlir
@@ -19,16 +19,14 @@ module {
 }
 
 // CHECK:  func.func private @main_raised(%arg0: tensor<100xf32>, %arg1: tensor<100xf32>) -> (tensor<100xf32>, tensor<100xf32>) {
-// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<10x10xi64>
+// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<10x10x1xi64>
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 {enzymexla.non_negative = [#enzymexla<guaranteed GUARANTEED>]} : tensor<10xi64>
 // CHECK-NEXT:    %1 = stablehlo.negate %0 : tensor<10xi64>
-// CHECK-NEXT:    %2 = stablehlo.iota dim = 0 : tensor<10x10xi64>
-// CHECK-NEXT:    %3 = stablehlo.broadcast_in_dim %1, dims = [1] {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<10xi64>) -> tensor<10x10xi64>
-// CHECK-NEXT:    %4 = stablehlo.add %2, %3 {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<10x10xi64>
-// CHECK-NEXT:    %5 = stablehlo.compare GE, %4, %c : (tensor<10x10xi64>, tensor<10x10xi64>) -> tensor<10x10xi1>
-// CHECK-NEXT:    %6 = stablehlo.reshape %arg1 : (tensor<100xf32>) -> tensor<10x10xf32>
-// CHECK-NEXT:    %7 = stablehlo.reshape %arg0 : (tensor<100xf32>) -> tensor<10x10xf32>
-// CHECK-NEXT:    %8 = stablehlo.select %5, %6, %7 : tensor<10x10xi1>, tensor<10x10xf32>
-// CHECK-NEXT:    %9 = stablehlo.reshape %8 : (tensor<10x10xf32>) -> tensor<100xf32>
-// CHECK-NEXT:    return %9, %arg1 : tensor<100xf32>, tensor<100xf32>
+// CHECK-NEXT:    %2 = stablehlo.iota dim = 0 : tensor<10x10x1xi64>
+// CHECK-NEXT:    %3 = stablehlo.broadcast_in_dim %1, dims = [1] : (tensor<10xi64>) -> tensor<10x10x1xi64>
+// CHECK-NEXT:    %4 = stablehlo.add %2, %3 {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<10x10x1xi64>
+// CHECK-NEXT:    %5 = stablehlo.compare GE, %4, %c : (tensor<10x10x1xi64>, tensor<10x10x1xi64>) -> tensor<10x10x1xi1>
+// CHECK-NEXT:    %6 = stablehlo.reshape %5 : (tensor<10x10x1xi1>) -> tensor<100xi1>
+// CHECK-NEXT:    %7 = stablehlo.select %6, %arg1, %arg0 : tensor<100xi1>, tensor<100xf32>
+// CHECK-NEXT:    return %7, %arg1 : tensor<100xf32>, tensor<100xf32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/raise_barrier_budget.mlir
+++ b/test/lit_tests/raising/raise_barrier_budget.mlir
@@ -23,7 +23,7 @@ func.func @budget(%out: memref<1024xf64, 1>, %in: memref<1024xf64, 1>, %qbuf: me
   return
 }
 
-// CHECK:    func.func @budget(%arg0: memref<1024xf64, 1>, %arg1: memref<1024xf64, 1>, %arg2: memref<i32, 1>, %arg3: index) {
+// CHECK:      func.func @budget(%arg0: memref<1024xf64, 1>, %arg1: memref<1024xf64, 1>, %arg2: memref<i32, 1>, %arg3: index) {
 // CHECK-NEXT:    %alloca = memref.alloca() : memref<i32>
 // CHECK-NEXT:    %c1 = arith.constant 1 : index
 // CHECK-NEXT:    %0 = affine.load %arg2[] : memref<i32, 1>
@@ -121,9 +121,10 @@ func.func @budget(%out: memref<1024xf64, 1>, %in: memref<1024xf64, 1>, %qbuf: me
 // CHECK-NEXT:    %46 = stablehlo.reshape %45 : (tensor<32x32xi64>) -> tensor<32x32x1xi64>
 // CHECK-NEXT:    %47 = stablehlo.reshape %40 : (tensor<1x32x32xf64>) -> tensor<32x32xf64>
 // CHECK-NEXT:    %48 = stablehlo.broadcast_in_dim %47, dims = [1, 0] : (tensor<32x32xf64>) -> tensor<32x32xf64>
-// CHECK-NEXT:    %49 = "stablehlo.gather"(%arg1, %46) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<1024xf64>, tensor<32x32x1xi64>) -> tensor<32x32xf64>
-// CHECK-NEXT:    %50 = stablehlo.select %26, %48, %49 : tensor<32x32xi1>, tensor<32x32xf64>
-// CHECK-NEXT:    %51 = "stablehlo.scatter"(%arg1, %46, %50) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = false}> ({
+// CHECK-NEXT:    %c_32 = stablehlo.constant dense<-1> : tensor<32x32x1xi64>
+// CHECK-NEXT:    %49 = stablehlo.broadcast_in_dim %26, dims = [0, 1] : (tensor<32x32xi1>) -> tensor<32x32x1xi1>
+// CHECK-NEXT:    %50 = stablehlo.select %49, %46, %c_32 : tensor<32x32x1xi1>, tensor<32x32x1xi64>
+// CHECK-NEXT:    %51 = "stablehlo.scatter"(%arg1, %50, %48) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = false}> ({
 // CHECK-NEXT:    ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
 // CHECK-NEXT:      stablehlo.return %arg4 : tensor<f64>
 // CHECK-NEXT:    }) : (tensor<1024xf64>, tensor<32x32x1xi64>, tensor<32x32xf64>) -> tensor<1024xf64>

--- a/test/lit_tests/raising/raise_broadcast_store.mlir
+++ b/test/lit_tests/raising/raise_broadcast_store.mlir
@@ -14,7 +14,7 @@ func.func @lane0(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>) {
   return
 }
 
-// CHECK:    func.func private @lane0_raised(%arg0: tensor<16xf64>, %arg1: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK:        func.func private @lane0_raised(%arg0: tensor<16xf64>, %arg1: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<32xi64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<32xi64>
 // CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<32xi64>
@@ -60,7 +60,7 @@ func.func @lane0_large(%out: memref<4096xf64, 1>, %in: memref<4096xf64, 1>) {
   return
 }
 
-// CHECK:    func.func private @lane0_large_raised(%arg0: tensor<4096xf64>, %arg1: tensor<4096xf64>) -> (tensor<4096xf64>, tensor<4096xf64>) {
+// CHECK:        func.func private @lane0_large_raised(%arg0: tensor<4096xf64>, %arg1: tensor<4096xf64>) -> (tensor<4096xf64>, tensor<4096xf64>) {
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<256xi64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<256xi64>
 // CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<256xi64>
@@ -106,7 +106,7 @@ func.func @row_small(%out: memref<16x32xf64, 1>, %in: memref<16x32xf64, 1>) {
   return
 }
 
-// CHECK:    func.func private @row_small_raised(%arg0: tensor<16x32xf64>, %arg1: tensor<16x32xf64>) -> (tensor<16x32xf64>, tensor<16x32xf64>) {
+// CHECK:        func.func private @row_small_raised(%arg0: tensor<16x32xf64>, %arg1: tensor<16x32xf64>) -> (tensor<16x32xf64>, tensor<16x32xf64>) {
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<16xi64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<16xi64>
 // CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<16xi64>
@@ -171,7 +171,7 @@ func.func @row_large(%out: memref<256x4096xf64, 1>, %in: memref<256x4096xf64, 1>
   return
 }
 
-// CHECK:    func.func private @row_large_raised(%arg0: tensor<256x4096xf64>, %arg1: tensor<256x4096xf64>) -> (tensor<256x4096xf64>, tensor<256x4096xf64>) {
+// CHECK:        func.func private @row_large_raised(%arg0: tensor<256x4096xf64>, %arg1: tensor<256x4096xf64>) -> (tensor<256x4096xf64>, tensor<256x4096xf64>) {
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<256xi64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<256xi64>
 // CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<256xi64>
@@ -251,7 +251,7 @@ func.func @bcast(%out: memref<?xf64, 1>, %in: memref<?xf64, 1>, %nbuf: memref<i6
   return
 }
 
-// CHECK:    func.func private @bcast_raised(%arg0: tensor<?xf64>, %arg1: tensor<?xf64>, %arg2: tensor<i64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<i64>) {
+// CHECK:        func.func private @bcast_raised(%arg0: tensor<?xf64>, %arg1: tensor<?xf64>, %arg2: tensor<i64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<i64>) {
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i64>
 // CHECK-NEXT:    %0:4 = stablehlo.while(%iterArg = %c, %iterArg_1 = %arg0, %iterArg_2 = %arg1, %iterArg_3 = %arg2) : tensor<i64>, tensor<?xf64>, tensor<?xf64>, tensor<i64> attributes {enzymexla.parallel}
@@ -360,7 +360,7 @@ func.func @bcast_scatter(%out: memref<100xf64, 1>, %in: memref<100xf64, 1>) {
   return
 }
 
-// CHECK:    func.func private @bcast_scatter_raised(%arg0: tensor<100xf64>, %arg1: tensor<100xf64>) -> (tensor<100xf64>, tensor<100xf64>) {
+// CHECK:        func.func private @bcast_scatter_raised(%arg0: tensor<100xf64>, %arg1: tensor<100xf64>) -> (tensor<100xf64>, tensor<100xf64>) {
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4xi64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<4xi64>
 // CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<4xi64>
@@ -376,12 +376,13 @@ func.func @bcast_scatter(%out: memref<100xf64, 1>, %in: memref<100xf64, 1>) {
 // CHECK-NEXT:    %7 = stablehlo.compare EQ, %5, %c_3 : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi1>
 // CHECK-NEXT:    %8 = arith.muli %2, %2 : tensor<4xi64>
 // CHECK-NEXT:    %9 = stablehlo.reshape %8 : (tensor<4xi64>) -> tensor<4x1xi64>
-// CHECK-NEXT:    %10 = "stablehlo.gather"(%arg0, %9) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<100xf64>, tensor<4x1xi64>) -> tensor<4xf64>
 // CHECK-NEXT:    %c_4 = stablehlo.constant dense<false> : tensor<i1>
-// CHECK-NEXT:    %11 = stablehlo.reduce(%7 init: %c_4) applies stablehlo.or across dimensions = [0] : (tensor<32xi1>, tensor<i1>) -> tensor<i1>
-// CHECK-NEXT:    %12 = stablehlo.broadcast_in_dim %11, dims = [] : (tensor<i1>) -> tensor<4xi1>
-// CHECK-NEXT:    %13 = stablehlo.select %12, %6, %10 : tensor<4xi1>, tensor<4xf64>
-// CHECK-NEXT:    %14 = "stablehlo.scatter"(%arg0, %9, %13) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    %10 = stablehlo.reduce(%7 init: %c_4) applies stablehlo.or across dimensions = [0] : (tensor<32xi1>, tensor<i1>) -> tensor<i1>
+// CHECK-NEXT:    %11 = stablehlo.broadcast_in_dim %10, dims = [] : (tensor<i1>) -> tensor<4xi1>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<-1> : tensor<4x1xi64>
+// CHECK-NEXT:    %12 = stablehlo.broadcast_in_dim %11, dims = [0] : (tensor<4xi1>) -> tensor<4x1xi1>
+// CHECK-NEXT:    %13 = stablehlo.select %12, %9, %c_5 : tensor<4x1xi1>, tensor<4x1xi64>
+// CHECK-NEXT:    %14 = "stablehlo.scatter"(%arg0, %13, %6) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
 // CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
 // CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
 // CHECK-NEXT:    }) : (tensor<100xf64>, tensor<4x1xi64>, tensor<4xf64>) -> tensor<100xf64>
@@ -417,7 +418,7 @@ func.func @bcast_scatter_large(%out: memref<8192xf64, 1>, %in: memref<4096xf64, 
   return
 }
 
-// CHECK:    func.func private @bcast_scatter_large_raised(%arg0: tensor<8192xf64>, %arg1: tensor<4096xf64>) -> (tensor<8192xf64>, tensor<4096xf64>) {
+// CHECK:        func.func private @bcast_scatter_large_raised(%arg0: tensor<8192xf64>, %arg1: tensor<4096xf64>) -> (tensor<8192xf64>, tensor<4096xf64>) {
 // CHECK-NEXT:    %c = stablehlo.constant dense<4095> : tensor<i64>
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4096xi64>
 // CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<4096xi64>
@@ -435,12 +436,13 @@ func.func @bcast_scatter_large(%out: memref<8192xf64, 1>, %in: memref<4096xf64, 
 // CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i64>) -> tensor<4096xi64>
 // CHECK-NEXT:    %9 = arith.andi %7, %8 : tensor<4096xi64>
 // CHECK-NEXT:    %10 = stablehlo.reshape %9 : (tensor<4096xi64>) -> tensor<4096x1xi64>
-// CHECK-NEXT:    %11 = "stablehlo.gather"(%arg0, %10) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<8192xf64>, tensor<4096x1xi64>) -> tensor<4096xf64>
 // CHECK-NEXT:    %c_5 = stablehlo.constant dense<false> : tensor<i1>
-// CHECK-NEXT:    %12 = stablehlo.reduce(%6 init: %c_5) applies stablehlo.or across dimensions = [0] : (tensor<256xi1>, tensor<i1>) -> tensor<i1>
-// CHECK-NEXT:    %13 = stablehlo.broadcast_in_dim %12, dims = [] : (tensor<i1>) -> tensor<4096xi1>
-// CHECK-NEXT:    %14 = stablehlo.select %13, %arg1, %11 : tensor<4096xi1>, tensor<4096xf64>
-// CHECK-NEXT:    %15 = "stablehlo.scatter"(%arg0, %10, %14) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    %11 = stablehlo.reduce(%6 init: %c_5) applies stablehlo.or across dimensions = [0] : (tensor<256xi1>, tensor<i1>) -> tensor<i1>
+// CHECK-NEXT:    %12 = stablehlo.broadcast_in_dim %11, dims = [] : (tensor<i1>) -> tensor<4096xi1>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<-1> : tensor<4096x1xi64>
+// CHECK-NEXT:    %13 = stablehlo.broadcast_in_dim %12, dims = [0] : (tensor<4096xi1>) -> tensor<4096x1xi1>
+// CHECK-NEXT:    %14 = stablehlo.select %13, %10, %c_6 : tensor<4096x1xi1>, tensor<4096x1xi64>
+// CHECK-NEXT:    %15 = "stablehlo.scatter"(%arg0, %14, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
 // CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
 // CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
 // CHECK-NEXT:    }) : (tensor<8192xf64>, tensor<4096x1xi64>, tensor<4096xf64>) -> tensor<8192xf64>


### PR DESCRIPTION
A store under a lane mask raises as gather-select-scatter, writing the *original* value back on masked-out lanes. But a dead lane's index expression is unconstrained — strip-mine bound clamps (`max(extent, tid + bd)`) collapse dead lanes onto live lanes' slots — and scatter applies duplicate indices in unspecified order, so the stale write-back can land after the live lane's update and clobber it.

Found via mfem's QuadratureInterpolator under the XLA backend (#2968): the dynamic 2D tensor-product eval kernel produced partially-zero, element-varying results; a PJRT harness on the raised module reproduced it deterministically, and redirecting dead lanes out of bounds fixes it bit-exactly.

The fix selects dead lanes' indices to `-1`; out-of-bounds scatter updates are dropped, so masked-out lanes write nothing. This also removes the gather of the original values.

This PR now carries only the raising change. The `enzyme-hlo-opt` half that resolves the masked index ahead of the single-point scatter-to-DUS rewrite (`ScatterMaskedIndexSimplify`) is split out into its own PR, and the bounds guard on that rewrite is #3022. Ordering matters: with this change a masked-out lane's correctness rests on the scatter dropping its out-of-bounds index, so the DUS rewrite must not clamp it. This should land with, or after, one of those two.

The previous form let `enzyme-hlo-opt` fold a full-grid masked store into a pure `select`; with the index-select form the scatter survives in `affine_to_stablehlo_masked_scatter.mlir`. Teaching the dense-scatter fold to look through the index select would recover that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
