### PR TITLE
CommonCompareExpressionRewrite: place the negation after the op it reads

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -21918,6 +21918,10 @@ struct CommonCompareExpressionRewrite
           rewriter.replaceOp(op, negatedCondition);
           return success();
         } else {
+          // The negation reads op's result, so it must sit after op — the
+          // rewriter's insertion point is before op here.
+          PatternRewriter::InsertionGuard guard(rewriter);
+          rewriter.setInsertionPoint(user);
           auto negatedCondition = stablehlo::NotOp::create(
               rewriter, userCompareOp.getLoc(), op.getResult());
           rewriter.replaceOp(user, negatedCondition);

--- a/test/lit_tests/commoncompare_neg_after.mlir
+++ b/test/lit_tests/commoncompare_neg_after.mlir
@@ -1,0 +1,15 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// The negated twin appears after the matched compare: the rewrite replaces
+// it with a negation of the earlier compare, which must be inserted after
+// the compare it reads, not at the match point before it.
+func.func @negpair(%a: tensor<4xi32>, %b: tensor<4xi32>) -> (tensor<4xi1>, tensor<4xi1>) {
+  %le = stablehlo.compare LE, %a, %b, SIGNED : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  %gt = stablehlo.compare GT, %a, %b, SIGNED : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  return %le, %gt : tensor<4xi1>, tensor<4xi1>
+}
+
+// CHECK-LABEL: func.func @negpair(
+// CHECK-NEXT:    %[[LE:.+]] = stablehlo.compare LE, %arg0, %arg1, SIGNED
+// CHECK-NEXT:    %[[NOT:.+]] = stablehlo.not %[[LE]]
+// CHECK-NEXT:    return %[[LE]], %[[NOT]]


### PR DESCRIPTION
When `CommonCompareExpressionRewrite` finds the negated twin *after* the matched compare, it created the `NotOp` at the rewriter's default insertion point — before the compare whose result it reads — producing IR that fails dominance verification (`operand #0 does not dominate this use`).

Hit by mfem's QuadratureInterpolator raised kernels under the XLA backend (#2968): masked strip-loop bounds emit `LE`/`GT` pairs on the same operands in one block, and whether the bad arm fires depends on block order, so it surfaced as a nondeterministic compile failure.

Fix: guard the insertion point and place the negation at the later compare's position. Lit test included (fails dominance verification without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD