### PR TITLE
canonicalize-parallel: choose a gep's base or index, not the gep

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -16,8 +16,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/Threading.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -173,6 +175,204 @@ struct Pointer2MemrefOfAddrSpaceCast
   }
 };
 
+/// Builds an if of the same flavour and condition with new result types.
+static scf::IfOp createLikeIf(PatternRewriter &rewriter, scf::IfOp ifOp,
+                              TypeRange types) {
+  return scf::IfOp::create(rewriter, ifOp.getLoc(), types, ifOp.getCondition(),
+                           /*withElseRegion=*/true);
+}
+static affine::AffineIfOp createLikeIf(PatternRewriter &rewriter,
+                                       affine::AffineIfOp ifOp,
+                                       TypeRange types) {
+  return affine::AffineIfOp::create(rewriter, ifOp.getLoc(), types,
+                                    ifOp.getIntegerSet(), ifOp.getOperands(),
+                                    /*withElseRegion=*/true);
+}
+
+/// The if counterpart of SelectOfSameBaseGEPs: arms that index one base
+/// differently choose the index instead, with a constant index materialized
+/// where the gep kept it in an attribute.
+template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
+  using OpRewritePattern<IfT>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IfT ifOp,
+                                PatternRewriter &rewriter) const override {
+    if (ifOp->getNumResults() == 0 || ifOp.getElseRegion().empty())
+      return failure();
+    Operation *thenY = ifOp.getThenRegion().front().getTerminator();
+    Operation *elseY = ifOp.getElseRegion().front().getTerminator();
+
+    SmallVector<Type> newTypes;
+    SmallVector<LLVM::GEPOp> tmpl(ifOp->getNumResults(), nullptr);
+    bool any = false;
+    for (auto [i, res] : llvm::enumerate(ifOp->getResults())) {
+      newTypes.push_back(res.getType());
+      auto t = dyn_cast_if_present<LLVM::GEPOp>(
+          thenY->getOperand(i).getDefiningOp());
+      auto f = dyn_cast_if_present<LLVM::GEPOp>(
+          elseY->getOperand(i).getDefiningOp());
+      if (!t || !f || t.getBase() != f.getBase() ||
+          t.getElemType() != f.getElemType() || t.getType() != f.getType() ||
+          t.getIndices().size() != 1 || f.getIndices().size() != 1)
+        continue;
+      auto dynT = dyn_cast_if_present<Value>(t.getIndices()[0]);
+      auto dynF = dyn_cast_if_present<Value>(f.getIndices()[0]);
+      if (dynT && dynF && dynT.getType() != dynF.getType())
+        continue;
+      tmpl[i] = t;
+      newTypes[i] = dynT   ? dynT.getType()
+                    : dynF ? dynF.getType()
+                           : rewriter.getI64Type();
+      any = true;
+    }
+    if (!any)
+      return failure();
+
+    auto newIf = createLikeIf(rewriter, ifOp, newTypes);
+    for (unsigned r = 0; r < 2; ++r) {
+      Region &from = r ? ifOp.getElseRegion() : ifOp.getThenRegion();
+      Region &to = r ? newIf.getElseRegion() : newIf.getThenRegion();
+      rewriter.inlineRegionBefore(from, to, to.begin());
+      rewriter.eraseBlock(&to.back());
+      Operation *y = to.front().getTerminator();
+      SmallVector<Value> ops(y->getOperands());
+      for (auto [i, g] : llvm::enumerate(tmpl)) {
+        if (!g)
+          continue;
+        auto gep = cast<LLVM::GEPOp>(ops[i].getDefiningOp());
+        auto idx = gep.getIndices()[0];
+        if (auto dv = dyn_cast_if_present<Value>(idx)) {
+          ops[i] = dv;
+          continue;
+        }
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(y);
+        ops[i] = arith::ConstantOp::create(
+                     rewriter, ifOp.getLoc(), newTypes[i],
+                     rewriter.getIntegerAttr(newTypes[i],
+                                             cast<IntegerAttr>(idx).getInt()))
+                     .getResult();
+      }
+      rewriter.modifyOpInPlace(y, [&] { y->setOperands(ops); });
+    }
+
+    rewriter.setInsertionPointAfter(newIf);
+    SmallVector<Value> results;
+    for (auto [i, g] : llvm::enumerate(tmpl)) {
+      Value v = newIf->getResult(i);
+      if (g)
+        v = LLVM::GEPOp::create(
+                rewriter, g.getLoc(), g.getType(), g.getElemType(), g.getBase(),
+                SmallVector<LLVM::GEPArg>{v}, g.getNoWrapFlags())
+                .getResult();
+      results.push_back(v);
+    }
+    rewriter.replaceOp(ifOp, results);
+    return success();
+  }
+};
+
+/// The other way two geps disagree: identical indices off different bases,
+/// as MFEM's shared memory slices are indexed. The branch chooses the base.
+/// Operands the arms share are defined above the branch already, since the
+/// sibling arm could not otherwise name them.
+static bool gepsDifferOnlyInBase(LLVM::GEPOp t, LLVM::GEPOp f) {
+  if (t.getElemType() != f.getElemType() || t.getType() != f.getType() ||
+      t.getNoWrapFlags() != f.getNoWrapFlags() ||
+      t.getRawConstantIndices() != f.getRawConstantIndices() ||
+      t.getBase() == f.getBase() ||
+      t.getDynamicIndices().size() != f.getDynamicIndices().size())
+    return false;
+  for (auto [a, b] :
+       llvm::zip_equal(t.getDynamicIndices(), f.getDynamicIndices()))
+    if (a != b)
+      return false;
+  return true;
+}
+
+template <typename IfT>
+struct IfOfDifferentBaseGEPs : public OpRewritePattern<IfT> {
+  using OpRewritePattern<IfT>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IfT ifOp,
+                                PatternRewriter &rewriter) const override {
+    if (ifOp->getNumResults() == 0 || ifOp.getElseRegion().empty())
+      return failure();
+    Operation *thenY = ifOp.getThenRegion().front().getTerminator();
+    Operation *elseY = ifOp.getElseRegion().front().getTerminator();
+
+    SmallVector<Type> newTypes;
+    SmallVector<LLVM::GEPOp> tmpl(ifOp->getNumResults(), nullptr);
+    bool any = false;
+    for (auto [i, res] : llvm::enumerate(ifOp->getResults())) {
+      newTypes.push_back(res.getType());
+      auto t = dyn_cast_if_present<LLVM::GEPOp>(
+          thenY->getOperand(i).getDefiningOp());
+      auto f = dyn_cast_if_present<LLVM::GEPOp>(
+          elseY->getOperand(i).getDefiningOp());
+      if (!t || !f || !gepsDifferOnlyInBase(t, f))
+        continue;
+      tmpl[i] = t;
+      newTypes[i] = t.getBase().getType();
+      any = true;
+    }
+    if (!any)
+      return failure();
+
+    auto newIf = createLikeIf(rewriter, ifOp, newTypes);
+    for (unsigned r = 0; r < 2; ++r) {
+      Region &from = r ? ifOp.getElseRegion() : ifOp.getThenRegion();
+      Region &to = r ? newIf.getElseRegion() : newIf.getThenRegion();
+      rewriter.inlineRegionBefore(from, to, to.begin());
+      rewriter.eraseBlock(&to.back());
+      Operation *y = to.front().getTerminator();
+      SmallVector<Value> ops(y->getOperands());
+      for (auto [i, g] : llvm::enumerate(tmpl))
+        if (g)
+          ops[i] = cast<LLVM::GEPOp>(ops[i].getDefiningOp()).getBase();
+      rewriter.modifyOpInPlace(y, [&] { y->setOperands(ops); });
+    }
+
+    rewriter.setInsertionPointAfter(newIf);
+    SmallVector<Value> results;
+    for (auto [i, g] : llvm::enumerate(tmpl)) {
+      Value v = newIf->getResult(i);
+      if (g) {
+        Operation *cloned = rewriter.clone(*g.getOperation());
+        cloned->setOperand(0, v);
+        v = cloned->getResult(0);
+      }
+      results.push_back(v);
+    }
+    rewriter.replaceOp(ifOp, results);
+    return success();
+  }
+};
+
+/// The select twin. A pointer result means the condition is a scalar i1: a
+/// shaped condition selects elementwise and would need a shaped result.
+struct SelectOfDifferentBaseGEPs : public OpRewritePattern<arith::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SelectOp sel,
+                                PatternRewriter &rewriter) const override {
+    if (!isa<LLVM::LLVMPointerType>(sel.getType()))
+      return failure();
+    auto t = sel.getTrueValue().getDefiningOp<LLVM::GEPOp>();
+    auto f = sel.getFalseValue().getDefiningOp<LLVM::GEPOp>();
+    if (!t || !f || !gepsDifferOnlyInBase(t, f))
+      return failure();
+    Value base =
+        arith::SelectOp::create(rewriter, sel.getLoc(), sel.getCondition(),
+                                t.getBase(), f.getBase())
+            .getResult();
+    Operation *cloned = rewriter.clone(*t.getOperation());
+    cloned->setOperand(0, base);
+    rewriter.replaceOp(sel, cloned->getResult(0));
+    return success();
+  }
+};
+
 struct CanonicalizeParallelPass
     : public enzyme::impl::CanonicalizeParallelPassBase<
           CanonicalizeParallelPass> {
@@ -188,9 +388,12 @@ struct CanonicalizeParallelPass
       dialect->getCanonicalizationPatterns(owningPatterns);
     for (RegisteredOperationName op : ctx->getRegisteredOperations())
       op.getCanonicalizationPatterns(owningPatterns, ctx);
-    owningPatterns
-        .add<TruncOrConst, SelectOfSameBaseGEPs, SinkAddrSpaceCastThroughGEP,
-             Pointer2MemrefOfAddrSpaceCast>(ctx);
+    owningPatterns.add<
+        TruncOrConst, SelectOfSameBaseGEPs, SinkAddrSpaceCastThroughGEP,
+        Pointer2MemrefOfAddrSpaceCast, IfOfSameBaseGEPs<scf::IfOp>,
+        IfOfSameBaseGEPs<affine::AffineIfOp>, IfOfDifferentBaseGEPs<scf::IfOp>,
+        IfOfDifferentBaseGEPs<affine::AffineIfOp>, SelectOfDifferentBaseGEPs>(
+        ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_gep_branch.mlir
+++ b/test/lit_tests/canonicalize_parallel_gep_branch.mlir
@@ -1,0 +1,141 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel)" --split-input-file | FileCheck %s
+
+// A gep chosen by a branch runs once, over a branch of what the arms
+// disagree on: one operand (the base), or the leading constant index a gep
+// keeps in an attribute rather than in its operands. Chains then collapse
+// to a single branch over a scalar offset.
+
+#set = affine_set<()[s0] : (s0 >= 1)>
+module {
+  // arms yield geps that differ only in the base
+  func.func private @diff_base(%b1: !llvm.ptr<3>, %b2: !llvm.ptr<3>, %i: i64, %s: index) -> !llvm.ptr<3> {
+    %r = affine.if #set()[%s] -> !llvm.ptr<3> {
+      %g = llvm.getelementptr inbounds|nuw %b2[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+      affine.yield %g : !llvm.ptr<3>
+    } else {
+      %g = llvm.getelementptr inbounds|nuw %b1[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+      affine.yield %g : !llvm.ptr<3>
+    }
+    return %r : !llvm.ptr<3>
+  }
+  // arms yield geps off one base that differ only in a constant index
+  func.func private @diff_const(%b: !llvm.ptr<3>, %s: index) -> !llvm.ptr<3> {
+    %r = affine.if #set()[%s] -> !llvm.ptr<3> {
+      %g = llvm.getelementptr inbounds|nuw %b[576] : (!llvm.ptr<3>) -> !llvm.ptr<3>, i8
+      affine.yield %g : !llvm.ptr<3>
+    } else {
+      %g = llvm.getelementptr inbounds|nuw %b[288] : (!llvm.ptr<3>) -> !llvm.ptr<3>, i8
+      affine.yield %g : !llvm.ptr<3>
+    }
+    return %r : !llvm.ptr<3>
+  }
+  // the chained case: gep-of-gep, both levels multiplexed
+  func.func private @chained(%b: !llvm.ptr<3>, %i: i64, %s: index) -> memref<?xf64> {
+    %p1 = llvm.getelementptr inbounds|nuw %b[288] : (!llvm.ptr<3>) -> !llvm.ptr<3>, i8
+    %p2 = llvm.getelementptr inbounds|nuw %b[576] : (!llvm.ptr<3>) -> !llvm.ptr<3>, i8
+    %r = affine.if #set()[%s] -> memref<?xf64> {
+      %g = llvm.getelementptr inbounds|nuw %p2[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+      %v = "enzymexla.pointer2memref"(%g) : (!llvm.ptr<3>) -> memref<?xf64>
+      affine.yield %v : memref<?xf64>
+    } else {
+      %g = llvm.getelementptr inbounds|nuw %p1[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+      %v = "enzymexla.pointer2memref"(%g) : (!llvm.ptr<3>) -> memref<?xf64>
+      affine.yield %v : memref<?xf64>
+    }
+    return %r : memref<?xf64>
+  }
+}
+
+// CHECK: func.func private @diff_base(%arg0: !llvm.ptr<3>, %arg1: !llvm.ptr<3>, %arg2: i64, %arg3: index) -> !llvm.ptr<3> {
+// CHECK-NEXT: %0 = affine.if #set()[%arg3] -> !llvm.ptr<3> {
+// CHECK-NEXT: affine.yield %arg1 : !llvm.ptr<3>
+// CHECK-NEXT: } else {
+// CHECK-NEXT: affine.yield %arg0 : !llvm.ptr<3>
+// CHECK-NEXT: }
+// CHECK-NEXT: %1 = llvm.getelementptr inbounds|nuw %0[%arg2] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+// CHECK-NEXT: return %1 : !llvm.ptr<3>
+// CHECK-NEXT: }
+
+// CHECK: func.func private @diff_const(%arg0: !llvm.ptr<3>, %arg1: index) -> !llvm.ptr<3> {
+// CHECK-NEXT: %c288_i64 = arith.constant 288 : i64
+// CHECK-NEXT: %c576_i64 = arith.constant 576 : i64
+// CHECK-NEXT: %0 = affine.if #set()[%arg1] -> i64 {
+// CHECK-NEXT: affine.yield %c576_i64 : i64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: affine.yield %c288_i64 : i64
+// CHECK-NEXT: }
+// CHECK-NEXT: %1 = llvm.getelementptr inbounds|nuw %arg0[%0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
+// CHECK-NEXT: return %1 : !llvm.ptr<3>
+// CHECK-NEXT: }
+
+// CHECK: func.func private @chained(%arg0: !llvm.ptr<3>, %arg1: i64, %arg2: index) -> memref<?xf64> {
+// CHECK-NEXT: %c288_i64 = arith.constant 288 : i64
+// CHECK-NEXT: %c576_i64 = arith.constant 576 : i64
+// CHECK-NEXT: %0 = affine.if #set()[%arg2] -> i64 {
+// CHECK-NEXT: affine.yield %c576_i64 : i64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: affine.yield %c288_i64 : i64
+// CHECK-NEXT: }
+// CHECK-NEXT: %1 = llvm.getelementptr inbounds|nuw %arg0[%0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
+// CHECK-NEXT: %2 = llvm.getelementptr inbounds|nuw %1[%arg1] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+// CHECK-NEXT: %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr<3>) -> memref<?xf64>
+// CHECK-NEXT: return %3 : memref<?xf64>
+// CHECK-NEXT: }
+
+// -----
+
+
+
+// A select is an if whose arms only yield: the same two matches apply.
+
+module {
+  // select of geps differing only in the base
+  func.func private @sel_base(%b1: !llvm.ptr<3>, %b2: !llvm.ptr<3>, %i: i64, %c: i1) -> !llvm.ptr<3> {
+    %g1 = llvm.getelementptr inbounds|nuw %b1[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+    %g2 = llvm.getelementptr inbounds|nuw %b2[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+    %r = arith.select %c, %g1, %g2 : !llvm.ptr<3>
+    return %r : !llvm.ptr<3>
+  }
+  // select of geps off one base differing in a constant index
+  func.func private @sel_const(%b: !llvm.ptr<3>, %c: i1) -> !llvm.ptr<3> {
+    %g1 = llvm.getelementptr inbounds|nuw %b[288] : (!llvm.ptr<3>) -> !llvm.ptr<3>, i8
+    %g2 = llvm.getelementptr inbounds|nuw %b[576] : (!llvm.ptr<3>) -> !llvm.ptr<3>, i8
+    %r = arith.select %c, %g1, %g2 : !llvm.ptr<3>
+    return %r : !llvm.ptr<3>
+  }
+  // chained through a select
+  func.func private @sel_chain(%b: !llvm.ptr<3>, %i: i64, %c: i1) -> memref<?xf64> {
+    %p1 = llvm.getelementptr inbounds|nuw %b[288] : (!llvm.ptr<3>) -> !llvm.ptr<3>, i8
+    %p2 = llvm.getelementptr inbounds|nuw %b[576] : (!llvm.ptr<3>) -> !llvm.ptr<3>, i8
+    %g1 = llvm.getelementptr inbounds|nuw %p1[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+    %g2 = llvm.getelementptr inbounds|nuw %p2[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+    %v1 = "enzymexla.pointer2memref"(%g1) : (!llvm.ptr<3>) -> memref<?xf64>
+    %v2 = "enzymexla.pointer2memref"(%g2) : (!llvm.ptr<3>) -> memref<?xf64>
+    %r = arith.select %c, %v1, %v2 : memref<?xf64>
+    return %r : memref<?xf64>
+  }
+}
+
+// CHECK: func.func private @sel_base(%arg0: !llvm.ptr<3>, %arg1: !llvm.ptr<3>, %arg2: i64, %arg3: i1) -> !llvm.ptr<3> {
+// CHECK-NEXT: %0 = arith.select %arg3, %arg0, %arg1 : !llvm.ptr<3>
+// CHECK-NEXT: %1 = llvm.getelementptr inbounds|nuw %0[%arg2] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+// CHECK-NEXT: return %1 : !llvm.ptr<3>
+// CHECK-NEXT: }
+
+// CHECK: func.func private @sel_const(%arg0: !llvm.ptr<3>, %arg1: i1) -> !llvm.ptr<3> {
+// CHECK-NEXT: %c288_i64 = arith.constant 288 : i64
+// CHECK-NEXT: %c576_i64 = arith.constant 576 : i64
+// CHECK-NEXT: %0 = arith.select %arg1, %c288_i64, %c576_i64 : i64
+// CHECK-NEXT: %1 = llvm.getelementptr inbounds|nuw %arg0[%0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
+// CHECK-NEXT: return %1 : !llvm.ptr<3>
+// CHECK-NEXT: }
+
+// CHECK: func.func private @sel_chain(%arg0: !llvm.ptr<3>, %arg1: i64, %arg2: i1) -> memref<?xf64> {
+// CHECK-NEXT: %c288_i64 = arith.constant 288 : i64
+// CHECK-NEXT: %c576_i64 = arith.constant 576 : i64
+// CHECK-NEXT: %0 = arith.select %arg2, %c288_i64, %c576_i64 : i64
+// CHECK-NEXT: %1 = llvm.getelementptr inbounds|nuw %arg0[%0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
+// CHECK-NEXT: %2 = llvm.getelementptr inbounds|nuw %1[%arg1] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
+// CHECK-NEXT: %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr<3>) -> memref<?xf64>
+// CHECK-NEXT: return %3 : memref<?xf64>
+// CHECK-NEXT: }


### PR DESCRIPTION
`SelectOfSameBaseGEPs` already sinks a select between geps off one base into the index. This adds the two cases it doesn't cover, in the same file and registered in the same pass:

- **`IfOfSameBaseGEPs`** (`scf.if`, `affine.if`) — that pattern's if counterpart. Arms indexing one base differently choose the index instead, with a constant index materialized where the gep kept it in an attribute rather than in its operands.
- **`IfOfDifferentBaseGEPs`** and **`SelectOfDifferentBaseGEPs`** — the other way two geps disagree: identical indices off different bases, which is how MFEM's shared-memory slices are multiplexed:

```mlir
%342 = llvm.getelementptr inbounds|nuw %202[%335] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
%343 = llvm.getelementptr inbounds|nuw %203[%335] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
%358 = affine.if #set3(%arg14) -> !llvm.ptr<3> {
  affine.yield %343 : !llvm.ptr<3>
} else {
  affine.yield %342 : !llvm.ptr<3>
}
```

The branch chooses the base and one gep follows it.

Together they collapse chains: the plane pointers `gep %193[288]` / `gep %193[576]` become the arms of the next branch up, until the whole address chain is one branch over a scalar offset —

```mlir
%0 = affine.if #set()[%s] -> i64 { affine.yield %c576_i64 } else { affine.yield %c288_i64 }
%1 = llvm.getelementptr %arg0[%0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
%2 = llvm.getelementptr %1[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<8 x i8>
%3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr<3>) -> memref<?xf64>
```

— which the raiser handles natively, unlike a pointer-typed branch.

Two notes on the conditions:

- Operands the arms share are already defined above the branch, since the sibling arm could not otherwise name them, so nothing has to be checked for the rebuilt gep to be placed after it.
- The select twin needs no condition check: a pointer result already means the condition is a scalar `i1`, since a shaped condition selects elementwise and would need a shaped result. That is also why `SelectOfSameBaseGEPs` is safe in pipelines that canonicalize after raising, where tensor selects are live.

Measured on `SmemPACurlCurlAssembleDiagonal3D<0,0>` replayed through the raising pipeline: in that kernel's wrapper, pointer-yielding ifs drop 4 -> 1 and geps 12 -> 2. It does not on its own let the MFEM kernels raise without the buffer normalizations — the branches that remain carry per-arm loads, which is branch expansion territory — so this lands as a canonicalization.

Lit coverage: both disagreements and the chained collapse, each through an `affine.if` and through an `arith.select`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
