### PR TITLE
Raising: canonicalize maps before permutation matching; while fallback for constant-bound loops

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -1265,8 +1265,18 @@ static LogicalResult tryRaisingForOpToStableHLOUnroll(
 //  it returns the permutation to apply to a in order to align to b.
 //
 static std::optional<SmallVector<int64_t>>
-memoryEquivalentPermutation(const affine::AffineValueMap &a,
-                            const affine::AffineValueMap &b) {
+memoryEquivalentPermutation(const affine::AffineValueMap &aIn,
+                            const affine::AffineValueMap &bIn) {
+  // Dims that appear in no result do not affect the laid-out memory (an
+  // eliminated unit axis leaves its dim behind); canonicalize them away so
+  // equivalent maps compare equal.
+  auto canonicalize = [](const affine::AffineValueMap &m) {
+    AffineMap map = m.getAffineMap();
+    SmallVector<Value> ops(m.getOperands().begin(), m.getOperands().end());
+    affine::canonicalizeMapAndOperands(&map, &ops);
+    return affine::AffineValueMap(map, ops);
+  };
+  affine::AffineValueMap a = canonicalize(aIn), b = canonicalize(bIn);
   SmallVector<int64_t> perm(a.getNumResults(), -1);
 
   auto amap = a.getAffineMap(), bmap = b.getAffineMap();
@@ -3388,6 +3398,14 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       return success();
     }
     if (tryRaisingForOpToStableHLOUnroll(forOp, mapping, builder, maps, pc)
+            .succeeded()) {
+      return success();
+    }
+    // The preference skipped the while for constant bounds; as a last
+    // resort a sequential while still raises what lockstep and unrolling
+    // could not (accumulators chained through nested reductions).
+    if (!pc.options.preferWhileRaising && forOp.hasConstantBounds() &&
+        tryRaisingForOpToStableHLOWhile(forOp, mapping, builder, maps, pc)
             .succeeded()) {
       return success();
     }


### PR DESCRIPTION
Two fixes that let mfem's EA mass-assembly kernels (7³ per-thread loop nests around chained 8×8 reductions) raise (#2968):

- `memoryEquivalentPermutation` failed when an eliminated unit axis left an unused dim behind in the yielded value's map — the while raise then rejected a carried accumulator whose map was memory-equivalent up to dead dims. Canonicalize both maps (drop unused dims/operands) before matching.
- When lockstep and unrolling both fail on a constant-bound `affine.for` (the chained-accumulator nests defeat both), fall back to the sequential while raise even under `prefer_while_raising=false`.

With these, `bilininteg_mass_ea`, `hdiv_kernels`, `hcurl_kernels`, `elasticity_kernels`, `mixedvecgrad_pa`, and `convection_ea` all raise strict; the raising lit suite is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD