### PR TITLE
Raising: forward the packed capture struct; distribute geps over selects

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3596,6 +3596,402 @@ struct AffineToStableHLORaisingPass
           AffineToStableHLORaisingPass> {
   using AffineToStableHLORaisingBase::AffineToStableHLORaisingBase;
 
+  // A side-selected view arrives as a select of byte offsets (or of the
+  // pointers themselves) feeding geps: distribute the gep and the memref
+  // view over the select so the buffer-branch expansion can take over.
+  static void distributeGepOverSelect(Operation *root) {
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      SmallVector<Operation *> worklist;
+      root->walk([&](Operation *op) {
+        if (isa<LLVM::GEPOp, enzymexla::Pointer2MemrefOp>(op))
+          worklist.push_back(op);
+      });
+      for (Operation *op : worklist) {
+        if (auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(op)) {
+          auto sel = p2m.getSource().getDefiningOp<arith::SelectOp>();
+          if (!sel)
+            continue;
+          auto condTy =
+              dyn_cast<RankedTensorType>(sel.getCondition().getType());
+          if (condTy)
+            continue;
+          OpBuilder b(op);
+          Value t = enzymexla::Pointer2MemrefOp::create(
+              b, op->getLoc(), p2m.getType(), sel.getTrueValue());
+          Value f = enzymexla::Pointer2MemrefOp::create(
+              b, op->getLoc(), p2m.getType(), sel.getFalseValue());
+          Value ns = arith::SelectOp::create(b, op->getLoc(),
+                                             sel.getCondition(), t, f);
+          op->getResult(0).replaceAllUsesWith(ns);
+          op->erase();
+          changed = true;
+          continue;
+        }
+        auto gep = cast<LLVM::GEPOp>(op);
+        // Base is a select of pointers.
+        if (auto sel = gep.getBase().getDefiningOp<arith::SelectOp>()) {
+          OpBuilder b(op);
+          IRMapping mt, mf;
+          mt.map(gep.getBase(), sel.getTrueValue());
+          mf.map(gep.getBase(), sel.getFalseValue());
+          Operation *gt = b.clone(*op, mt);
+          Operation *gf = b.clone(*op, mf);
+          Value ns =
+              arith::SelectOp::create(b, op->getLoc(), sel.getCondition(),
+                                      gt->getResult(0), gf->getResult(0));
+          op->getResult(0).replaceAllUsesWith(ns);
+          op->erase();
+          changed = true;
+          continue;
+        }
+        // A single dynamic index that is a select of two values.
+        if (gep.getDynamicIndices().size() == 1) {
+          auto sel =
+              gep.getDynamicIndices()[0].getDefiningOp<arith::SelectOp>();
+          if (!sel || isa<RankedTensorType>(sel.getCondition().getType()))
+            continue;
+          OpBuilder b(op);
+          IRMapping mt, mf;
+          mt.map(gep.getDynamicIndices()[0], sel.getTrueValue());
+          mf.map(gep.getDynamicIndices()[0], sel.getFalseValue());
+          Operation *gt = b.clone(*op, mt);
+          Operation *gf = b.clone(*op, mf);
+          Value ns =
+              arith::SelectOp::create(b, op->getLoc(), sel.getCondition(),
+                                      gt->getResult(0), gf->getResult(0));
+          op->getResult(0).replaceAllUsesWith(ns);
+          op->erase();
+          changed = true;
+        }
+      }
+    }
+  }
+
+  // A not-quite-inlined device lambda packs its captures into a stack
+  // struct and reads them back through typed views at constant offsets.
+  // Forward each load to the unique dominating store of the same slot so
+  // the pointer-typed members never reach the raising as memory.
+  static void forwardPackedScratch(Operation *root) {
+    SmallVector<LLVM::AllocaOp> allocas;
+    root->walk([&](LLVM::AllocaOp a) { allocas.push_back(a); });
+    for (auto a : allocas) {
+      // Transitively collect constant-byte-offset accesses.
+      struct Access {
+        Operation *op;
+        int64_t byteOff;
+        bool isStore;
+        Type ty;
+        Value value; // stored value for stores
+      };
+      SmallVector<Access> accesses;
+      struct DynLoad {
+        Operation *op;
+        int64_t viewBase;
+        int64_t esz;
+        Type ty;
+        Value idx;
+      };
+      SmallVector<DynLoad> dynLoads;
+      SmallVector<Operation *> chain;
+      bool ok = true;
+      SmallVector<std::pair<Value, int64_t>> work{{a.getResult(), 0}};
+      DataLayout dl = DataLayout::closest(a);
+      while (ok && !work.empty()) {
+        auto [v, off] = work.pop_back_val();
+        for (Operation *u : v.getUsers()) {
+          if (auto gep = dyn_cast<LLVM::GEPOp>(u)) {
+            // A constant-valued SSA index is as good as an attribute one.
+            auto constIdx = [](llvm::PointerUnion<IntegerAttr, Value> e)
+                -> std::optional<int64_t> {
+              if (auto attr = dyn_cast<IntegerAttr>(e))
+                return attr.getInt();
+              llvm::APInt c;
+              if (!getenv("DISABLE_CONST_SSA_GEP") &&
+                  matchPattern(cast<Value>(e), m_ConstantInt(&c)))
+                return c.getSExtValue();
+              return std::nullopt;
+            };
+            if (gep.getBase() != v) {
+              ok = false;
+              break;
+            }
+            int64_t gepOff = 0;
+            Type cur = gep.getElemType();
+            auto idxs = gep.getIndices();
+            bool constGep = idxs.size() >= 1;
+            if (constGep) {
+              auto c0 = constIdx(idxs[0]);
+              constGep = c0.has_value();
+              if (constGep)
+                gepOff = *c0 * (int64_t)dl.getTypeSize(cur);
+            }
+            for (unsigned i = 1; constGep && i < idxs.size(); ++i) {
+              auto ci = constIdx(idxs[i]);
+              if (!ci) {
+                constGep = false;
+                break;
+              }
+              int64_t want = *ci;
+              if (auto AT = dyn_cast<LLVM::LLVMArrayType>(cur)) {
+                cur = AT.getElementType();
+                gepOff += want * (int64_t)dl.getTypeSize(cur);
+              } else if (auto ST = dyn_cast<LLVM::LLVMStructType>(cur)) {
+                if (ST.isOpaque() || (size_t)want >= ST.getBody().size()) {
+                  constGep = false;
+                  break;
+                }
+                for (int64_t k = 0; k < want; ++k) {
+                  int64_t sz = (int64_t)dl.getTypeSize(ST.getBody()[k]);
+                  int64_t al = (int64_t)dl.getTypeABIAlignment(ST.getBody()[k]);
+                  gepOff = (gepOff + al - 1) / al * al + sz;
+                }
+                int64_t al =
+                    (int64_t)dl.getTypeABIAlignment(ST.getBody()[want]);
+                gepOff = (gepOff + al - 1) / al * al;
+                cur = ST.getBody()[want];
+              } else {
+                constGep = false;
+              }
+            }
+            if (!constGep) {
+              ok = false;
+              break;
+            }
+            chain.push_back(gep);
+            work.push_back({gep.getResult(), off + gepOff});
+            continue;
+          }
+          if (auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(u)) {
+            auto MT = p2m.getType();
+            if (MT.getRank() != 1) {
+              ok = false;
+              break;
+            }
+            Type ET = MT.getElementType();
+            int64_t esz =
+                isa<LLVM::LLVMPointerType>(ET)
+                    ? 8
+                    : (ET.isIntOrFloat() ? (ET.getIntOrFloatBitWidth() + 7) / 8
+                                         : 0);
+            if (esz == 0) {
+              ok = false;
+              break;
+            }
+            bool viewOk = true;
+            for (Operation *au : p2m->getUsers()) {
+              std::optional<int64_t> idx;
+              if (auto ld = dyn_cast<affine::AffineLoadOp>(au)) {
+                if (auto c = getConstant(ld.getAffineMap()))
+                  idx = *c;
+                else if (!isa<LLVM::LLVMPointerType>(ET) &&
+                         ld.getAffineMap().getNumResults() == 1) {
+                  // Runtime-indexed scalar read through an affine map.
+                  OpBuilder eb(au);
+                  auto expanded = affine::expandAffineMap(
+                      eb, au->getLoc(), ld.getAffineMap(), ld.getMapOperands());
+                  if (expanded) {
+                    dynLoads.push_back({au, off, esz, ET, (*expanded)[0]});
+                    continue;
+                  }
+                }
+              } else if (auto st = dyn_cast<affine::AffineStoreOp>(au)) {
+                if (st.getValue() != p2m.getResult())
+                  if (auto c = getConstant(st.getAffineMap()))
+                    idx = *c;
+              } else if (auto ld = dyn_cast<memref::LoadOp>(au)) {
+                // A runtime-indexed scalar read (a shape array walked in a
+                // loop) selects among the constant-offset slots of its own
+                // element type.
+                if (!isa<LLVM::LLVMPointerType>(ET) &&
+                    ld.getIndices().size() == 1) {
+                  dynLoads.push_back({au, off, esz, ET, ld.getIndices()[0]});
+                  continue;
+                }
+              }
+              if (!idx) {
+                if (getenv("DEBUG_FWD"))
+                  llvm::errs() << "FWD bail view user: " << *au
+                               << "\n  for alloca: " << *a << "\n";
+                viewOk = false;
+                break;
+              }
+              bool isStore = isa<affine::AffineStoreOp>(au);
+              accesses.push_back(
+                  {au, off + *idx * esz, isStore, ET,
+                   isStore ? cast<affine::AffineStoreOp>(au).getValue()
+                           : Value()});
+            }
+            if (!viewOk) {
+              ok = false;
+              break;
+            }
+            chain.push_back(p2m);
+            continue;
+          }
+          if (auto ld = dyn_cast<LLVM::LoadOp>(u)) {
+            accesses.push_back({u, off, false, ld.getType(), Value()});
+            continue;
+          }
+          if (auto st = dyn_cast<LLVM::StoreOp>(u)) {
+            if (st.getValue() == v) {
+              ok = false;
+              break;
+            }
+            accesses.push_back(
+                {u, off, true, st.getValue().getType(), st.getValue()});
+            continue;
+          }
+          if (isa<LLVM::LifetimeStartOp, LLVM::LifetimeEndOp>(u)) {
+            chain.push_back(u);
+            continue;
+          }
+          // Buffer-branch expansion strands dead pointer selects over views
+          // of the struct; they observe nothing. Only that exact shape is
+          // skipped: a general dead-user skip admits big register scratch
+          // whose forwarding corrupts downstream passes.
+          if (u->use_empty() && isa<arith::SelectOp>(u) &&
+              isa<LLVM::LLVMPointerType>(u->getResult(0).getType())) {
+            chain.push_back(u);
+            continue;
+          }
+          if (getenv("DEBUG_FWD"))
+            llvm::errs() << "FWD bail user: " << *u << "\n  for alloca: " << *a
+                         << "\n";
+          ok = false;
+          break;
+        }
+      }
+      if (!ok)
+        continue;
+      // One store per slot, dominating every load of that slot.
+      DominanceInfo dom(root);
+      llvm::DenseMap<int64_t, Access *> storeAt;
+      bool legal = true;
+      for (auto &acc : accesses)
+        if (acc.isStore) {
+          if (storeAt.count(acc.byteOff)) {
+            legal = false;
+            break;
+          }
+          storeAt[acc.byteOff] = &acc;
+        }
+      if (!legal)
+        continue;
+      for (auto &acc : accesses) {
+        if (acc.isStore)
+          continue;
+        auto it = storeAt.find(acc.byteOff);
+        if (it == storeAt.end() || it->second->ty != acc.ty ||
+            !dom.properlyDominates(it->second->op, acc.op)) {
+          legal = false;
+          break;
+        }
+      }
+      // A store contributes the slots it covers: its own slot for an exact
+      // type match, or several for a wider integer store (two i32 sizes
+      // packed into one i64 write). Little-endian extraction.
+      DataLayout dlq = dl;
+      auto coveredSlots =
+          [&](Access &acc, int64_t viewBase, int64_t esz,
+              Type ty) -> SmallVector<std::pair<int64_t, int64_t>> {
+        // pairs of (slot index, byte offset of the piece inside the store)
+        SmallVector<std::pair<int64_t, int64_t>> out;
+        if (acc.byteOff < viewBase)
+          return out;
+        if (acc.ty == ty && (acc.byteOff - viewBase) % esz == 0) {
+          out.push_back({(acc.byteOff - viewBase) / esz, 0});
+          return out;
+        }
+        auto sInt = dyn_cast<IntegerType>(acc.ty);
+        auto dInt = dyn_cast<IntegerType>(ty);
+        if (!sInt || !dInt)
+          return out;
+        int64_t ssz = (int64_t)dlq.getTypeSize(acc.ty);
+        if (ssz <= esz || (acc.byteOff - viewBase) % esz != 0)
+          return out;
+        for (int64_t b = 0; b + esz <= ssz; b += esz)
+          out.push_back({(acc.byteOff + b - viewBase) / esz, b});
+        return out;
+      };
+      // Every candidate slot of a dynamic load must be forwardable.
+      for (auto &dyn : llvm::make_range(
+               dynLoads.begin(), legal ? dynLoads.end() : dynLoads.begin())) {
+        bool any = false;
+        for (auto &acc : accesses) {
+          if (!acc.isStore)
+            continue;
+          auto cov = coveredSlots(acc, dyn.viewBase, dyn.esz, dyn.ty);
+          if (cov.empty())
+            continue;
+          if (!dom.properlyDominates(acc.op, dyn.op)) {
+            legal = false;
+            break;
+          }
+          any = true;
+        }
+        if (!any)
+          legal = false;
+        if (!legal)
+          break;
+      }
+      if (!legal)
+        continue;
+      for (auto &acc : accesses) {
+        if (acc.isStore)
+          continue;
+        acc.op->getResult(0).replaceAllUsesWith(storeAt[acc.byteOff]->value);
+        acc.op->erase();
+      }
+      for (auto &dyn : dynLoads) {
+        OpBuilder b(dyn.op);
+        Location loc = dyn.op->getLoc();
+        Value idx = dyn.idx;
+        Value res;
+        for (auto &acc : accesses) {
+          if (!acc.isStore)
+            continue;
+          for (auto [slot, pieceOff] :
+               coveredSlots(acc, dyn.viewBase, dyn.esz, dyn.ty)) {
+            Value piece = acc.value;
+            if (piece.getType() != dyn.ty) {
+              if (pieceOff != 0) {
+                Value sh = arith::ConstantOp::create(
+                    b, loc, IntegerAttr::get(piece.getType(), pieceOff * 8));
+                piece = arith::ShRUIOp::create(b, loc, piece, sh);
+              }
+              piece = arith::TruncIOp::create(b, loc, dyn.ty, piece);
+            }
+            if (!res) {
+              res = piece;
+              continue;
+            }
+            Value c = arith::ConstantIndexOp::create(b, loc, slot);
+            Value eq =
+                arith::CmpIOp::create(b, loc, arith::CmpIPredicate::eq, idx, c);
+            res = arith::SelectOp::create(b, loc, eq, piece, res);
+          }
+        }
+        dyn.op->getResult(0).replaceAllUsesWith(res);
+        dyn.op->erase();
+      }
+      for (auto &acc : accesses)
+        if (acc.isStore)
+          acc.op->erase();
+      // The walk can reach one op through several operands (a dead select
+      // over two views of this alloca): erase each op once.
+      {
+        llvm::SmallPtrSet<Operation *, 8> erased;
+        for (Operation *c : llvm::reverse(chain))
+          if (erased.insert(c).second && c->use_empty())
+            c->erase();
+      }
+      if (a->use_empty())
+        a.erase();
+    }
+  }
+
   // An access does not care about the address space of its base, but the
   // raising identifies buffers by SSA root: a memory_space_cast view would
   // split one buffer into two roots and lose store propagation. Retarget the
@@ -3903,6 +4299,8 @@ struct AffineToStableHLORaisingPass
     // Peeling rewrites loops, so it stays scoped to the regions this pass
     // actually raises.
     for (auto func : funcs) {
+      distributeGepOverSelect(func);
+      forwardPackedScratch(func);
       stripAccessMemorySpaceCasts(func);
       boundParallelAxes(func);
       peelDynamicParallelDims(func);
@@ -3926,6 +4324,8 @@ struct AffineToStableHLORaisingPass
     std::vector<enzymexla::GPUWrapperOp> gwrap;
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
+      distributeGepOverSelect(g);
+      forwardPackedScratch(g);
       stripAccessMemorySpaceCasts(g);
       boundParallelAxes(g);
       peelDynamicParallelDims(g);

--- a/test/lit_tests/raising/packed_capture_scratch.mlir
+++ b/test/lit_tests/raising/packed_capture_scratch.mlir
@@ -1,0 +1,33 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// A not-quite-inlined device lambda packs its captures into a stack struct
+// and reads them back through typed views: pointer slots forward to the
+// stored pointer, and a shape array read at a runtime index resolves as a
+// select over the constant-offset stores.
+
+// CHECK-LABEL: @packed_raised
+// CHECK-NOT: llvm.alloca
+
+module {
+  func.func private @packed(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>, %nbuf: memref<1xi32, 1>) {
+    %c1 = arith.constant 1 : i32
+    %n = affine.load %nbuf[0] : memref<1xi32, 1>
+    %st = llvm.alloca %c1 x !llvm.struct<packed (ptr<1>, i32, i32)> : (i32) -> !llvm.ptr
+    %pv = "enzymexla.pointer2memref"(%st) : (!llvm.ptr) -> memref<?x!llvm.ptr<1>>
+    %iv = "enzymexla.pointer2memref"(%st) : (!llvm.ptr) -> memref<?xi32>
+    %p = "enzymexla.memref2pointer"(%in) : (memref<16xf64, 1>) -> !llvm.ptr<1>
+    affine.store %p, %pv[0] : memref<?x!llvm.ptr<1>>
+    affine.store %n, %iv[2] : memref<?xi32>
+    affine.store %c1, %iv[3] : memref<?xi32>
+    affine.parallel (%t) = (0) to (16) {
+      %pl = affine.load %pv[0] : memref<?x!llvm.ptr<1>>
+      %view = "enzymexla.pointer2memref"(%pl) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+      %d = affine.load %iv[%t mod 2 + 2] : memref<?xi32>
+      %di = arith.index_cast %d : i32 to index
+      %vidx = arith.addi %t, %di : index
+      %v = memref.load %view[%vidx] : memref<?xf64, 1>
+      affine.store %v, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}


### PR DESCRIPTION
Stacks on #3007 (which stacks on #3006).

A not-quite-inlined device lambda packs its captures (DeviceTensors: pointer + sizes) into a stack struct and reads them back through typed views at constant offsets. Forward each load to the unique dominating store of its slot so the pointer-typed members never reach the raising as memory:

- constant-attribute **and** constant-valued-SSA gep indexing;
- wide integer stores covering several slots (two i32 sizes packed into one i64 write, extracted little-endian shift+trunc);
- runtime-indexed shape reads (`sizes[i]` walked in a loop, as a `memref.load` or an affine map like `s0 floordiv 4`) resolved as a select chain over the constant-offset stores of their element type;
- stranded dead pointer selects (left by the buffer-branch expansion) skipped — narrowly, since a general dead-user skip admits big register scratch whose forwarding is unsound.

Also **distributeGepOverSelect**: a side-selected view (`select` of byte offsets or of the pointers themselves feeding geps) distributes the gep and the memref view over the select so the buffer-branch expansion (#3007) can take over.

This is what makes mfem's `bilininteg_vecdiffusion_pa.cpp` and the batched LOR kernels raise fully (#2968).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD