### PR TITLE
Also split branched accesses once the accesses are memrefs

### DIFF
--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -139,10 +139,6 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       "func.func(canonicalize-loops),"
       "llvm.func(canonicalize-loops),"
       "canonicalize-scf-for,"
-      // An access at a branch-chosen index names no slot the forwarding can
-      // see; splitting it into the arms gives each a constant one, which is
-      // why another mem2reg run follows. The branch it needs is only here,
-      // once affine-cfg has structured it.
       "" + canonicalize + ",affine-cfg," + canonicalize + ","
       "split-branched-accesses," + canonicalize + ",polygeist-mem2reg,"
       "" + canonicalize + ","
@@ -151,6 +147,8 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
       "" + canonicalize + ",llvm-to-affine-access,"
       "" + canonicalize + ",delinearize-indexing," + canonicalize + ",simplify-affine-exprs,"
       "affine-cfg," + canonicalize + ",llvm-to-affine-access," + canonicalize + ","
+      "split-branched-accesses," + canonicalize + ",polygeist-mem2reg,"
+      "" + canonicalize + ","
       "func.func(affine-loop-invariant-code-motion),"
       "" + canonicalize + ",sort-memory,llvm-to-tessera,tessera-apply-pdl,tessera-to-llvm,";
   // Differentiation runs before the backends diverge, so on xla the


### PR DESCRIPTION
`split-branched-accesses` (#3038) reads memref and affine loads and stores. Where it ran — right after `affine-cfg` structures the branch it needs — the access it wants is still an `llvm.load` through a gep. On MFEM's `SmemPACurlCurlAssembleDiagonal3D` it matched nothing there, and the `polygeist-mem2reg` run after it had nothing new to forward: the pre-raise IR was byte for byte what it is with the pass deleted.

Both halves of the shape are in hand after the second `llvm-to-affine-access`, so it runs there too:

```mlir
%346:5 = affine.if #set3(%arg14) -> (f64, f64, f64, f64, index) {
  affine.yield %286, %262, %262, %286, %c41 : f64, f64, f64, f64, index
} else {
  affine.yield %287, %261, %261, %287, %c38 : f64, f64, f64, f64, index
}
%347 = memref.load %173[%346#4] : memref<?xi32>
```

The first run stays where it was, and it earns its place: an access that is already a memref by then is split before the accesses are rebuilt around it.

**Measured on that kernel**, replaying the pipeline the plugin itself prints under `DEBUG_REACTANT`, cut before `raise-affine-to-stablehlo`:

| | as merged | second run only | both runs |
|---|---|---|---|
| wrapper `llvm.alloca` | 1 | 0 | 0 |
| wrapper stores | 55 | 7 | 7 |
| wrapper lines | 533 | 492 | 480 |
| kernel function lines | 1708 | 1588 | 1582 |
| module lines at pre-raise | 3695 | 3558 | 3552 |

The alloca and its 48 stores are what the second run buys; the 12 further wrapper lines are what the first run adds on top, which is why it stays rather than moving.

The gated 127-TU MFEM sweep is unchanged by either arrangement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
