### PR TITLE
Guard the pointer round trip canonicalization; declare dependent dialects

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Dialect.cpp
+++ b/src/enzyme_ad/jax/Dialect/Dialect.cpp
@@ -11,7 +11,11 @@
 #include "Ops.h"
 #include "mlir/IR/DialectImplementation.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/InterleavedRange.h"

--- a/src/enzyme_ad/jax/Dialect/Dialect.td
+++ b/src/enzyme_ad/jax/Dialect/Dialect.td
@@ -22,7 +22,13 @@ def EnzymeXLA_Dialect : Dialect {
   let cppNamespace = "::mlir::enzymexla";
   let useDefaultAttributePrinterParser = 1;
   // let useDefaultTypePrinterParser = 1;
-  let dependentDialects = ["mlir::gpu::GPUDialect"];
+  // Canonicalization patterns on these ops build memref views, arith
+  // selects and scf/affine ifs, so those dialects must be loaded
+  // wherever enzymexla is.
+  let dependentDialects = ["mlir::gpu::GPUDialect",
+                           "mlir::memref::MemRefDialect",
+                           "mlir::arith::ArithDialect", "mlir::scf::SCFDialect",
+                           "mlir::affine::AffineDialect"];
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -246,7 +246,7 @@ void JITCallOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<ReadOnlyArg<JITCallOp>, ReadNoneArg<JITCallOp>>(context);
 }
 
-/// Simplify pointer2memref(memref2pointer(x)) to cast(x)
+/// Simplify pointer2memref(memref2pointer(x)) to a view of x
 class Memref2Pointer2MemrefCast final
     : public OpRewritePattern<Pointer2MemrefOp> {
 public:
@@ -259,19 +259,30 @@ public:
       return failure();
     auto smt = cast<MemRefType>(src.getSource().getType());
     auto omt = cast<MemRefType>(op.getType());
-    if (smt.getShape().size() != omt.getShape().size())
-      return failure();
-    for (unsigned i = 1; i < smt.getShape().size(); i++) {
-      if (smt.getShape()[i] != omt.getShape()[i])
-        return failure();
-    }
     if (smt.getElementType() != omt.getElementType())
       return failure();
-    if (smt.getMemorySpace() != omt.getMemorySpace())
+    // A strided source is not the flat view the pointer handed out, and a
+    // rank change is what delinearization rebuilds into typed accesses.
+    if (!smt.getLayout().isIdentity() || !omt.getLayout().isIdentity() ||
+        smt.getRank() != omt.getRank())
       return failure();
 
-    rewriter.replaceOpWithNewOp<memref::CastOp>(op, op.getType(),
-                                                src.getSource());
+    // The shapes adapt in the source's own space, so a memory space cast
+    // lands last, closest to the accesses, where it can sink into them.
+    auto inSrcSpace =
+        MemRefType::get(omt.getShape(), omt.getElementType(),
+                        MemRefLayoutAttrInterface{}, smt.getMemorySpace());
+    Value v = src.getSource();
+    if (inSrcSpace != smt) {
+      if (!memref::CastOp::areCastCompatible(smt, inSrcSpace))
+        return failure();
+      v = memref::CastOp::create(rewriter, op.getLoc(), inSrcSpace, v)
+              .getResult();
+    }
+    if (smt.getMemorySpace() != omt.getMemorySpace())
+      v = memref::MemorySpaceCastOp::create(rewriter, op.getLoc(), omt, v)
+              .getResult();
+    rewriter.replaceOp(op, v);
     return success();
   }
 };

--- a/test/lit_tests/memref2pointer2memref.mlir
+++ b/test/lit_tests/memref2pointer2memref.mlir
@@ -1,0 +1,93 @@
+// RUN: enzymexlamlir-opt %s --canonicalize --split-input-file | FileCheck %s
+
+// A pointer round trip is a view of the source buffer. The shapes adapt in
+// the source's own space and the memory space cast lands last, next to the
+// accesses, where the raising preprocessing strips it.
+
+func.func private @space(%m: memref<30xf64>, %i: index) -> f64 {
+  %p = "enzymexla.memref2pointer"(%m) : (memref<30xf64>) -> !llvm.ptr<3>
+  %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64, 3>
+  %x = memref.load %v[%i] : memref<?xf64, 3>
+  return %x : f64
+}
+
+// CHECK:  func.func private @space(%[[m:.+]]: memref<30xf64>, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  %[[cast:.+]] = memref.cast %[[m]] : memref<30xf64> to memref<?xf64>
+// CHECK-NEXT:  %[[sp:.+]] = memref.memory_space_cast %[[cast]] : memref<?xf64> to memref<?xf64, 3>
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[sp]][%[[i]]] : memref<?xf64, 3>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+// Same space: the view is just a cast, which folds into the access.
+
+func.func private @same_space(%m: memref<30xf64>, %i: index) -> f64 {
+  %p = "enzymexla.memref2pointer"(%m) : (memref<30xf64>) -> !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+  %x = memref.load %v[%i] : memref<?xf64>
+  return %x : f64
+}
+
+// CHECK:  func.func private @same_space(%[[m:.+]]: memref<30xf64>, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[m]][%[[i]]] : memref<30xf64>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+// Shapes that are not cast compatible would need a differently sized buffer:
+// the round trip stays. (This built an invalid memref.cast before the
+// dimension zero check.)
+
+func.func private @incompatible(%m: memref<30xf64>, %i: index) -> f64 {
+  %p = "enzymexla.memref2pointer"(%m) : (memref<30xf64>) -> !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<20xf64>
+  %x = memref.load %v[%i] : memref<20xf64>
+  return %x : f64
+}
+
+// CHECK:  func.func private @incompatible(%[[m:.+]]: memref<30xf64>, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  %[[p:.+]] = "enzymexla.memref2pointer"(%[[m]]) : (memref<30xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[v:.+]] = "enzymexla.pointer2memref"(%[[p]]) : (!llvm.ptr) -> memref<20xf64>
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[v]][%[[i]]] : memref<20xf64>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+// A strided source is not the flat view the pointer handed out: rewriting it
+// to an access of the source would apply the source's stride.
+
+func.func private @strided(%m: memref<30xf64, strided<[2]>>, %i: index) -> f64 {
+  %p = "enzymexla.memref2pointer"(%m) : (memref<30xf64, strided<[2]>>) -> !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+  %x = memref.load %v[%i] : memref<?xf64>
+  return %x : f64
+}
+
+// CHECK:  func.func private @strided(%[[m:.+]]: memref<30xf64, strided<[2]>>, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  %[[p:.+]] = "enzymexla.memref2pointer"(%[[m]]) : (memref<30xf64, strided<[2]>>) -> !llvm.ptr
+// CHECK-NEXT:  %[[v:.+]] = "enzymexla.pointer2memref"(%[[p]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[v]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+// A rank change is the flat view delinearization rebuilds into typed
+// multi-dimensional accesses: leave it alone.
+
+func.func private @rank_change(%m: memref<6x5xf64>, %i: index) -> f64 {
+  %p = "enzymexla.memref2pointer"(%m) : (memref<6x5xf64>) -> !llvm.ptr
+  %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+  %x = memref.load %v[%i] : memref<?xf64>
+  return %x : f64
+}
+
+// CHECK:  func.func private @rank_change(%[[m:.+]]: memref<6x5xf64>, %[[i:.+]]: index) -> f64 {
+// CHECK-NEXT:  %[[p:.+]] = "enzymexla.memref2pointer"(%[[m]]) : (memref<6x5xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[v:.+]] = "enzymexla.pointer2memref"(%[[p]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[v]][%[[i]]] : memref<?xf64>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }


### PR DESCRIPTION
`Memref2Pointer2MemrefCast` rewrites `pointer2memref(memref2pointer(x))` into a view of `x`, but it compared dimensions `1..n` and never dimension zero, and it never looked at the layout. Two consequences:

- `memref<30xf64> -> memref<20xf64>` built a `memref.cast` between incompatible types (invalid IR; it survived only because the cast then folded into the accesses).
- A flat pointer view of a **strided** buffer became an access of the strided source, i.e. `base + 2*i*8` where the round trip meant `base + i*8` — silently wrong addresses.

It now asks `memref::CastOp::areCastCompatible`, requires identity layouts on both sides, and additionally handles a differing memory space with a `memref.memory_space_cast` emitted **last** — closest to the accesses, which is where the raising preprocessing (`stripAccessMemorySpaceCasts`) can strip it, since that only fires when every user of the cast is a load or store.

A rank change is deliberately left alone: `llvm-to-affine-access` leaves the flat pointer view in place precisely so `delinearize-indexing` can rebuild typed multi-dimensional accesses, and flattening the memref first destroys that (an earlier draft of this PR did exactly that and turned `memref.load %arg1[%12, %11, %9] : memref<2x2x2xf64, 1>` into 1-D loads on duplicated `collapse_shape` results).

**Release-build crash, fixed at the root.** Building memref ops requires the MemRef dialect to be *loaded*, and the enzymexla dialect declared only `gpu` as dependent. `OpBuilder::create` hides its `dyn_cast<OpTy>` behind an assert, so in a release build an unloaded dialect silently yields a null op whose `getResult(0)` is a dangling Value: `enzymexlamlir-opt --canonicalize` segfaulted on any module that mentions no `memref.*` op (which is why it only showed up in isolation). The `arith`, `scf` and `affine` dialects have the same exposure through the select and if-yield canonicalizations added in #3033, so all four are declared now.

Lit coverage: differing space, same space (folds into the access), incompatible shapes, strided source, and rank change. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
