### PR TITLE
Raising: ignore llvm.intr.assume

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -3442,6 +3442,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     return success();
   }
 
+  // An optimizer hint carries no semantics a tensor program needs.
+  if (isa<LLVM::AssumeOp>(op))
+    return success();
+
   return op->emitError("cannot raise op to stablehlo") << *op;
 }
 

--- a/test/lit_tests/raising/ignore_assume.mlir
+++ b/test/lit_tests/raising/ignore_assume.mlir
@@ -1,0 +1,21 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// An optimizer hint carries no semantics a tensor program needs; a kernel
+// carrying llvm.intr.assume still raises.
+
+// CHECK-LABEL: @with_assume
+// CHECK-NOT: llvm.intr.assume
+
+module {
+  func.func private @with_assume(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>, %nbuf: memref<1xi32, 1>) {
+    %c0_i32 = arith.constant 0 : i32
+    affine.parallel (%t) = (0) to (16) {
+      %n = affine.load %nbuf[0] : memref<1xi32, 1>
+      %pos = arith.cmpi sgt, %n, %c0_i32 : i32
+      "llvm.intr.assume"(%pos) <{op_bundle_sizes = array<i32>, op_bundle_tags = []}> : (i1) -> ()
+      %v = affine.load %in[%t] : memref<16xf64, 1>
+      affine.store %v, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}


### PR DESCRIPTION
An optimizer hint carries no semantics a tensor program needs; dropping it lets kernels that carry assumes raise (this was the last blocker for `fem/hybridization_ext.cpp` in the MFEM CUDA→xla-gpu campaign, #2968).

Includes a lit test of an assume-carrying kernel raising end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD