### PR TITLE
llvm-to-affine-access: split stores through selected views into the arms

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -883,6 +883,38 @@ struct LoadSelect : public OpRewritePattern<affine::AffineLoadOp> {
   }
 };
 
+// The store twin of LoadSelect: a store through a selected view executes
+// on whichever arm the condition chose, so it splits into an if with one
+// store per arm - each through a concrete view the later rewrites can see.
+template <typename T> struct StoreSelect : public OpRewritePattern<T> {
+  using OpRewritePattern<T>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(T st,
+                                PatternRewriter &rewriter) const override {
+    auto sel = st.getMemRef().template getDefiningOp<arith::SelectOp>();
+    if (!sel)
+      return failure();
+
+    auto newIfOp = scf::IfOp::create(rewriter, sel.getLoc(), TypeRange{},
+                                     sel.getCondition(),
+                                     /*hasElse=*/true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(newIfOp.thenBlock());
+      auto st2 = cast<T>(rewriter.clone(*st));
+      st2.getMemrefMutable().set(sel.getTrueValue());
+    }
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(newIfOp.elseBlock());
+      auto st2 = cast<T>(rewriter.clone(*st));
+      st2.getMemrefMutable().set(sel.getFalseValue());
+    }
+    rewriter.eraseOp(st);
+    return success();
+  }
+};
+
 } // namespace
 
 static MemRefVal convertToMemref(PtrVal addr) {
@@ -2179,6 +2211,7 @@ convertLLVMToAffineAccess(Operation *op,
         SimplifyDeadAlloc<memref::AllocaOp>, SimplifyDeadAlloc<memref::AllocOp>,
         SimplifyDeadAlloc<LLVM::AllocaOp>,
         SimplifyDeadAlloc<gpu::AllocOp, true>, Pointer2MemrefSelect, LoadSelect,
+        StoreSelect<affine::AffineStoreOp>, StoreSelect<memref::StoreOp>,
         AffineIfDeadResults, SimpleMem2Reg<memref::AllocaOp>>(context);
     GreedyRewriteConfig config;
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);

--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -915,6 +915,131 @@ template <typename T> struct StoreSelect : public OpRewritePattern<T> {
   }
 };
 
+// A view can also arrive through an if that merely multiplexes two views
+// defined above it. The access cannot move into the original arms - its
+// other operands are computed after the if - but it can re-condition at
+// the access site: a fresh if with the same guard, each arm accessing its
+// concrete view.
+static bool definedAbove(Value v, Operation *ifOp) {
+  if (Operation *def = v.getDefiningOp())
+    return !ifOp->isAncestor(def);
+  return !ifOp->isAncestor(cast<BlockArgument>(v).getOwner()->getParentOp());
+}
+
+// Returns the two views the if result multiplexes, when both dominate it.
+static std::optional<std::pair<Value, Value>> ifYieldedViews(Value memref) {
+  auto res = dyn_cast<OpResult>(memref);
+  if (!res)
+    return std::nullopt;
+  Value tv, fv;
+  if (auto ifOp = dyn_cast<scf::IfOp>(res.getOwner())) {
+    if (ifOp.getElseRegion().empty())
+      return std::nullopt;
+    tv = ifOp.thenYield().getOperand(res.getResultNumber());
+    fv = ifOp.elseYield().getOperand(res.getResultNumber());
+    if (!definedAbove(tv, ifOp) || !definedAbove(fv, ifOp))
+      return std::nullopt;
+    return std::make_pair(tv, fv);
+  }
+  if (auto ifOp = dyn_cast<affine::AffineIfOp>(res.getOwner())) {
+    if (!ifOp.hasElse())
+      return std::nullopt;
+    tv = cast<affine::AffineYieldOp>(ifOp.getThenBlock()->getTerminator())
+             .getOperand(res.getResultNumber());
+    fv = cast<affine::AffineYieldOp>(ifOp.getElseBlock()->getTerminator())
+             .getOperand(res.getResultNumber());
+    if (!definedAbove(tv, ifOp) || !definedAbove(fv, ifOp))
+      return std::nullopt;
+    return std::make_pair(tv, fv);
+  }
+  return std::nullopt;
+}
+
+// Rebuilds the guard at the access site and runs armFn in each arm.
+template <typename FnT>
+static LogicalResult recondition(Operation *acc, Value memref,
+                                 PatternRewriter &rewriter, TypeRange results,
+                                 FnT &&armFn) {
+  Operation *ifOp = cast<OpResult>(memref).getOwner();
+  if (auto sif = dyn_cast<scf::IfOp>(ifOp)) {
+    auto newIf = scf::IfOp::create(rewriter, acc->getLoc(), results,
+                                   sif.getCondition(), /*hasElse=*/true);
+    for (int arm = 0; arm < 2; ++arm) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      Block *b = arm ? newIf.elseBlock() : newIf.thenBlock();
+      // The zero-result builder already made the terminator.
+      if (b->empty())
+        rewriter.setInsertionPointToStart(b);
+      else
+        rewriter.setInsertionPoint(b->getTerminator());
+      Value v = armFn(arm, rewriter);
+      if (v)
+        scf::YieldOp::create(rewriter, acc->getLoc(), ValueRange{v});
+    }
+    if (!results.empty())
+      rewriter.replaceOp(acc, newIf);
+    else
+      rewriter.eraseOp(acc);
+    return success();
+  }
+  auto aif = cast<affine::AffineIfOp>(ifOp);
+  auto newIf = affine::AffineIfOp::create(
+      rewriter, acc->getLoc(), results, aif.getIntegerSet(), aif.getOperands(),
+      /*withElseRegion=*/true);
+  for (int arm = 0; arm < 2; ++arm) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    Block *b = arm ? newIf.getElseBlock() : newIf.getThenBlock();
+    if (b->empty())
+      rewriter.setInsertionPointToStart(b);
+    else
+      rewriter.setInsertionPoint(b->getTerminator());
+    Value v = armFn(arm, rewriter);
+    if (v)
+      affine::AffineYieldOp::create(rewriter, acc->getLoc(), ValueRange{v});
+  }
+  if (!results.empty())
+    rewriter.replaceOp(acc, newIf);
+  else
+    rewriter.eraseOp(acc);
+  return success();
+}
+
+template <typename T> struct LoadIfYield : public OpRewritePattern<T> {
+  using OpRewritePattern<T>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(T ld,
+                                PatternRewriter &rewriter) const override {
+    auto views = ifYieldedViews(ld.getMemRef());
+    if (!views)
+      return failure();
+    return recondition(ld, ld.getMemRef(), rewriter, TypeRange{ld.getType()},
+                       [&](int arm, PatternRewriter &rw) -> Value {
+                         auto ld2 = cast<T>(rw.clone(*ld));
+                         ld2.getMemrefMutable().set(arm ? views->second
+                                                        : views->first);
+                         return ld2->getResult(0);
+                       });
+  }
+};
+
+template <typename T> struct StoreIfYield : public OpRewritePattern<T> {
+  using OpRewritePattern<T>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(T st,
+                                PatternRewriter &rewriter) const override {
+    auto views = ifYieldedViews(st.getMemRef());
+    if (!views)
+      return failure();
+    return recondition(st, st.getMemRef(), rewriter, TypeRange{},
+                       [&](int arm, PatternRewriter &rw) -> Value {
+                         auto st2 = cast<T>(rw.clone(*st));
+                         st2.getMemrefMutable().set(arm ? views->second
+                                                        : views->first);
+                         return Value();
+                       });
+  }
+};
+
 } // namespace
 
 static MemRefVal convertToMemref(PtrVal addr) {
@@ -2212,6 +2337,8 @@ convertLLVMToAffineAccess(Operation *op,
         SimplifyDeadAlloc<LLVM::AllocaOp>,
         SimplifyDeadAlloc<gpu::AllocOp, true>, Pointer2MemrefSelect, LoadSelect,
         StoreSelect<affine::AffineStoreOp>, StoreSelect<memref::StoreOp>,
+        LoadIfYield<affine::AffineLoadOp>, LoadIfYield<memref::LoadOp>,
+        StoreIfYield<affine::AffineStoreOp>, StoreIfYield<memref::StoreOp>,
         AffineIfDeadResults, SimpleMem2Reg<memref::AllocaOp>>(context);
     GreedyRewriteConfig config;
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);

--- a/test/lit_tests/if_yield_access.mlir
+++ b/test/lit_tests/if_yield_access.mlir
@@ -1,0 +1,77 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access)" --split-input-file | FileCheck %s
+
+// An access through an if that merely multiplexes two views defined above
+// it re-conditions at the access site: a fresh if with the same guard,
+// each arm accessing its concrete view.
+
+#set = affine_set<()[s0] : (s0 >= 1)>
+func.func @affine_if_access(%a: memref<16xf64, 1>, %b: memref<16xf64, 1>, %s: index, %v: f64, %i: index) -> f64 {
+  %m = affine.if #set()[%s] -> memref<16xf64, 1> {
+    affine.yield %a : memref<16xf64, 1>
+  } else {
+    affine.yield %b : memref<16xf64, 1>
+  }
+  memref.store %v, %m[%i] : memref<16xf64, 1>
+  %x = memref.load %m[%i] : memref<16xf64, 1>
+  return %x : f64
+}
+
+// CHECK:  func.func @affine_if_access(%[[a:.+]]: memref<16xf64, 1>, %[[b:.+]]: memref<16xf64, 1>, %[[s:.+]]: index, %[[v:.+]]: f64, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  affine.if #set()[%[[s]]] {
+// CHECK-NEXT:    memref.store %[[v]], %[[a]][%[[i]]] : memref<16xf64, 1>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    memref.store %[[v]], %[[b]][%[[i]]] : memref<16xf64, 1>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[x:.+]] = affine.if #set()[%[[s]]] -> f64 {
+// CHECK-NEXT:    %[[l1:.+]] = memref.load %[[a]][%[[i]]] : memref<16xf64, 1>
+// CHECK-NEXT:    affine.yield %[[l1]] : f64
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    %[[l2:.+]] = memref.load %[[b]][%[[i]]] : memref<16xf64, 1>
+// CHECK-NEXT:    affine.yield %[[l2]] : f64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+func.func @scf_if_access(%a: memref<16xf64, 1>, %b: memref<16xf64, 1>, %c: i1, %v: f64, %i: index) {
+  %m = scf.if %c -> memref<16xf64, 1> {
+    scf.yield %a : memref<16xf64, 1>
+  } else {
+    scf.yield %b : memref<16xf64, 1>
+  }
+  memref.store %v, %m[%i] : memref<16xf64, 1>
+  return
+}
+
+// CHECK:  func.func @scf_if_access(%[[a:.+]]: memref<16xf64, 1>, %[[b:.+]]: memref<16xf64, 1>, %[[c:.+]]: i1, %[[v:.+]]: f64, %[[i:.+]]: index) {
+// CHECK-NEXT:  scf.if %[[c]] {
+// CHECK-NEXT:    memref.store %[[v]], %[[a]][%[[i]]] : memref<16xf64, 1>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    memref.store %[[v]], %[[b]][%[[i]]] : memref<16xf64, 1>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// -----
+
+// A view produced inside an arm does not dominate the access site: the
+// access stays where it is.
+
+func.func @arm_defined_view(%p: !llvm.ptr, %q: !llvm.ptr, %c: i1, %v: f64, %i: index) {
+  %m = scf.if %c -> memref<?xf64> {
+    %mv = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+    scf.yield %mv : memref<?xf64>
+  } else {
+    %mv = "enzymexla.pointer2memref"(%q) : (!llvm.ptr) -> memref<?xf64>
+    scf.yield %mv : memref<?xf64>
+  }
+  memref.store %v, %m[%i] : memref<?xf64>
+  return
+}
+
+// CHECK:  func.func @arm_defined_view(%[[p:.+]]: !llvm.ptr, %[[q:.+]]: !llvm.ptr, %[[c:.+]]: i1, %[[v:.+]]: f64, %[[i:.+]]: index) {
+// CHECK-NEXT:  %[[m:.+]] = scf.if %[[c]] -> (memref<?xf64>) {
+// CHECK:  memref.store %[[v]], %[[m]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }

--- a/test/lit_tests/store_select.mlir
+++ b/test/lit_tests/store_select.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(llvm-to-affine-access)" --split-input-file | FileCheck %s
+
+// The store twin of LoadSelect: a store through a selected view splits into
+// an if with one store per arm, each through a concrete view.
+
+func.func @store_select(%a: memref<16xf64, 1>, %b: memref<16xf64, 1>, %c: i1, %v: f64, %i: index) {
+  %m = arith.select %c, %a, %b : memref<16xf64, 1>
+  memref.store %v, %m[%i] : memref<16xf64, 1>
+  return
+}
+
+// CHECK:  func.func @store_select(%[[a:.+]]: memref<16xf64, 1>, %[[b:.+]]: memref<16xf64, 1>, %[[c:.+]]: i1, %[[v:.+]]: f64, %[[i:.+]]: index) {
+// CHECK-NEXT:  scf.if %[[c]] {
+// CHECK-NEXT:    memref.store %[[v]], %[[a]][%[[i]]] : memref<16xf64, 1>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    memref.store %[[v]], %[[b]][%[[i]]] : memref<16xf64, 1>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// -----
+
+func.func @affine_store_select(%a: memref<16xf64, 1>, %b: memref<16xf64, 1>, %c: i1, %v: f64) {
+  affine.parallel (%t) = (0) to (16) {
+    %m = arith.select %c, %a, %b : memref<16xf64, 1>
+    affine.store %v, %m[%t] : memref<16xf64, 1>
+  }
+  return
+}
+
+// CHECK:  func.func @affine_store_select(%[[a:.+]]: memref<16xf64, 1>, %[[b:.+]]: memref<16xf64, 1>, %[[c:.+]]: i1, %[[v:.+]]: f64) {
+// CHECK-NEXT:  affine.parallel (%[[t:.+]]) = (0) to (16) {
+// CHECK-NEXT:    scf.if %[[c]] {
+// CHECK-NEXT:      affine.store %[[v]], %[[a]][%[[t]]] : memref<16xf64, 1>
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.store %[[v]], %[[b]][%[[t]]] : memref<16xf64, 1>
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }


### PR DESCRIPTION
The store twin of `LoadSelect`: a store through a selected view executes on whichever arm the condition chose, so it splits into an `scf.if` with one store per arm — each through a concrete view the later rewrites can see.

Loads through selected views have split this way since `LoadSelect` (the pattern right above), but stores kept the select alive: MFEM's symmetric/nonsymmetric kernels (`Reshape(pa_data.Read(), ..., symmetric ? 6 : 9, NE)`-style layout selects, and `symmetric ? realbuf : nullptr` guards) reached raising as writes through branch-chosen buffers, which the raiser's whole-buffer-select path explicitly refuses ("a write would have to fan back out into both source buffers"). Splitting at the same place as the loads does that fan-out in the IR, after which each arm's store is an ordinary conditional store: null-armed ones drop (#3010) and real ones raise as masked stores.

Measured on the 7 MFEM kernel TUs that fail with the raising-side gep normalizations disabled: this pattern alone flips none of them — their store-through-branch instances go through `affine.if`/`scf.if` *results* (clang's own control flow, with per-arm loads), not `arith.select`s, so they are #3016's territory (its `expandBufferBranches` handles if-yields for loads and stores). This PR closes the select-form gap for symmetry and for the cases the early pipeline does produce.

**Second commit — the if form**: an access through an if that merely multiplexes two views *defined above it* cannot move into the original arms (its other operands are computed after the if), but it can re-condition at the access site: a fresh if with the same guard, each arm accessing its concrete view. Covers loads and stores through both `scf.if` and `affine.if` results; views produced inside an arm stay untouched (dominance guard). On the real curlcurl TU this eliminates every memref-yielding if from the pre-raise IR (89 → 0).

Updated measurement: even so, none of the 7 gated MFEM TUs flip — the remaining gates are *pointer*-typed if yields with in-arm work (`scf.if -> !llvm.ptr` with loads inside the arms, gep chains on the if result) and per-TU extras, which are #3016's region-aware expansion territory. These patterns clear the shapes the early pipeline can clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
