### PR TITLE
Raising: expand a branch between buffers read back through a pointer

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -4015,17 +4015,40 @@ struct AffineToStableHLORaisingPass
           continue;
         Value thenV = thenB->getTerminator()->getOperand(i);
         Value elseV = elseB->getTerminator()->getOperand(i);
-        for (OpOperand &use : llvm::make_early_inc_range(res.getUses())) {
-          Operation *user = use.getOwner();
-          bool isLoad = isa<memref::LoadOp, affine::AffineLoadOp>(user);
-          bool isStore = isa<memref::StoreOp, affine::AffineStoreOp>(user);
-          unsigned memIdx = isLoad ? 0 : 1;
-          if ((!isLoad && !isStore) || use.getOperandNumber() != memIdx)
+        // The access may name the result itself, or reach it back through a
+        // pointer: the buffer is converted to one and viewed again, and the
+        // access is on that view.
+        SmallVector<std::pair<Operation *, SmallVector<Operation *>>> reached;
+        for (Operation *user : res.getUsers()) {
+          if (isa<memref::LoadOp, affine::AffineLoadOp, memref::StoreOp,
+                  affine::AffineStoreOp>(user)) {
+            reached.push_back({user, {}});
             continue;
-          OpBuilder b(user);
+          }
+          auto m2p = dyn_cast<enzymexla::Memref2PointerOp>(user);
+          if (!m2p)
+            continue;
+          for (Operation *pu : m2p->getUsers()) {
+            auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(pu);
+            if (!p2m)
+              continue;
+            for (Operation *acc : p2m->getUsers())
+              if (isa<memref::LoadOp, affine::AffineLoadOp, memref::StoreOp,
+                      affine::AffineStoreOp>(acc))
+                reached.push_back({acc, {m2p, p2m}});
+          }
+        }
+        for (auto &[acc, chain] : reached) {
+          bool isLoad = isa<memref::LoadOp, affine::AffineLoadOp>(acc);
+          unsigned memIdx = isLoad ? 0 : 1;
+          // The buffer must be what the access reads, not what it stores.
+          Value accessed = chain.empty() ? res : chain.back()->getResult(0);
+          if (acc->getOperand(memIdx) != accessed)
+            continue;
+          OpBuilder b(acc);
           auto newIf = affine::AffineIfOp::create(
-              b, user->getLoc(),
-              isLoad ? TypeRange(user->getResult(0).getType()) : TypeRange(),
+              b, acc->getLoc(),
+              isLoad ? TypeRange(acc->getResult(0).getType()) : TypeRange(),
               ifOp.getIntegerSet(), ifOp.getOperands(),
               /*withElseRegion=*/true);
           auto fillArm = [&](Block *srcArm, Value yielded, Block *dstArm) {
@@ -4036,19 +4059,32 @@ struct AffineToStableHLORaisingPass
             OpBuilder ab = OpBuilder::atBlockEnd(dstArm);
             for (Operation &armOp : srcArm->without_terminator())
               ab.clone(armOp, m);
-            Operation *access = ab.clone(*user, m);
-            access->setOperand(memIdx, m.lookupOrDefault(yielded));
+            Value buf = m.lookupOrDefault(yielded);
+            for (Operation *link : chain) {
+              Operation *cloned = ab.clone(*link, m);
+              cloned->setOperand(0, buf);
+              buf = cloned->getResult(0);
+            }
+            Operation *access = ab.clone(*acc, m);
+            access->setOperand(memIdx, buf);
             affine::AffineYieldOp::create(
-                ab, user->getLoc(),
+                ab, acc->getLoc(),
                 isLoad ? ValueRange(access->getResult(0)) : ValueRange());
           };
           fillArm(thenB, thenV, newIf.getThenBlock());
           fillArm(elseB, elseV, newIf.getElseBlock());
           if (isLoad)
-            user->getResult(0).replaceAllUsesWith(newIf.getResult(0));
-          user->erase();
+            acc->getResult(0).replaceAllUsesWith(newIf.getResult(0));
+          acc->erase();
+          // The conversions the access reached the buffer through are the
+          // only thing still naming the branch; with the access gone they
+          // are dead, and while they stand the branch cannot be raised.
+          for (Operation *link : llvm::reverse(chain))
+            if (link->use_empty())
+              link->erase();
         }
       }
+
       if (llvm::all_of(ifOp.getResults(),
                        [](Value r) { return r.use_empty(); })) {
         ifOp.erase();

--- a/test/lit_tests/raising/if_memref_yield.mlir
+++ b/test/lit_tests/raising/if_memref_yield.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// A branch choosing between scratch buffers, read back through a pointer: the
+// access names neither the branch's result nor a view of it, but a view of a
+// pointer taken of it. Each access moves into the arms, onto that arm's own
+// buffer, so the branch is left with nothing to raise -- which is what lets
+// the function raise at all, since scratch that is written elsewhere can
+// never be selected between as whole tensors.
+
+// CHECK-LABEL: @pick_scratch
+// CHECK-NOT: affine.if
+// CHECK-NOT: enzymexla.memref2pointer
+
+#set = affine_set<(d0) : (d0 - 2 == 0)>
+module {
+  func.func private @pick_scratch(%out: memref<4xf64, 1>, %in: memref<4xf64, 1>) {
+    %a = memref.alloca() : memref<4xf64>
+    %b = memref.alloca() : memref<4xf64>
+    affine.parallel (%t) = (0) to (4) {
+      %v = affine.load %in[%t] : memref<4xf64, 1>
+      affine.store %v, %a[%t] : memref<4xf64>
+      affine.store %v, %b[%t] : memref<4xf64>
+      %sel = affine.if #set(%t) -> memref<4xf64> {
+        affine.yield %a : memref<4xf64>
+      } else {
+        affine.yield %b : memref<4xf64>
+      }
+      %p = "enzymexla.memref2pointer"(%sel) : (memref<4xf64>) -> !llvm.ptr
+      %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+      %ld = affine.load %m[%t] : memref<?xf64>
+      affine.store %ld, %out[%t] : memref<4xf64, 1>
+    }
+    return
+  }
+}


### PR DESCRIPTION
Stacked on #3027 (`expandBufferBranches`); merge that first.

When an `affine.if` yields one of two buffers as a memref and the result is only read back through `enzymexla.memref2pointer` → `enzymexla.pointer2memref` (the shape MFEM's `Vector`/`DeviceTensor` wrappers produce after `Memref2Pointer2MemrefCast`, #3068, has done its part but the intermediate buffer is a different rank), the branch cannot be raised: the yielded memref has no affine access to follow. This extends `expandBufferBranches` so that a memref result whose users are either direct `affine.load`/`affine.store`s, or such accesses through an m2p/p2m chain, is expanded per access — each access is cloned into a fresh `affine.if` with the arm's buffer substituted, the dead chain links are erased, and the original branch disappears.

The pointer-yield case (a branch yielding `!llvm.ptr` that is the same base as, or a gep of, the other side) is now handled generally in `canonicalize-parallel` by #3072 and is no longer part of this PR.

Test: `test/lit_tests/raising/if_memref_yield.mlir`.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
