### PR TITLE
canonicalize-parallel: merge geps whose flags or element types differ

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -16,6 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Analysis/DataLayoutAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -204,6 +205,8 @@ template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
 
     SmallVector<Type> newTypes;
     SmallVector<LLVM::GEPOp> tmpl(ifOp->getNumResults(), nullptr);
+    SmallVector<LLVM::GEPOp> other(ifOp->getNumResults(), nullptr);
+    SmallVector<char> inBytes(ifOp->getNumResults(), 0);
     bool any = false;
     for (auto [i, res] : llvm::enumerate(ifOp->getResults())) {
       newTypes.push_back(res.getType());
@@ -212,17 +215,28 @@ template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
       auto f = dyn_cast_if_present<LLVM::GEPOp>(
           elseY->getOperand(i).getDefiningOp());
       if (!t || !f || t.getBase() != f.getBase() ||
-          t.getElemType() != f.getElemType() || t.getType() != f.getType() ||
-          t.getIndices().size() != 1 || f.getIndices().size() != 1)
+          t.getType() != f.getType() || t.getIndices().size() != 1 ||
+          f.getIndices().size() != 1)
         continue;
       auto dynT = dyn_cast_if_present<Value>(t.getIndices()[0]);
       auto dynF = dyn_cast_if_present<Value>(f.getIndices()[0]);
-      if (dynT && dynF && dynT.getType() != dynF.getType())
+      // Element types that disagree share no index scale, so the arms choose
+      // a byte offset and the rebuilt gep walks bytes.
+      bool bytes = t.getElemType() != f.getElemType();
+      Type i64 = rewriter.getI64Type();
+      if (bytes) {
+        if ((dynT && dynT.getType() != i64) || (dynF && dynF.getType() != i64))
+          continue;
+      } else if (dynT && dynF && dynT.getType() != dynF.getType()) {
         continue;
+      }
       tmpl[i] = t;
-      newTypes[i] = dynT   ? dynT.getType()
+      other[i] = f;
+      inBytes[i] = bytes;
+      newTypes[i] = bytes  ? i64
+                    : dynT ? dynT.getType()
                     : dynF ? dynF.getType()
-                           : rewriter.getI64Type();
+                           : i64;
       any = true;
     }
     if (!any)
@@ -241,16 +255,28 @@ template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
           continue;
         auto gep = cast<LLVM::GEPOp>(ops[i].getDefiningOp());
         auto idx = gep.getIndices()[0];
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(y);
+        int64_t scale = inBytes[i]
+                            ? (int64_t)DataLayout::closest(gep).getTypeSize(
+                                  gep.getElemType())
+                            : 1;
         if (auto dv = dyn_cast_if_present<Value>(idx)) {
+          if (scale != 1) {
+            Value k = arith::ConstantOp::create(
+                          rewriter, ifOp.getLoc(), newTypes[i],
+                          rewriter.getIntegerAttr(newTypes[i], scale))
+                          .getResult();
+            dv = arith::MulIOp::create(rewriter, ifOp.getLoc(), dv, k)
+                     .getResult();
+          }
           ops[i] = dv;
           continue;
         }
-        OpBuilder::InsertionGuard guard(rewriter);
-        rewriter.setInsertionPoint(y);
         ops[i] = arith::ConstantOp::create(
                      rewriter, ifOp.getLoc(), newTypes[i],
-                     rewriter.getIntegerAttr(newTypes[i],
-                                             cast<IntegerAttr>(idx).getInt()))
+                     rewriter.getIntegerAttr(
+                         newTypes[i], cast<IntegerAttr>(idx).getInt() * scale))
                      .getResult();
       }
       rewriter.modifyOpInPlace(y, [&] { y->setOperands(ops); });
@@ -260,11 +286,14 @@ template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
     SmallVector<Value> results;
     for (auto [i, g] : llvm::enumerate(tmpl)) {
       Value v = newIf->getResult(i);
-      if (g)
-        v = LLVM::GEPOp::create(
-                rewriter, g.getLoc(), g.getType(), g.getElemType(), g.getBase(),
-                SmallVector<LLVM::GEPArg>{v}, g.getNoWrapFlags())
+      if (g) {
+        Type elem = inBytes[i] ? rewriter.getI8Type() : g.getElemType();
+        // Neither arm's guarantees hold on the other's path.
+        v = LLVM::GEPOp::create(rewriter, g.getLoc(), g.getType(), elem,
+                                g.getBase(), SmallVector<LLVM::GEPArg>{v},
+                                g.getNoWrapFlags() & other[i].getNoWrapFlags())
                 .getResult();
+      }
       results.push_back(v);
     }
     rewriter.replaceOp(ifOp, results);
@@ -278,7 +307,6 @@ template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
 /// sibling arm could not otherwise name them.
 static bool gepsDifferOnlyInBase(LLVM::GEPOp t, LLVM::GEPOp f) {
   if (t.getElemType() != f.getElemType() || t.getType() != f.getType() ||
-      t.getNoWrapFlags() != f.getNoWrapFlags() ||
       t.getRawConstantIndices() != f.getRawConstantIndices() ||
       t.getBase() == f.getBase() ||
       t.getDynamicIndices().size() != f.getDynamicIndices().size())
@@ -303,6 +331,7 @@ struct IfOfDifferentBaseGEPs : public OpRewritePattern<IfT> {
 
     SmallVector<Type> newTypes;
     SmallVector<LLVM::GEPOp> tmpl(ifOp->getNumResults(), nullptr);
+    SmallVector<LLVM::GEPOp> other(ifOp->getNumResults(), nullptr);
     bool any = false;
     for (auto [i, res] : llvm::enumerate(ifOp->getResults())) {
       newTypes.push_back(res.getType());
@@ -313,6 +342,7 @@ struct IfOfDifferentBaseGEPs : public OpRewritePattern<IfT> {
       if (!t || !f || !gepsDifferOnlyInBase(t, f))
         continue;
       tmpl[i] = t;
+      other[i] = f;
       newTypes[i] = t.getBase().getType();
       any = true;
     }
@@ -338,9 +368,11 @@ struct IfOfDifferentBaseGEPs : public OpRewritePattern<IfT> {
     for (auto [i, g] : llvm::enumerate(tmpl)) {
       Value v = newIf->getResult(i);
       if (g) {
-        Operation *cloned = rewriter.clone(*g.getOperation());
-        cloned->setOperand(0, v);
-        v = cloned->getResult(0);
+        auto cloned = cast<LLVM::GEPOp>(rewriter.clone(*g.getOperation()));
+        cloned.setOperand(0, v);
+        // Neither arm's guarantees hold on the other's path.
+        cloned.setNoWrapFlags(g.getNoWrapFlags() & other[i].getNoWrapFlags());
+        v = cloned.getResult();
       }
       results.push_back(v);
     }
@@ -366,9 +398,10 @@ struct SelectOfDifferentBaseGEPs : public OpRewritePattern<arith::SelectOp> {
         arith::SelectOp::create(rewriter, sel.getLoc(), sel.getCondition(),
                                 t.getBase(), f.getBase())
             .getResult();
-    Operation *cloned = rewriter.clone(*t.getOperation());
-    cloned->setOperand(0, base);
-    rewriter.replaceOp(sel, cloned->getResult(0));
+    auto cloned = cast<LLVM::GEPOp>(rewriter.clone(*t.getOperation()));
+    cloned.setOperand(0, base);
+    cloned.setNoWrapFlags(t.getNoWrapFlags() & f.getNoWrapFlags());
+    rewriter.replaceOp(sel, cloned.getResult());
     return success();
   }
 };

--- a/test/lit_tests/canonicalize_parallel_gep_branch.mlir
+++ b/test/lit_tests/canonicalize_parallel_gep_branch.mlir
@@ -139,3 +139,57 @@ module {
 // CHECK-NEXT: %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr<3>) -> memref<?xf64>
 // CHECK-NEXT: return %3 : memref<?xf64>
 // CHECK-NEXT: }
+
+// -----
+
+// The arms need not agree on the no-wrap flags or on the element type: the
+// rebuilt gep keeps only the guarantees both made, and element types that
+// disagree share no index scale, so the choice becomes a byte offset.
+
+#set = affine_set<()[s0] : (s0 >= 1)>
+module {
+  // the real shape: same base, different element types AND different nowrap flags
+  func.func private @mixed_elem_and_flags(%b: !llvm.ptr<3>, %i: i64, %j: i64, %s: index) -> !llvm.ptr<3> {
+    %g1 = llvm.getelementptr inbounds %b[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<288 x i8>
+    %g2 = llvm.getelementptr inbounds|nuw %b[%j] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
+    %r = affine.if #set()[%s] -> !llvm.ptr<3> {
+      affine.yield %g1 : !llvm.ptr<3>
+    } else {
+      affine.yield %g2 : !llvm.ptr<3>
+    }
+    return %r : !llvm.ptr<3>
+  }
+  // same element type, differing flags only
+  func.func private @flags_only(%b: !llvm.ptr<3>, %i: i64, %j: i64, %s: index) -> !llvm.ptr<3> {
+    %g1 = llvm.getelementptr inbounds %b[%i] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f64
+    %g2 = llvm.getelementptr inbounds|nuw %b[%j] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f64
+    %r = affine.if #set()[%s] -> !llvm.ptr<3> {
+      affine.yield %g1 : !llvm.ptr<3>
+    } else {
+      affine.yield %g2 : !llvm.ptr<3>
+    }
+    return %r : !llvm.ptr<3>
+  }
+}
+
+// CHECK:  func.func private @mixed_elem_and_flags(%[[f1:.+]]: !llvm.ptr<3>, %[[f2:.+]]: i64, %[[f3:.+]]: i64, %[[f4:.+]]: index) -> !llvm.ptr<3> {
+// CHECK-NEXT:  %[[f5:.+]] = arith.constant 288 : i64
+// CHECK-NEXT:  %[[f6:.+]] = affine.if #set()[%[[f4]]] -> i64 {
+// CHECK-NEXT:  %[[f7:.+]] = arith.muli %[[f2]], %[[f5]] : i64
+// CHECK-NEXT:  affine.yield %[[f7]] : i64
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  affine.yield %[[f3]] : i64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[f8:.+]] = llvm.getelementptr inbounds %[[f1]][%[[f6]]] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
+// CHECK-NEXT:  return %[[f8]] : !llvm.ptr<3>
+// CHECK-NEXT:  }
+
+// CHECK:  func.func private @flags_only(%[[f1:.+]]: !llvm.ptr<3>, %[[f2:.+]]: i64, %[[f3:.+]]: i64, %[[f4:.+]]: index) -> !llvm.ptr<3> {
+// CHECK-NEXT:  %[[f5:.+]] = affine.if #set()[%[[f4]]] -> i64 {
+// CHECK-NEXT:  affine.yield %[[f2]] : i64
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  affine.yield %[[f3]] : i64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[f6:.+]] = llvm.getelementptr inbounds %[[f1]][%[[f5]]] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, f64
+// CHECK-NEXT:  return %[[f6]] : !llvm.ptr<3>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Follow-up to #3035. Arms that index one base need not agree on everything for the branch to choose the index rather than the gep.

**No-wrap flags.** `IfOfSameBaseGEPs` took the then arm's flags outright, which could claim `nuw` on a path that never promised it; differing flags also blocked the different-base match entirely. All three patterns now keep the intersection — what both arms guaranteed — which is what `SelectOfSameBaseGEPs` already did.

**Element types.** Two geps with different element types share no index scale, so the choice becomes a byte offset: each arm's index is scaled by its own element size and the rebuilt gep walks `i8`.

MFEM's diagonal assembly multiplexes exactly such a pair — an `array<288 x i8>` walk against a byte walk off one shared block, with `inbounds` on one side and `inbounds|nuw` on the other:

```mlir
%246 = llvm.getelementptr inbounds     %193[%245] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<288 x i8>
%348 = llvm.getelementptr inbounds|nuw %193[%347] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
%349 = affine.if #set4(%arg14) -> !llvm.ptr<3> {
  affine.yield %246 : !llvm.ptr<3>
} else {
  affine.yield %348 : !llvm.ptr<3>
}
```

which now becomes

```mlir
%0 = affine.if #set()[%s] -> i64 {
  %2 = arith.muli %arg1, %c288_i64 : i64
  affine.yield %2 : i64
} else {
  affine.yield %arg2 : i64
}
%1 = llvm.getelementptr inbounds %arg0[%0] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
```

— one gep, `nuw` correctly dropped, and the branch reduced to a scalar offset.

Lit coverage: differing flags alone, and differing flags together with differing element types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
