### PR TITLE
delinearize-indexing: rebuild a view of any buffer, not only of an argument

### DIFF
--- a/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
+++ b/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
@@ -251,17 +251,26 @@ LogicalResult reshapeAtAddr(enzymexla::Pointer2MemrefOp &atAddr) {
   //                         << " memref loads, " << memrefStores
   //                         << " memref stores, " << others << " others\n");
 
+  // A buffer handed in as a block argument, or one allocated here: both are
+  // named by the shape they were declared with, and neither is a view of
+  // something else whose own shape would be the one to rebuild on.
+  Value buffer = m2p.getSource();
+  if (!isa<BlockArgument>(buffer) &&
+      !buffer.getDefiningOp<memref::AllocaOp>()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Failed: buffer is neither a block argument nor an alloca\n");
+    return failure();
+  }
+
   auto memref = atAddr.getResult();
   auto oldMt = cast<MemRefType>(memref.getType());
 
   if (newMt.getElementType() != oldMt.getElementType())
     return failure();
 
-  // The buffer the view is taken of is named by the shape it was declared
-  // with, wherever it came from: a function's argument, or an alloca beside
-  // the accesses. The view's flat index splits over that shape exactly, by
-  // floordiv and mod, so nothing has to be proven in bounds for the split to
-  // mean what the flat index meant.
+  // The view's flat index splits over the buffer's shape exactly, by floordiv
+  // and mod, so nothing has to be proven in bounds for the split to mean what
+  // the flat index meant.
   return reshapeMemref2(memref, shape, [&](RewriterBase &rewriter) {
     rewriter.setInsertionPoint(atAddr);
 

--- a/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
+++ b/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
@@ -251,27 +251,23 @@ LogicalResult reshapeAtAddr(enzymexla::Pointer2MemrefOp &atAddr) {
   //                         << " memref loads, " << memrefStores
   //                         << " memref stores, " << others << " others\n");
 
-  if (auto ba = dyn_cast<BlockArgument>(m2p.getSource())) {
-    if (isa<FunctionOpInterface>(ba.getOwner()->getParentOp())) {
-      if (&(ba.getOwner()->getParent()->front()) == ba.getOwner()) {
+  auto memref = atAddr.getResult();
+  auto oldMt = cast<MemRefType>(memref.getType());
 
-        auto memref = atAddr.getResult();
-        auto oldMt = cast<MemRefType>(memref.getType());
+  if (newMt.getElementType() != oldMt.getElementType())
+    return failure();
 
-        if (newMt.getElementType() != oldMt.getElementType())
-          return failure();
+  // The buffer the view is taken of is named by the shape it was declared
+  // with, wherever it came from: a function's argument, or an alloca beside
+  // the accesses. The view's flat index splits over that shape exactly, by
+  // floordiv and mod, so nothing has to be proven in bounds for the split to
+  // mean what the flat index meant.
+  return reshapeMemref2(memref, shape, [&](RewriterBase &rewriter) {
+    rewriter.setInsertionPoint(atAddr);
 
-        return reshapeMemref2(memref, shape, [&](RewriterBase &rewriter) {
-          rewriter.setInsertionPoint(atAddr);
-
-          atAddr = rewriter.replaceOpWithNewOp<enzymexla::Pointer2MemrefOp>(
-              atAddr, newMt, atAddr.getSource());
-        });
-      }
-    }
-  }
-
-  return failure();
+    atAddr = rewriter.replaceOpWithNewOp<enzymexla::Pointer2MemrefOp>(
+        atAddr, newMt, atAddr.getSource());
+  });
 }
 
 } // namespace

--- a/test/lit_tests/delinearize_alloca_base.mlir
+++ b/test/lit_tests/delinearize_alloca_base.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s --delinearize-indexing | FileCheck %s
 
 // A flat view of a buffer is rebuilt on the shape the buffer was declared
-// with, whether that buffer is a function's argument or an alloca beside the
-// accesses. MFEM's shared-memory scratch is the latter, and left flat it
+// with, for the two forms whose shape is their own: a block argument and an
+// alloca. MFEM's shared-memory scratch is the latter, and left flat it
 // reaches the raiser as a view that is stored through.
 
 #set = affine_set<(d0, d1) : (-d0 + 1 >= 0, d1 == 0)>
@@ -50,7 +50,7 @@ module {
     return
   }
 
-  // a heap buffer
+  // a heap buffer is not one of the two forms this rebuilds on
   func.func @from_alloc(%v: f64) {
     %a = memref.alloc() : memref<2x3xf64>
     %p = "enzymexla.memref2pointer"(%a) : (memref<2x3xf64>) -> !llvm.ptr
@@ -115,11 +115,11 @@ module {
 // CHECK-NEXT:  return
 // CHECK-NEXT:  }
 
-// CHECK:  func.func @from_alloc(%[[w1:.+]]: f64) {
-// CHECK-NEXT:  %[[w2:.+]] = memref.alloc() : memref<2x3xf64>
-// CHECK-NEXT:  %[[w3:.+]] = "enzymexla.memref2pointer"(%[[w2]]) : (memref<2x3xf64>) -> !llvm.ptr
-// CHECK-NEXT:  %[[w4:.+]] = "enzymexla.pointer2memref"(%[[w3]]) : (!llvm.ptr) -> memref<2x3xf64>
-// CHECK-NEXT:  affine.store %[[w1]], %[[w4]][1, 1] : memref<2x3xf64>
+// CHECK:  func.func @from_alloc(%[[h1:.+]]: f64) {
+// CHECK-NEXT:  %[[h2:.+]] = memref.alloc() : memref<2x3xf64>
+// CHECK-NEXT:  %[[h3:.+]] = "enzymexla.memref2pointer"(%[[h2]]) : (memref<2x3xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[h4:.+]] = "enzymexla.pointer2memref"(%[[h3]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  affine.store %[[h1]], %[[h4]][4] : memref<?xf64>
 // CHECK-NEXT:  return
 // CHECK-NEXT:  }
 

--- a/test/lit_tests/delinearize_alloca_base.mlir
+++ b/test/lit_tests/delinearize_alloca_base.mlir
@@ -49,6 +49,30 @@ module {
     affine.store %v, %m[5] : memref<?xi32>
     return
   }
+
+  // a heap buffer
+  func.func @from_alloc(%v: f64) {
+    %a = memref.alloc() : memref<2x3xf64>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<2x3xf64>) -> !llvm.ptr
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+    affine.store %v, %m[4] : memref<?xf64>
+    return
+  }
+
+  // a buffer that arrives as a block argument of a loop, not of the function
+  func.func @from_loop_arg(%a: memref<2x3xf64>, %b: memref<2x3xf64>, %v: f64) -> memref<2x3xf64> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %r = scf.for %i = %c0 to %c2 step %c1 iter_args(%buf = %a) -> memref<2x3xf64> {
+      %p = "enzymexla.memref2pointer"(%buf) : (memref<2x3xf64>) -> !llvm.ptr
+      %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+      affine.store %v, %m[5] : memref<?xf64>
+      scf.yield %b : memref<2x3xf64>
+    }
+    return %r : memref<2x3xf64>
+  }
+
 }
 
 // CHECK:  func.func @from_alloca(%[[v1:.+]]: f64) {
@@ -89,4 +113,25 @@ module {
 // CHECK-NEXT:  %[[v4:.+]] = "enzymexla.pointer2memref"(%[[v3]]) : (!llvm.ptr) -> memref<?xi32>
 // CHECK-NEXT:  affine.store %[[v1]], %[[v4]][5] : memref<?xi32>
 // CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @from_alloc(%[[w1:.+]]: f64) {
+// CHECK-NEXT:  %[[w2:.+]] = memref.alloc() : memref<2x3xf64>
+// CHECK-NEXT:  %[[w3:.+]] = "enzymexla.memref2pointer"(%[[w2]]) : (memref<2x3xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[w4:.+]] = "enzymexla.pointer2memref"(%[[w3]]) : (!llvm.ptr) -> memref<2x3xf64>
+// CHECK-NEXT:  affine.store %[[w1]], %[[w4]][1, 1] : memref<2x3xf64>
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @from_loop_arg(%[[w1:.+]]: memref<2x3xf64>, %[[w2:.+]]: memref<2x3xf64>, %[[w3:.+]]: f64) -> memref<2x3xf64> {
+// CHECK-NEXT:  %[[w4:.+]] = arith.constant 0 : index
+// CHECK-NEXT:  %[[w5:.+]] = arith.constant 1 : index
+// CHECK-NEXT:  %[[w6:.+]] = arith.constant 2 : index
+// CHECK-NEXT:  %[[w7:.+]] = scf.for %arg3 = %[[w4]] to %[[w6]] step %[[w5]] iter_args(%arg4 = %[[w1]]) -> (memref<2x3xf64>) {
+// CHECK-NEXT:  %[[w8:.+]] = "enzymexla.memref2pointer"(%arg4) : (memref<2x3xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[w9:.+]] = "enzymexla.pointer2memref"(%[[w8]]) : (!llvm.ptr) -> memref<2x3xf64>
+// CHECK-NEXT:  affine.store %[[w3]], %[[w9]][1, 2] : memref<2x3xf64>
+// CHECK-NEXT:  scf.yield %[[w2]] : memref<2x3xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return %[[w7]] : memref<2x3xf64>
 // CHECK-NEXT:  }

--- a/test/lit_tests/delinearize_alloca_base.mlir
+++ b/test/lit_tests/delinearize_alloca_base.mlir
@@ -1,0 +1,92 @@
+// RUN: enzymexlamlir-opt %s --delinearize-indexing | FileCheck %s
+
+// A flat view of a buffer is rebuilt on the shape the buffer was declared
+// with, whether that buffer is a function's argument or an alloca beside the
+// accesses. MFEM's shared-memory scratch is the latter, and left flat it
+// reaches the raiser as a view that is stored through.
+
+#set = affine_set<(d0, d1) : (-d0 + 1 >= 0, d1 == 0)>
+module {
+
+  func.func @from_alloca(%v: f64) {
+    %a = memref.alloca() {alignment = 8 : i64} : memref<2x3xf64>
+    affine.parallel (%i, %j, %k) = (0, 0, 0) to (3, 3, 3) {
+      affine.if #set(%j, %k) {
+        %p = "enzymexla.memref2pointer"(%a) : (memref<2x3xf64>) -> !llvm.ptr<3>
+        %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64>
+        affine.store %v, %m[%i + %j * 3] : memref<?xf64>
+      }
+    }
+    return
+  }
+
+  func.func @from_arg(%a: memref<2x3xf64>, %v: f64) {
+    affine.parallel (%i, %j, %k) = (0, 0, 0) to (3, 3, 3) {
+      affine.if #set(%j, %k) {
+        %p = "enzymexla.memref2pointer"(%a) : (memref<2x3xf64>) -> !llvm.ptr<3>
+        %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64>
+        affine.store %v, %m[%i + %j * 3] : memref<?xf64>
+      }
+    }
+    return
+  }
+
+  // a load and a store of the same view, over three dimensions
+  func.func @three_dims(%v: f64) -> f64 {
+    %a = memref.alloca() : memref<2x3x4xf64>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<2x3x4xf64>) -> !llvm.ptr
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+    affine.store %v, %m[7] : memref<?xf64>
+    %r = affine.load %m[13] : memref<?xf64>
+    return %r : f64
+  }
+
+  // an element type the view does not share with its buffer is left alone
+  func.func @element_type_differs(%v: i32) {
+    %a = memref.alloca() : memref<2x3xf64>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<2x3xf64>) -> !llvm.ptr
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xi32>
+    affine.store %v, %m[5] : memref<?xi32>
+    return
+  }
+}
+
+// CHECK:  func.func @from_alloca(%[[v1:.+]]: f64) {
+// CHECK-NEXT:  %[[v2:.+]] = memref.alloca() {alignment = 8 : i64} : memref<2x3xf64>
+// CHECK-NEXT:  affine.parallel (%arg1, %arg2, %arg3) = (0, 0, 0) to (3, 3, 3) {
+// CHECK-NEXT:  affine.if #set(%arg2, %arg3) {
+// CHECK-NEXT:  %[[v3:.+]] = "enzymexla.memref2pointer"(%[[v2]]) : (memref<2x3xf64>) -> !llvm.ptr<3>
+// CHECK-NEXT:  %[[v4:.+]] = "enzymexla.pointer2memref"(%[[v3]]) : (!llvm.ptr<3>) -> memref<2x3xf64>
+// CHECK-NEXT:  affine.store %[[v1]], %[[v4]][%arg1 floordiv 3 + %arg2, %arg1 mod 3] : memref<2x3xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @from_arg(%[[v1:.+]]: memref<2x3xf64>, %[[v2:.+]]: f64) {
+// CHECK-NEXT:  affine.parallel (%arg2, %arg3, %arg4) = (0, 0, 0) to (3, 3, 3) {
+// CHECK-NEXT:  affine.if #set(%arg3, %arg4) {
+// CHECK-NEXT:  %[[v3:.+]] = "enzymexla.memref2pointer"(%[[v1]]) : (memref<2x3xf64>) -> !llvm.ptr<3>
+// CHECK-NEXT:  %[[v4:.+]] = "enzymexla.pointer2memref"(%[[v3]]) : (!llvm.ptr<3>) -> memref<2x3xf64>
+// CHECK-NEXT:  affine.store %[[v2]], %[[v4]][%arg2 floordiv 3 + %arg3, %arg2 mod 3] : memref<2x3xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @three_dims(%[[v1:.+]]: f64) -> f64 {
+// CHECK-NEXT:  %[[v2:.+]] = memref.alloca() : memref<2x3x4xf64>
+// CHECK-NEXT:  %[[v3:.+]] = "enzymexla.memref2pointer"(%[[v2]]) : (memref<2x3x4xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[v4:.+]] = "enzymexla.pointer2memref"(%[[v3]]) : (!llvm.ptr) -> memref<2x3x4xf64>
+// CHECK-NEXT:  affine.store %[[v1]], %[[v4]][0, 1, 3] : memref<2x3x4xf64>
+// CHECK-NEXT:  %[[v5:.+]] = affine.load %[[v4]][1, 0, 1] : memref<2x3x4xf64>
+// CHECK-NEXT:  return %[[v5]] : f64
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @element_type_differs(%[[v1:.+]]: i32) {
+// CHECK-NEXT:  %[[v2:.+]] = memref.alloca() : memref<2x3xf64>
+// CHECK-NEXT:  %[[v3:.+]] = "enzymexla.memref2pointer"(%[[v2]]) : (memref<2x3xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[v4:.+]] = "enzymexla.pointer2memref"(%[[v3]]) : (!llvm.ptr) -> memref<?xi32>
+// CHECK-NEXT:  affine.store %[[v1]], %[[v4]][5] : memref<?xi32>
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }


### PR DESCRIPTION
`reshapeAtAddr` rebuilds a flat `pointer2memref` view on the shape its buffer was declared with. It did so only when that buffer was a function's **entry block** argument, so a buffer that is an alloca beside the accesses — which is what MFEM's shared memory scratch is — kept its flat view. Two functions that differ in nothing else:

```mlir
// base is an alloca: left alone
affine.store %arg0, %1[%arg1 + %arg2 * 3] : memref<?xf64>
// base is an argument: rebuilt
affine.store %arg1, %1[%arg2 floordiv 3 + %arg3, %arg2 mod 3] : memref<2x3xf64>
```

This accepts the two forms of buffer whose shape is genuinely their own — a block argument, and a `memref.alloca` — where before it took only the first, and only at a function's entry. Neither form is a view of something else whose own shape would be the one to rebuild on. A heap `memref.alloc` and everything else are left alone, as is a view whose element type its buffer does not share; and `reshapeMemref2` still declines unless every user of the view is a load or a store.

Nothing in the rewrite depends on which of the two forms it is. The flat index splits over the declared shape exactly, by `floordiv` and `mod`, so no access has to be shown in bounds for the split to mean what the flat index meant — an index past the buffer is as wrong after as it was before.

**What it fixes.** A flat view that survives to the raiser is refused where it is stored through — `cannot raise a store through an aliasing view`, from the `Pointer2MemrefOp` case in `AffineToStableHLORaising.cpp`, which is right to refuse it: the view aliases a buffer that is itself being raised. On `fem/integ/bilininteg_mixedcurl_pa.cpp` that accounted for 18 errors, and they are gone.

**Measured.** In the gated 127-TU MFEM sweep, `bilininteg_mixedcurl_pa.cpp` goes from red to green and nothing else moves: 13 red → 12, with no TU newly red. The full lit suite passes.

The test covers each accepted form — a view of an alloca, of a function argument, and of a loop-carried block argument — a three-dimensional buffer, and the two rejections: a heap `memref.alloc`, and an element type the view does not share with its buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
