### PR TITLE
mem2reg: bind all symbol operands when comparing affine offsets

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -177,7 +177,7 @@ public:
     for (unsigned i = 0; i < numDims; i++)
       dim.push_back(vals[i]);
 
-    for (unsigned i = numDims; i < numSymbols; i++)
+    for (unsigned i = numDims; i < numDims + numSymbols; i++)
       sym.push_back(vals[i]);
 
     type = Type::Affine;

--- a/test/lit_tests/mem2reg_distinct_symbols.mlir
+++ b/test/lit_tests/mem2reg_distinct_symbols.mlir
@@ -1,0 +1,24 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+// Two accesses whose affine maps agree land on the same slot only when the
+// symbols bound to the map agree as well; a load indexed by a different
+// symbol names a different location and must not be forwarded.
+func.func @distinct_symbols(%i: index, %s1: index, %s2: index, %v: f64) -> f64 {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %mem = llvm.alloca %c1 x !llvm.array<81 x f64> : (i32) -> !llvm.ptr
+  %view = "enzymexla.pointer2memref"(%mem) : (!llvm.ptr) -> memref<?xf64>
+  affine.store %v, %view[%i + symbol(%s1) * 9] : memref<?xf64>
+  %a = affine.load %view[%i + symbol(%s1) * 9] : memref<?xf64>
+  %b = affine.load %view[%i + symbol(%s2) * 9] : memref<?xf64>
+  %r = arith.addf %a, %b : f64
+  return %r : f64
+}
+
+// The store and the first load bind the same symbol, so that load takes the
+// stored value; the second load binds another symbol and stays a load.
+// CHECK-LABEL: func.func @distinct_symbols(
+// CHECK-SAME: %[[I:[a-z0-9]+]]: index, %[[S1:[a-z0-9]+]]: index, %[[S2:[a-z0-9]+]]: index, %[[V:[a-z0-9]+]]: f64
+// CHECK: affine.store %[[V]], %{{.*}}[%[[I]] + symbol(%[[S1]]) * 9]
+// CHECK: %[[B:.+]] = affine.load %{{.*}}[%[[I]] + symbol(%[[S2]]) * 9]
+// CHECK: %[[R:.+]] = arith.addf %[[V]], %[[B]] : f64
+// CHECK: return %[[R]] : f64


### PR DESCRIPTION
The `Offset` constructor taking a flattened affine operand range copied symbols with `for (i = numDims; i < numSymbols; i++)`, so whenever `numSymbols <= numDims` the symbol list came out empty (and was truncated otherwise). Two accesses sharing an affine map and dim operands but bound to **different symbols** then compared equal, and load forwarding merged distinct locations.

Found debugging the MFEM CUDA suite (EnzymeAD/Enzyme-JAX#2968): `SmemPACurlCurlAssembleDiagonal3D`'s `sop[i23]` and `sop[i32]` loads share the map `d0 + s0 * 9` and differ only in the bound symbol, so polygeist-mem2reg forwarded one into the other and the asymmetric-coefficient CurlCurl diagonal collapsed `-(O23+O32)` to `-2*O23` (the last failing assertion in the "Hcurl/Hdiv diagonal PA" row). With this fix the raised kernel matches the numpy oracle exactly.

The lit test pins the boundary: a load bound to the same symbol as a prior store is forwarded; a load bound to a different symbol survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD