### PR TITLE
arith-raise: sign extension of i1 negates the boolean conversion

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -612,6 +612,9 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
         continue;
       }
       if (auto idx = decast.getDefiningOp<ExtSIOp>()) {
+        // Sign extension of i1 flips the value (true -> -1).
+        if (idx.getIn().getType().isInteger(1))
+          break;
         decast = idx.getIn();
         continue;
       }
@@ -1447,7 +1450,8 @@ bool isValidIndex(Value val, Region *scope) {
     return isValidIndex(cast.getOperand(), scope);
 
   if (auto cast = val.getDefiningOp<ExtSIOp>())
-    return isValidIndex(cast.getOperand(), scope);
+    if (!cast.getOperand().getType().isInteger(1))
+      return isValidIndex(cast.getOperand(), scope);
 
   if (auto cast = val.getDefiningOp<ExtUIOp>())
     return isValidIndex(cast.getOperand(), scope);

--- a/src/enzyme_ad/jax/Passes/ArithRaising.cpp
+++ b/src/enzyme_ad/jax/Passes/ArithRaising.cpp
@@ -110,6 +110,18 @@ struct RaiseToConvert : public OpRewritePattern<SrcOp> {
     if (!ty)
       return failure();
 
+    // stablehlo.convert reads i1 as boolean (true -> 1), but a sign
+    // extension of i1 means true -> -1: negate the boolean's conversion.
+    if (std::is_same_v<SrcOp, arith::ExtSIOp> &&
+        cast<RankedTensorType>(op.getIn().getType())
+            .getElementType()
+            .isInteger(1)) {
+      Value conv =
+          stablehlo::ConvertOp::create(rewriter, op.getLoc(), ty, op.getIn());
+      rewriter.replaceOpWithNewOp<stablehlo::NegOp>(op, conv);
+      return success();
+    }
+
     rewriter.replaceOpWithNewOp<stablehlo::ConvertOp>(op, ty, op.getIn());
     return success();
   }

--- a/test/lit_tests/arith_extsi_bool.mlir
+++ b/test/lit_tests/arith_extsi_bool.mlir
@@ -1,0 +1,32 @@
+// RUN: enzymexlamlir-opt %s --arith-raise | FileCheck %s
+
+// A sign extension of i1 means true -> -1; stablehlo.convert reads i1 as
+// boolean (true -> 1), so the raised form negates the conversion.
+
+// CHECK-LABEL: @extsi_bool
+// CHECK: %[[C:.+]] = stablehlo.convert %arg0 : (tensor<4xi1>) -> tensor<4xi32>
+// CHECK: %[[N:.+]] = stablehlo.negate %[[C]] : tensor<4xi32>
+// CHECK: return %[[N]]
+
+// CHECK-LABEL: @extsi_wide
+// CHECK: stablehlo.convert
+// CHECK-NOT: stablehlo.negate
+
+// CHECK-LABEL: @extui_bool
+// CHECK: stablehlo.convert
+// CHECK-NOT: stablehlo.negate
+
+module {
+  func.func @extsi_bool(%arg0: tensor<4xi1>) -> tensor<4xi32> {
+    %0 = arith.extsi %arg0 : tensor<4xi1> to tensor<4xi32>
+    return %0 : tensor<4xi32>
+  }
+  func.func @extsi_wide(%arg0: tensor<4xi8>) -> tensor<4xi32> {
+    %0 = arith.extsi %arg0 : tensor<4xi8> to tensor<4xi32>
+    return %0 : tensor<4xi32>
+  }
+  func.func @extui_bool(%arg0: tensor<4xi1>) -> tensor<4xi32> {
+    %0 = arith.extui %arg0 : tensor<4xi1> to tensor<4xi32>
+    return %0 : tensor<4xi32>
+  }
+}


### PR DESCRIPTION
`stablehlo.convert` reads `i1` as boolean (`true → 1`), but `arith.extsi` of `i1` means `true → -1`. Raising it as a plain convert miscompiled every raised kernel computing extents as `base + extsi(cmp)` — clang's lowering of conditional ±1 offsets.

Found via the MFEM CUDA→xla-gpu campaign (#2968): `PADivDivApply3D`'s per-component H(div) extents (`D1Dz = D1D + (c==2 ? 0 : -1)`) came out **+1 instead of −1**, inflating every loop bound and stride multiplier so each element's contributions smeared across the whole output E-vector (localized by exec replay + numpy oracle down to the exact index chain). Fix: `extsi` from `i1` raises as `negate(convert(x))`; wider sources keep the plain convert (StableHLO sign-extends those correctly). Also guards the affine index walkers that look through `extsi` against `i1` sources.

Includes a lit test covering `extsi(i1)` (negated), `extsi(i8)` (plain convert), and `extui(i1)` (plain convert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD