### PR TITLE
Raising: rewrite pointer induction to indexed accesses

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3912,6 +3912,201 @@ struct AffineToStableHLORaisingPass
     }
   }
 
+  // A loop that walks a pointer forward by a constant stride each iteration
+  // carries it as an iter arg the raising cannot type as a tensor. The
+  // pointer is a pure function of the induction variable, so accesses
+  // through it rebase onto the init pointer at `orig + k*stride` and the
+  // carried pointer disappears from the loop.
+  static void rewritePointerInduction(Operation *root) {
+    SmallVector<affine::AffineForOp> fors;
+    // Post-order walk: inner loops rewrite before the outer loops that
+    // contain them.
+    root->walk([&](affine::AffineForOp f) {
+      if (f.getNumIterOperands() > 0)
+        fors.push_back(f);
+    });
+    if (getenv("DEBUG_PTRIND"))
+      llvm::errs() << "PTRIND: " << fors.size() << " candidate fors\n";
+    for (auto f : fors) {
+      if (f.getStepAsInt() != 1 || f.getLowerBoundMap().getNumResults() != 1)
+        continue;
+      auto yield = cast<affine::AffineYieldOp>(f.getBody()->getTerminator());
+      DataLayout dl = DataLayout::closest(f);
+      unsigned n = f.getNumIterOperands();
+      SmallVector<bool> drop(n, false);
+      struct Induction {
+        unsigned idx;
+        int64_t byteStep;
+        LLVM::GEPOp advance;
+      };
+      SmallVector<Induction> inductions;
+      bool ok = true;
+      bool anyPtr = false;
+      for (unsigned i = 0; ok && i < n; ++i) {
+        Value init = f.getInits()[i];
+        if (!isa<LLVM::LLVMPointerType>(init.getType()))
+          continue;
+        anyPtr = true;
+        if (!f.getResult(i).use_empty()) {
+          ok = false;
+          break;
+        }
+        BlockArgument arg = f.getRegionIterArgs()[i];
+        if (arg.use_empty()) {
+          drop[i] = true;
+          continue;
+        }
+        auto gep = yield.getOperand(i).getDefiningOp<LLVM::GEPOp>();
+        if (!gep || gep.getBase() != arg || !gep.getDynamicIndices().empty() ||
+            gep.getIndices().size() != 1) {
+          ok = false;
+          break;
+        }
+        int64_t byteStep = cast<IntegerAttr>(gep.getIndices()[0]).getInt() *
+                           (int64_t)dl.getTypeSize(gep.getElemType());
+        for (Operation *u : arg.getUsers()) {
+          if (u == gep.getOperation())
+            continue;
+          auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(u);
+          if (!p2m || p2m.getType().getRank() != 1 ||
+              !p2m.getType().getElementType().isIntOrFloat() ||
+              byteStep %
+                      (int64_t)dl.getTypeSize(p2m.getType().getElementType()) !=
+                  0) {
+            ok = false;
+            break;
+          }
+          for (Operation *a : p2m->getUsers()) {
+            if (auto ld = dyn_cast<affine::AffineLoadOp>(a)) {
+              if (ld.getMap().getNumResults() == 1)
+                continue;
+            } else if (auto st = dyn_cast<affine::AffineStoreOp>(a)) {
+              if (st.getMap().getNumResults() == 1 &&
+                  st.getValueToStore() != p2m.getResult())
+                continue;
+            } else if (auto ld = dyn_cast<memref::LoadOp>(a)) {
+              if (ld.getIndices().size() == 1)
+                continue;
+            } else if (auto st = dyn_cast<memref::StoreOp>(a)) {
+              if (st.getIndices().size() == 1 &&
+                  st.getValueToStore() != p2m.getResult())
+                continue;
+            }
+            ok = false;
+            break;
+          }
+          if (!ok)
+            break;
+        }
+        if (!ok)
+          break;
+        inductions.push_back({i, byteStep, gep});
+        drop[i] = true;
+      }
+      if (!ok || !anyPtr || llvm::none_of(drop, [](bool d) { return d; }))
+        continue;
+
+      // Completed iterations: k = iv - lb.
+      OpBuilder kb(f.getBody(), f.getBody()->begin());
+      Location loc = f.getLoc();
+      Value k = f.getInductionVar();
+      AffineMap lbMap = f.getLowerBoundMap();
+      if (!(lbMap.isSingleConstant() && lbMap.getSingleConstantResult() == 0)) {
+        Value lb = affine::AffineApplyOp::create(kb, loc, lbMap,
+                                                 f.getLowerBoundOperands());
+        k = arith::SubIOp::create(kb, loc, k, lb);
+      }
+
+      for (auto &ind : inductions) {
+        Value init = f.getInits()[ind.idx];
+        BlockArgument arg = f.getRegionIterArgs()[ind.idx];
+        for (Operation *u : llvm::make_early_inc_range(arg.getUsers())) {
+          auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(u);
+          if (!p2m)
+            continue;
+          int64_t stepElts = ind.byteStep / (int64_t)dl.getTypeSize(
+                                                p2m.getType().getElementType());
+          OpBuilder vb(p2m);
+          Value nv = enzymexla::Pointer2MemrefOp::create(vb, p2m.getLoc(),
+                                                         p2m.getType(), init);
+          Value off = k;
+          if (stepElts != 1)
+            off = arith::MulIOp::create(
+                vb, loc, k, arith::ConstantIndexOp::create(vb, loc, stepElts));
+          for (Operation *a : llvm::make_early_inc_range(p2m->getUsers())) {
+            OpBuilder ab(a);
+            auto add = [&](Value idx) {
+              return arith::AddIOp::create(ab, a->getLoc(), idx, off)
+                  .getResult();
+            };
+            if (auto ld = dyn_cast<affine::AffineLoadOp>(a)) {
+              auto expanded = affine::expandAffineMap(
+                  ab, a->getLoc(), ld.getMap(), ld.getMapOperands());
+              Value nl = memref::LoadOp::create(
+                  ab, a->getLoc(), nv, ValueRange{add((*expanded)[0])});
+              a->getResult(0).replaceAllUsesWith(nl);
+              a->erase();
+            } else if (auto st = dyn_cast<affine::AffineStoreOp>(a)) {
+              auto expanded = affine::expandAffineMap(
+                  ab, a->getLoc(), st.getMap(), st.getMapOperands());
+              memref::StoreOp::create(ab, a->getLoc(), st.getValueToStore(), nv,
+                                      ValueRange{add((*expanded)[0])});
+              a->erase();
+            } else if (auto ld = dyn_cast<memref::LoadOp>(a)) {
+              Value nl = memref::LoadOp::create(
+                  ab, a->getLoc(), nv, ValueRange{add(ld.getIndices()[0])});
+              a->getResult(0).replaceAllUsesWith(nl);
+              a->erase();
+            } else {
+              auto st = cast<memref::StoreOp>(a);
+              memref::StoreOp::create(ab, a->getLoc(), st.getValueToStore(), nv,
+                                      ValueRange{add(st.getIndices()[0])});
+              a->erase();
+            }
+          }
+          p2m.erase();
+        }
+      }
+
+      // Rebuild the loop without the pointer iter args.
+      SmallVector<Value> newInits;
+      for (unsigned i = 0; i < n; ++i)
+        if (!drop[i])
+          newInits.push_back(f.getInits()[i]);
+      OpBuilder b(f);
+      auto nf = affine::AffineForOp::create(
+          b, f.getLoc(), f.getLowerBoundOperands(), f.getLowerBoundMap(),
+          f.getUpperBoundOperands(), f.getUpperBoundMap(), f.getStepAsInt(),
+          newInits);
+      Block *ob = f.getBody(), *nb = nf.getBody();
+      if (!nb->empty())
+        nb->clear();
+      f.getInductionVar().replaceAllUsesWith(nf.getInductionVar());
+      unsigned kept = 0;
+      for (unsigned i = 0; i < n; ++i)
+        if (!drop[i])
+          f.getRegionIterArgs()[i].replaceAllUsesWith(
+              nf.getRegionIterArgs()[kept++]);
+      SmallVector<Value> keptYields;
+      for (unsigned i = 0; i < n; ++i)
+        if (!drop[i])
+          keptYields.push_back(yield.getOperand(i));
+      OpBuilder yb(yield);
+      affine::AffineYieldOp::create(yb, yield.getLoc(), keptYields);
+      yield.erase();
+      // The advancing geps are dead now that nothing yields them.
+      for (auto &ind : inductions)
+        if (ind.advance->use_empty())
+          ind.advance.erase();
+      nb->getOperations().splice(nb->end(), ob->getOperations());
+      kept = 0;
+      for (unsigned i = 0; i < n; ++i)
+        if (!drop[i])
+          f.getResult(i).replaceAllUsesWith(nf.getResult(kept++));
+      f.erase();
+    }
+  }
+
   static void stripAccessMemorySpaceCasts(Operation *root) {
     SmallVector<memref::MemorySpaceCastOp> casts;
     root->walk([&](memref::MemorySpaceCastOp c) { casts.push_back(c); });
@@ -4220,6 +4415,7 @@ struct AffineToStableHLORaisingPass
         stripAccessMemorySpaceCasts(func);
         rebaseViewedGeps(func);
         convertRawGepAccesses(func);
+        rewritePointerInduction(func);
       }
       dropDeadPointerChains(func);
       boundParallelAxes(func);
@@ -4256,6 +4452,7 @@ struct AffineToStableHLORaisingPass
         stripAccessMemorySpaceCasts(root);
         rebaseViewedGeps(root);
         convertRawGepAccesses(root);
+        rewritePointerInduction(root);
       }
       dropDeadPointerChains(root);
       boundParallelAxes(g);

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -15,6 +15,7 @@
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "src/enzyme_ad/jax/Utils.h"
 
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -3938,32 +3939,108 @@ struct AffineToStableHLORaisingPass
         unsigned idx;
         int64_t byteStep;
         LLVM::GEPOp advance;
+        Type advanceElemType;
+        Attribute advanceIdxAttr;
+        Value dynStep;
       };
       SmallVector<Induction> inductions;
+      // A rotated loop can carry a lagging copy of another pointer
+      // induction: dead in the body, re-yielding that induction's advance.
+      struct Alias {
+        unsigned idx;
+        unsigned baseIdx;
+      };
+      SmallVector<Alias> aliases;
       bool ok = true;
       bool anyPtr = false;
+      // A used final pointer is the init advanced by the whole trip count;
+      // that needs a single-result upper bound to materialize.
+      bool resultUsed = false;
       for (unsigned i = 0; ok && i < n; ++i) {
         Value init = f.getInits()[i];
         if (!isa<LLVM::LLVMPointerType>(init.getType()))
           continue;
         anyPtr = true;
         if (!f.getResult(i).use_empty()) {
-          ok = false;
-          break;
+          if (f.getUpperBoundMap().getNumResults() != 1) {
+            ok = false;
+            break;
+          }
+          resultUsed = true;
         }
         BlockArgument arg = f.getRegionIterArgs()[i];
-        if (arg.use_empty()) {
+        if (arg.use_empty() && f.getResult(i).use_empty()) {
           drop[i] = true;
           continue;
         }
         auto gep = yield.getOperand(i).getDefiningOp<LLVM::GEPOp>();
-        if (!gep || gep.getBase() != arg || !gep.getDynamicIndices().empty() ||
-            gep.getIndices().size() != 1) {
+        if (!gep || gep.getIndices().size() != 1) {
           ok = false;
           break;
         }
-        int64_t byteStep = cast<IntegerAttr>(gep.getIndices()[0]).getInt() *
-                           (int64_t)dl.getTypeSize(gep.getElemType());
+        if (gep.getBase() != arg) {
+          auto base = dyn_cast<BlockArgument>(gep.getBase());
+          if (!arg.use_empty() || !base || base.getOwner() != f.getBody() ||
+              base.getArgNumber() == 0) {
+            ok = false;
+            break;
+          }
+          // Validated against the base once every induction is known; its
+          // final value is the base's final for any completed trip and its
+          // own init otherwise.
+          aliases.push_back({i, base.getArgNumber() - 1});
+          drop[i] = true;
+          continue;
+        }
+        // The stride may be a loop-invariant runtime value (an inner
+        // loop's whole-trip advance); it must still address whole
+        // elements of every view.
+        Value dynStep;
+        int64_t byteStep = 0;
+        llvm::APInt cstStep;
+        if (gep.getDynamicIndices().empty()) {
+          byteStep = cast<IntegerAttr>(gep.getIndices()[0]).getInt() *
+                     (int64_t)dl.getTypeSize(gep.getElemType());
+        } else if (matchPattern(gep.getDynamicIndices()[0],
+                                m_ConstantInt(&cstStep))) {
+          // A constant-valued SSA stride (a folded whole-trip advance) is as
+          // good as an attribute one.
+          byteStep = cstStep.getSExtValue() *
+                     (int64_t)dl.getTypeSize(gep.getElemType());
+        } else {
+          dynStep = gep.getDynamicIndices()[0];
+          // The stride may be computed inside the body (an inner loop's
+          // materialized whole-trip advance); it is usable if nothing in
+          // its backward slice depends on this loop's iteration.
+          auto invariantIn = [&](Value v) {
+            SmallVector<Value> work{v};
+            llvm::SmallPtrSet<Value, 16> seen;
+            while (!work.empty()) {
+              Value c = work.pop_back_val();
+              if (!seen.insert(c).second)
+                continue;
+              if (auto ba = dyn_cast<BlockArgument>(c)) {
+                if (ba.getOwner()->getParentOp() == f.getOperation() ||
+                    f->isAncestor(ba.getOwner()->getParentOp()))
+                  return false;
+                continue;
+              }
+              Operation *def = c.getDefiningOp();
+              if (!f->isAncestor(def))
+                continue;
+              if (!isMemoryEffectFree(def) || def->getNumRegions())
+                return false;
+              for (Value o : def->getOperands())
+                work.push_back(o);
+            }
+            return true;
+          };
+          if (!invariantIn(dynStep)) {
+            ok = false;
+            break;
+          }
+          byteStep = (int64_t)dl.getTypeSize(gep.getElemType());
+        }
         for (Operation *u : arg.getUsers()) {
           if (u == gep.getOperation())
             continue;
@@ -3972,7 +4049,9 @@ struct AffineToStableHLORaisingPass
               !p2m.getType().getElementType().isIntOrFloat() ||
               byteStep %
                       (int64_t)dl.getTypeSize(p2m.getType().getElementType()) !=
-                  0) {
+                  0 ||
+              (dynStep && (int64_t)dl.getTypeSize(
+                              p2m.getType().getElementType()) > byteStep)) {
             ok = false;
             break;
           }
@@ -4000,10 +4079,57 @@ struct AffineToStableHLORaisingPass
         }
         if (!ok)
           break;
-        inductions.push_back({i, byteStep, gep});
+        Attribute idxAttr;
+        if (gep.getDynamicIndices().empty())
+          idxAttr = cast<IntegerAttr>(gep.getIndices()[0]);
+        else if (!dynStep)
+          idxAttr = IntegerAttr::get(IntegerType::get(f->getContext(), 64),
+                                     cstStep.getSExtValue());
+        inductions.push_back(
+            {i, byteStep, gep, gep.getElemType(), idxAttr, dynStep});
         drop[i] = true;
       }
-      if (!ok || !anyPtr || llvm::none_of(drop, [](bool d) { return d; }))
+      for (auto &al : aliases) {
+        if (!ok)
+          break;
+        const Induction *base = nullptr;
+        for (auto &ind : inductions)
+          if (ind.idx == al.baseIdx)
+            base = &ind;
+        if (!base || yield.getOperand(al.idx) != yield.getOperand(al.baseIdx))
+          ok = false;
+      }
+      if (!ok || !anyPtr || llvm::none_of(drop, [](bool d) { return d; })) {
+        if (getenv("DEBUG_PTRIND") && anyPtr)
+          llvm::errs() << "PTRIND bail ok=" << ok
+                       << " aliases=" << aliases.size() << " for: " << f
+                       << "\n";
+        continue;
+      }
+
+      // An invariant step chain can live inside the body (an inner loop's
+      // materialized whole-trip advance, emitted after that loop); clone
+      // it above this loop so accesses anywhere in the body and the final
+      // materialization can use it.
+      for (auto &ind : inductions) {
+        Operation *def = ind.dynStep ? ind.dynStep.getDefiningOp() : nullptr;
+        if (!def || !f->isAncestor(def))
+          continue;
+        SetVector<Operation *> slice;
+        BackwardSliceOptions opts;
+        opts.inclusive = true;
+        opts.filter = [&](Operation *op) { return f->isAncestor(op); };
+        if (getBackwardSlice(ind.dynStep, &slice, opts).failed()) {
+          ok = false;
+          break;
+        }
+        OpBuilder hb(f);
+        IRMapping hm;
+        for (Operation *op : slice)
+          hb.clone(*op, hm);
+        ind.dynStep = hm.lookupOrDefault(ind.dynStep);
+      }
+      if (!ok)
         continue;
 
       // Completed iterations: k = iv - lb.
@@ -4024,13 +4150,25 @@ struct AffineToStableHLORaisingPass
           auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(u);
           if (!p2m)
             continue;
-          int64_t stepElts = ind.byteStep / (int64_t)dl.getTypeSize(
-                                                p2m.getType().getElementType());
+          int64_t viewSz =
+              (int64_t)dl.getTypeSize(p2m.getType().getElementType());
+          if (ind.byteStep % viewSz != 0)
+            continue;
+          int64_t stepElts = ind.byteStep / viewSz;
           OpBuilder vb(p2m);
           Value nv = enzymexla::Pointer2MemrefOp::create(vb, p2m.getLoc(),
                                                          p2m.getType(), init);
           Value off = k;
-          if (stepElts != 1)
+          if (ind.dynStep) {
+            Value ds = ind.dynStep;
+            if (!isa<IndexType>(ds.getType()))
+              ds = arith::IndexCastOp::create(vb, loc, vb.getIndexType(), ds);
+            if (stepElts != 1)
+              ds = arith::MulIOp::create(
+                  vb, loc, ds,
+                  arith::ConstantIndexOp::create(vb, loc, stepElts));
+            off = arith::MulIOp::create(vb, loc, k, ds);
+          } else if (stepElts != 1)
             off = arith::MulIOp::create(
                 vb, loc, k, arith::ConstantIndexOp::create(vb, loc, stepElts));
           for (Operation *a : llvm::make_early_inc_range(p2m->getUsers())) {
@@ -4039,18 +4177,46 @@ struct AffineToStableHLORaisingPass
               return arith::AddIOp::create(ab, a->getLoc(), idx, off)
                   .getResult();
             };
+            // A static step composes into the affine map so the access
+            // stays affine; a runtime step forces an arith-indexed access.
+            bool affineStep = !ind.dynStep && isa<BlockArgument>(k);
+            auto composed = [&](AffineMap m) {
+              AffineExpr e =
+                  m.getResult(0) +
+                  getAffineDimExpr(m.getNumDims(), m.getContext()) * stepElts;
+              return AffineMap::get(m.getNumDims() + 1, m.getNumSymbols(), e);
+            };
+            auto composedOps = [&](OperandRange ops, AffineMap m) {
+              SmallVector<Value> nops(ops.begin(), ops.end());
+              nops.insert(nops.begin() + m.getNumDims(), k);
+              return nops;
+            };
             if (auto ld = dyn_cast<affine::AffineLoadOp>(a)) {
-              auto expanded = affine::expandAffineMap(
-                  ab, a->getLoc(), ld.getMap(), ld.getMapOperands());
-              Value nl = memref::LoadOp::create(
-                  ab, a->getLoc(), nv, ValueRange{add((*expanded)[0])});
+              Value nl;
+              if (affineStep) {
+                nl = affine::AffineLoadOp::create(
+                    ab, a->getLoc(), nv, composed(ld.getMap()),
+                    composedOps(ld.getMapOperands(), ld.getMap()));
+              } else {
+                auto expanded = affine::expandAffineMap(
+                    ab, a->getLoc(), ld.getMap(), ld.getMapOperands());
+                nl = memref::LoadOp::create(ab, a->getLoc(), nv,
+                                            ValueRange{add((*expanded)[0])});
+              }
               a->getResult(0).replaceAllUsesWith(nl);
               a->erase();
             } else if (auto st = dyn_cast<affine::AffineStoreOp>(a)) {
-              auto expanded = affine::expandAffineMap(
-                  ab, a->getLoc(), st.getMap(), st.getMapOperands());
-              memref::StoreOp::create(ab, a->getLoc(), st.getValueToStore(), nv,
-                                      ValueRange{add((*expanded)[0])});
+              if (affineStep) {
+                affine::AffineStoreOp::create(
+                    ab, a->getLoc(), st.getValueToStore(), nv,
+                    composed(st.getMap()),
+                    composedOps(st.getMapOperands(), st.getMap()));
+              } else {
+                auto expanded = affine::expandAffineMap(
+                    ab, a->getLoc(), st.getMap(), st.getMapOperands());
+                memref::StoreOp::create(ab, a->getLoc(), st.getValueToStore(),
+                                        nv, ValueRange{add((*expanded)[0])});
+              }
               a->erase();
             } else if (auto ld = dyn_cast<memref::LoadOp>(a)) {
               Value nl = memref::LoadOp::create(
@@ -4103,6 +4269,96 @@ struct AffineToStableHLORaisingPass
       for (unsigned i = 0; i < n; ++i)
         if (!drop[i])
           f.getResult(i).replaceAllUsesWith(nf.getResult(kept++));
+      if (resultUsed) {
+        OpBuilder fb(nf->getContext());
+        fb.setInsertionPointAfter(nf);
+        Location loc = nf.getLoc();
+        // A statically known trip folds the whole advance to a constant so
+        // downstream users stay affine.
+        std::optional<int64_t> ctrip;
+        if (f.getLowerBoundMap().isSingleConstant() &&
+            f.getUpperBoundMap().isSingleConstant())
+          ctrip = std::max<int64_t>(
+              0, f.getUpperBoundMap().getSingleConstantResult() -
+                     f.getLowerBoundMap().getSingleConstantResult());
+        Value zero = arith::ConstantIndexOp::create(fb, loc, 0);
+        Value trip, trip64;
+        if (ctrip) {
+          trip = arith::ConstantIndexOp::create(fb, loc, *ctrip);
+          trip64 =
+              arith::ConstantOp::create(fb, loc, fb.getI64IntegerAttr(*ctrip));
+        } else {
+          Value lbv = affine::AffineApplyOp::create(
+              fb, loc, f.getLowerBoundMap(), f.getLowerBoundOperands());
+          Value ubv = affine::AffineApplyOp::create(
+              fb, loc, f.getUpperBoundMap(), f.getUpperBoundOperands());
+          trip = arith::SubIOp::create(fb, loc, ubv, lbv);
+          Value neg = arith::CmpIOp::create(fb, loc, arith::CmpIPredicate::slt,
+                                            trip, zero);
+          trip = arith::SelectOp::create(fb, loc, neg, zero, trip);
+          trip64 = arith::IndexCastOp::create(fb, loc, fb.getI64Type(), trip);
+        }
+        auto finFor = [&](const Induction &ind) -> Value {
+          // Emit the advance in the widest aligned element so downstream
+          // rebasing sees whole-element addressing.
+          Type finElem = ind.advanceElemType;
+          int64_t finIdxScale = 1;
+          if (ind.byteStep % 8 == 0) {
+            finElem = fb.getF64Type();
+            finIdxScale = ind.byteStep / 8;
+          } else if (isa<IntegerAttr>(ind.advanceIdxAttr)) {
+            finIdxScale = cast<IntegerAttr>(ind.advanceIdxAttr).getInt();
+          }
+          Value scaled;
+          if (ctrip && !ind.dynStep) {
+            scaled = arith::ConstantOp::create(
+                fb, loc, fb.getI64IntegerAttr(*ctrip * finIdxScale));
+          } else {
+            scaled = arith::MulIOp::create(
+                fb, loc, trip64,
+                arith::ConstantOp::create(fb, loc,
+                                          fb.getI64IntegerAttr(finIdxScale)));
+            if (ind.dynStep) {
+              Value ds = ind.dynStep;
+              if (isa<IndexType>(ds.getType()))
+                ds = arith::IndexCastOp::create(fb, loc, fb.getI64Type(), ds);
+              else if (ds.getType() != fb.getI64Type())
+                ds = arith::ExtSIOp::create(fb, loc, fb.getI64Type(), ds);
+              scaled = arith::MulIOp::create(fb, loc, scaled, ds);
+            }
+          }
+          return LLVM::GEPOp::create(fb, loc, f.getInits()[ind.idx].getType(),
+                                     finElem, f.getInits()[ind.idx],
+                                     ValueRange{scaled});
+        };
+        for (auto &ind : inductions) {
+          if (f.getResult(ind.idx).use_empty())
+            continue;
+          f.getResult(ind.idx).replaceAllUsesWith(finFor(ind));
+        }
+        for (auto &al : aliases) {
+          if (f.getResult(al.idx).use_empty())
+            continue;
+          const Induction *base = nullptr;
+          for (auto &ind : inductions)
+            if (ind.idx == al.baseIdx)
+              base = &ind;
+          Value init = f.getInits()[al.idx];
+          Value repl;
+          if (init.getDefiningOp<ub::PoisonOp>() ||
+              init.getDefiningOp<LLVM::UndefOp>() ||
+              init.getDefiningOp<LLVM::PoisonOp>()) {
+            // A poison zero-trip value never materializes; the base's
+            // final stands unconditionally.
+            repl = finFor(*base);
+          } else {
+            Value pos = arith::CmpIOp::create(
+                fb, loc, arith::CmpIPredicate::sgt, trip, zero);
+            repl = arith::SelectOp::create(fb, loc, pos, finFor(*base), init);
+          }
+          f.getResult(al.idx).replaceAllUsesWith(repl);
+        }
+      }
       f.erase();
     }
   }

--- a/test/lit_tests/raising/pointer_induction.mlir
+++ b/test/lit_tests/raising/pointer_induction.mlir
@@ -28,3 +28,34 @@ module {
     return
   }
 }
+
+// A used final pointer is the init advanced by the whole trip count; the
+// following access rebases onto the init with the trip folded in.
+
+// CHECK-LABEL: @final_used
+// CHECK: stablehlo.while
+// CHECK-NOT: !llvm.ptr
+
+module {
+  func.func private @final_used(%in: memref<64xf64, 1>, %dst: memref<16xf64, 1>, %nbuf: memref<1xi32, 1>) {
+    %c0 = arith.constant 0.0 : f64
+    %n = affine.load %nbuf[0] : memref<1xi32, 1>
+    %ni = arith.index_cast %n : i32 to index
+    %p0 = "enzymexla.memref2pointer"(%in) : (memref<64xf64, 1>) -> !llvm.ptr<1>
+    affine.parallel (%t) = (0) to (16) {
+      %r:2 = affine.for %i = 0 to %ni iter_args(%acc = %c0, %p = %p0) -> (f64, !llvm.ptr<1>) {
+        %view = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+        %v = affine.load %view[%t] : memref<?xf64, 1>
+        %a = arith.addf %acc, %v : f64
+        %adv = llvm.getelementptr %p[1] : (!llvm.ptr<1>) -> !llvm.ptr<1>, f64
+        affine.yield %a, %adv : f64, !llvm.ptr<1>
+      }
+      %viewf = "enzymexla.pointer2memref"(%r#1) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+      %w = affine.load %viewf[%t] : memref<?xf64, 1>
+      %b = arith.addf %r#0, %w : f64
+      affine.store %b, %dst[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+

--- a/test/lit_tests/raising/pointer_induction.mlir
+++ b/test/lit_tests/raising/pointer_induction.mlir
@@ -1,0 +1,30 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// A loop that walks a pointer forward by a constant stride each iteration
+// carries it as an iter arg no tensor can stand for; the pointer is a pure
+// function of the induction variable, so accesses rebase onto the init
+// pointer and the carried pointer disappears.
+
+// CHECK-LABEL: @walk_raised
+// CHECK: stablehlo.while
+// CHECK-NOT: !llvm.ptr
+
+module {
+  func.func private @walk(%out: memref<16xf64, 1>, %in: memref<64xf64, 1>, %nbuf: memref<1xi32, 1>) {
+    %c0 = arith.constant 0.0 : f64
+    %n = affine.load %nbuf[0] : memref<1xi32, 1>
+    %ni = arith.index_cast %n : i32 to index
+    %p0 = "enzymexla.memref2pointer"(%in) : (memref<64xf64, 1>) -> !llvm.ptr<1>
+    affine.parallel (%t) = (0) to (16) {
+      %sum:2 = affine.for %i = 0 to %ni iter_args(%acc = %c0, %p = %p0) -> (f64, !llvm.ptr<1>) {
+        %view = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+        %v = affine.load %view[%t] : memref<?xf64, 1>
+        %a = arith.addf %acc, %v : f64
+        %adv = llvm.getelementptr %p[1] : (!llvm.ptr<1>) -> !llvm.ptr<1>, f64
+        affine.yield %a, %adv : f64, !llvm.ptr<1>
+      }
+      affine.store %sum#0, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}

--- a/test/lit_tests/raising/pointer_induction_partial.mlir
+++ b/test/lit_tests/raising/pointer_induction_partial.mlir
@@ -1,0 +1,66 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(raise-affine-to-stablehlo{err_if_not_fully_raised=false})" | FileCheck %s
+
+// The rotated nest a do-while lowering produces: the inner loop carries the
+// walking pointer plus a poison-initialized lagging copy that re-yields the
+// same advance; the outer loop is carried through the lagging copy's result.
+// The pointer machinery rewrites away entirely: a static whole-trip stride
+// composes into the affine access map, a runtime stride (dynamic inner trip)
+// becomes an arith-indexed access. Raising the remaining scalar nest is a
+// separate concern; this file checks the rewrite.
+
+// CHECK-LABEL: @nest
+// CHECK: affine.load %{{.*}}[%{{.*}} + %{{.*}} + %{{.*}} * 4] : memref<?xf64, 1>
+// CHECK-NOT: llvm.getelementptr
+
+// CHECK-LABEL: @nest_dynstride
+// CHECK: arith.muli
+// CHECK: memref.load
+// CHECK-NOT: llvm.getelementptr
+
+module {
+  func.func private @nest(%in: memref<256xf64, 1>, %dst: memref<16xf64, 1>, %nbuf: memref<1xi32, 1>) {
+    %c0 = arith.constant 0.0 : f64
+    %pz = ub.poison : !llvm.ptr<1>
+    %n = affine.load %nbuf[0] : memref<1xi32, 1>
+    %ni = arith.index_cast %n : i32 to index
+    %p0 = "enzymexla.memref2pointer"(%in) : (memref<256xf64, 1>) -> !llvm.ptr<1>
+    affine.parallel (%t) = (0) to (16) {
+      %o:2 = affine.for %i = 0 to %ni iter_args(%oacc = %c0, %p = %p0) -> (f64, !llvm.ptr<1>) {
+        %r:3 = affine.for %j = 0 to 4 iter_args(%acc = %oacc, %q = %p, %lag = %pz) -> (f64, !llvm.ptr<1>, !llvm.ptr<1>) {
+          %view = "enzymexla.pointer2memref"(%q) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+          %v = affine.load %view[%t] : memref<?xf64, 1>
+          %a = arith.addf %acc, %v : f64
+          %adv = llvm.getelementptr %q[1] : (!llvm.ptr<1>) -> !llvm.ptr<1>, f64
+          affine.yield %a, %adv, %adv : f64, !llvm.ptr<1>, !llvm.ptr<1>
+        }
+        affine.yield %r#0, %r#2 : f64, !llvm.ptr<1>
+      }
+      affine.store %o#0, %dst[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+module {
+  func.func private @nest_dynstride(%in: memref<256xf64, 1>, %dst: memref<16xf64, 1>, %nbuf: memref<1xi32, 1>) {
+    %c0 = arith.constant 0.0 : f64
+    %pz = ub.poison : !llvm.ptr<1>
+    %n = affine.load %nbuf[0] : memref<1xi32, 1>
+    %ni = arith.index_cast %n : i32 to index
+    %p0 = "enzymexla.memref2pointer"(%in) : (memref<256xf64, 1>) -> !llvm.ptr<1>
+    affine.parallel (%t) = (0) to (16) {
+      %o:2 = affine.for %i = 0 to 8 iter_args(%oacc = %c0, %p = %p0) -> (f64, !llvm.ptr<1>) {
+        %r:3 = affine.for %j = 0 to %ni iter_args(%acc = %oacc, %q = %p, %lag = %pz) -> (f64, !llvm.ptr<1>, !llvm.ptr<1>) {
+          %view = "enzymexla.pointer2memref"(%q) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+          %v = affine.load %view[%t] : memref<?xf64, 1>
+          %a = arith.addf %acc, %v : f64
+          %adv = llvm.getelementptr %q[1] : (!llvm.ptr<1>) -> !llvm.ptr<1>, f64
+          affine.yield %a, %adv, %adv : f64, !llvm.ptr<1>, !llvm.ptr<1>
+        }
+        affine.yield %r#0, %r#2 : f64, !llvm.ptr<1>
+      }
+      affine.store %o#0, %dst[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}


### PR DESCRIPTION
Stacks on #3006.

A loop that walks a pointer forward by a constant stride each iteration (mfem's `*y++ += ...` accumulation loops in `hybridization_ext.cpp`) carries the pointer as an iter arg no tensor can stand for. The pointer is a pure function of the induction variable, so accesses through it rebase onto the init pointer at `orig + k*stride` (with the byte stride converted into the view's element units) and the loop rebuilds without the pointer iter args; dead carried pointers drop with it.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD