### PR TITLE
Raising: forward the packed capture struct; distribute geps over selects

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -4847,6 +4847,534 @@ struct AffineToStableHLORaisingPass
       cmp->moveBefore(g);
   }
 
+  // A side-selected view arrives as a select of byte offsets (or of the
+  // pointers themselves) feeding geps: distribute the gep and the memref
+  // view over the select so the buffer-branch expansion can take over.
+  static void distributeGepOverSelect(Operation *root) {
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      SmallVector<Operation *> worklist;
+      root->walk([&](Operation *op) {
+        if (isa<LLVM::GEPOp, enzymexla::Pointer2MemrefOp>(op))
+          worklist.push_back(op);
+      });
+      for (Operation *op : worklist) {
+        if (auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(op)) {
+          auto sel = p2m.getSource().getDefiningOp<arith::SelectOp>();
+          if (!sel)
+            continue;
+          auto condTy =
+              dyn_cast<RankedTensorType>(sel.getCondition().getType());
+          if (condTy)
+            continue;
+          OpBuilder b(op);
+          Value t = enzymexla::Pointer2MemrefOp::create(
+              b, op->getLoc(), p2m.getType(), sel.getTrueValue());
+          Value f = enzymexla::Pointer2MemrefOp::create(
+              b, op->getLoc(), p2m.getType(), sel.getFalseValue());
+          Value ns = arith::SelectOp::create(b, op->getLoc(),
+                                             sel.getCondition(), t, f);
+          op->getResult(0).replaceAllUsesWith(ns);
+          op->erase();
+          changed = true;
+          continue;
+        }
+        auto gep = cast<LLVM::GEPOp>(op);
+        // Base is a select of pointers.
+        if (auto sel = gep.getBase().getDefiningOp<arith::SelectOp>()) {
+          OpBuilder b(op);
+          IRMapping mt, mf;
+          mt.map(gep.getBase(), sel.getTrueValue());
+          mf.map(gep.getBase(), sel.getFalseValue());
+          Operation *gt = b.clone(*op, mt);
+          Operation *gf = b.clone(*op, mf);
+          Value ns =
+              arith::SelectOp::create(b, op->getLoc(), sel.getCondition(),
+                                      gt->getResult(0), gf->getResult(0));
+          op->getResult(0).replaceAllUsesWith(ns);
+          op->erase();
+          changed = true;
+          continue;
+        }
+        // A single dynamic index that is a select of two values.
+        if (gep.getDynamicIndices().size() == 1) {
+          auto sel =
+              gep.getDynamicIndices()[0].getDefiningOp<arith::SelectOp>();
+          if (!sel || isa<RankedTensorType>(sel.getCondition().getType()))
+            continue;
+          OpBuilder b(op);
+          IRMapping mt, mf;
+          mt.map(gep.getDynamicIndices()[0], sel.getTrueValue());
+          mf.map(gep.getDynamicIndices()[0], sel.getFalseValue());
+          Operation *gt = b.clone(*op, mt);
+          Operation *gf = b.clone(*op, mf);
+          Value ns =
+              arith::SelectOp::create(b, op->getLoc(), sel.getCondition(),
+                                      gt->getResult(0), gf->getResult(0));
+          op->getResult(0).replaceAllUsesWith(ns);
+          op->erase();
+          changed = true;
+        }
+      }
+    }
+  }
+
+  // A slot index picked by a select of constants (a side-selected member)
+  // still names constant slots, one per arm. Fold the index arithmetic
+  // through the selects into a decision tree: a leaf holds a slot, a node the
+  // select's condition. Fails on anything else.
+  struct SlotNode {
+    Value cond;
+    int64_t slot;
+    int t, f;
+  };
+  static std::optional<int> slotTree(Value v,
+                                     SmallVectorImpl<SlotNode> &nodes) {
+    llvm::APInt c;
+    if (matchPattern(v, m_ConstantInt(&c))) {
+      nodes.push_back({nullptr, c.getSExtValue(), -1, -1});
+      return nodes.size() - 1;
+    }
+    if (auto sel = v.getDefiningOp<arith::SelectOp>()) {
+      if (isa<RankedTensorType>(sel.getCondition().getType()))
+        return std::nullopt;
+      auto t = slotTree(sel.getTrueValue(), nodes);
+      if (!t)
+        return std::nullopt;
+      auto f = slotTree(sel.getFalseValue(), nodes);
+      if (!f)
+        return std::nullopt;
+      nodes.push_back({sel.getCondition(), 0, *t, *f});
+      return nodes.size() - 1;
+    }
+    Operation *def = v.getDefiningOp();
+    if (!def)
+      return std::nullopt;
+    if (isa<arith::IndexCastOp, arith::IndexCastUIOp, arith::ExtSIOp,
+            arith::ExtUIOp, arith::TruncIOp>(def))
+      return slotTree(def->getOperand(0), nodes);
+    if (def->getNumOperands() != 2)
+      return std::nullopt;
+    bool lhsConst = matchPattern(def->getOperand(0), m_ConstantInt(&c));
+    if (!lhsConst && !matchPattern(def->getOperand(1), m_ConstantInt(&c)))
+      return std::nullopt;
+    int64_t k = c.getSExtValue();
+    std::function<std::optional<int64_t>(int64_t)> fold;
+    if (isa<arith::AddIOp>(def))
+      fold = [k](int64_t x) { return x + k; };
+    else if (isa<arith::MulIOp>(def))
+      fold = [k](int64_t x) { return x * k; };
+    else if (isa<arith::SubIOp>(def))
+      fold = [k, lhsConst](int64_t x) { return lhsConst ? k - x : x - k; };
+    else if (isa<arith::DivSIOp, arith::DivUIOp>(def))
+      fold = [k, lhsConst](int64_t x) -> std::optional<int64_t> {
+        if (lhsConst || k == 0 || x < 0)
+          return std::nullopt;
+        return x / k;
+      };
+    else if (isa<arith::ShRSIOp, arith::ShRUIOp>(def))
+      fold = [k, lhsConst](int64_t x) -> std::optional<int64_t> {
+        if (lhsConst || k < 0 || k >= 64 || x < 0)
+          return std::nullopt;
+        return x >> k;
+      };
+    else
+      return std::nullopt;
+    size_t start = nodes.size();
+    auto sub = slotTree(def->getOperand(lhsConst ? 1 : 0), nodes);
+    if (!sub)
+      return std::nullopt;
+    for (size_t i = start; i < nodes.size(); ++i) {
+      if (nodes[i].cond)
+        continue;
+      auto r = fold(nodes[i].slot);
+      if (!r)
+        return std::nullopt;
+      nodes[i].slot = *r;
+    }
+    return sub;
+  }
+
+  // A not-quite-inlined device lambda packs its captures into a stack
+  // struct and reads them back through typed views at constant offsets.
+  // Forward each load to the unique dominating store of the same slot so
+  // the pointer-typed members never reach the raising as memory.
+  static void forwardPackedScratch(Operation *root) {
+    SmallVector<LLVM::AllocaOp> allocas;
+    root->walk([&](LLVM::AllocaOp a) { allocas.push_back(a); });
+    for (auto a : allocas) {
+      // Transitively collect constant-byte-offset accesses.
+      struct Access {
+        Operation *op;
+        int64_t byteOff;
+        bool isStore;
+        Type ty;
+        Value value; // stored value for stores
+      };
+      SmallVector<Access> accesses;
+      struct DynLoad {
+        Operation *op;
+        int64_t viewBase;
+        int64_t esz;
+        Type ty;
+        Value idx;
+        // Set when the index folds to a decision tree of slots.
+        SmallVector<SlotNode> tree;
+        int root = -1;
+      };
+      SmallVector<DynLoad> dynLoads;
+      SmallVector<Operation *> chain;
+      bool ok = true;
+      SmallVector<std::pair<Value, int64_t>> work{{a.getResult(), 0}};
+      DataLayout dl = DataLayout::closest(a);
+      while (ok && !work.empty()) {
+        auto [v, off] = work.pop_back_val();
+        for (Operation *u : v.getUsers()) {
+          if (auto gep = dyn_cast<LLVM::GEPOp>(u)) {
+            // A constant-valued SSA index is as good as an attribute one.
+            auto constIdx = [](llvm::PointerUnion<IntegerAttr, Value> e)
+                -> std::optional<int64_t> {
+              if (auto attr = dyn_cast<IntegerAttr>(e))
+                return attr.getInt();
+              llvm::APInt c;
+              if (!getenv("DISABLE_CONST_SSA_GEP") &&
+                  matchPattern(cast<Value>(e), m_ConstantInt(&c)))
+                return c.getSExtValue();
+              return std::nullopt;
+            };
+            if (gep.getBase() != v) {
+              ok = false;
+              break;
+            }
+            int64_t gepOff = 0;
+            Type cur = gep.getElemType();
+            auto idxs = gep.getIndices();
+            bool constGep = idxs.size() >= 1;
+            if (constGep) {
+              auto c0 = constIdx(idxs[0]);
+              constGep = c0.has_value();
+              if (constGep)
+                gepOff = *c0 * (int64_t)dl.getTypeSize(cur);
+            }
+            for (unsigned i = 1; constGep && i < idxs.size(); ++i) {
+              auto ci = constIdx(idxs[i]);
+              if (!ci) {
+                constGep = false;
+                break;
+              }
+              int64_t want = *ci;
+              if (auto AT = dyn_cast<LLVM::LLVMArrayType>(cur)) {
+                cur = AT.getElementType();
+                gepOff += want * (int64_t)dl.getTypeSize(cur);
+              } else if (auto ST = dyn_cast<LLVM::LLVMStructType>(cur)) {
+                if (ST.isOpaque() || (size_t)want >= ST.getBody().size()) {
+                  constGep = false;
+                  break;
+                }
+                for (int64_t k = 0; k < want; ++k) {
+                  int64_t sz = (int64_t)dl.getTypeSize(ST.getBody()[k]);
+                  int64_t al = (int64_t)dl.getTypeABIAlignment(ST.getBody()[k]);
+                  gepOff = (gepOff + al - 1) / al * al + sz;
+                }
+                int64_t al =
+                    (int64_t)dl.getTypeABIAlignment(ST.getBody()[want]);
+                gepOff = (gepOff + al - 1) / al * al;
+                cur = ST.getBody()[want];
+              } else {
+                constGep = false;
+              }
+            }
+            if (!constGep) {
+              ok = false;
+              break;
+            }
+            chain.push_back(gep);
+            work.push_back({gep.getResult(), off + gepOff});
+            continue;
+          }
+          if (auto p2m = dyn_cast<enzymexla::Pointer2MemrefOp>(u)) {
+            auto MT = p2m.getType();
+            if (MT.getRank() != 1) {
+              ok = false;
+              break;
+            }
+            Type ET = MT.getElementType();
+            int64_t esz =
+                isa<LLVM::LLVMPointerType>(ET)
+                    ? 8
+                    : (ET.isIntOrFloat() ? (ET.getIntOrFloatBitWidth() + 7) / 8
+                                         : 0);
+            if (esz == 0) {
+              ok = false;
+              break;
+            }
+            bool viewOk = true;
+            for (Operation *au : p2m->getUsers()) {
+              std::optional<int64_t> idx;
+              // A runtime index picked by selects of constants forwards
+              // each arm's slot; any other runtime-indexed scalar read (a
+              // shape array walked in a loop) selects among the
+              // constant-offset slots of its own element type.
+              auto dynLoad = [&](Value index) {
+                DynLoad dyn{au, off, esz, ET, index};
+                if (auto root = slotTree(index, dyn.tree))
+                  dyn.root = *root;
+                else if (isa<LLVM::LLVMPointerType>(ET))
+                  return false;
+                dynLoads.push_back(std::move(dyn));
+                return true;
+              };
+              if (auto ld = dyn_cast<affine::AffineLoadOp>(au)) {
+                if (auto c = getConstant(ld.getAffineMap()))
+                  idx = *c;
+                else if (ld.getAffineMap().getNumResults() == 1) {
+                  OpBuilder eb(au);
+                  auto expanded = affine::expandAffineMap(
+                      eb, au->getLoc(), ld.getAffineMap(), ld.getMapOperands());
+                  if (expanded && dynLoad((*expanded)[0]))
+                    continue;
+                }
+              } else if (auto st = dyn_cast<affine::AffineStoreOp>(au)) {
+                if (st.getValue() != p2m.getResult())
+                  if (auto c = getConstant(st.getAffineMap()))
+                    idx = *c;
+              } else if (auto ld = dyn_cast<memref::LoadOp>(au)) {
+                if (ld.getIndices().size() == 1 && dynLoad(ld.getIndices()[0]))
+                  continue;
+              }
+              if (!idx) {
+                if (getenv("DEBUG_FWD"))
+                  llvm::errs() << "FWD bail view user: " << *au
+                               << "\n  for alloca: " << *a << "\n";
+                viewOk = false;
+                break;
+              }
+              bool isStore = isa<affine::AffineStoreOp>(au);
+              accesses.push_back(
+                  {au, off + *idx * esz, isStore, ET,
+                   isStore ? cast<affine::AffineStoreOp>(au).getValue()
+                           : Value()});
+            }
+            if (!viewOk) {
+              ok = false;
+              break;
+            }
+            chain.push_back(p2m);
+            continue;
+          }
+          if (auto ld = dyn_cast<LLVM::LoadOp>(u)) {
+            accesses.push_back({u, off, false, ld.getType(), Value()});
+            continue;
+          }
+          if (auto st = dyn_cast<LLVM::StoreOp>(u)) {
+            if (st.getValue() == v) {
+              ok = false;
+              break;
+            }
+            accesses.push_back(
+                {u, off, true, st.getValue().getType(), st.getValue()});
+            continue;
+          }
+          if (isa<LLVM::LifetimeStartOp, LLVM::LifetimeEndOp>(u)) {
+            chain.push_back(u);
+            continue;
+          }
+          // Buffer-branch expansion strands dead pointer selects over views
+          // of the struct; they observe nothing. Only that exact shape is
+          // skipped: a general dead-user skip admits big register scratch
+          // whose forwarding corrupts downstream passes.
+          if (u->use_empty() && isa<arith::SelectOp>(u) &&
+              isa<LLVM::LLVMPointerType>(u->getResult(0).getType())) {
+            chain.push_back(u);
+            continue;
+          }
+          if (getenv("DEBUG_FWD"))
+            llvm::errs() << "FWD bail user: " << *u << "\n  for alloca: " << *a
+                         << "\n";
+          ok = false;
+          break;
+        }
+      }
+      if (!ok)
+        continue;
+      // One store per slot, dominating every load of that slot.
+      DominanceInfo dom(root);
+      llvm::DenseMap<int64_t, Access *> storeAt;
+      bool legal = true;
+      for (auto &acc : accesses)
+        if (acc.isStore) {
+          if (storeAt.count(acc.byteOff)) {
+            legal = false;
+            break;
+          }
+          storeAt[acc.byteOff] = &acc;
+        }
+      if (!legal)
+        continue;
+      for (auto &acc : accesses) {
+        if (acc.isStore)
+          continue;
+        auto it = storeAt.find(acc.byteOff);
+        if (it == storeAt.end() || it->second->ty != acc.ty ||
+            !dom.properlyDominates(it->second->op, acc.op)) {
+          legal = false;
+          break;
+        }
+      }
+      // A store contributes the slots it covers: its own slot for an exact
+      // type match, or several for a wider integer store (two i32 sizes
+      // packed into one i64 write). Little-endian extraction.
+      DataLayout dlq = dl;
+      auto coveredSlots =
+          [&](Access &acc, int64_t viewBase, int64_t esz,
+              Type ty) -> SmallVector<std::pair<int64_t, int64_t>> {
+        // pairs of (slot index, byte offset of the piece inside the store)
+        SmallVector<std::pair<int64_t, int64_t>> out;
+        if (acc.byteOff < viewBase)
+          return out;
+        if (acc.ty == ty && (acc.byteOff - viewBase) % esz == 0) {
+          out.push_back({(acc.byteOff - viewBase) / esz, 0});
+          return out;
+        }
+        auto sInt = dyn_cast<IntegerType>(acc.ty);
+        auto dInt = dyn_cast<IntegerType>(ty);
+        if (!sInt || !dInt)
+          return out;
+        int64_t ssz = (int64_t)dlq.getTypeSize(acc.ty);
+        if (ssz <= esz || (acc.byteOff - viewBase) % esz != 0)
+          return out;
+        for (int64_t b = 0; b + esz <= ssz; b += esz)
+          out.push_back({(acc.byteOff + b - viewBase) / esz, b});
+        return out;
+      };
+      // Every candidate slot of a dynamic load must be forwardable: each
+      // leaf of a slot tree, else every slot of the element type.
+      auto slotStore = [&](DynLoad &dyn, int64_t slot,
+                           int64_t &pieceOff) -> Access * {
+        for (auto &acc : accesses) {
+          if (!acc.isStore)
+            continue;
+          for (auto [s, b] : coveredSlots(acc, dyn.viewBase, dyn.esz, dyn.ty))
+            if (s == slot) {
+              pieceOff = b;
+              return &acc;
+            }
+        }
+        return nullptr;
+      };
+      for (auto &dyn : llvm::make_range(
+               dynLoads.begin(), legal ? dynLoads.end() : dynLoads.begin())) {
+        bool any = false;
+        if (dyn.root >= 0) {
+          any = true;
+          for (auto &n : dyn.tree) {
+            if (n.cond)
+              continue;
+            int64_t pieceOff;
+            Access *st = slotStore(dyn, n.slot, pieceOff);
+            if (!st || !dom.properlyDominates(st->op, dyn.op)) {
+              legal = false;
+              break;
+            }
+          }
+          if (!legal)
+            break;
+          continue;
+        }
+        for (auto &acc : accesses) {
+          if (!acc.isStore)
+            continue;
+          auto cov = coveredSlots(acc, dyn.viewBase, dyn.esz, dyn.ty);
+          if (cov.empty())
+            continue;
+          if (!dom.properlyDominates(acc.op, dyn.op)) {
+            legal = false;
+            break;
+          }
+          any = true;
+        }
+        if (!any)
+          legal = false;
+        if (!legal)
+          break;
+      }
+      if (!legal)
+        continue;
+      for (auto &acc : accesses) {
+        if (acc.isStore)
+          continue;
+        acc.op->getResult(0).replaceAllUsesWith(storeAt[acc.byteOff]->value);
+        acc.op->erase();
+      }
+      for (auto &dyn : dynLoads) {
+        OpBuilder b(dyn.op);
+        Location loc = dyn.op->getLoc();
+        Value idx = dyn.idx;
+        Value res;
+        auto pieceOf = [&](Access &acc, int64_t pieceOff) {
+          Value piece = acc.value;
+          if (piece.getType() != dyn.ty) {
+            if (pieceOff != 0) {
+              Value sh = arith::ConstantOp::create(
+                  b, loc, IntegerAttr::get(piece.getType(), pieceOff * 8));
+              piece = arith::ShRUIOp::create(b, loc, piece, sh);
+            }
+            piece = arith::TruncIOp::create(b, loc, dyn.ty, piece);
+          }
+          return piece;
+        };
+        if (dyn.root >= 0) {
+          std::function<Value(int)> build = [&](int n) -> Value {
+            SlotNode &node = dyn.tree[n];
+            if (!node.cond) {
+              int64_t pieceOff;
+              return pieceOf(*slotStore(dyn, node.slot, pieceOff), pieceOff);
+            }
+            Value t = build(node.t);
+            Value f = build(node.f);
+            return arith::SelectOp::create(b, loc, node.cond, t, f);
+          };
+          res = build(dyn.root);
+          dyn.op->getResult(0).replaceAllUsesWith(res);
+          dyn.op->erase();
+          continue;
+        }
+        for (auto &acc : accesses) {
+          if (!acc.isStore)
+            continue;
+          for (auto [slot, pieceOff] :
+               coveredSlots(acc, dyn.viewBase, dyn.esz, dyn.ty)) {
+            Value piece = pieceOf(acc, pieceOff);
+            if (!res) {
+              res = piece;
+              continue;
+            }
+            Value c = arith::ConstantIndexOp::create(b, loc, slot);
+            Value eq =
+                arith::CmpIOp::create(b, loc, arith::CmpIPredicate::eq, idx, c);
+            res = arith::SelectOp::create(b, loc, eq, piece, res);
+          }
+        }
+        dyn.op->getResult(0).replaceAllUsesWith(res);
+        dyn.op->erase();
+      }
+      for (auto &acc : accesses)
+        if (acc.isStore)
+          acc.op->erase();
+      // The walk can reach one op through several operands (a dead select
+      // over two views of this alloca): erase each op once.
+      {
+        llvm::SmallPtrSet<Operation *, 8> erased;
+        for (Operation *c : llvm::reverse(chain))
+          if (erased.insert(c).second && c->use_empty())
+            c->erase();
+      }
+      if (a->use_empty())
+        a.erase();
+    }
+  }
+
   // An access does not care about the address space of its base, but the
   // raising identifies buffers by SSA root: a memory_space_cast view would
   // split one buffer into two roots and lose store propagation. Retarget the
@@ -5154,6 +5682,8 @@ struct AffineToStableHLORaisingPass
     // Peeling rewrites loops, so it stays scoped to the regions this pass
     // actually raises.
     for (auto func : funcs) {
+      distributeGepOverSelect(func);
+      forwardPackedScratch(func);
       stripAccessMemorySpaceCasts(func);
       boundParallelAxes(func);
       peelDynamicParallelDims(func);
@@ -5177,6 +5707,8 @@ struct AffineToStableHLORaisingPass
     std::vector<enzymexla::GPUWrapperOp> gwrap;
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
+      distributeGepOverSelect(g);
+      forwardPackedScratch(g);
       stripAccessMemorySpaceCasts(g);
       hoistWrapperInvariantPointerCompares(g);
       boundParallelAxes(g);

--- a/test/lit_tests/raising/packed_capture_scratch.mlir
+++ b/test/lit_tests/raising/packed_capture_scratch.mlir
@@ -1,0 +1,74 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// A not-quite-inlined device lambda packs its captures into a stack struct
+// and reads them back through typed views: pointer slots forward to the
+// stored pointer, and a shape array read at a runtime index resolves as a
+// select over the constant-offset stores.
+
+// CHECK-LABEL: @packed_raised
+// CHECK-NOT: llvm.alloca
+
+module {
+  func.func private @packed(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>, %nbuf: memref<1xi32, 1>) {
+    %c1 = arith.constant 1 : i32
+    %n = affine.load %nbuf[0] : memref<1xi32, 1>
+    %st = llvm.alloca %c1 x !llvm.struct<packed (ptr<1>, i32, i32)> : (i32) -> !llvm.ptr
+    %pv = "enzymexla.pointer2memref"(%st) : (!llvm.ptr) -> memref<?x!llvm.ptr<1>>
+    %iv = "enzymexla.pointer2memref"(%st) : (!llvm.ptr) -> memref<?xi32>
+    %p = "enzymexla.memref2pointer"(%in) : (memref<16xf64, 1>) -> !llvm.ptr<1>
+    affine.store %p, %pv[0] : memref<?x!llvm.ptr<1>>
+    affine.store %n, %iv[2] : memref<?xi32>
+    affine.store %c1, %iv[3] : memref<?xi32>
+    affine.parallel (%t) = (0) to (16) {
+      %pl = affine.load %pv[0] : memref<?x!llvm.ptr<1>>
+      %view = "enzymexla.pointer2memref"(%pl) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+      %d = affine.load %iv[%t mod 2 + 2] : memref<?xi32>
+      %di = arith.index_cast %d : i32 to index
+      %vidx = arith.addi %t, %di : index
+      %v = memref.load %view[%vidx] : memref<?xf64, 1>
+      affine.store %v, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// -----
+
+// A member chosen by side arrives as a select of byte offsets into the
+// struct; the slot it names is constant per arm, so the read forwards to a
+// select of the two stored values rather than a scan over every slot.
+
+// CHECK-LABEL: @sided_raised
+// CHECK-NOT: llvm.alloca
+// CHECK: %[[side:.+]] = arith.cmpi ne
+// CHECK-NOT: arith.cmpi
+// CHECK: arith.select %[[side]], %{{.+}}, %{{.+}} : tensor<i1>, tensor<i32>
+// CHECK-NOT: arith.cmpi
+
+module {
+  func.func private @sided(%out: memref<16xi32, 1>, %nbuf: memref<2xi32, 1>, %fbuf: memref<1xi32, 1>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i64
+    %c8 = arith.constant 8 : i64
+    %c12 = arith.constant 12 : i64
+    %f = affine.load %fbuf[0] : memref<1xi32, 1>
+    %n0 = affine.load %nbuf[0] : memref<2xi32, 1>
+    %n1 = affine.load %nbuf[1] : memref<2xi32, 1>
+    %st = llvm.alloca %c1 x !llvm.struct<packed (i32, i32, i32, i32)> : (i32) -> !llvm.ptr
+    %iv = "enzymexla.pointer2memref"(%st) : (!llvm.ptr) -> memref<?xi32>
+    affine.store %f, %iv[0] : memref<?xi32>
+    affine.store %n0, %iv[2] : memref<?xi32>
+    affine.store %n1, %iv[3] : memref<?xi32>
+    affine.parallel (%t) = (0) to (16) {
+      %fl = affine.load %iv[0] : memref<?xi32>
+      %side = arith.cmpi ne, %fl, %c0 : i32
+      %off = arith.select %side, %c12, %c8 : i64
+      %slot = arith.divsi %off, %c4 : i64
+      %si = arith.index_cast %slot : i64 to index
+      %n = memref.load %iv[%si] : memref<?xi32>
+      affine.store %n, %out[%t] : memref<16xi32, 1>
+    }
+    return
+  }
+}


### PR DESCRIPTION
Rebased onto main (replaces #3009, whose base was locked by the PR-stack feature). Forwards constant-offset stores through the packed lambda-capture struct to their loads — including wide-store decomposition and dynamic scalar reads as selects over the constant-offset stores — and distributes geps/pointer2memrefs over pointer selects so the branch expansion can consume them.

Update after #3064: with the gep→access fold applying to views of pointers, a side-selected member no longer arrives as a gep the select distribution can split but as a load at `divsi(index_cast(select(c, 136, 104)), 8) + 1` on a pointer-typed view. The forwarding now folds such an index through its arithmetic and selects into a decision tree of constant slots and forwards the read to the same tree over the stored values (scalar reads take that route too instead of scanning every slot of their type). Without it the MFEM `dgdiffusion_pa` capture struct stays unforwarded on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
