### PR TITLE
hlo-opt: broadcast unmapped grid dims in single-mapping gather rewrite

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -15875,6 +15875,18 @@ struct GatherOpCanon final
             rewriter, op.getLoc(), result, rewriter.getDenseI64ArrayAttr({0}));
       }
 
+      // The grid may carry dimensions beyond the single mapped one, along
+      // which the index is constant; the slice only covers the mapped
+      // extent, so the rest comes back by broadcast, not reshape.
+      auto gridResultTy =
+          RankedTensorType::get(gridTy.getShape(), operandTy.getElementType());
+      if (gridResultTy.getNumElements() !=
+          cast<ShapedType>(result.getType()).getNumElements()) {
+        result = stablehlo::BroadcastInDimOp::create(
+            rewriter, op.getLoc(), gridResultTy, result,
+            rewriter.getDenseI64ArrayAttr({analysis.mappings[0].gridDim}));
+      }
+
       if (result.getType() != op.getType()) {
         result = stablehlo::ReshapeOp::create(rewriter, op.getLoc(),
                                               op.getType(), result);

--- a/test/lit_tests/gather_grid_broadcast.mlir
+++ b/test/lit_tests/gather_grid_broadcast.mlir
@@ -1,0 +1,18 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// The iota grid varies only along the last result dimension; the other two
+// are broadcast. The single-mapping rewrite must restore them by broadcast —
+// a reshape of the 3-element slice to the 27-element result does not verify.
+func.func @gather_grid_broadcast(%tbl: tensor<6xf64>) -> tensor<3x3x3xf64> {
+  %iota = stablehlo.iota dim = 0 : tensor<3xi64>
+  %b = stablehlo.broadcast_in_dim %iota, dims = [2] : (tensor<3xi64>) -> tensor<3x3x3xi64>
+  %r = stablehlo.reshape %b : (tensor<3x3x3xi64>) -> tensor<3x3x3x1xi64>
+  %g = "stablehlo.gather"(%tbl, %r) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 3>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<6xf64>, tensor<3x3x3x1xi64>) -> tensor<3x3x3xf64>
+  return %g : tensor<3x3x3xf64>
+}
+
+// CHECK-LABEL: func.func @gather_grid_broadcast(
+// CHECK-SAME: %[[TBL:[a-z0-9]+]]: tensor<6xf64>
+// CHECK: %[[S:.+]] = stablehlo.slice %[[TBL]] [0:3] : (tensor<6xf64>) -> tensor<3xf64>
+// CHECK: %[[B:.+]] = stablehlo.broadcast_in_dim %[[S]], dims = [2] : (tensor<3xf64>) -> tensor<3x3x3xf64>
+// CHECK: return %[[B]] : tensor<3x3x3xf64>


### PR DESCRIPTION
GatherOpCanon's iota-grid rewrite has a fast path when exactly one grid dimension is mapped: slice the 1D operand, then reshape to the gather's result type. When the index grid also carries **broadcast dimensions** (the index is constant along them), the slice holds only the mapped extent and the reshape does not verify — e.g. a 3-element slice reshaped to `tensor<3x3x3>`:

```
error: number of output elements (27) doesn't match expected number of elements (3)
```

Restore the unmapped dimensions with a `broadcast_in_dim` on the mapped grid dimension, exactly as the multi-mapping path below already does. (No silent miscompile was possible: element counts can only agree when every unmapped dim is 1, in which case the reshape was correct.)

Hit by MFEM's `SmemPACurlCurlAssembleDiagonal3D` under the runtime exec pipeline (EnzymeAD/Enzyme-JAX#2968): every exec logged `exec pipeline produced invalid IR` twice and fell back to running without enzyme-hlo-opt. With the fix the optimized module (17x smaller) verifies and matches the numpy oracle bit-for-bit on CPU replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD