### PR TITLE
Do an access at a branch-chosen index in each arm instead

### DIFF
--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -453,6 +453,19 @@ def SROAWrappersPass : Pass<"sroa-wrappers", "mlir::ModuleOp"> {
   ];
 }
 
+def SplitBranchedAccessesPass : Pass<"split-branched-accesses"> {
+  let summary = "Do an access whose index a branch chose in each arm instead";
+  let description = [{
+    An access at an index chosen between constants by a branch names no slot
+    the store forwarding can see. Doing it in each arm, at the constant that
+    arm chose, gives a constant index there, and the arithmetic in between
+    rides along and folds.
+  }];
+  let dependentDialects = ["affine::AffineDialect", "arith::ArithDialect",
+                           "memref::MemRefDialect", "scf::SCFDialect",
+  ];
+}
+
 def CanonicalizeParallelPass : Pass<"canonicalize-parallel"> {
   let summary = "Canonicalize top-level ops in parallel, confining region simplification to each";
   let options = [Option<

--- a/src/enzyme_ad/jax/Passes/SplitBranchedAccesses.cpp
+++ b/src/enzyme_ad/jax/Passes/SplitBranchedAccesses.cpp
@@ -1,0 +1,157 @@
+//===- SplitBranchedAccesses.cpp - Accesses at a chosen index ------------===//
+//
+// An access whose index is chosen by a branch reads or writes a place the
+// forwarding cannot name: the index is not a constant, so it may be any slot
+// of the allocation and blocks the one it reads. Where the branch chooses
+// between constants, the access can be done in each arm instead, at the
+// constant that arm chose, which is a place the forwarding does know.
+//
+// The arithmetic that stood between a branch and an access -- a byte offset
+// cast and scaled into an element index -- is sunk into the arms beforehand
+// by canonicalization, so the index arrives here as the branch's own result.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Pass/Pass.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_SPLITBRANCHEDACCESSESPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+/// The branch an index came from.
+struct BranchedIndex {
+  Operation *ifOp;
+  unsigned resultNo;
+};
+
+static bool yieldsConstant(Operation *yield, unsigned resultNo) {
+  Attribute cst;
+  return matchPattern(yield->getOperand(resultNo), m_Constant(&cst));
+}
+
+/// Both arms of an if hand back a constant for this result. An if without an
+/// else has an empty second region and chooses nothing.
+static bool bothArmsConstant(Operation *ifOp, unsigned resultNo) {
+  for (Region &arm : ifOp->getRegions()) {
+    if (arm.empty())
+      return false;
+    if (!yieldsConstant(arm.front().getTerminator(), resultNo))
+      return false;
+  }
+  return true;
+}
+
+/// The branch that chose an index, when the index is a branch's result and
+/// both arms hand back a constant.
+static std::optional<BranchedIndex> branchThatChose(Value index) {
+  auto res = dyn_cast<OpResult>(index);
+  if (!res)
+    return std::nullopt;
+  Operation *ifOp = res.getOwner();
+  if (!isa<scf::IfOp, affine::AffineIfOp>(ifOp))
+    return std::nullopt;
+  if (!bothArmsConstant(ifOp, res.getResultNumber()))
+    return std::nullopt;
+  return BranchedIndex{ifOp, res.getResultNumber()};
+}
+
+static Operation *makeIfLike(OpBuilder &builder, Operation *ifOp,
+                             TypeRange results) {
+  if (auto sif = dyn_cast<scf::IfOp>(ifOp))
+    return scf::IfOp::create(builder, sif.getLoc(), results, sif.getCondition(),
+                             /*withElseRegion=*/true);
+  auto aif = cast<affine::AffineIfOp>(ifOp);
+  return affine::AffineIfOp::create(builder, aif.getLoc(), results,
+                                    aif.getIntegerSet(), aif.getOperands(),
+                                    /*withElseRegion=*/true);
+}
+
+/// Rebuilds `access` in each arm of a copy of `br.ifOp`, at the constant that
+/// arm chose.
+static void splitAccess(Operation *access, Value index,
+                        const BranchedIndex &br) {
+  // The branch is asked again where the access already stands, rather than
+  // the access being carried up to where the branch was: everything the
+  // access names is in hand here, and nothing has to be shown to survive a
+  // move. What the branch is asked -- its condition, or the set and the
+  // values it is taken over -- was in hand before it, so it is in hand here
+  // too.
+  OpBuilder builder(access);
+  Operation *newIf = makeIfLike(builder, br.ifOp, access->getResultTypes());
+
+  // The regions of both flavours of if are the arms, in order.
+  for (unsigned arm = 0; arm < 2; ++arm) {
+    Block *body = &newIf->getRegion(arm).front();
+    OpBuilder armBuilder(body, body->begin());
+    IRMapping map;
+    // The constant this arm chose stands in for the branch's result.
+    Value chose = br.ifOp->getRegion(arm).front().getTerminator()->getOperand(
+        br.resultNo);
+    Operation *chosen = armBuilder.clone(*chose.getDefiningOp());
+    map.map(br.ifOp->getResult(br.resultNo), chosen->getResult(0));
+    Operation *cloned = armBuilder.clone(*access, map);
+    if (cloned->getNumResults()) {
+      if (isa<scf::IfOp>(newIf))
+        scf::YieldOp::create(armBuilder, access->getLoc(),
+                             cloned->getResults());
+      else
+        affine::AffineYieldOp::create(armBuilder, access->getLoc(),
+                                      cloned->getResults());
+    }
+  }
+
+  access->replaceAllUsesWith(newIf->getResults());
+  access->erase();
+}
+
+/// The index of an access, when it has exactly one.
+static Value soleIndex(Operation *op) {
+  if (auto ld = dyn_cast<memref::LoadOp>(op))
+    return ld.getIndices().size() == 1 ? ld.getIndices()[0] : Value();
+  if (auto st = dyn_cast<memref::StoreOp>(op))
+    return st.getIndices().size() == 1 ? st.getIndices()[0] : Value();
+  if (auto ld = dyn_cast<affine::AffineLoadOp>(op))
+    return ld.getMapOperands().size() == 1 ? ld.getMapOperands()[0] : Value();
+  if (auto st = dyn_cast<affine::AffineStoreOp>(op))
+    return st.getMapOperands().size() == 1 ? st.getMapOperands()[0] : Value();
+  return Value();
+}
+
+struct SplitBranchedAccessesPass
+    : public enzyme::impl::SplitBranchedAccessesPassBase<
+          SplitBranchedAccessesPass> {
+  using SplitBranchedAccessesPassBase::SplitBranchedAccessesPassBase;
+
+  void runOnOperation() override {
+    SmallVector<std::pair<Operation *, BranchedIndex>> work;
+    getOperation()->walk([&](Operation *op) {
+      if (!isa<memref::LoadOp, memref::StoreOp, affine::AffineLoadOp,
+               affine::AffineStoreOp>(op))
+        return;
+      Value index = soleIndex(op);
+      if (!index)
+        return;
+      if (auto br = branchThatChose(index))
+        work.emplace_back(op, *br);
+    });
+
+    for (auto &[op, br] : work)
+      splitAccess(op, soleIndex(op), br);
+  }
+};
+
+} // namespace

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -139,7 +139,13 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       "func.func(canonicalize-loops),"
       "llvm.func(canonicalize-loops),"
       "canonicalize-scf-for,"
+      // An access at a branch-chosen index names no slot the forwarding can
+      // see; splitting it into the arms gives each a constant one, which is
+      // why another mem2reg run follows. The branch it needs is only here,
+      // once affine-cfg has structured it.
       "" + canonicalize + ",affine-cfg," + canonicalize + ","
+      "split-branched-accesses," + canonicalize + ",polygeist-mem2reg,"
+      "" + canonicalize + ","
       "func.func(canonicalize-loops),"
       "llvm.func(canonicalize-loops),"
       "" + canonicalize + ",llvm-to-affine-access,"

--- a/test/lit_tests/split_branched_accesses.mlir
+++ b/test/lit_tests/split_branched_accesses.mlir
@@ -1,0 +1,110 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(split-branched-accesses,canonicalize)" | FileCheck %s
+
+// An access at an index a branch chose between constants is done in each arm
+// instead, at the constant that arm chose. Arithmetic between the branch and
+// the access is sunk into the arms beforehand by canonicalization
+// (canonicalize_parallel_if_constants.mlir), so the index arrives here as the
+// branch's own result.
+
+#set = affine_set<()[s0] : (s0 >= 1)>
+module {
+
+  func.func @scf_load(%m: memref<?xi32>, %c: i1) -> i32 {
+    %c3 = arith.constant 3 : index
+    %c7 = arith.constant 7 : index
+    %i = scf.if %c -> index { scf.yield %c3 : index } else { scf.yield %c7 : index }
+    %v = memref.load %m[%i] : memref<?xi32>
+    return %v : i32
+  }
+  func.func @affine_store(%m: memref<?xf64>, %s: index, %val: f64) {
+    %c3 = arith.constant 3 : index
+    %c7 = arith.constant 7 : index
+    %i = affine.if #set()[%s] -> index { affine.yield %c3 : index } else { affine.yield %c7 : index }
+    affine.store %val, %m[%i] : memref<?xf64>
+    return
+  }
+  func.func @scf_store(%m: memref<?xi32>, %c: i1, %val: i32) {
+    %c3 = arith.constant 3 : index
+    %c7 = arith.constant 7 : index
+    %i = scf.if %c -> index { scf.yield %c3 : index } else { scf.yield %c7 : index }
+    memref.store %val, %m[%i] : memref<?xi32>
+    return
+  }
+
+  // an arm that does not choose a constant is left alone
+  func.func @dynamic_arm(%m: memref<?xi32>, %c: i1, %d: index) -> i32 {
+    %c3 = arith.constant 3 : index
+    %i = scf.if %c -> index {
+      scf.yield %c3 : index
+    } else {
+      scf.yield %d : index
+    }
+    %v = memref.load %m[%i] : memref<?xi32>
+    return %v : i32
+  }
+
+  // the memref and the value stored are computed after the branch: the branch
+  // is asked again where the access stands, so nothing has to move
+  func.func @operands_after_branch(%p: !llvm.ptr, %s: index, %x: f64) {
+    %c3 = arith.constant 3 : index
+    %c7 = arith.constant 7 : index
+    %i = affine.if #set()[%s] -> index { affine.yield %c3 : index } else { affine.yield %c7 : index }
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+    %v = arith.addf %x, %x : f64
+    memref.store %v, %m[%i] : memref<?xf64>
+    return
+  }
+}
+
+// CHECK:  func.func @scf_load(%[[v1:.+]]: memref<?xi32>, %[[v2:.+]]: i1) -> i32 {
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 3 : index
+// CHECK-NEXT:  %[[v4:.+]] = arith.constant 7 : index
+// CHECK-NEXT:  %[[v5:.+]] = scf.if %[[v2]] -> (i32) {
+// CHECK-NEXT:  %[[v6:.+]] = memref.load %[[v1]][%[[v3]]] : memref<?xi32>
+// CHECK-NEXT:  scf.yield %[[v6]] : i32
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  %[[v7:.+]] = memref.load %[[v1]][%[[v4]]] : memref<?xi32>
+// CHECK-NEXT:  scf.yield %[[v7]] : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return %[[v5]] : i32
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @affine_store(%[[v1:.+]]: memref<?xf64>, %[[v2:.+]]: index, %[[v3:.+]]: f64) {
+// CHECK-NEXT:  affine.if #set()[%[[v2]]] {
+// CHECK-NEXT:  affine.store %[[v3]], %[[v1]][3] : memref<?xf64>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  affine.store %[[v3]], %[[v1]][7] : memref<?xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @scf_store(%[[v1:.+]]: memref<?xi32>, %[[v2:.+]]: i1, %[[v3:.+]]: i32) {
+// CHECK-NEXT:  %[[v4:.+]] = arith.constant 3 : index
+// CHECK-NEXT:  %[[v5:.+]] = arith.constant 7 : index
+// CHECK-NEXT:  scf.if %[[v2]] {
+// CHECK-NEXT:  memref.store %[[v3]], %[[v1]][%[[v4]]] : memref<?xi32>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  memref.store %[[v3]], %[[v1]][%[[v5]]] : memref<?xi32>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @dynamic_arm(%[[v1:.+]]: memref<?xi32>, %[[v2:.+]]: i1, %[[v3:.+]]: index) -> i32 {
+// CHECK-NEXT:  %[[v4:.+]] = arith.constant 3 : index
+// CHECK-NEXT:  %[[v5:.+]] = arith.select %[[v2]], %[[v4]], %[[v3]] : index
+// CHECK-NEXT:  %[[v6:.+]] = memref.load %[[v1]][%[[v5]]] : memref<?xi32>
+// CHECK-NEXT:  return %[[v6]] : i32
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @operands_after_branch(%[[o1:.+]]: !llvm.ptr, %[[o2:.+]]: index, %[[o3:.+]]: f64) {
+// CHECK-NEXT:  %[[o4:.+]] = arith.constant 3 : index
+// CHECK-NEXT:  %[[o5:.+]] = arith.constant 7 : index
+// CHECK-NEXT:  %[[o6:.+]] = "enzymexla.pointer2memref"(%[[o1]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[o7:.+]] = arith.addf %[[o3]], %[[o3]] : f64
+// CHECK-NEXT:  affine.if #set()[%[[o2]]] {
+// CHECK-NEXT:  memref.store %[[o7]], %[[o6]][%[[o4]]] : memref<?xf64>
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  memref.store %[[o7]], %[[o6]][%[[o5]]] : memref<?xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }


### PR DESCRIPTION
An access whose index a branch chose names no slot the store forwarding can see: the index is not a constant, so it may be any slot of the allocation, and the forwarding gives up on the one it reads. Where the branch chooses between constants, the access can be done in each arm instead, at the constant that arm chose:

```mlir
%i = affine.if #set()[%s] -> index { affine.yield %c41 : index } else { affine.yield %c38 : index }
%v = memref.load %m[%i] : memref<?xi32>
```

becomes

```mlir
%v = affine.if #set()[%s] -> i32 {
  %l = memref.load %m[%c41] : memref<?xi32>
  affine.yield %l : i32
} else {
  %l = memref.load %m[%c38] : memref<?xi32>
  affine.yield %l : i32
}
```

Both flavours of branch (`scf.if`, `affine.if`) and both directions of access (load, store) take part; an arm that does not choose a constant is left alone.

**What the index has to look like.** The branch's own result, with a constant in each arm — nothing to walk back through. Arithmetic that stands between a branch and its access (MFEM's is a byte offset cast to `index` and divided by the element size) is sunk into the arms by canonicalization, #3039, which is what turns the offsets 164 and 152 into the slots 41 and 38 above. That pass runs immediately before this one, so this one has only the finished shape to recognize.

**Where the new branch is built.** At the access, not at the original branch: the branch is asked again where the access already stands, rather than the access being carried up to where the branch was. So no operand of the access has to be shown to survive a move — everything it names is already in hand at that point, and what the new branch is asked (its condition, or the set and the values it is taken over) was in hand before the original branch, hence in hand here too. The access is then replaced by the new branch's results and erased. A memref computed after the original branch, or a value stored that is computed after it, splits like any other (`@operands_after_branch` in the test).

**Where the pass runs.** After `affine-cfg`, which is where such a branch first appears — the two existing `polygeist-mem2reg` runs precede `enzyme-lift-cf-to-scf`, where the choice is still a phi in unstructured control flow — and another forwarding run follows it to take the constant slots.

**What it buys** (with #3039). MFEM's `SmemPACurlCurlAssembleDiagonal3D` reads one field of its capture struct at an offset chosen by the `symmetric` flag. After #3037 that single read was the only thing keeping the struct alive; with it split, the allocation and its 48 stores go: on that kernel's wrapper, allocas 1 → 0, stores 55 → 7, and 55 lines with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
