### PR TITLE
PolygeistMem2Reg: relate accesses by the bytes they touch

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -794,6 +794,28 @@ public:
     if (!sameExtent && (!size || !osize))
       return Match::Maybe;
 
+    // Two accesses that each land at a known byte and reach a known distance
+    // either share bytes or they do not, whatever units either counted its way
+    // there in: a byte written through one spelling of the allocation says
+    // nothing about a field that lies elsewhere, however differently that
+    // field is read. The stride comparison below cannot relate two paths
+    // counted in different sizes, so it would call such a pair Maybe.
+    if (size && osize) {
+      auto mine = constantOffset(dl), theirs = o.constantOffset(dl);
+      if (mine && theirs) {
+        uint64_t myEnd = *mine + *size, oEnd = *theirs + *osize;
+        if (*theirs >= myEnd || *mine >= oEnd)
+          return Match::None;
+        if (*mine == *theirs && *size == *osize)
+          return Match::Exact;
+        if (*theirs >= *mine && oEnd <= myEnd && containedAt) {
+          *containedAt = *theirs - *mine;
+          return Match::Contains;
+        }
+        return Match::Maybe;
+      }
+    }
+
     // Lying wholly within is a question of where each lands and how far it
     // reaches, which needs nothing of how either counts its way there. It is
     // a real relationship whether or not the caller wants the offset: hand

--- a/test/lit_tests/mem2reg_disjoint_views.mlir
+++ b/test/lit_tests/mem2reg_disjoint_views.mlir
@@ -1,0 +1,84 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg -split-input-file | FileCheck %s
+
+// A store through a view that counts in other units than the load says
+// nothing about a field it does not reach: the two are related by where they
+// land and how far they reach, not by the units either counted its way in.
+
+func.func @disjoint_byte_store(%b: i8) -> i32 {
+  %c1 = arith.constant 1 : i32
+  %v = arith.constant 42 : i32
+  %a = llvm.alloca %c1 x !llvm.struct<"S", (i32, i32, i32, i32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %mi = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi32>
+  %mb = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi8>
+  affine.store %v, %mi[1] : memref<?xi32>
+  affine.store %b, %mb[12] : memref<?xi8>
+  %r = affine.load %mi[1] : memref<?xi32>
+  return %r : i32
+}
+
+// CHECK-LABEL: func.func @disjoint_byte_store(
+// CHECK-NOT: affine.load
+// CHECK: return %c42_i32 : i32
+
+// -----
+
+// A byte written inside the field the load reads is a different matter: the
+// load cannot be answered from the store before it.
+
+func.func @overlapping_byte_store(%b: i8) -> i32 {
+  %c1 = arith.constant 1 : i32
+  %v = arith.constant 42 : i32
+  %a = llvm.alloca %c1 x !llvm.struct<"S", (i32, i32, i32, i32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %mi = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi32>
+  %mb = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi8>
+  affine.store %v, %mi[1] : memref<?xi32>
+  affine.store %b, %mb[5] : memref<?xi8>
+  %r = affine.load %mi[1] : memref<?xi32>
+  return %r : i32
+}
+
+// CHECK-LABEL: func.func @overlapping_byte_store(
+// CHECK: affine.load
+
+// -----
+
+// A load through another view reads and so clobbers nothing, wherever it
+// lands.
+
+func.func @disjoint_byte_load() -> (i32, i8) {
+  %c1 = arith.constant 1 : i32
+  %v = arith.constant 42 : i32
+  %a = llvm.alloca %c1 x !llvm.struct<"S", (i32, i32, i32, i32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %mi = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi32>
+  %mb = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi8>
+  affine.store %v, %mi[1] : memref<?xi32>
+  %r = affine.load %mi[1] : memref<?xi32>
+  %q = affine.load %mb[12] : memref<?xi8>
+  return %r, %q : i32, i8
+}
+
+// CHECK-LABEL: func.func @disjoint_byte_load(
+// CHECK: %[[q:.+]] = affine.load
+// CHECK: return %c42_i32, %[[q]] : i32, i8
+
+// -----
+
+// An index that could be anywhere still blocks the slot it reads, and only
+// that one: the constant slots around it forward.
+
+func.func @dynamic_index_load(%b: i8, %d: index) -> (i32, i32) {
+  %c1 = arith.constant 1 : i32
+  %v = arith.constant 42 : i32
+  %a = llvm.alloca %c1 x !llvm.struct<"S", (i32, i32, i32, i32)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %mi = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi32>
+  %mb = "enzymexla.pointer2memref"(%a) : (!llvm.ptr) -> memref<?xi8>
+  affine.store %v, %mi[1] : memref<?xi32>
+  affine.store %b, %mb[12] : memref<?xi8>
+  %r = affine.load %mi[1] : memref<?xi32>
+  %dyn = memref.load %mi[%d] : memref<?xi32>
+  return %r, %dyn : i32, i32
+}
+
+// CHECK-LABEL: func.func @dynamic_index_load(
+// CHECK: %[[dyn:.+]] = memref.load
+// CHECK: return %c42_i32, %[[dyn]] : i32, i32

--- a/test/lit_tests/mem2reg_offsets.mlir
+++ b/test/lit_tests/mem2reg_offsets.mlir
@@ -97,9 +97,9 @@ llvm.func @gep_unknown_index(%val: f32, %i: i64) -> f32 {
 // -----
 
 // Two views of one allocation with different shapes reach the same byte by
-// different routes: [1, 0] of a 4x4 is element 4, which is [4] of a 16. The
-// store through one must not be taken for a different place than the load
-// through the other.
+// different routes: [1, 0] of a 4x4 is element 4, which is [4] of a 16. Both
+// land at byte 16 and read four bytes, so they name one place and the load
+// takes what the later store left there.
 llvm.func @cross_shape_same_byte(%val: f32, %other: f32) -> f32 {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
@@ -115,8 +115,9 @@ llvm.func @cross_shape_same_byte(%val: f32, %other: f32) -> f32 {
 }
 
 // CHECK-LABEL: llvm.func @cross_shape_same_byte(
-// CHECK: %[[LD:.+]] = memref.load
-// CHECK: llvm.return %[[LD]] : f32
+// CHECK-SAME: %[[val:.+]]: f32, %[[other:.+]]: f32
+// CHECK-NOT: memref.load
+// CHECK: llvm.return %[[other]] : f32
 
 // -----
 


### PR DESCRIPTION
Two accesses of one allocation that each land at a known byte and reach a known distance either share bytes or they do not, whatever units either counted its way there in. `OffsetTree::matches` had no such test: its stride comparison cannot relate two paths counted in different sizes, so it answered `Maybe` — and a `Maybe` from a store is a clobber. A store through a view of other units therefore blocked forwarding for every slot, however far from it that store landed.

`matches` now decides arithmetically whenever both sides have a constant byte offset (`constantOffset` already declines anything dynamic) and a known size: disjoint is `None`, same place and extent is `Exact`, wholly inside is `Contains`, and a partial overlap stays `Maybe`.

The case that motivated it: a packed capture struct is filled through several typed views at once, so clang's byte stores into the packed fields blocked the forwarding of every field around them. MFEM's `SmemPACurlCurlAssembleDiagonal3D` passes such a struct — 48 stores and 22 loads through `i32`, `i8` and `ptr` views of one `llvm.alloca`, with byte stores at 12–15, 20–23 and 52–55. **All 22 field loads forward now** (22 → 0); the allocation itself remains only for the one load that reads it at an index not known here, which is a separate matter — a dynamic *load* clobbers nothing and blocks only itself.

One existing expectation changed, and for the better. `mem2reg_offsets.mlir`'s `cross_shape_same_byte` has `%flat[4]` of a `memref<16xf32>` and `%square[1, 0]` of a `memref<4x4xf32>`: both land at byte 16 and read four bytes, so they name one place. The test asserted the conservative fallback of leaving the load; the pass now relates the two routes and the load takes what the later store left there. Its stated intent — that a store through one view is not taken for a different place than the load through the other — is unchanged.

New lit coverage in `mem2reg_disjoint_views.mlir`: a disjoint byte store (forwards), an overlapping one (still blocks), a load through another view (clobbers nothing), and a dynamic index (blocks only the slot it reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
