### PR TITLE
Raising: atomic adds as combining scatters

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -1100,7 +1100,7 @@ static Value
 emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
                    OpBuilder &builder,
                    llvm::DenseMap<Value, affine::AffineValueMap> &maps,
-                   const ParallelContext &pc) {
+                   const ParallelContext &pc, bool accumulate = false) {
   affine::AffineValueMap updateValueMap = maps.lookup(update);
 
   auto UTy = cast<RankedTensorType>(update.getType());
@@ -1196,8 +1196,9 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
           /*indexVectorDim*/ (int64_t)gridShape.size()),
       /*indicesAreSorted*/ false,
       // With a mask, masked-out positions scatter orig back at potentially
-      // repeated indices — uniqueness can only be claimed without a mask.
-      /*uniqueIndices*/ !pc.mask);
+      // repeated indices — uniqueness can only be claimed without a mask; an
+      // accumulating scatter's colliding indices are the whole point.
+      /*uniqueIndices*/ !pc.mask && !accumulate);
   Value res = scatter.getResult(0);
 
   Block *updateBody = new Block();
@@ -1205,13 +1206,20 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
 
   auto unrankedTy = RankedTensorType::get(
       {}, cast<RankedTensorType>(update.getType()).getElementType());
-  updateBody->addArgument(unrankedTy, loc);
+  Value currentInBody = updateBody->addArgument(unrankedTy, loc);
   Value updateInBody = updateBody->addArgument(unrankedTy, loc);
 
   {
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(updateBody);
-    stablehlo::ReturnOp::create(builder, loc, updateInBody);
+    Value out = updateInBody;
+    if (accumulate) {
+      // An atomic add raises as a combining scatter: adds commute (up to
+      // rounding, exactly like the atomic), so application order is
+      // irrelevant.
+      out = stablehlo::AddOp::create(builder, loc, currentInBody, updateInBody);
+    }
+    stablehlo::ReturnOp::create(builder, loc, out);
   }
 
   return res;
@@ -2984,6 +2992,36 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     }
     mapping.map(loadOp.getResult(), res);
 
+    return success();
+  }
+
+  if (auto rmw = dyn_cast<memref::AtomicRMWOp>(op)) {
+    // Only accumulation raises (as a combining scatter), and only when the
+    // old value is unobserved.
+    if ((rmw.getKind() != arith::AtomicRMWKind::addf &&
+         rmw.getKind() != arith::AtomicRMWKind::addi) ||
+        !rmw.getResult().use_empty())
+      return failure();
+    Value value = rmw.getValue();
+    Value memref = rmw.getMemref();
+    SmallVector<Value> sIndices;
+    for (auto idx : rmw.getIndices()) {
+      Value mapped = mapping.lookupOrNull(idx);
+      if (!mapped || !maps.count(mapped))
+        return failure();
+      sIndices.push_back(mapped);
+    }
+    if (!mapping.lookupOrNull(value) || !mapping.lookupOrNull(memref))
+      return failure();
+    Value res = emitStoreAsScatter(
+        rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
+        mapping.lookup(value), mapping.lookup(memref), sIndices, builder, maps,
+        pc, /*accumulate=*/true);
+    if (!res)
+      return op->emitError(
+                 "atomic add is dependent on less dims than stored value: ")
+             << *op;
+    mapping.map(memref, res);
     return success();
   }
 

--- a/test/lit_tests/raising/atomic_add_scatter.mlir
+++ b/test/lit_tests/raising/atomic_add_scatter.mlir
@@ -1,0 +1,72 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// An atomic add whose result is unused raises as a combining scatter: adds
+// commute (up to rounding, exactly like the atomic), so application order
+// is irrelevant even at colliding indices. The llvm.atomicrmw form arrives
+// here as memref.atomic_rmw via llvm-to-memref-access.
+
+module {
+  func.func private @atomic_add(%buf: memref<8xf64, 1>, %idx: memref<16xi32, 1>, %val: memref<16xf64, 1>) {
+    affine.parallel (%t) = (0) to (16) {
+      %i = affine.load %idx[%t] : memref<16xi32, 1>
+      %iidx = arith.index_cast %i : i32 to index
+      %v = affine.load %val[%t] : memref<16xf64, 1>
+      %old = memref.atomic_rmw addf %v, %buf[%iidx] : (f64, memref<8xf64, 1>) -> f64
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @atomic_add_raised(%[[buf:.+]]: tensor<8xf64>, %[[idx:.+]]: tensor<16xi32>, %[[val:.+]]: tensor<16xf64>) -> (tensor<8xf64>, tensor<16xi32>, tensor<16xf64>) {
+// CHECK-NEXT:    %[[iota:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[c0:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[lanes:.+]] = stablehlo.add %[[iota]], %[[c0]] : tensor<16xi64>
+// CHECK-NEXT:    %[[c1:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %{{.+}} = stablehlo.multiply %[[lanes]], %[[c1]] : tensor<16xi64>
+// CHECK-NEXT:    %[[idxr:.+]] = stablehlo.reshape %[[idx]] : (tensor<16xi32>) -> tensor<16xi32>
+// CHECK-NEXT:    %[[idx64:.+]] = stablehlo.convert %[[idxr]] : (tensor<16xi32>) -> tensor<16xi64>
+// CHECK-NEXT:    %[[valr:.+]] = stablehlo.reshape %[[val]] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:    %[[sidx:.+]] = stablehlo.reshape %[[idx64]] : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %[[upd:.+]] = stablehlo.broadcast_in_dim %[[valr]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:    %[[scat:.+]] = "stablehlo.scatter"(%[[buf]], %[[sidx]], %[[upd]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%[[a:.+]]: tensor<f64>, %[[b:.+]]: tensor<f64>):
+// CHECK-NEXT:      %[[sum:.+]] = stablehlo.add %[[a]], %[[b]] : tensor<f64>
+// CHECK-NEXT:      stablehlo.return %[[sum]] : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<8xf64>, tensor<16x1xi64>, tensor<16xf64>) -> tensor<8xf64>
+// CHECK-NEXT:    return %[[scat]], %[[idx]], %[[val]] : tensor<8xf64>, tensor<16xi32>, tensor<16xf64>
+// CHECK-NEXT:  }
+
+// -----
+
+// Integer atomic adds take the same path.
+
+module {
+  func.func private @atomic_add_int(%buf: memref<8xi32, 1>, %idx: memref<16xi32, 1>, %val: memref<16xi32, 1>) {
+    affine.parallel (%t) = (0) to (16) {
+      %i = affine.load %idx[%t] : memref<16xi32, 1>
+      %iidx = arith.index_cast %i : i32 to index
+      %v = affine.load %val[%t] : memref<16xi32, 1>
+      %old = memref.atomic_rmw addi %v, %buf[%iidx] : (i32, memref<8xi32, 1>) -> i32
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @atomic_add_int_raised(%[[buf:.+]]: tensor<8xi32>, %[[idx:.+]]: tensor<16xi32>, %[[val:.+]]: tensor<16xi32>) -> (tensor<8xi32>, tensor<16xi32>, tensor<16xi32>) {
+// CHECK-NEXT:    %[[iota:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[c0:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[lanes:.+]] = stablehlo.add %[[iota]], %[[c0]] : tensor<16xi64>
+// CHECK-NEXT:    %[[c1:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %{{.+}} = stablehlo.multiply %[[lanes]], %[[c1]] : tensor<16xi64>
+// CHECK-NEXT:    %[[idxr:.+]] = stablehlo.reshape %[[idx]] : (tensor<16xi32>) -> tensor<16xi32>
+// CHECK-NEXT:    %[[idx64:.+]] = stablehlo.convert %[[idxr]] : (tensor<16xi32>) -> tensor<16xi64>
+// CHECK-NEXT:    %[[valr:.+]] = stablehlo.reshape %[[val]] : (tensor<16xi32>) -> tensor<16xi32>
+// CHECK-NEXT:    %[[sidx:.+]] = stablehlo.reshape %[[idx64]] : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %[[upd:.+]] = stablehlo.broadcast_in_dim %[[valr]], dims = [0] : (tensor<16xi32>) -> tensor<16xi32>
+// CHECK-NEXT:    %[[scat:.+]] = "stablehlo.scatter"(%[[buf]], %[[sidx]], %[[upd]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%[[a:.+]]: tensor<i32>, %[[b:.+]]: tensor<i32>):
+// CHECK-NEXT:      %[[sum:.+]] = stablehlo.add %[[a]], %[[b]] : tensor<i32>
+// CHECK-NEXT:      stablehlo.return %[[sum]] : tensor<i32>
+// CHECK-NEXT:    }) : (tensor<8xi32>, tensor<16x1xi64>, tensor<16xi32>) -> tensor<8xi32>
+// CHECK-NEXT:    return %[[scat]], %[[idx]], %[[val]] : tensor<8xi32>, tensor<16xi32>, tensor<16xi32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
An `llvm.atomicrmw fadd/add` whose result is unused converts to `memref.atomic_rmw` through the raw-gep access normalization and view rebasing, and raises as a `stablehlo.scatter` whose update region adds: adds commute (up to rounding, exactly like the atomic), so application order is irrelevant even at colliding indices, and `unique_indices` stays `false`.

This is the normalization behind `derefmat_op`/`pderefmat_op` raising strict in the MFEM CUDA→xla-gpu campaign (#2968). Stacked on #3006 (base `pb/buffer-normalizations`) for the raw-gep access machinery.

Includes a lit test of a colliding-index atomic add raising to a combining scatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD