### PR TITLE
canonicalize-parallel: sink a cast or a divide into the branch that chose its operand

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -190,6 +190,72 @@ static affine::AffineIfOp createLikeIf(PatternRewriter &rewriter,
                                     /*withElseRegion=*/true);
 }
 
+static void createLikeYield(PatternRewriter &rewriter, Location loc, scf::IfOp,
+                            ValueRange values) {
+  scf::YieldOp::create(rewriter, loc, values);
+}
+static void createLikeYield(PatternRewriter &rewriter, Location loc,
+                            affine::AffineIfOp, ValueRange values) {
+  affine::AffineYieldOp::create(rewriter, loc, values);
+}
+
+/// An op over what a branch chose between constants is the branch choosing
+/// between the op's own results: the op rides into the arms, where it meets a
+/// constant and folds. What a branch chose then reaches its user as the
+/// branch's own result rather than at the far end of some arithmetic, which
+/// is how an index reaches an access for split-branched-accesses.
+template <typename OpT, typename IfT>
+struct SinkThroughIfOfConstants : public OpRewritePattern<OpT> {
+  using OpRewritePattern<OpT>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpT op,
+                                PatternRewriter &rewriter) const override {
+    // One operand comes from the branch and the rest are constants, so each
+    // arm folds to a constant of its own.
+    OpResult branched;
+    for (Value operand : op->getOperands()) {
+      Attribute cst;
+      if (matchPattern(operand, m_Constant(&cst)))
+        continue;
+      auto res = dyn_cast<OpResult>(operand);
+      if (branched || !res || !isa<IfT>(res.getOwner()))
+        return failure();
+      branched = res;
+    }
+    // A second user would keep the branch alive and pay for it twice.
+    if (!branched || !branched.hasOneUse())
+      return failure();
+
+    auto ifOp = cast<IfT>(branched.getOwner());
+    if (ifOp->getRegion(1).empty())
+      return failure();
+    // The regions of both flavours of if are the arms, in order.
+    unsigned resultNo = branched.getResultNumber();
+    Value arms[2];
+    for (unsigned arm = 0; arm < 2; ++arm) {
+      arms[arm] =
+          ifOp->getRegion(arm).front().getTerminator()->getOperand(resultNo);
+      Attribute cst;
+      if (!matchPattern(arms[arm], m_Constant(&cst)))
+        return failure();
+    }
+
+    // Built where the op stands, so what the branch is taken over -- in hand
+    // before the branch -- is in hand here too.
+    auto newIf = createLikeIf(rewriter, ifOp, op->getResultTypes());
+    for (unsigned arm = 0; arm < 2; ++arm) {
+      rewriter.setInsertionPointToStart(&newIf->getRegion(arm).front());
+      Operation *chosen = rewriter.clone(*arms[arm].getDefiningOp());
+      IRMapping map;
+      map.map(branched, chosen->getResult(0));
+      Operation *cloned = rewriter.clone(*op.getOperation(), map);
+      createLikeYield(rewriter, op.getLoc(), newIf, cloned->getResults());
+    }
+    rewriter.replaceOp(op, newIf->getResults());
+    return success();
+  }
+};
+
 /// The if counterpart of SelectOfSameBaseGEPs: arms that index one base
 /// differently choose the index instead, with a constant index materialized
 /// where the gep kept it in an attribute.
@@ -425,8 +491,13 @@ struct CanonicalizeParallelPass
         TruncOrConst, SelectOfSameBaseGEPs, SinkAddrSpaceCastThroughGEP,
         Pointer2MemrefOfAddrSpaceCast, IfOfSameBaseGEPs<scf::IfOp>,
         IfOfSameBaseGEPs<affine::AffineIfOp>, IfOfDifferentBaseGEPs<scf::IfOp>,
-        IfOfDifferentBaseGEPs<affine::AffineIfOp>, SelectOfDifferentBaseGEPs>(
-        ctx);
+        IfOfDifferentBaseGEPs<affine::AffineIfOp>, SelectOfDifferentBaseGEPs,
+        SinkThroughIfOfConstants<arith::IndexCastOp, scf::IfOp>,
+        SinkThroughIfOfConstants<arith::IndexCastOp, affine::AffineIfOp>,
+        SinkThroughIfOfConstants<arith::DivSIOp, scf::IfOp>,
+        SinkThroughIfOfConstants<arith::DivSIOp, affine::AffineIfOp>,
+        SinkThroughIfOfConstants<arith::DivUIOp, scf::IfOp>,
+        SinkThroughIfOfConstants<arith::DivUIOp, affine::AffineIfOp>>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_if_constants.mlir
+++ b/test/lit_tests/canonicalize_parallel_if_constants.mlir
@@ -1,0 +1,128 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel{parallel=false})" | FileCheck %s
+
+// An op over what a branch chose between constants rides into the arms and
+// folds there, so what the branch chose reaches its user as the branch's own
+// result: a byte offset cast and scaled arrives as the element slot itself.
+
+#set = affine_set<()[s0] : (s0 >= 1)>
+module {
+
+  func.func @cast_and_divide(%s: index) -> index {
+    %c4 = arith.constant 4 : index
+    %c152 = arith.constant 152 : i64
+    %c164 = arith.constant 164 : i64
+    %off = affine.if #set()[%s] -> i64 { affine.yield %c164 : i64 } else { affine.yield %c152 : i64 }
+    %i = arith.index_cast %off : i64 to index
+    %j = arith.divsi %i, %c4 : index
+    return %j : index
+  }
+
+  func.func @divide_unsigned(%s: index) -> i64 {
+    %c8 = arith.constant 8 : i64
+    %c48 = arith.constant 48 : i64
+    %c64 = arith.constant 64 : i64
+    %off = affine.if #set()[%s] -> i64 { affine.yield %c64 : i64 } else { affine.yield %c48 : i64 }
+    %j = arith.divui %off, %c8 : i64
+    return %j : i64
+  }
+
+  // the branch is the divisor
+  func.func @divide_by_branched(%s: index) -> i64 {
+    %c2 = arith.constant 2 : i64
+    %c4 = arith.constant 4 : i64
+    %c96 = arith.constant 96 : i64
+    %d = affine.if #set()[%s] -> i64 { affine.yield %c4 : i64 } else { affine.yield %c2 : i64 }
+    %j = arith.divsi %c96, %d : i64
+    return %j : i64
+  }
+
+  // an scf branch over constants is a select before it is anything else, and
+  // the cast sinks into that
+  func.func @scf_branch(%c: i1) -> index {
+    %c152 = arith.constant 152 : i64
+    %c164 = arith.constant 164 : i64
+    %off = scf.if %c -> i64 { scf.yield %c164 : i64 } else { scf.yield %c152 : i64 }
+    %i = arith.index_cast %off : i64 to index
+    return %i : index
+  }
+
+  // a second user of the branch's result: sinking would ask the branch twice
+  func.func @two_uses(%s: index) -> (index, i64) {
+    %c152 = arith.constant 152 : i64
+    %c164 = arith.constant 164 : i64
+    %off = affine.if #set()[%s] -> i64 { affine.yield %c164 : i64 } else { affine.yield %c152 : i64 }
+    %i = arith.index_cast %off : i64 to index
+    return %i, %off : index, i64
+  }
+
+  // an arm that does not choose a constant has nothing to fold against
+  func.func @dynamic_arm(%s: index, %d: i64) -> index {
+    %c164 = arith.constant 164 : i64
+    %off = affine.if #set()[%s] -> i64 { affine.yield %c164 : i64 } else { affine.yield %d : i64 }
+    %i = arith.index_cast %off : i64 to index
+    return %i : index
+  }
+}
+
+// CHECK:  func.func @cast_and_divide(%[[v1:.+]]: index) -> index {
+// CHECK-NEXT:  %[[v2:.+]] = arith.constant 38 : index
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 41 : index
+// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> index {
+// CHECK-NEXT:  affine.yield %[[v3]] : index
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  affine.yield %[[v2]] : index
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return %[[v4]] : index
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @divide_unsigned(%[[v1:.+]]: index) -> i64 {
+// CHECK-NEXT:  %[[v2:.+]] = arith.constant 6 : i64
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 8 : i64
+// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> i64 {
+// CHECK-NEXT:  affine.yield %[[v3]] : i64
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  affine.yield %[[v2]] : i64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return %[[v4]] : i64
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @divide_by_branched(%[[v1:.+]]: index) -> i64 {
+// CHECK-NEXT:  %[[v2:.+]] = arith.constant 48 : i64
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 24 : i64
+// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> i64 {
+// CHECK-NEXT:  affine.yield %[[v3]] : i64
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  affine.yield %[[v2]] : i64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return %[[v4]] : i64
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @scf_branch(%[[v1:.+]]: i1) -> index {
+// CHECK-NEXT:  %[[v2:.+]] = arith.constant 152 : index
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 164 : index
+// CHECK-NEXT:  %[[v4:.+]] = arith.select %[[v1]], %[[v3]], %[[v2]] : index
+// CHECK-NEXT:  return %[[v4]] : index
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @two_uses(%[[v1:.+]]: index) -> (index, i64) {
+// CHECK-NEXT:  %[[v2:.+]] = arith.constant 152 : i64
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 164 : i64
+// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> i64 {
+// CHECK-NEXT:  affine.yield %[[v3]] : i64
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  affine.yield %[[v2]] : i64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[v5:.+]] = arith.index_cast %[[v4]] : i64 to index
+// CHECK-NEXT:  return %[[v5]], %[[v4]] : index, i64
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @dynamic_arm(%[[v1:.+]]: index, %[[v2:.+]]: i64) -> index {
+// CHECK-NEXT:  %[[v3:.+]] = arith.constant 164 : i64
+// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> i64 {
+// CHECK-NEXT:  affine.yield %[[v3]] : i64
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:  affine.yield %[[v2]] : i64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[v5:.+]] = arith.index_cast %[[v4]] : i64 to index
+// CHECK-NEXT:  return %[[v5]] : index
+// CHECK-NEXT:  }


### PR DESCRIPTION
An op over what a branch chose between constants is the branch choosing between the op's own results. The op rides into the arms, where it meets a constant and folds:

```mlir
%off = affine.if #set()[%s] -> i64 { affine.yield %c164 : i64 } else { affine.yield %c152 : i64 }
%i = arith.index_cast %off : i64 to index
%j = arith.divsi %i, %c4 : index
```

becomes

```mlir
%j = affine.if #set()[%s] -> index { affine.yield %c41 : index } else { affine.yield %c38 : index }
```

which is how a byte offset a branch chose arrives as the element slot it names: 164 and 152, cast to `index` and divided by the element size, are 41 and 38.

What the branch chose then reaches its user as the branch's own result rather than at the far end of some arithmetic. That matters beyond the folding: a consumer that wants to know what a branch chose — #3038 looks for exactly this shape, an access at an index a branch chose between constants — has one thing to look at instead of a chain to walk back through.

Registered for `arith.index_cast`, `arith.divsi` and `arith.divui` over both flavours of branch, in either operand position (`@divide_by_branched` divides by what the branch chose). The new branch is built where the op stood, so what the branch is taken over — in hand before the branch — is in hand there too. The branch's result must have this one use, or the branch would be asked twice over; an arm that chooses no constant has nothing to fold against and is left alone.

`@scf_branch` records what an `scf.if` over two constants does here: upstream's own canonicalization makes it an `arith.select`, and the cast sinks into that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
