### PR TITLE
delinearize-indexing: rebuild a view of a buffer a branch chose

### DIFF
--- a/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
+++ b/src/enzyme_ad/jax/Passes/DelinearizeIndexing.cpp
@@ -209,6 +209,32 @@ reshapeMemref2(Value memref, ArrayRef<int64_t> shape,
   return success();
 }
 
+/// A buffer named by the shape it was declared with, rather than a view of
+/// something else whose own shape would be the one to rebuild on: one handed
+/// in as a block argument, one allocated here, or a branch between such
+/// buffers -- as a ternary picking one of two shared arrays to index leaves.
+static bool isDeclaredBuffer(Value buffer) {
+  SmallVector<Value> worklist{buffer};
+  SmallPtrSet<Value, 4> seen;
+  while (!worklist.empty()) {
+    Value v = worklist.pop_back_val();
+    if (!seen.insert(v).second)
+      continue;
+    if (isa<BlockArgument>(v))
+      continue;
+    Operation *def = v.getDefiningOp();
+    if (isa<memref::AllocaOp>(def))
+      continue;
+    if (auto sel = dyn_cast<arith::SelectOp>(def)) {
+      worklist.push_back(sel.getTrueValue());
+      worklist.push_back(sel.getFalseValue());
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 LogicalResult reshapeAtAddr(enzymexla::Pointer2MemrefOp &atAddr) {
   auto source = atAddr.getSource();
   auto m2p = source.getDefiningOp<enzymexla::Memref2PointerOp>();
@@ -251,14 +277,8 @@ LogicalResult reshapeAtAddr(enzymexla::Pointer2MemrefOp &atAddr) {
   //                         << " memref loads, " << memrefStores
   //                         << " memref stores, " << others << " others\n");
 
-  // A buffer handed in as a block argument, or one allocated here: both are
-  // named by the shape they were declared with, and neither is a view of
-  // something else whose own shape would be the one to rebuild on.
-  Value buffer = m2p.getSource();
-  if (!isa<BlockArgument>(buffer) &&
-      !buffer.getDefiningOp<memref::AllocaOp>()) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Failed: buffer is neither a block argument nor an alloca\n");
+  if (!isDeclaredBuffer(m2p.getSource())) {
+    LLVM_DEBUG(llvm::dbgs() << "Failed: buffer is not one declared here\n");
     return failure();
   }
 

--- a/test/lit_tests/delinearize_alloca_base.mlir
+++ b/test/lit_tests/delinearize_alloca_base.mlir
@@ -73,6 +73,31 @@ module {
     return %r : memref<2x3xf64>
   }
 
+
+  // a ternary picking one of two buffers to index, as mfem's
+  //   (c == 2) ? sBo[qz][dz] : sBc[qz][dz]
+  // leaves: the branch chooses the buffer, and the view is taken of that
+  func.func @select_of_allocas(%c: i1, %v: f64) {
+    %a = memref.alloca() : memref<2x3xf64>
+    %b = memref.alloca() : memref<2x3xf64>
+    %s = arith.select %c, %a, %b : memref<2x3xf64>
+    %p = "enzymexla.memref2pointer"(%s) : (memref<2x3xf64>) -> !llvm.ptr<3>
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64>
+    affine.store %v, %m[4] : memref<?xf64>
+    return
+  }
+
+  // a branch with a heap buffer on one side is not one of the forms
+  func.func @select_with_alloc(%c: i1, %v: f64) {
+    %a = memref.alloca() : memref<2x3xf64>
+    %b = memref.alloc() : memref<2x3xf64>
+    %s = arith.select %c, %a, %b : memref<2x3xf64>
+    %p = "enzymexla.memref2pointer"(%s) : (memref<2x3xf64>) -> !llvm.ptr
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+    affine.store %v, %m[4] : memref<?xf64>
+    return
+  }
+
 }
 
 // CHECK:  func.func @from_alloca(%[[v1:.+]]: f64) {
@@ -134,4 +159,24 @@ module {
 // CHECK-NEXT:  scf.yield %[[w2]] : memref<2x3xf64>
 // CHECK-NEXT:  }
 // CHECK-NEXT:  return %[[w7]] : memref<2x3xf64>
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @select_of_allocas(%[[s1:.+]]: i1, %[[s2:.+]]: f64) {
+// CHECK-NEXT:  %[[s3:.+]] = memref.alloca() : memref<2x3xf64>
+// CHECK-NEXT:  %[[s4:.+]] = memref.alloca() : memref<2x3xf64>
+// CHECK-NEXT:  %[[s5:.+]] = arith.select %[[s1]], %[[s3]], %[[s4]] : memref<2x3xf64>
+// CHECK-NEXT:  %[[s6:.+]] = "enzymexla.memref2pointer"(%[[s5]]) : (memref<2x3xf64>) -> !llvm.ptr<3>
+// CHECK-NEXT:  %[[s7:.+]] = "enzymexla.pointer2memref"(%[[s6]]) : (!llvm.ptr<3>) -> memref<2x3xf64>
+// CHECK-NEXT:  affine.store %[[s2]], %[[s7]][1, 1] : memref<2x3xf64>
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @select_with_alloc(%[[s1:.+]]: i1, %[[s2:.+]]: f64) {
+// CHECK-NEXT:  %[[s3:.+]] = memref.alloca() : memref<2x3xf64>
+// CHECK-NEXT:  %[[s4:.+]] = memref.alloc() : memref<2x3xf64>
+// CHECK-NEXT:  %[[s5:.+]] = arith.select %[[s1]], %[[s3]], %[[s4]] : memref<2x3xf64>
+// CHECK-NEXT:  %[[s6:.+]] = "enzymexla.memref2pointer"(%[[s5]]) : (memref<2x3xf64>) -> !llvm.ptr
+// CHECK-NEXT:  %[[s7:.+]] = "enzymexla.pointer2memref"(%[[s6]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  affine.store %[[s2]], %[[s7]][4] : memref<?xf64>
+// CHECK-NEXT:  return
 // CHECK-NEXT:  }


### PR DESCRIPTION
A ternary that picks one of two shared arrays to index, as in mfem's `bilininteg_hcurl_kernels.hpp`:

```cpp
const real_t wz = ((c == 2) ? sBo[qz][dz] : sBc[qz][dz]);
```

reaches MLIR as one access through a select of the two bases:

```mlir
%204 = arith.select %186, %alloca_2, %alloca_0 : memref<2x3xf64>
%205 = "enzymexla.memref2pointer"(%204) : (memref<2x3xf64>) -> !llvm.ptr<3>
%255 = "enzymexla.pointer2memref"(%205) : (!llvm.ptr<3>) -> memref<?xf64>
```

The buffer of the view is then that select rather than an alloca, so #3041 declined and the view stayed flat — which is how it reaches the raiser, where a store through it is refused as aliasing.

A select between buffers that are themselves declared here is as good as either arm: both name the same shape, and that shape is what the view is rebuilt on. Chains of selects are followed to their leaves by an explicit worklist; a branch with anything else on either side — a heap `memref.alloc` included — is left alone, so this stays the set of buffers whose shape is their own rather than any value.

**What it fixes.** On `fem/integ/bilininteg_mixedcurl_pa.cpp` these are 9 views, over the shared arrays of each order (2x3, 3x4, 4x5, 5x6). Diffing the pass with and without this, they are exactly the sites that differ, and they are what stands between that TU and raising.

**Measured.** Two full runs of the gated 127-TU MFEM sweep, same machine and flags, differing only in this change:

| | TUs | red |
|---|---|---|
| without | 127 | 13 |
| with | 127 | 12 |

`bilininteg_mixedcurl_pa.cpp` is the one TU that differs — red without, green with — and no TU is newly red. (`linalg/batched/native.cpp` is red in both arms, confirmed by four isolated compiles, two per build; it is unrelated to this change.) The full lit suite passes.

The test adds the branch of two allocas and the rejection — a branch with a heap buffer on one arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
