### PR TITLE
Raising: read constant globals as tensors

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -2901,6 +2901,19 @@ static int64_t unrollCost(Operation *op) {
   return std::min(std::max(trip, (int64_t)1) * body, (int64_t)1 << 40);
 }
 
+// A constant global with a dense initializer (a kernel-local lookup table
+// the optimizer promoted to rodata) is a tensor the module already holds.
+static DenseElementsAttr constantGlobalInitializer(LLVM::AddressOfOp addr) {
+  auto g = SymbolTable::lookupNearestSymbolFrom<LLVM::GlobalOp>(
+      addr, addr.getGlobalNameAttr());
+  if (!g || !g.getConstant())
+    return nullptr;
+  auto dense = dyn_cast_or_null<DenseElementsAttr>(g.getValueOrNull());
+  if (!dense || !isXLACompatiblePrimitive(dense.getElementType()))
+    return nullptr;
+  return dense;
+}
+
 static LogicalResult
 tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
                         llvm::DenseMap<Value, affine::AffineValueMap> &maps,
@@ -4211,6 +4224,22 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     return success();
   }
 
+  // The address of a constant global reads as the initializer, flattened:
+  // the view a pointer2memref takes of it and the loads through that view
+  // then raise like those of any other buffer.
+  if (auto addr = dyn_cast<LLVM::AddressOfOp>(op)) {
+    auto dense = constantGlobalInitializer(addr);
+    if (!dense)
+      return failure();
+    auto ty =
+        RankedTensorType::get({dense.getNumElements()}, dense.getElementType());
+    Value cst = stablehlo::ConstantOp::create(
+        builder, rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
+        ty, dense.reshape(ty));
+    mapping.map(addr.getResult(), cst);
+    return success();
+  }
+
   if (auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(op)) {
     Value operand = op->getOperand(0), result = op->getResult(0);
     auto input = mapping.lookupOrNull(operand);
@@ -4229,6 +4258,23 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
         cast<AutoDiffTypeInterface>(ty.getElementType()).getApproxSize();
     size_t inSize =
         cast<AutoDiffTypeInterface>(inTy.getElementType()).getApproxSize();
+
+    // A view of a static tensor holds a known number of elements: size its
+    // one dynamic dimension from that instead of reading it back at runtime.
+    if (inTy.hasStaticShape() && !ty.hasStaticShape() &&
+        llvm::count(ty.getShape(), ShapedType::kDynamic) == 1) {
+      int64_t bytes = inTy.getNumElements() * (int64_t)inSize;
+      int64_t known = 1;
+      for (int64_t d : ty.getShape())
+        if (d != ShapedType::kDynamic)
+          known *= d;
+      if (bytes % ((int64_t)outSize * known) == 0) {
+        SmallVector<int64_t> shape(ty.getShape());
+        *llvm::find(shape, ShapedType::kDynamic) =
+            bytes / ((int64_t)outSize * known);
+        ty = RankedTensorType::get(shape, ty.getElementType());
+      }
+    }
 
     Value res;
     if (outSize == inSize) {
@@ -4851,6 +4897,31 @@ struct AffineToStableHLORaisingPass
   // raising identifies buffers by SSA root: a memory_space_cast view would
   // split one buffer into two roots and lose store propagation. Retarget the
   // accesses to the source and drop the cast.
+  // If `arg` (a memref view or a pointer) is the address of a constant
+  // global, clone the address (and the view) to the region entry and redirect
+  // the region's uses to the clone; being constant, nothing in the region
+  // could have written through it.
+  static bool moveConstantGlobalViewIntoRegion(Value arg, Operation *region,
+                                               Block *body) {
+    auto p2m = arg.getDefiningOp<enzymexla::Pointer2MemrefOp>();
+    Value ptr = p2m ? p2m.getSource() : arg;
+    auto addr = ptr.getDefiningOp<LLVM::AddressOfOp>();
+    if (!addr || !constantGlobalInitializer(addr))
+      return false;
+    OpBuilder b(region->getContext());
+    b.setInsertionPointToStart(body);
+    IRMapping cl;
+    Operation *c = b.clone(*addr, cl);
+    if (p2m) {
+      b.setInsertionPointAfter(c);
+      b.clone(*p2m, cl);
+    }
+    arg.replaceUsesWithIf(cl.lookup(arg), [&](OpOperand &use) {
+      return region->isProperAncestor(use.getOwner());
+    });
+    return true;
+  }
+
   static void stripAccessMemorySpaceCasts(Operation *root) {
     SmallVector<memref::MemorySpaceCastOp> casts;
     root->walk([&](memref::MemorySpaceCastOp c) { casts.push_back(c); });
@@ -5268,6 +5339,14 @@ struct AffineToStableHLORaisingPass
                            << ", old arg: " << ic << "\n";
             }
           }
+
+          // A view of a constant global (a lookup table promoted to rodata)
+          // is no buffer the kernel could receive: move its address chain
+          // into the region, where it raises as a constant tensor. The view
+          // is taken either outside the region (a memref operand) or inside
+          // it (a pointer operand).
+          if (moveConstantGlobalViewIntoRegion(arg, g, body))
+            continue;
 
           if (isa<LLVM::LLVMPointerType>(arg.getType())) {
             OpBuilder b(g);

--- a/test/lit_tests/raising/constant_global_tensor.mlir
+++ b/test/lit_tests/raising/constant_global_tensor.mlir
@@ -1,0 +1,169 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// A kernel-local constant table promoted to a rodata global reads as a
+// stablehlo.constant of its initializer: constant indices slice it, runtime
+// indices gather from it, and the raised kernel never captures its address.
+
+module {
+  llvm.mlir.global private constant @map(dense<[0, 3, 6, 1]> : tensor<4xi32>) {addr_space = 0 : i32} : !llvm.array<4 x i32>
+  func.func private @table(%out: memref<16xf64, 1>) {
+    %g = llvm.mlir.addressof @map : !llvm.ptr
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xi32>
+    affine.parallel (%t) = (0) to (16) {
+      %c = affine.load %m[2] : memref<?xi32>
+      %d = affine.load %m[%t mod 4] : memref<?xi32>
+      %s = arith.addi %c, %d : i32
+      %f = arith.sitofp %s : i32 to f64
+      affine.store %f, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// CHECK:  module {
+// CHECK-NEXT:  llvm.mlir.global private constant @map(dense<[0, 3, 6, 1]> : tensor<4xi32>) {addr_space = 0 : i32} : !llvm.array<4 x i32>
+// CHECK-NEXT:  func.func private @table_raised(%arg0: tensor<16xf64>) -> tensor<16xf64> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<[0, 3, 6, 1]> : tensor<4xi32>
+// CHECK-NEXT:    %0 = stablehlo.bitcast_convert %c : (tensor<4xi32>) -> tensor<4xi32>
+// CHECK-NEXT:    %1 = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %2 = stablehlo.add %1, %c_0 : tensor<16xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %3 = stablehlo.multiply %2, %c_1 : tensor<16xi64>
+// CHECK-NEXT:    %4 = stablehlo.slice %0 [2:3] : (tensor<4xi32>) -> tensor<1xi32>
+// CHECK-NEXT:    %5 = stablehlo.reshape %4 : (tensor<1xi32>) -> tensor<i32>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<4> : tensor<i64>
+// CHECK-NEXT:    %6 = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<16xi64>
+// CHECK-NEXT:    %7 = stablehlo.remainder %3, %6 : tensor<16xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %8 = stablehlo.compare LT, %7, %c_3 : (tensor<16xi64>, tensor<16xi64>) -> tensor<16xi1>
+// CHECK-NEXT:    %9 = stablehlo.add %7, %6 : tensor<16xi64>
+// CHECK-NEXT:    %10 = stablehlo.select %8, %9, %7 : tensor<16xi1>, tensor<16xi64>
+// CHECK-NEXT:    %11 = stablehlo.reshape %10 : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %12 = "stablehlo.gather"(%0, %11) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<4xi32>, tensor<16x1xi64>) -> tensor<16xi32>
+// CHECK-NEXT:    %13 = stablehlo.broadcast_in_dim %5, dims = [] : (tensor<i32>) -> tensor<16xi32>
+// CHECK-NEXT:    %14 = arith.addi %13, %12 : tensor<16xi32>
+// CHECK-NEXT:    %15 = arith.sitofp %14 : tensor<16xi32> to tensor<16xf64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_8 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_9 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %16 = stablehlo.broadcast_in_dim %15, dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:    %17 = stablehlo.dynamic_update_slice %arg0, %16, %c_9 : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:    return %17 : tensor<16xf64>
+// CHECK-NEXT:  }
+
+// -----
+
+// In the host form the view of the table is taken outside the wrapper; it
+// moves inside instead of becoming a kernel operand.
+
+module {
+  llvm.mlir.global private constant @map(dense<[0, 3, 6, 1, 4, 7, 2, 5, 8]> : tensor<9xi32>) {addr_space = 0 : i32} : !llvm.array<9 x i32>
+  func.func @host(%out: memref<9xf64, 1>, %in: memref<9xf64, 1>, %grid: index) {
+    %c1 = arith.constant 1 : index
+    %g = llvm.mlir.addressof @map : !llvm.ptr
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xi32>
+    "enzymexla.gpu_wrapper"(%grid, %c1, %c1, %c1, %c1, %c1) ({
+      affine.parallel (%i) = (0) to (9) {
+        %j = affine.load %m[%i] : memref<?xi32>
+        %ji = arith.index_cast %j : i32 to index
+        %v = memref.load %in[%ji] : memref<9xf64, 1>
+        affine.store %v, %out[%i] : memref<9xf64, 1>
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK:  module {
+// CHECK-NEXT:  llvm.mlir.global private constant @map(dense<[0, 3, 6, 1, 4, 7, 2, 5, 8]> : tensor<9xi32>) {addr_space = 0 : i32} : !llvm.array<9 x i32>
+// CHECK-NEXT:  func.func @host(%arg0: memref<9xf64, 1>, %arg1: memref<9xf64, 1>, %arg2: index) {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %0 = llvm.mlir.addressof @map : !llvm.ptr
+// CHECK-NEXT:    %1 = "enzymexla.pointer2memref"(%0) : (!llvm.ptr) -> memref<?xi32>
+// CHECK-NEXT:    enzymexla.xla_wrapper @rxla$raised_0 (%arg1, %arg0) : (memref<9xf64, 1>, memref<9xf64, 1>) -> ()
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @rxla$raised_0(%arg0: tensor<9xf64>, %arg1: tensor<9xf64>) -> (tensor<9xf64>, tensor<9xf64>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<[0, 3, 6, 1, 4, 7, 2, 5, 8]> : tensor<9xi32>
+// CHECK-NEXT:    %0 = stablehlo.bitcast_convert %c : (tensor<9xi32>) -> tensor<9xi32>
+// CHECK-NEXT:    %1 = stablehlo.iota dim = 0 : tensor<9xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<9xi64>
+// CHECK-NEXT:    %2 = stablehlo.add %1, %c_0 : tensor<9xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<9xi64>
+// CHECK-NEXT:    %3 = stablehlo.multiply %2, %c_1 : tensor<9xi64>
+// CHECK-NEXT:    %4 = stablehlo.reshape %0 : (tensor<9xi32>) -> tensor<9xi32>
+// CHECK-NEXT:    %5 = stablehlo.convert %4 : (tensor<9xi32>) -> tensor<9xi64>
+// CHECK-NEXT:    %6 = stablehlo.reshape %5 : (tensor<9xi64>) -> tensor<9x1xi64>
+// CHECK-NEXT:    %7 = "stablehlo.gather"(%arg0, %6) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<9xf64>, tensor<9x1xi64>) -> tensor<9xf64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %7, dims = [0] : (tensor<9xf64>) -> tensor<9xf64>
+// CHECK-NEXT:    %9 = stablehlo.dynamic_update_slice %arg1, %8, %c_7 : (tensor<9xf64>, tensor<9xf64>, tensor<i64>) -> tensor<9xf64>
+// CHECK-NEXT:    return %arg0, %9 : tensor<9xf64>, tensor<9xf64>
+// CHECK-NEXT:  }
+
+// -----
+
+// The view may also be taken inside the wrapper, leaving the table's address
+// as the operand: the same move applies to the pointer.
+
+module {
+  llvm.mlir.global private constant @map(dense<[0, 3, 6, 1, 4, 7, 2, 5, 8]> : tensor<9xi32>) {addr_space = 0 : i32} : !llvm.array<9 x i32>
+  func.func @host_ptr(%out: memref<9xf64, 1>, %in: memref<9xf64, 1>, %grid: index) {
+    %c1 = arith.constant 1 : index
+    %g = llvm.mlir.addressof @map : !llvm.ptr
+    "enzymexla.gpu_wrapper"(%grid, %c1, %c1, %c1, %c1, %c1) ({
+      %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xi32>
+      affine.parallel (%i) = (0) to (9) {
+        %j = affine.load %m[%i] : memref<?xi32>
+        %ji = arith.index_cast %j : i32 to index
+        %v = memref.load %in[%ji] : memref<9xf64, 1>
+        affine.store %v, %out[%i] : memref<9xf64, 1>
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK:  module {
+// CHECK-NEXT:  llvm.mlir.global private constant @map(dense<[0, 3, 6, 1, 4, 7, 2, 5, 8]> : tensor<9xi32>) {addr_space = 0 : i32} : !llvm.array<9 x i32>
+// CHECK-NEXT:  func.func @host_ptr(%arg0: memref<9xf64, 1>, %arg1: memref<9xf64, 1>, %arg2: index) {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %0 = llvm.mlir.addressof @map : !llvm.ptr
+// CHECK-NEXT:    enzymexla.xla_wrapper @rxla$raised_0 (%arg1, %arg0) : (memref<9xf64, 1>, memref<9xf64, 1>) -> ()
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @rxla$raised_0(%arg0: tensor<9xf64>, %arg1: tensor<9xf64>) -> (tensor<9xf64>, tensor<9xf64>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<[0, 3, 6, 1, 4, 7, 2, 5, 8]> : tensor<9xi32>
+// CHECK-NEXT:    %0 = stablehlo.bitcast_convert %c : (tensor<9xi32>) -> tensor<9xi32>
+// CHECK-NEXT:    %1 = stablehlo.iota dim = 0 : tensor<9xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<9xi64>
+// CHECK-NEXT:    %2 = stablehlo.add %1, %c_0 : tensor<9xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<9xi64>
+// CHECK-NEXT:    %3 = stablehlo.multiply %2, %c_1 : tensor<9xi64>
+// CHECK-NEXT:    %4 = stablehlo.reshape %0 : (tensor<9xi32>) -> tensor<9xi32>
+// CHECK-NEXT:    %5 = stablehlo.convert %4 : (tensor<9xi32>) -> tensor<9xi64>
+// CHECK-NEXT:    %6 = stablehlo.reshape %5 : (tensor<9xi64>) -> tensor<9x1xi64>
+// CHECK-NEXT:    %7 = "stablehlo.gather"(%arg0, %6) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<9xf64>, tensor<9x1xi64>) -> tensor<9xf64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %7, dims = [0] : (tensor<9xf64>) -> tensor<9xf64>
+// CHECK-NEXT:    %9 = stablehlo.dynamic_update_slice %arg1, %8, %c_7 : (tensor<9xf64>, tensor<9xf64>, tensor<i64>) -> tensor<9xf64>
+// CHECK-NEXT:    return %arg0, %9 : tensor<9xf64>, tensor<9xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
mfem's `VectorDiffusionIntegrator::AssemblePA` keeps a kernel-local `const int map[9] = {0,3,6,1,4,7,2,5,8}` that the optimizer promotes to a host `.rodata` global; the raised kernel captured its **address** as a buffer argument, which compiled fine and failed only at runtime ("pointer does not belong to any reactant allocation" — found via gdb `info symbol` on the failing pointer: `__const.<AssemblePA lambda>.map`).

A constant global with a dense initializer is a tensor the module already holds, so the raiser now reads it as one instead of rewriting the loads:

- `llvm.mlir.addressof` of such a global raises to a `stablehlo.constant` of the (flattened) initializer. The `pointer2memref` view and the loads through it then go through the existing buffer raising unchanged (slices for constant indices, gathers for runtime ones).
- A wrapper operand rooted at such a global (the view taken outside the `gpu_wrapper`, or the raw pointer with the view inside, which is mfem's shape) is cloned into the region, like the index casts already are, instead of becoming a kernel operand; the global being constant, nothing in the region can have written through it.
- A `pointer2memref` of a static tensor to a `memref<?x...>` view now sizes the view statically instead of reading the dimension back at runtime; without it the constant-index load raises through the dynamic-extent path (`get_dimension_size` + `dynamic_pad` + slice of a `tensor<?xi32>`) instead of a plain slice.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
