### PR TITLE
canonicalize-parallel: sink a select over same-base geps into the index

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "src/enzyme_ad/jax/Dialect/Ops.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 
 namespace mlir {
@@ -126,6 +127,52 @@ struct SelectOfSameBaseGEPs : public OpRewritePattern<arith::SelectOp> {
   }
 };
 
+// Clang lowers every CUDA __shared__ access through one generic-izing
+// addrspacecast, and all gep arithmetic happens on the generic pointer.
+// Sink the cast toward its uses - the cast does not change the pointed-at
+// bytes, so the offsets are identical in either space - until it dies at a
+// pointer2memref, whose view type already tolerates the space mismatch.
+struct SinkAddrSpaceCastThroughGEP : public OpRewritePattern<LLVM::GEPOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::GEPOp gep,
+                                PatternRewriter &rewriter) const override {
+    auto asc = gep.getBase().getDefiningOp<LLVM::AddrSpaceCastOp>();
+    if (!asc)
+      return failure();
+    auto srcTy = cast<LLVM::LLVMPointerType>(asc.getArg().getType());
+    SmallVector<LLVM::GEPArg> args;
+    for (auto idx : gep.getIndices()) {
+      if (auto v = dyn_cast_if_present<Value>(idx))
+        args.push_back(v);
+      else
+        args.push_back(cast<IntegerAttr>(idx).getValue().getSExtValue());
+    }
+    auto newGep = LLVM::GEPOp::create(
+        rewriter, gep.getLoc(),
+        LLVM::LLVMPointerType::get(gep.getContext(), srcTy.getAddressSpace()),
+        gep.getElemType(), asc.getArg(), args, gep.getNoWrapFlags());
+    rewriter.replaceOpWithNewOp<LLVM::AddrSpaceCastOp>(gep, gep.getType(),
+                                                       newGep);
+    return success();
+  }
+};
+
+struct Pointer2MemrefOfAddrSpaceCast
+    : public OpRewritePattern<enzymexla::Pointer2MemrefOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(enzymexla::Pointer2MemrefOp p2m,
+                                PatternRewriter &rewriter) const override {
+    auto asc = p2m.getSource().getDefiningOp<LLVM::AddrSpaceCastOp>();
+    if (!asc)
+      return failure();
+    rewriter.replaceOpWithNewOp<enzymexla::Pointer2MemrefOp>(p2m, p2m.getType(),
+                                                             asc.getArg());
+    return success();
+  }
+};
+
 struct CanonicalizeParallelPass
     : public enzyme::impl::CanonicalizeParallelPassBase<
           CanonicalizeParallelPass> {
@@ -141,7 +188,9 @@ struct CanonicalizeParallelPass
       dialect->getCanonicalizationPatterns(owningPatterns);
     for (RegisteredOperationName op : ctx->getRegisteredOperations())
       op.getCanonicalizationPatterns(owningPatterns, ctx);
-    owningPatterns.add<TruncOrConst, SelectOfSameBaseGEPs>(ctx);
+    owningPatterns
+        .add<TruncOrConst, SelectOfSameBaseGEPs, SinkAddrSpaceCastThroughGEP,
+             Pointer2MemrefOfAddrSpaceCast>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/Threading.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -67,6 +68,64 @@ struct TruncOrConst : public OpRewritePattern<arith::TruncIOp> {
   }
 };
 
+// The symmetric/nonsymmetric slice picks of MFEM kernels reach MLIR as a
+// select over geps off one base: clang folds the constant slice indices
+// into the addressing, and the conditional survives as pointer control
+// flow. Sink the select back into the index so the address chain stays a
+// single gep, which the view rebasing canonicalizations can see through.
+struct SelectOfSameBaseGEPs : public OpRewritePattern<arith::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SelectOp sel,
+                                PatternRewriter &rewriter) const override {
+    if (!isa<LLVM::LLVMPointerType>(sel.getType()))
+      return failure();
+    auto gepT = sel.getTrueValue().getDefiningOp<LLVM::GEPOp>();
+    auto gepF = sel.getFalseValue().getDefiningOp<LLVM::GEPOp>();
+    if (!gepT || !gepF)
+      return failure();
+    if (gepT.getBase() != gepF.getBase() ||
+        gepT.getElemType() != gepF.getElemType())
+      return failure();
+    if (gepT.getIndices().size() != 1 || gepF.getIndices().size() != 1)
+      return failure();
+
+    auto dynT = dyn_cast_if_present<Value>(gepT.getIndices()[0]);
+    auto dynF = dyn_cast_if_present<Value>(gepF.getIndices()[0]);
+    Type idxTy;
+    if (dynT && dynF) {
+      if (dynT.getType() != dynF.getType())
+        return failure();
+      idxTy = dynT.getType();
+    } else if (dynT) {
+      idxTy = dynT.getType();
+    } else if (dynF) {
+      idxTy = dynF.getType();
+    } else {
+      idxTy = rewriter.getI64Type();
+    }
+
+    auto materialize = [&](LLVM::GEPOp gep, Value dyn) -> Value {
+      if (dyn)
+        return dyn;
+      auto attr = cast<IntegerAttr>(gep.getIndices()[0]);
+      Value c = arith::ConstantOp::create(
+          rewriter, gep.getLoc(),
+          IntegerAttr::get(idxTy, attr.getValue().getSExtValue()));
+      return c;
+    };
+    Value idxT = materialize(gepT, dynT);
+    Value idxF = materialize(gepF, dynF);
+    Value idx = arith::SelectOp::create(rewriter, sel.getLoc(),
+                                        sel.getCondition(), idxT, idxF);
+    rewriter.replaceOpWithNewOp<LLVM::GEPOp>(
+        sel, sel.getType(), gepT.getElemType(), gepT.getBase(),
+        SmallVector<LLVM::GEPArg>{idx},
+        gepT.getNoWrapFlags() & gepF.getNoWrapFlags());
+    return success();
+  }
+};
+
 struct CanonicalizeParallelPass
     : public enzyme::impl::CanonicalizeParallelPassBase<
           CanonicalizeParallelPass> {
@@ -82,7 +141,7 @@ struct CanonicalizeParallelPass
       dialect->getCanonicalizationPatterns(owningPatterns);
     for (RegisteredOperationName op : ctx->getRegisteredOperations())
       op.getCanonicalizationPatterns(owningPatterns, ctx);
-    owningPatterns.add<TruncOrConst>(ctx);
+    owningPatterns.add<TruncOrConst, SelectOfSameBaseGEPs>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_addrspacecast.mlir
+++ b/test/lit_tests/canonicalize_parallel_addrspacecast.mlir
@@ -1,0 +1,66 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel)" --split-input-file | FileCheck %s
+
+// Clang lowers every CUDA __shared__ access through one generic-izing
+// addrspacecast with all gep arithmetic on the generic pointer. The cast
+// sinks through geps and dies at the pointer2memref view, whose type
+// already tolerates the space mismatch.
+
+func.func private @sunk(%p: !llvm.ptr<3>, %d: i64) -> !llvm.ptr {
+  %g = llvm.addrspacecast %p : !llvm.ptr<3> to !llvm.ptr
+  %a = llvm.getelementptr inbounds|nuw %g[%d] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+  return %a : !llvm.ptr
+}
+
+// CHECK:  func.func private @sunk(%[[v1:.+]]: !llvm.ptr<3>, %[[v2:.+]]: i64) -> !llvm.ptr {
+// CHECK-NEXT:  %[[v3:.+]] = llvm.getelementptr inbounds|nuw %[[v1]][%[[v2]]] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f64
+// CHECK-NEXT:  %[[v4:.+]] = llvm.addrspacecast %[[v3]] : !llvm.ptr<3> to !llvm.ptr
+// CHECK-NEXT:  return %[[v4]] : !llvm.ptr
+// CHECK-NEXT:  }
+
+// -----
+
+
+func.func private @view(%p: !llvm.ptr<3>) -> memref<?xf64> {
+  %g = llvm.addrspacecast %p : !llvm.ptr<3> to !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xf64>
+  return %v : memref<?xf64>
+}
+
+// CHECK:  func.func private @view(%[[v1:.+]]: !llvm.ptr<3>) -> memref<?xf64> {
+// CHECK-NEXT:  %[[v2:.+]] = "enzymexla.pointer2memref"(%[[v1]]) : (!llvm.ptr<3>) -> memref<?xf64>
+// CHECK-NEXT:  return %[[v2]] : memref<?xf64>
+// CHECK-NEXT:  }
+
+// -----
+
+
+// End to end on the MFEM shared-slice shape: the cast sinks out of the gep
+// chain, the view rebases onto the shared block, and the constant plane
+// offset joins the index.
+
+func.func private @smem(%m: memref<9x6x6xf64>, %out: memref<16xf64, 1>, %d: i64, %i: index) {
+  affine.parallel (%t) = (0) to (16) {
+    %p3 = "enzymexla.memref2pointer"(%m) : (memref<9x6x6xf64>) -> !llvm.ptr<3>
+    %p = llvm.addrspacecast %p3 : !llvm.ptr<3> to !llvm.ptr
+    %g1 = llvm.getelementptr inbounds|nuw %p[288] : (!llvm.ptr) -> !llvm.ptr, i8
+    %g2 = llvm.getelementptr inbounds|nuw %g1[%d] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+    %v = "enzymexla.pointer2memref"(%g2) : (!llvm.ptr) -> memref<?xf64>
+    %x = memref.load %v[%i] : memref<?xf64>
+    affine.store %x, %out[%t] : memref<16xf64, 1>
+  }
+  return
+}
+
+// CHECK:  func.func private @smem(%[[v1:.+]]: memref<9x6x6xf64>, %[[v2:.+]]: memref<16xf64, 1>, %[[v3:.+]]: i64, %[[v4:.+]]: index) {
+// CHECK-NEXT:  %[[v5:.+]] = arith.constant 36 : index
+// CHECK-NEXT:  affine.parallel (%[[v6:.+]]) = (0) to (16) {
+// CHECK-NEXT:    %[[v7:.+]] = "enzymexla.memref2pointer"(%[[v1]]) : (memref<9x6x6xf64>) -> !llvm.ptr<3>
+// CHECK-NEXT:    %[[v8:.+]] = "enzymexla.pointer2memref"(%[[v7]]) : (!llvm.ptr<3>) -> memref<?xf64>
+// CHECK-NEXT:    %[[v9:.+]] = arith.index_cast %[[v3]] : i64 to index
+// CHECK-NEXT:    %[[v10:.+]] = arith.addi %[[v9]], %[[v5]] : index
+// CHECK-NEXT:    %[[v11:.+]] = arith.addi %[[v4]], %[[v10]] : index
+// CHECK-NEXT:    %[[v12:.+]] = memref.load %[[v8]][%[[v11]]] : memref<?xf64>
+// CHECK-NEXT:    affine.store %[[v12]], %[[v2]][%[[v6]]] : memref<16xf64, 1>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }

--- a/test/lit_tests/canonicalize_parallel_select_gep.mlir
+++ b/test/lit_tests/canonicalize_parallel_select_gep.mlir
@@ -1,0 +1,101 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel)" --split-input-file | FileCheck %s
+
+// A select over geps off one base (MFEM's symmetric/nonsymmetric slice
+// picks, after clang folds the slice constants into the addressing) sinks
+// back into the index, so the address chain stays a single gep.
+
+func.func private @const_arms(%p: !llvm.ptr, %c: i1) -> !llvm.ptr {
+  %a = llvm.getelementptr inbounds|nuw %p[1152] : (!llvm.ptr) -> !llvm.ptr, i8
+  %b = llvm.getelementptr inbounds|nuw %p[1440] : (!llvm.ptr) -> !llvm.ptr, i8
+  %s = arith.select %c, %a, %b : !llvm.ptr
+  return %s : !llvm.ptr
+}
+
+// CHECK:  func.func private @const_arms(%[[p:.+]]: !llvm.ptr, %[[c:.+]]: i1) -> !llvm.ptr {
+// CHECK-NEXT:  %[[cA:.+]] = arith.constant 1152 : i64
+// CHECK-NEXT:  %[[cB:.+]] = arith.constant 1440 : i64
+// CHECK-NEXT:  %[[idx:.+]] = arith.select %[[c]], %[[cA]], %[[cB]] : i64
+// CHECK-NEXT:  %[[g:.+]] = llvm.getelementptr inbounds|nuw %[[p]][%[[idx]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+// CHECK-NEXT:  return %[[g]] : !llvm.ptr
+// CHECK-NEXT:  }
+
+// -----
+
+// A dynamic arm keeps its index type; the constant arm joins it.
+
+func.func private @mixed_arms(%p: !llvm.ptr, %c: i1, %d: i64) -> !llvm.ptr {
+  %a = llvm.getelementptr %p[%d] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+  %b = llvm.getelementptr %p[36] : (!llvm.ptr) -> !llvm.ptr, f64
+  %s = arith.select %c, %a, %b : !llvm.ptr
+  return %s : !llvm.ptr
+}
+
+// CHECK:  func.func private @mixed_arms(%[[p:.+]]: !llvm.ptr, %[[c:.+]]: i1, %[[d:.+]]: i64) -> !llvm.ptr {
+// CHECK-NEXT:  %[[c36:.+]] = arith.constant 36 : i64
+// CHECK-NEXT:  %[[idx:.+]] = arith.select %[[c]], %[[d]], %[[c36]] : i64
+// CHECK-NEXT:  %[[g:.+]] = llvm.getelementptr %[[p]][%[[idx]]] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+// CHECK-NEXT:  return %[[g]] : !llvm.ptr
+// CHECK-NEXT:  }
+
+// -----
+
+// Different bases stay a pointer select.
+
+func.func private @different_bases(%p: !llvm.ptr, %q: !llvm.ptr, %c: i1) -> !llvm.ptr {
+  %a = llvm.getelementptr %p[8] : (!llvm.ptr) -> !llvm.ptr, i8
+  %b = llvm.getelementptr %q[16] : (!llvm.ptr) -> !llvm.ptr, i8
+  %s = arith.select %c, %a, %b : !llvm.ptr
+  return %s : !llvm.ptr
+}
+
+// CHECK:  func.func private @different_bases(%[[p:.+]]: !llvm.ptr, %[[q:.+]]: !llvm.ptr, %[[c:.+]]: i1) -> !llvm.ptr {
+// CHECK-NEXT:  %[[a:.+]] = llvm.getelementptr %[[p]][8] : (!llvm.ptr) -> !llvm.ptr, i8
+// CHECK-NEXT:  %[[b:.+]] = llvm.getelementptr %[[q]][16] : (!llvm.ptr) -> !llvm.ptr, i8
+// CHECK-NEXT:  %[[s:.+]] = arith.select %[[c]], %[[a]], %[[b]] : !llvm.ptr
+// CHECK-NEXT:  return %[[s]] : !llvm.ptr
+// CHECK-NEXT:  }
+
+// -----
+
+// Different element types stay a pointer select.
+
+func.func private @different_elem(%p: !llvm.ptr, %c: i1, %d: i64) -> !llvm.ptr {
+  %a = llvm.getelementptr %p[%d] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+  %b = llvm.getelementptr %p[%d] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+  %s = arith.select %c, %a, %b : !llvm.ptr
+  return %s : !llvm.ptr
+}
+
+// CHECK:  func.func private @different_elem(%[[p:.+]]: !llvm.ptr, %[[c:.+]]: i1, %[[d:.+]]: i64) -> !llvm.ptr {
+// CHECK-NEXT:  %[[a:.+]] = llvm.getelementptr %[[p]][%[[d]]] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+// CHECK-NEXT:  %[[b:.+]] = llvm.getelementptr %[[p]][%[[d]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+// CHECK-NEXT:  %[[s:.+]] = arith.select %[[c]], %[[a]], %[[b]] : !llvm.ptr
+// CHECK-NEXT:  return %[[s]] : !llvm.ptr
+// CHECK-NEXT:  }
+
+// -----
+
+// End to end: the sunk select feeds a pointer2memref view, and the load
+// rebases onto the base buffer through the existing gep-view fold.
+
+func.func private @through_view(%p: !llvm.ptr, %c: i1, %i: index) -> f64 {
+  %a = llvm.getelementptr inbounds|nuw %p[288] : (!llvm.ptr) -> !llvm.ptr, i8
+  %b = llvm.getelementptr inbounds|nuw %p[576] : (!llvm.ptr) -> !llvm.ptr, i8
+  %s = arith.select %c, %a, %b : !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%s) : (!llvm.ptr) -> memref<?xf64>
+  %x = memref.load %v[%i] : memref<?xf64>
+  return %x : f64
+}
+
+// CHECK:  func.func private @through_view(%[[p:.+]]: !llvm.ptr, %[[c:.+]]: i1, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  %[[c8:.+]] = arith.constant 8 : index
+// CHECK-NEXT:  %[[cA:.+]] = arith.constant 288 : i64
+// CHECK-NEXT:  %[[cB:.+]] = arith.constant 576 : i64
+// CHECK-NEXT:  %[[bsel:.+]] = arith.select %[[c]], %[[cA]], %[[cB]] : i64
+// CHECK-NEXT:  %[[view:.+]] = "enzymexla.pointer2memref"(%[[p]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[cast:.+]] = arith.index_cast %[[bsel]] : i64 to index
+// CHECK-NEXT:  %[[div:.+]] = arith.divsi %[[cast]], %[[c8]] : index
+// CHECK-NEXT:  %[[add:.+]] = arith.addi %[[i]], %[[div]] : index
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[view]][%[[add]]] : memref<?xf64>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }


### PR DESCRIPTION
MFEM's symmetric/nonsymmetric slice picks (`const int i22 = symmetric ? 3 : 4; ... sop[i22][qx][qy]`, bilininteg_hcurl_kernels.hpp) reach MLIR with no integer select left: clang -O3 folds the constant slice indices into the addressing, hoists a constant gep per slice, and the conditional survives as pointer control flow — `arith.select %symmetric, (gep %base[1152]), (gep %base[1440]) : !llvm.ptr` after cf-to-scf lifting and trivial-if canonicalization.

Sink the select back into the index when both arms are single-index geps off the same base with the same element type: `gep %base[select %symmetric, 1152, 1440]`. The address chain stays a single gep, which the existing `LoadStorePointer2MemrefGEP` fold sees through — the combined result turns a load through a selected view into a load of the base buffer at a selected element offset, with no pointer-typed values reaching raising for this shape.

Now also sinks clang's generic-izing `addrspacecast` (from CUDA `__shared__` lowering) through geps until it dies at a `pointer2memref` — whose view type already tolerates the space mismatch — so the MFEM shared-slice chains `p2m(gep(gep(addrspacecast(m2p(alloca)))))` collapse to loads of the shared block at combined indices.

Registered in canonicalize-parallel alongside `TruncOrConst`. Measured on the real TU (`bilininteg_curlcurl_pa.cpp` replayed through the raising pipeline): raise failures at main drop from 60 to 30; the survivors are branch-yielded views (`affine.if`/`scf.if` yielding one of several gep views, some arms with conditionally executed loads) — after these patterns the failure signatures reduce to geps rooted at branch results, which need branch expansion (#3016) rather than any address rewrite. Measured across all 127 MFEM kernel TUs with the raising-side gep normalizations disabled: the same 5 smem-carving TUs still need them, each containing at least one branch-yielded view. Lit coverage: constant arms, mixed dynamic/constant arms, the end-to-end collapse through a `pointer2memref` load, and negative cases (different bases, different element types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
