### PR TITLE
Pointer2MemrefOp canonicalization: hoist a conversion yielded by every arm

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -992,13 +992,118 @@ void MetaPointer2Memref<affine::AffineStoreOp>::rewriteInternal(
   rewriter.replaceOpWithNewOp<LLVM::StoreOp>(op, op.getValue(), ptr);
 }
 
+// An if whose arms all yield the same pointer/memref conversion does the
+// conversion once on the if result instead: the conversion depends only on
+// the yielded value, so hoisting it needs nothing to dominate anything new.
+// Chains of such ifs (nested ternaries picking a slice) collapse to one
+// conversion over a pointer-yielding if.
+template <typename IfT>
+struct HoistIfYieldConversion : public OpRewritePattern<IfT> {
+  using OpRewritePattern<IfT>::OpRewritePattern;
+
+  static Operation *yieldOf(Region &r) { return r.front().getTerminator(); }
+
+  LogicalResult matchAndRewrite(IfT ifOp,
+                                PatternRewriter &rewriter) const override {
+    if (ifOp->getNumResults() == 0 || ifOp.getElseRegion().empty())
+      return failure();
+    Operation *thenY = yieldOf(ifOp.getThenRegion());
+    Operation *elseY = yieldOf(ifOp.getElseRegion());
+
+    SmallVector<Type> newTypes;
+    SmallVector<Operation *> conv(ifOp->getNumResults(), nullptr);
+    bool any = false;
+    for (auto [i, res] : llvm::enumerate(ifOp->getResults())) {
+      Operation *t = thenY->getOperand(i).getDefiningOp();
+      Operation *f = elseY->getOperand(i).getDefiningOp();
+      if (t && f && t->getName() == f->getName() &&
+          isa<Pointer2MemrefOp, Memref2PointerOp>(t) &&
+          t->getOperand(0).getType() == f->getOperand(0).getType()) {
+        conv[i] = t;
+        newTypes.push_back(t->getOperand(0).getType());
+        any = true;
+        continue;
+      }
+      newTypes.push_back(res.getType());
+    }
+    if (!any)
+      return failure();
+
+    auto newIf = create(rewriter, ifOp, newTypes);
+    for (unsigned r = 0; r < 2; ++r) {
+      Region &from = r ? ifOp.getElseRegion() : ifOp.getThenRegion();
+      Region &to = r ? newIf.getElseRegion() : newIf.getThenRegion();
+      rewriter.inlineRegionBefore(from, to, to.begin());
+      rewriter.eraseBlock(&to.back());
+      Operation *y = yieldOf(to);
+      SmallVector<Value> ops(y->getOperands());
+      for (auto [i, c] : llvm::enumerate(conv))
+        if (c)
+          ops[i] = ops[i].getDefiningOp()->getOperand(0);
+      rewriter.modifyOpInPlace(y, [&] { y->setOperands(ops); });
+    }
+
+    rewriter.setInsertionPointAfter(newIf);
+    SmallVector<Value> results;
+    for (auto [i, c] : llvm::enumerate(conv)) {
+      Value v = newIf->getResult(i);
+      if (c) {
+        Operation *cloned = rewriter.clone(*c);
+        cloned->setOperand(0, v);
+        v = cloned->getResult(0);
+      }
+      results.push_back(v);
+    }
+    rewriter.replaceOp(ifOp, results);
+    return success();
+  }
+
+  static scf::IfOp create(PatternRewriter &rewriter, scf::IfOp ifOp,
+                          TypeRange types) {
+    return scf::IfOp::create(rewriter, ifOp.getLoc(), types,
+                             ifOp.getCondition(), /*withElseRegion=*/true);
+  }
+  static affine::AffineIfOp create(PatternRewriter &rewriter,
+                                   affine::AffineIfOp ifOp, TypeRange types) {
+    return affine::AffineIfOp::create(rewriter, ifOp.getLoc(), types,
+                                      ifOp.getIntegerSet(), ifOp.getOperands(),
+                                      /*withElseRegion=*/true);
+  }
+};
+
+// The select twin of the above: an if whose arms only yield existing values
+// becomes a select before this pattern can see it, so hoist there too.
+struct HoistSelectConversion : public OpRewritePattern<arith::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SelectOp sel,
+                                PatternRewriter &rewriter) const override {
+    Operation *t = sel.getTrueValue().getDefiningOp();
+    Operation *f = sel.getFalseValue().getDefiningOp();
+    if (!t || !f || t->getName() != f->getName() ||
+        !isa<Pointer2MemrefOp, Memref2PointerOp>(t) ||
+        t->getOperand(0).getType() != f->getOperand(0).getType())
+      return failure();
+    Value inner =
+        arith::SelectOp::create(rewriter, sel.getLoc(), sel.getCondition(),
+                                t->getOperand(0), f->getOperand(0));
+    Operation *conv = rewriter.clone(*t);
+    conv->setOperand(0, inner);
+    rewriter.replaceOp(sel, conv->getResult(0));
+    return success();
+  }
+};
+
 void Pointer2MemrefOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                    MLIRContext *context) {
   results.insert<Pointer2MemrefCast, Pointer2Memref2PointerCast,
                  LoadStorePointer2MemrefGEP<memref::LoadOp>,
                  LoadStorePointer2MemrefGEP<affine::AffineLoadOp>,
                  LoadStorePointer2MemrefGEP<memref::StoreOp>,
-                 LoadStorePointer2MemrefGEP<affine::AffineStoreOp>>(context);
+                 LoadStorePointer2MemrefGEP<affine::AffineStoreOp>,
+                 HoistIfYieldConversion<scf::IfOp>,
+                 HoistIfYieldConversion<affine::AffineIfOp>,
+                 HoistSelectConversion>(context);
   /*
   results.insert<Pointer2MemrefCast, Pointer2Memref2PointerCast,
                  MetaPointer2Memref<memref::LoadOp>,

--- a/test/lit_tests/pointer2memref_if_conv.mlir
+++ b/test/lit_tests/pointer2memref_if_conv.mlir
@@ -1,0 +1,162 @@
+// RUN: enzymexlamlir-opt %s --canonicalize --split-input-file | FileCheck %s
+
+// An if whose arms all yield the same pointer/memref conversion does the
+// conversion once on the if result instead. Chains of such ifs (nested
+// ternaries picking a slice) collapse to one conversion over a
+// pointer-yielding if chain.
+
+#set = affine_set<()[s0] : (s0 >= 1)>
+func.func private @nested(%p1: !llvm.ptr<3>, %p2: !llvm.ptr<3>, %p3: !llvm.ptr<3>, %s: index, %i: index) -> f64 {
+  %a = affine.if #set()[%s] -> memref<?xf64> {
+    %v = "enzymexla.pointer2memref"(%p1) : (!llvm.ptr<3>) -> memref<?xf64>
+    affine.yield %v : memref<?xf64>
+  } else {
+    %v = "enzymexla.pointer2memref"(%p2) : (!llvm.ptr<3>) -> memref<?xf64>
+    affine.yield %v : memref<?xf64>
+  }
+  %b = affine.if #set()[%s] -> memref<?xf64> {
+    %v = "enzymexla.pointer2memref"(%p3) : (!llvm.ptr<3>) -> memref<?xf64>
+    affine.yield %v : memref<?xf64>
+  } else {
+    affine.yield %a : memref<?xf64>
+  }
+  %x = memref.load %b[%i] : memref<?xf64>
+  return %x : f64
+}
+
+// CHECK:  func.func private @nested(%[[p1:.+]]: !llvm.ptr<3>, %[[p2:.+]]: !llvm.ptr<3>, %[[p3:.+]]: !llvm.ptr<3>, %[[s:.+]]: index, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  %[[a:.+]] = affine.if #set()[%[[s]]] -> !llvm.ptr<3> {
+// CHECK-NEXT:    affine.yield %[[p1]] : !llvm.ptr<3>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    affine.yield %[[p2]] : !llvm.ptr<3>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[b:.+]] = affine.if #set()[%[[s]]] -> !llvm.ptr<3> {
+// CHECK-NEXT:    affine.yield %[[p3]] : !llvm.ptr<3>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    affine.yield %[[a]] : !llvm.ptr<3>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[v:.+]] = "enzymexla.pointer2memref"(%[[b]]) : (!llvm.ptr<3>) -> memref<?xf64>
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[v]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+// The memref2pointer direction hoists the same way; the pointer-free if is
+// then a trivial select.
+
+func.func private @m2p_arms(%m1: memref<8xf64>, %m2: memref<8xf64>, %c: i1) -> !llvm.ptr {
+  %r = scf.if %c -> !llvm.ptr {
+    %v = "enzymexla.memref2pointer"(%m1) : (memref<8xf64>) -> !llvm.ptr
+    scf.yield %v : !llvm.ptr
+  } else {
+    %v = "enzymexla.memref2pointer"(%m2) : (memref<8xf64>) -> !llvm.ptr
+    scf.yield %v : !llvm.ptr
+  }
+  return %r : !llvm.ptr
+}
+
+// CHECK:  func.func private @m2p_arms(%[[m1:.+]]: memref<8xf64>, %[[m2:.+]]: memref<8xf64>, %[[c:.+]]: i1) -> !llvm.ptr {
+// CHECK-NEXT:  %[[sel:.+]] = arith.select %[[c]], %[[m1]], %[[m2]] : memref<8xf64>
+// CHECK-NEXT:  %[[p:.+]] = "enzymexla.memref2pointer"(%[[sel]]) : (memref<8xf64>) -> !llvm.ptr
+// CHECK-NEXT:  return %[[p]] : !llvm.ptr
+// CHECK-NEXT:  }
+
+// -----
+
+// Mixed arms (one conversion, one raw view) stay as they are.
+
+func.func private @mixed_arms(%p1: !llvm.ptr<3>, %m: memref<?xf64>, %c: i1) -> memref<?xf64> {
+  %r = scf.if %c -> memref<?xf64> {
+    %v = "enzymexla.pointer2memref"(%p1) : (!llvm.ptr<3>) -> memref<?xf64>
+    scf.yield %v : memref<?xf64>
+  } else {
+    scf.yield %m : memref<?xf64>
+  }
+  return %r : memref<?xf64>
+}
+
+// CHECK:  func.func private @mixed_arms(%[[p1:.+]]: !llvm.ptr<3>, %[[m:.+]]: memref<?xf64>, %[[c:.+]]: i1) -> memref<?xf64> {
+// CHECK-NEXT:  %[[r:.+]] = scf.if %[[c]] -> (memref<?xf64>) {
+// CHECK-NEXT:    %[[v:.+]] = "enzymexla.pointer2memref"(%[[p1]]) : (!llvm.ptr<3>) -> memref<?xf64>
+// CHECK-NEXT:    scf.yield %[[v]] : memref<?xf64>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    scf.yield %[[m]] : memref<?xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return %[[r]] : memref<?xf64>
+// CHECK-NEXT:  }
+
+// -----
+
+// Conversions defined outside the if hoist too. An if whose arms only yield
+// existing values becomes a select before the if pattern can see it, so the
+// select twin carries the same rewrite.
+
+func.func private @m2p_outside(%m1: memref<8xf64>, %m2: memref<8xf64>, %c: i1) -> !llvm.ptr {
+  %p1 = "enzymexla.memref2pointer"(%m1) : (memref<8xf64>) -> !llvm.ptr
+  %p2 = "enzymexla.memref2pointer"(%m2) : (memref<8xf64>) -> !llvm.ptr
+  %r = scf.if %c -> !llvm.ptr {
+    scf.yield %p1 : !llvm.ptr
+  } else {
+    scf.yield %p2 : !llvm.ptr
+  }
+  return %r : !llvm.ptr
+}
+
+// CHECK:  func.func private @m2p_outside(%[[m1:.+]]: memref<8xf64>, %[[m2:.+]]: memref<8xf64>, %[[c:.+]]: i1) -> !llvm.ptr {
+// CHECK-NEXT:  %[[sel:.+]] = arith.select %[[c]], %[[m1]], %[[m2]] : memref<8xf64>
+// CHECK-NEXT:  %[[p:.+]] = "enzymexla.memref2pointer"(%[[sel]]) : (memref<8xf64>) -> !llvm.ptr
+// CHECK-NEXT:  return %[[p]] : !llvm.ptr
+// CHECK-NEXT:  }
+
+// -----
+
+// One arm's conversion outside, the other inside: the if survives the
+// trivial-select fold and the if pattern hoists it.
+
+#set1 = affine_set<()[s0] : (s0 >= 1)>
+func.func private @mixed_inside_outside(%q1: !llvm.ptr<3>, %q2: !llvm.ptr<3>, %s: index, %i: index) -> f64 {
+  %v1 = "enzymexla.pointer2memref"(%q1) : (!llvm.ptr<3>) -> memref<?xf64>
+  %a = affine.if #set1()[%s] -> memref<?xf64> {
+    affine.yield %v1 : memref<?xf64>
+  } else {
+    %v2 = "enzymexla.pointer2memref"(%q2) : (!llvm.ptr<3>) -> memref<?xf64>
+    affine.yield %v2 : memref<?xf64>
+  }
+  %x = memref.load %a[%i] : memref<?xf64>
+  return %x : f64
+}
+
+// CHECK:  func.func private @mixed_inside_outside(%[[q1:.+]]: !llvm.ptr<3>, %[[q2:.+]]: !llvm.ptr<3>, %[[s:.+]]: index, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  %[[a:.+]] = affine.if #set()[%[[s]]] -> !llvm.ptr<3> {
+// CHECK-NEXT:    affine.yield %[[q1]] : !llvm.ptr<3>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    affine.yield %[[q2]] : !llvm.ptr<3>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[v:.+]] = "enzymexla.pointer2memref"(%[[a]]) : (!llvm.ptr<3>) -> memref<?xf64>
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[v]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+// An outside conversion kept alive by another use stays; the hoisted one is
+// materialized fresh.
+
+func.func private @outside_still_used(%m1: memref<8xf64>, %m2: memref<8xf64>, %c: i1) -> (!llvm.ptr, !llvm.ptr) {
+  %p1 = "enzymexla.memref2pointer"(%m1) : (memref<8xf64>) -> !llvm.ptr
+  %p2 = "enzymexla.memref2pointer"(%m2) : (memref<8xf64>) -> !llvm.ptr
+  %r = scf.if %c -> !llvm.ptr {
+    scf.yield %p1 : !llvm.ptr
+  } else {
+    scf.yield %p2 : !llvm.ptr
+  }
+  return %r, %p1 : !llvm.ptr, !llvm.ptr
+}
+
+// CHECK:  func.func private @outside_still_used(%[[m1:.+]]: memref<8xf64>, %[[m2:.+]]: memref<8xf64>, %[[c:.+]]: i1) -> (!llvm.ptr, !llvm.ptr) {
+// CHECK-NEXT:  %[[p1:.+]] = "enzymexla.memref2pointer"(%[[m1]]) : (memref<8xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[sel:.+]] = arith.select %[[c]], %[[m1]], %[[m2]] : memref<8xf64>
+// CHECK-NEXT:  %[[p:.+]] = "enzymexla.memref2pointer"(%[[sel]]) : (memref<8xf64>) -> !llvm.ptr
+// CHECK-NEXT:  return %[[p]], %[[p1]] : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:  }


### PR DESCRIPTION
An if whose arms all yield the same `pointer2memref`/`memref2pointer` does the conversion once on the if result instead. The hoist is unconditionally valid — the conversion depends only on the yielded value, so nothing new has to dominate anything — and it is applied per result, so an if with mixed arms (one conversion, one raw view) is left alone.

Registered on `Pointer2MemrefOp` alongside the load/store gep rebasing (which is likewise rooted on other ops), so the rewrites run wherever the canonicalizer runs rather than only inside `canonicalize-parallel`. Follow-up to #3031, same family of address-form canonicalizations. MFEM's `symmetric ? i23 : 7`-style nested ternaries pick a shared-memory slice, and after clang folds the constants into hoisted plane pointers each arm ends up building its own view:

```mlir
%a = affine.if #set()[%s] -> memref<?xf64> { yield p2m(%p1) } else { yield p2m(%p2) }
%b = affine.if #set()[%s] -> memref<?xf64> { yield p2m(%p3) } else { yield %a }
%x = memref.load %b[%i]
```

becomes a pointer-yielding if chain with a single conversion:

```mlir
%a = affine.if #set()[%s] -> !llvm.ptr<3> { yield %p1 } else { yield %p2 }
%b = affine.if #set()[%s] -> !llvm.ptr<3> { yield %p3 } else { yield %a }
%v = "enzymexla.pointer2memref"(%b) : (!llvm.ptr<3>) -> memref<?xf64>
%x = memref.load %v[%i]
```

The `memref2pointer` direction leaves a pointer-free if that the trivial select canonicalization finishes into `select` + one conversion.

A select twin carries the same rewrite for the case where the conversions are defined *above* the if: such an if yields only existing values, so MLIR turns it into a select before the if pattern can see it, and without the twin the result is a pointer-typed select instead of the canonical form. Covered by tests for both-outside, one-outside/one-inside, and an outside conversion kept alive by another use.

Measured on `SmemPACurlCurlAssembleDiagonal3D<0,0>` replayed through the raising pipeline: every memref-yielding if disappears from the pre-raise IR (4 → 0), leaving one uniform pointer-yielding form. That TU still needs the raising-side gep normalization on its own (the branch still stands between the access and its address — expansion territory, #3016), so this lands as a canonicalization, not a fix for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
