### PR TITLE
Raising: unroll budget for constant-bound loops

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -296,6 +296,7 @@ struct ParallelContext {
     bool dump_failed_lockstep = false;
     bool preferWhileRaising = true;
     bool strip_llvm_debuginfo = false;
+    int64_t unrollBudget = 1 << 16;
   } options;
 
   explicit ParallelContext(Options &options) : options(options) {}
@@ -3402,8 +3403,9 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       }
       return body;
     };
-    bool hugeUnroll = forOp.hasConstantBounds() &&
-                      unrollCost(forOp.getOperation()) > (1 << 16);
+    bool hugeUnroll =
+        pc.options.unrollBudget >= 0 && forOp.hasConstantBounds() &&
+        unrollCost(forOp.getOperation()) > pc.options.unrollBudget;
     // A loop whose trip count is only known at runtime can still iterate as
     // a while, whatever the preference says.
     if ((pc.options.preferWhileRaising || !forOp.hasConstantBounds() ||
@@ -3889,8 +3891,8 @@ struct AffineToStableHLORaisingPass
 
   void runOnOperation() override {
     ParallelContext::Options options{enable_lockstep_for, dump_failed_lockstep,
-                                     prefer_while_raising,
-                                     strip_llvm_debuginfo};
+                                     prefer_while_raising, strip_llvm_debuginfo,
+                                     unroll_budget};
     std::vector<func::FuncOp> funcs;
 
     auto context = getOperation()->getContext();

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -2076,6 +2076,24 @@ static LogicalResult tryRaisingLockStepForOpToStableHLO(
   return failure();
 }
 
+// The op count of `op` once every constant-bound affine.for inside it (and
+// `op` itself, if it is one) is unrolled, saturating at 2^40.
+static int64_t unrollCost(Operation *op) {
+  int64_t body = 1;
+  for (Region &r : op->getRegions())
+    for (Block &b : r)
+      for (Operation &inner : b)
+        body = std::min(body + unrollCost(&inner), (int64_t)1 << 40);
+  auto forOp = dyn_cast<affine::AffineForOp>(op);
+  if (!forOp || !forOp.hasConstantBounds())
+    return body;
+  int64_t step = forOp.getStepAsInt();
+  int64_t trip = (forOp.getConstantUpperBound() -
+                  forOp.getConstantLowerBound() + step - 1) /
+                 step;
+  return std::min(std::max(trip, (int64_t)1) * body, (int64_t)1 << 40);
+}
+
 static LogicalResult
 tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
                         llvm::DenseMap<Value, affine::AffineValueMap> &maps,
@@ -3385,24 +3403,6 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     // max-degree kernel reaches millions of ops and gigabytes of module
     // text); past a budget, iterating as a while beats unrolling even when
     // the preference says otherwise.
-    std::function<int64_t(Operation *)> unrollCost =
-        [&](Operation *o) -> int64_t {
-      int64_t body = 1;
-      for (Region &r : o->getRegions())
-        for (Block &b : r)
-          for (Operation &inner : b)
-            body = std::min(body + unrollCost(&inner), (int64_t)1 << 40);
-      if (auto f = dyn_cast<affine::AffineForOp>(o)) {
-        if (!f.hasConstantBounds())
-          return body;
-        int64_t step = f.getStepAsInt();
-        int64_t trip =
-            (f.getConstantUpperBound() - f.getConstantLowerBound() + step - 1) /
-            step;
-        return std::min(std::max(trip, (int64_t)1) * body, (int64_t)1 << 40);
-      }
-      return body;
-    };
     bool hugeUnroll =
         pc.options.unrollBudget >= 0 && forOp.hasConstantBounds() &&
         unrollCost(forOp.getOperation()) > pc.options.unrollBudget;

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3380,9 +3380,34 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
             .succeeded()) {
       return success();
     }
+    // Nested constant-bound loops unroll multiplicatively (a generic
+    // max-degree kernel reaches millions of ops and gigabytes of module
+    // text); past a budget, iterating as a while beats unrolling even when
+    // the preference says otherwise.
+    std::function<int64_t(Operation *)> unrollCost =
+        [&](Operation *o) -> int64_t {
+      int64_t body = 1;
+      for (Region &r : o->getRegions())
+        for (Block &b : r)
+          for (Operation &inner : b)
+            body = std::min(body + unrollCost(&inner), (int64_t)1 << 40);
+      if (auto f = dyn_cast<affine::AffineForOp>(o)) {
+        if (!f.hasConstantBounds())
+          return body;
+        int64_t step = f.getStepAsInt();
+        int64_t trip =
+            (f.getConstantUpperBound() - f.getConstantLowerBound() + step - 1) /
+            step;
+        return std::min(std::max(trip, (int64_t)1) * body, (int64_t)1 << 40);
+      }
+      return body;
+    };
+    bool hugeUnroll = forOp.hasConstantBounds() &&
+                      unrollCost(forOp.getOperation()) > (1 << 16);
     // A loop whose trip count is only known at runtime can still iterate as
     // a while, whatever the preference says.
-    if ((pc.options.preferWhileRaising || !forOp.hasConstantBounds()) &&
+    if ((pc.options.preferWhileRaising || !forOp.hasConstantBounds() ||
+         hugeUnroll) &&
         tryRaisingForOpToStableHLOWhile(forOp, mapping, builder, maps, pc)
             .succeeded()) {
       return success();

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -1269,6 +1269,14 @@ def AffineToStableHLORaising : Pass<"raise-affine-to-stablehlo"> {
            /*default=*/"true",
            /*description=*/
            "Whether to prefer raising to while instead of unrolling">,
+       Option<
+           /*C++ variable name=*/"unroll_budget",
+           /*CLI argument=*/"unroll_budget",
+           /*type=*/"int64_t",
+           /*default=*/"65536",
+           /*description=*/
+           "Raise a constant-bound loop as a while instead of unrolling when "
+           "its nested unrolled op count exceeds this. -1 for no budget">,
   ];
 }
 

--- a/test/lit_tests/raising/affine_to_stablehlo_unroll_budget.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_unroll_budget.mlir
@@ -1,4 +1,6 @@
 // RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false' | FileCheck %s
+// RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false unroll_budget=8' | FileCheck %s --check-prefix=TIGHT
+// RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false unroll_budget=-1' | FileCheck %s --check-prefix=UNBOUNDED
 
 // A constant-bound loop whose (nested) unrolled size exceeds the budget
 // iterates as a while even when unrolling is preferred.
@@ -8,6 +10,18 @@
 
 // CHECK-LABEL: @big_raised
 // CHECK: stablehlo.while
+
+// TIGHT-LABEL: @small_raised
+// TIGHT: stablehlo.while
+
+// TIGHT-LABEL: @big_raised
+// TIGHT: stablehlo.while
+
+// UNBOUNDED-LABEL: @small_raised
+// UNBOUNDED-NOT: stablehlo.while
+
+// UNBOUNDED-LABEL: @big_raised
+// UNBOUNDED-NOT: stablehlo.while
 
 module {
   func.func private @big(%arg0: memref<16xf64, 1>) {

--- a/test/lit_tests/raising/affine_to_stablehlo_unroll_budget.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_unroll_budget.mlir
@@ -1,0 +1,36 @@
+// RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false' | FileCheck %s
+
+// A constant-bound loop whose (nested) unrolled size exceeds the budget
+// iterates as a while even when unrolling is preferred.
+
+// CHECK-LABEL: @small_raised
+// CHECK-NOT: stablehlo.while
+
+// CHECK-LABEL: @big_raised
+// CHECK: stablehlo.while
+
+module {
+  func.func private @big(%arg0: memref<16xf64, 1>) {
+    %cst = arith.constant 5.000000e-01 : f64
+    affine.parallel (%t) = (0) to (16) {
+      affine.for %i = 0 to 100000 {
+        %0 = affine.load %arg0[%t] : memref<16xf64, 1>
+        %1 = arith.addf %0, %cst : f64
+        affine.store %1, %arg0[%t] : memref<16xf64, 1>
+      }
+    }
+    return
+  }
+
+  func.func private @small(%arg0: memref<16xf64, 1>) {
+    %cst = arith.constant 5.000000e-01 : f64
+    affine.parallel (%t) = (0) to (16) {
+      affine.for %i = 0 to 4 {
+        %0 = affine.load %arg0[%t] : memref<16xf64, 1>
+        %1 = arith.addf %0, %cst : f64
+        affine.store %1, %arg0[%t] : memref<16xf64, 1>
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
Nested constant-bound loops unroll multiplicatively: mfem's generic max-degree EA fallback kernels (runtime degree, loops bounded by `MAX_D1D`-style constants) reached **millions of ops** — `bilininteg_diffusion_ea.cpp` produced a 2 GB object whose largest embedded module was a gigabyte of textual IR with SSA ids past 2.2M. Estimate the unrolled op count recursively and, past a budget, try the while raising first even when unrolling is preferred (`prefer_while_raising=false`): the diffusion EA object shrinks to 78 MB, convection EA 935 MB → 30 MB, all still raising fully.

The budget is a pass option, `unroll_budget` (default 65536, the nested unrolled op count past which a constant-bound `affine.for` raises as a while); `-1` disables it. The test covers the default, a tight budget that pushes a 4-trip loop to a while, and `-1` unrolling the 100000-trip loop.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
