### PR TITLE
While raising: broadcast under-attributed yields to the carried layout

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -881,6 +881,27 @@ static Block *getRaisedEntryBlock(Operation *op) {
   return &op->getParentRegion()->front();
 }
 
+// A loop-carried value can be yielded with fewer attributed axes than the
+// carried argument (a uniform chain through an index-table gather loses its
+// lane attribution): broadcast the yield up to the carried layout before
+// matching the permutation.
+static bool
+broadcastYieldToCarried(Value &yielded, Value carried, OpBuilder &builder,
+                        llvm::DenseMap<Value, affine::AffineValueMap> &maps,
+                        ParallelContext &pc) {
+  if (yielded.getType() == carried.getType())
+    return true;
+  Value a = carried;
+  Value b = yielded;
+  auto outMap = alignMemoryAccess(a, maps.lookup(carried), b,
+                                  maps.lookup(yielded), builder, pc);
+  if (failed(outMap) || a.getType() != carried.getType())
+    return false;
+  maps[b] = *outMap;
+  yielded = b;
+  return true;
+}
+
 static LogicalResult tryRaisingForOpToStableHLOWhile(
     affine::AffineForOp forOp, IRMapping &parentMapping, OpBuilder &builder,
     llvm::DenseMap<Value, affine::AffineValueMap> &maps, ParallelContext pc,
@@ -1677,6 +1698,9 @@ static LogicalResult tryRaisingForOpToStableHLOWhile(
         return failure();
 
       if (!maps.count(raisedYieldedIterArg) || !maps.count(raisedIterArg))
+        return failure();
+      if (!broadcastYieldToCarried(raisedYieldedIterArg, raisedIterArg, builder,
+                                   maps, pc))
         return failure();
       auto perm = memoryEquivalentPermutation(maps.lookup(raisedYieldedIterArg),
                                               maps.lookup(raisedIterArg));

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -2000,6 +2000,9 @@ static LogicalResult tryRaisingSCFForOpToStableHLOWhile(
         return failure();
       if (!maps.count(raisedYielded) || !maps.count(raisedIterArg))
         return failure();
+      if (!broadcastYieldToCarried(raisedYielded, raisedIterArg, builder, maps,
+                                   pc))
+        return failure();
       auto perm = memoryEquivalentPermutation(maps.lookup(raisedYielded),
                                               maps.lookup(raisedIterArg));
       if (!perm.has_value()) {

--- a/test/lit_tests/raising/affine_to_stablehlo_tridiagonal.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_tridiagonal.mlir
@@ -675,7 +675,9 @@ module {
   }
 }
 
-// CHECK:      %[[ALIGN1:.+]] = stablehlo.transpose %3191, dims = [0, 2, 3, 1] : (tensor<2x16x16x3xf32>) -> tensor<2x16x3x16xf32>
-// CHECK-NEXT:      %[[ALIGN2:.+]] = stablehlo.transpose %3508, dims = [0, 2, 3, 1] : (tensor<2x16x16x3xf32>) -> tensor<2x16x3x16xf32>
+// The yielded accumulators re-align onto the carried layout as permuting
+// broadcasts before the return.
+// CHECK:      %[[ALIGN1:.+]] = stablehlo.broadcast_in_dim %3191, dims = [0, 3, 1, 2] : (tensor<2x16x16x3xf32>) -> tensor<2x16x3x16xf32>
+// CHECK-NEXT:      %[[ALIGN2:.+]] = stablehlo.broadcast_in_dim %3508, dims = [0, 3, 1, 2] : (tensor<2x16x16x3xf32>) -> tensor<2x16x3x16xf32>
 // CHECK-NEXT:      stablehlo.return %{{.+}}, %[[ALIGN1]], %[[ALIGN2]], %{{.+}}, %{{.+}}, %iterArg_491, %iterArg_492, %iterArg_493, %iterArg_494, %iterArg_495, %iterArg_496, %iterArg_497, %iterArg_498, %iterArg_499 : tensor<i64>, tensor<2x16x3x16xf32>, tensor<2x16x3x16xf32>, tensor<61x28x46xf32>, tensor<50x18x36xf32>, tensor<61xf32>, tensor<60xf32>, tensor<1x28x46xf32>, tensor<60x28x46xf32>, tensor<60x28x46xf32>, tensor<60x28x46xf32>, tensor<f32>, tensor<f32>, tensor<f32>
 // CHECK-NEXT:    }


### PR DESCRIPTION
mfem's `bilininteg_diffusion_kernels.cpp` accumulators chain through index-table gathers whose raised values lose their lane attribution (a `() -> ()` map with a tensor type); the while raising then rejected the loop because the yield's layout could not be permutation-matched to the carried argument. Broadcast the yield up to the carried layout via `alignMemoryAccess` before matching, and let `alignMemoryAccess` report incompatibility through an `ok` out-flag instead of asserting on accesses it cannot size.

The tridiagonal golden changes form: the align at the loop tail now emits a permuting `broadcast_in_dim` (`dims = [0, 3, 1, 2]`) instead of a transpose — equivalent IR.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD