### PR TITLE
Raising: raise alloca scopes and execute regions in the descent

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -64,6 +64,7 @@ static Block *getAllocaBlock(Operation *op) {
 namespace enzyme {
 #define GEN_PASS_DEF_AFFINETOSTABLEHLORAISING
 #include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+#include <deque>
 } // namespace enzyme
 } // namespace mlir
 
@@ -827,6 +828,43 @@ static LogicalResult tryRaisingForOpToStableHLOWhile(
     llvm::DenseMap<Value, affine::AffineValueMap> &maps, ParallelContext pc,
     stablehlo::WhileOp *createdWhileOp = nullptr,
     SmallVectorImpl<Value> *carriedBuffers = nullptr);
+
+// Blocks guaranteed to reach llvm.unreachable (abort branches), mirroring
+// Enzyme's getGuaranteedUnreachable in FunctionUtils.h.
+static DenseSet<Block *> getGuaranteedUnreachable(Region &r) {
+  DenseSet<Block *> knownUnreachable;
+  std::deque<Block *> todo;
+  for (Block &b : r)
+    todo.push_back(&b);
+
+  while (!todo.empty()) {
+    Block *next = todo.front();
+    todo.pop_front();
+
+    if (knownUnreachable.contains(next))
+      continue;
+
+    bool unreachable = isa<LLVM::UnreachableOp>(next->getTerminator());
+    if (!unreachable) {
+      auto succs = next->getSuccessors();
+      unreachable = !succs.empty();
+      for (Block *succ : succs) {
+        if (!knownUnreachable.contains(succ)) {
+          unreachable = false;
+          break;
+        }
+      }
+    }
+    if (!unreachable)
+      continue;
+
+    knownUnreachable.insert(next);
+    for (Block *pred : next->getPredecessors())
+      todo.push_back(pred);
+  }
+
+  return knownUnreachable;
+}
 
 static LogicalResult
 emitIfAsSelect(Operation *ifOp, Value cond, affine::AffineValueMap map,
@@ -3340,6 +3378,72 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     }
 
     return success();
+  }
+
+  // An alloca scope only delimits stack lifetime, meaningless under value
+  // semantics: raise its single-block body and forward the yields.
+  if (auto scope = dyn_cast<memref::AllocaScopeOp>(op)) {
+    Region &r = scope.getBodyRegion();
+    if (!r.hasOneBlock())
+      return failure();
+    Block *body = &r.front();
+    for (auto &innerOp : body->without_terminator()) {
+      if (tryRaisingOpToStableHLO(&innerOp, mapping, builder, maps, pc)
+              .failed())
+        return failure();
+    }
+    Operation *term = body->getTerminator();
+    for (auto [res, yielded] :
+         llvm::zip_equal(scope->getResults(), term->getOperands()))
+      mapping.map(res, mapping.lookup(yielded));
+    return success();
+  }
+
+  // An execute region wraps the inliner's cloned callee CFG. It raises when
+  // there is a unique live path from the entry to the yield, where a block
+  // is dead if every path out of it reaches llvm.unreachable (abort
+  // branches); a real diamond or a revisited block fails.
+  if (auto exec = dyn_cast<scf::ExecuteRegionOp>(op)) {
+    Region &r = exec.getRegion();
+    DenseSet<Block *> trapping = getGuaranteedUnreachable(r);
+    Block *cur = &r.front();
+    DenseSet<Block *> visited;
+    while (true) {
+      if (!visited.insert(cur).second)
+        return failure();
+      for (auto &innerOp : cur->without_terminator()) {
+        if (tryRaisingOpToStableHLO(&innerOp, mapping, builder, maps, pc)
+                .failed())
+          return failure();
+      }
+      Operation *term = cur->getTerminator();
+      if (isa<scf::YieldOp>(term)) {
+        for (auto [res, yielded] :
+             llvm::zip_equal(exec->getResults(), term->getOperands()))
+          mapping.map(res, mapping.lookup(yielded));
+        return success();
+      }
+      auto br = dyn_cast<BranchOpInterface>(term);
+      if (!br)
+        return failure();
+      Block *next = nullptr;
+      int64_t liveIdx = -1;
+      for (auto [i, succ] : llvm::enumerate(term->getSuccessors())) {
+        if (trapping.contains(succ))
+          continue;
+        if (next)
+          return failure();
+        next = succ;
+        liveIdx = i;
+      }
+      if (!next)
+        return failure();
+      auto sops = br.getSuccessorOperands(liveIdx);
+      for (auto [ba, v] :
+           llvm::zip(next->getArguments(), sops.getForwardedOperands()))
+        mapping.map(ba, mapping.lookup(v));
+      cur = next;
+    }
   }
 
   if (auto ifOp = dyn_cast<scf::IfOp>(op)) {

--- a/test/lit_tests/raising/inline_alloca_scope.mlir
+++ b/test/lit_tests/raising/inline_alloca_scope.mlir
@@ -1,0 +1,148 @@
+// RUN: enzymexlamlir-opt %s --split-input-file --raise-affine-to-stablehlo | FileCheck %s
+
+// An alloca scope only delimits stack lifetime, which raised value semantics
+// make meaningless: the descent recurses into its body and forwards the
+// yielded result.
+
+module {
+  func.func private @scoped(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>) {
+    affine.parallel (%t) = (0) to (16) {
+      %r = memref.alloca_scope -> f64 {
+        %v = affine.load %in[%t] : memref<16xf64, 1>
+        %two = arith.constant 2.0 : f64
+        %d = arith.mulf %v, %two : f64
+        memref.alloca_scope.return %d : f64
+      }
+      affine.store %r, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @scoped_raised(%[[v1:.+]]: tensor<16xf64>, %[[v2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:  %[[v3:.+]] = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-NEXT:  %[[v4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:  %[[v5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:  %[[v6:.+]] = stablehlo.add %[[v4]], %[[v5]] : tensor<16xi64>
+// CHECK-NEXT:  %[[v7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:  %[[v8:.+]] = stablehlo.multiply %[[v6]], %[[v7]] : tensor<16xi64>
+// CHECK-NEXT:  %[[v9:.+]] = stablehlo.reshape %[[v2]] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v10:.+]] = stablehlo.broadcast_in_dim %[[v3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v11:.+]] = arith.mulf %[[v9]], %[[v10]] : tensor<16xf64>
+// CHECK-NEXT:  %[[v12:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v13:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v14:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v15:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v17:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:  %[[v18:.+]] = stablehlo.broadcast_in_dim %[[v11]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v19:.+]] = stablehlo.dynamic_update_slice %[[v1]], %[[v18]], %[[v17]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:  return %[[v19]], %[[v2]] : tensor<16xf64>, tensor<16xf64>
+// CHECK-NEXT:  }
+
+// -----
+
+
+// Inliner wrappers leave scf.execute_region regions whose extra blocks only
+// branch to a trap: blocks guaranteed to end in llvm.unreachable do not
+// count as live, so the unique live path raises, forwarding block arguments
+// along the way.
+
+module {
+  func.func private @trapped(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>) {
+    affine.parallel (%t) = (0) to (16) {
+      %r = scf.execute_region -> f64 {
+        %v = affine.load %in[%t] : memref<16xf64, 1>
+        %c0 = arith.constant 0.0 : f64
+        %ok = arith.cmpf uge, %v, %c0 : f64
+        cf.cond_br %ok, ^live(%v : f64), ^trap
+      ^live(%lv: f64):
+        %s = arith.addf %lv, %lv : f64
+        scf.yield %s : f64
+      ^trap:
+        llvm.unreachable
+      }
+      affine.store %r, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @trapped_raised(%[[v1:.+]]: tensor<16xf64>, %[[v2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:  %[[v3:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:  %[[v4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:  %[[v5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:  %[[v6:.+]] = stablehlo.add %[[v4]], %[[v5]] : tensor<16xi64>
+// CHECK-NEXT:  %[[v7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:  %[[v8:.+]] = stablehlo.multiply %[[v6]], %[[v7]] : tensor<16xi64>
+// CHECK-NEXT:  %[[v9:.+]] = stablehlo.reshape %[[v2]] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v10:.+]] = stablehlo.broadcast_in_dim %[[v3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v11:.+]] = arith.cmpf uge, %[[v9]], %[[v10]] : tensor<16xf64>
+// CHECK-NEXT:  %[[v12:.+]] = arith.addf %[[v9]], %[[v9]] : tensor<16xf64>
+// CHECK-NEXT:  %[[v13:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v14:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v15:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v17:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v18:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:  %[[v19:.+]] = stablehlo.broadcast_in_dim %[[v12]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v20:.+]] = stablehlo.dynamic_update_slice %[[v1]], %[[v19]], %[[v18]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:  return %[[v20]], %[[v2]] : tensor<16xf64>, tensor<16xf64>
+// CHECK-NEXT:  }
+
+// -----
+
+
+// A chain of trap-guarded branches (stacked MFEM_VERIFY-style aborts, the
+// second trap reached through its own guard block) still has one live path.
+
+module {
+  func.func private @chained(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>) {
+    affine.parallel (%t) = (0) to (16) {
+      %r = scf.execute_region -> f64 {
+        %v = affine.load %in[%t] : memref<16xf64, 1>
+        %c0 = arith.constant 0.0 : f64
+        %ok = arith.cmpf uge, %v, %c0 : f64
+        cf.cond_br %ok, ^next, ^pretrap
+      ^next:
+        %c1 = arith.constant 1.0 : f64
+        %ok2 = arith.cmpf ule, %v, %c1 : f64
+        cf.cond_br %ok2, ^live, ^trap
+      ^pretrap:
+        cf.br ^trap
+      ^live:
+        %s = arith.mulf %v, %v : f64
+        scf.yield %s : f64
+      ^trap:
+        llvm.unreachable
+      }
+      affine.store %r, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @chained_raised(%[[v1:.+]]: tensor<16xf64>, %[[v2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:  %[[v3:.+]] = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:  %[[v4:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:  %[[v5:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:  %[[v6:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:  %[[v7:.+]] = stablehlo.add %[[v5]], %[[v6]] : tensor<16xi64>
+// CHECK-NEXT:  %[[v8:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:  %[[v9:.+]] = stablehlo.multiply %[[v7]], %[[v8]] : tensor<16xi64>
+// CHECK-NEXT:  %[[v10:.+]] = stablehlo.reshape %[[v2]] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v11:.+]] = stablehlo.broadcast_in_dim %[[v4]], dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v12:.+]] = arith.cmpf uge, %[[v10]], %[[v11]] : tensor<16xf64>
+// CHECK-NEXT:  %[[v13:.+]] = stablehlo.broadcast_in_dim %[[v3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v14:.+]] = arith.cmpf ule, %[[v10]], %[[v13]] : tensor<16xf64>
+// CHECK-NEXT:  %[[v15:.+]] = arith.mulf %[[v10]], %[[v10]] : tensor<16xf64>
+// CHECK-NEXT:  %[[v16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v17:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v18:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v19:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v20:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:  %[[v21:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:  %[[v22:.+]] = stablehlo.broadcast_in_dim %[[v15]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[v23:.+]] = stablehlo.dynamic_update_slice %[[v1]], %[[v22]], %[[v21]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:  return %[[v23]], %[[v2]] : tensor<16xf64>, tensor<16xf64>
+// CHECK-NEXT:  }

--- a/test/lit_tests/raising/inline_alloca_scope_reject.mlir
+++ b/test/lit_tests/raising/inline_alloca_scope_reject.mlir
@@ -1,0 +1,83 @@
+// RUN: enzymexlamlir-opt %s --split-input-file --raise-affine-to-stablehlo=err_if_not_fully_raised=false | FileCheck %s
+
+module {
+  func.func private @diamond(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>) {
+    affine.parallel (%t) = (0) to (16) {
+      %r = scf.execute_region -> f64 {
+        %v = affine.load %in[%t] : memref<16xf64, 1>
+        %c0 = arith.constant 0.0 : f64
+        %ok = arith.cmpf uge, %v, %c0 : f64
+        cf.cond_br %ok, ^a, ^b
+      ^a:
+        %s = arith.addf %v, %v : f64
+        scf.yield %s : f64
+      ^b:
+        %m = arith.mulf %v, %v : f64
+        scf.yield %m : f64
+      }
+      affine.store %r, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @diamond(%[[v1:.+]]: memref<16xf64, 1>, %[[v2:.+]]: memref<16xf64, 1>) {
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:  affine.parallel (%arg2) = (0) to (16) {
+// CHECK-NEXT:    %[[v4:.+]] = scf.execute_region -> f64 {
+// CHECK-NEXT:      %[[v5:.+]] = affine.load %[[v2]][%arg2] : memref<16xf64, 1>
+// CHECK-NEXT:      %[[v6:.+]] = arith.cmpf uge, %[[v5]], %[[v3]] : f64
+// CHECK-NEXT:      cf.cond_br %[[v6]], ^bb1, ^bb2
+// CHECK-NEXT:    ^bb1:  // pred: ^bb0
+// CHECK-NEXT:      %[[v7:.+]] = arith.addf %[[v5]], %[[v5]] : f64
+// CHECK-NEXT:      scf.yield %[[v7]] : f64
+// CHECK-NEXT:    ^bb2:  // pred: ^bb0
+// CHECK-NEXT:      %[[v8:.+]] = arith.mulf %[[v5]], %[[v5]] : f64
+// CHECK-NEXT:      scf.yield %[[v8]] : f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    affine.store %[[v4]], %[[v1]][%arg2] : memref<16xf64, 1>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// -----
+
+
+// A back edge revisits a block on the live path: the raise refuses it and
+// the kernel is left alone.
+
+module {
+  func.func private @looped(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>) {
+    affine.parallel (%t) = (0) to (16) {
+      %r = scf.execute_region -> f64 {
+        %v = affine.load %in[%t] : memref<16xf64, 1>
+        cf.br ^h(%v : f64)
+      ^h(%i: f64):
+        %c0 = arith.constant 0.0 : f64
+        %ok = arith.cmpf uge, %i, %c0 : f64
+        cf.cond_br %ok, ^h(%i : f64), ^trap
+      ^trap:
+        llvm.unreachable
+      }
+      affine.store %r, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @looped(%[[v1:.+]]: memref<16xf64, 1>, %[[v2:.+]]: memref<16xf64, 1>) {
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:  affine.parallel (%arg2) = (0) to (16) {
+// CHECK-NEXT:    %[[v4:.+]] = scf.execute_region -> f64 {
+// CHECK-NEXT:      %[[v5:.+]] = affine.load %[[v2]][%arg2] : memref<16xf64, 1>
+// CHECK-NEXT:      cf.br ^bb1(%[[v5]] : f64)
+// CHECK-NEXT:    ^bb1(%2: f64):  // 2 preds: ^bb0, ^bb1
+// CHECK-NEXT:      %[[v6:.+]] = arith.cmpf uge, %2, %[[v3]] : f64
+// CHECK-NEXT:      cf.cond_br %[[v6]], ^bb1(%2 : f64), ^bb2
+// CHECK-NEXT:    ^bb2:  // pred: ^bb1
+// CHECK-NEXT:      llvm.unreachable
+// CHECK-NEXT:    }
+// CHECK-NEXT:    affine.store %[[v4]], %[[v1]][%arg2] : memref<16xf64, 1>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }


### PR DESCRIPTION
The inliner wraps a cloned callee body in `scf.execute_region` (holding the callee's multi-block CFG) inside `memref.alloca_scope` (bounding the callee's stack). Neither carries semantics a raised value program needs — stack lifetime is meaningless once allocas become SSA tensor values.

Both ops are handled in the recursive descent, with no pre-raise IR mutation, as two separate handlers:

- `memref.alloca_scope`: must have a single-block body; raise it and forward the yields.
- `scf.execute_region`: compute the set of blocks guaranteed to terminate in `llvm.unreachable` (backward fixpoint: terminator is unreachable, or every successor traps — the MFEM_VERIFY abort branches), then walk the unique live path from the entry, raising each block and forwarding branch operands into block arguments. More than one live successor (a real diamond) or a revisited block (a loop) fails the raise cleanly — leaving room to support unstructured control flow properly later.

Split out of #3006. Lit coverage: scope-body raise with result forwarding; a trap-guarded `execute_region` with block-argument forwarding; a chain of stacked trap guards (one reached through its own guard block); and rejection tests showing a genuine diamond and a back edge leave the kernel unraised (`inline_alloca_scope_reject.mlir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
