### PR TITLE
Raise the enzyme atomic as a combining scatter too

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -15,6 +15,7 @@
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "src/enzyme_ad/jax/Utils.h"
 
+#include "Enzyme/MLIR/Dialect/Ops.h"
 #include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -3036,6 +3037,38 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
   if (auto rmw = dyn_cast<memref::AtomicRMWOp>(op)) {
     // Only accumulation raises (as a combining scatter), and only when the
     // old value is unobserved.
+    if ((rmw.getKind() != arith::AtomicRMWKind::addf &&
+         rmw.getKind() != arith::AtomicRMWKind::addi) ||
+        !rmw.getResult().use_empty())
+      return failure();
+    Value value = rmw.getValue();
+    Value memref = rmw.getMemref();
+    SmallVector<Value> sIndices;
+    for (auto idx : rmw.getIndices()) {
+      Value mapped = mapping.lookupOrNull(idx);
+      if (!mapped || !maps.count(mapped))
+        return failure();
+      sIndices.push_back(mapped);
+    }
+    if (!mapping.lookupOrNull(value) || !mapping.lookupOrNull(memref))
+      return failure();
+    Value res = emitStoreAsScatter(
+        rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
+        mapping.lookup(value), mapping.lookup(memref), sIndices, builder, maps,
+        pc, /*accumulate=*/true);
+    if (!res)
+      return op->emitError(
+                 "atomic add is dependent on less dims than stored value: ")
+             << *op;
+    mapping.map(memref, res);
+    return success();
+  }
+
+  if (auto rmw = dyn_cast<enzyme::AtomicRMWOp>(op)) {
+    // As for the memref one: only accumulation raises, as a combining
+    // scatter, and only when the old value is unobserved. The ordering the op
+    // carries says nothing once the accumulation is a scatter over the whole
+    // iteration space.
     if ((rmw.getKind() != arith::AtomicRMWKind::addf &&
          rmw.getKind() != arith::AtomicRMWKind::addi) ||
         !rmw.getResult().use_empty())

--- a/test/lit_tests/raising/atomic_add_scatter_enzyme.mlir
+++ b/test/lit_tests/raising/atomic_add_scatter_enzyme.mlir
@@ -1,0 +1,36 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// The enzyme atomic raises like the memref one: an accumulation whose old
+// value is unused becomes a combining scatter. It is the form an llvm
+// atomicrmw takes when the ordering it carried has to survive the rewrite.
+
+module {
+  func.func private @atomic_add(%buf: memref<8xf64, 1>, %idx: memref<16xi32, 1>, %val: memref<16xf64, 1>) {
+    affine.parallel (%t) = (0) to (16) {
+      %i = affine.load %idx[%t] : memref<16xi32, 1>
+      %iidx = arith.index_cast %i : i32 to index
+      %v = affine.load %val[%t] : memref<16xf64, 1>
+      %old = enzyme.atomic_rmw addf %v, %buf[%iidx] monotonic : (f64, memref<8xf64, 1>) -> f64
+    }
+    return
+  }
+}
+
+// CHECK:  func.func private @atomic_add_raised(%[[r1:.+]]: tensor<8xf64>, %[[r2:.+]]: tensor<16xi32>, %[[r3:.+]]: tensor<16xf64>) -> (tensor<8xf64>, tensor<16xi32>, tensor<16xf64>) {
+// CHECK-NEXT:  %[[r4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:  %[[r5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:  %[[r6:.+]] = stablehlo.add %[[r4]], %[[r5]] : tensor<16xi64>
+// CHECK-NEXT:  %[[r7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:  %[[r8:.+]] = stablehlo.multiply %[[r6]], %[[r7]] : tensor<16xi64>
+// CHECK-NEXT:  %[[r9:.+]] = stablehlo.reshape %[[r2]] : (tensor<16xi32>) -> tensor<16xi32>
+// CHECK-NEXT:  %[[r10:.+]] = stablehlo.convert %[[r9]] : (tensor<16xi32>) -> tensor<16xi64>
+// CHECK-NEXT:  %[[r11:.+]] = stablehlo.reshape %[[r3]] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[r12:.+]] = stablehlo.reshape %[[r10]] : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:  %[[r13:.+]] = stablehlo.broadcast_in_dim %[[r11]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:  %[[r14:.+]] = "stablehlo.scatter"(%[[r1]], %[[r12]], %[[r13]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:  ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
+// CHECK-NEXT:  %[[r15:.+]] = stablehlo.add %arg3, %arg4 : tensor<f64>
+// CHECK-NEXT:  stablehlo.return %[[r15]] : tensor<f64>
+// CHECK-NEXT:  }) : (tensor<8xf64>, tensor<16x1xi64>, tensor<16xf64>) -> tensor<8xf64>
+// CHECK-NEXT:  return %[[r14]], %[[r2]], %[[r3]] : tensor<8xf64>, tensor<16xi32>, tensor<16xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
The raiser knows `memref.atomic_rmw` and not `enzyme.atomic_rmw`, though the two say the same thing about an accumulation — the enzyme one additionally carrying the ordering and alignment of the `llvm.atomicrmw` it came from, which is why an atomic that has to keep its ordering takes that form.

Give it the same handler it gives the memref one: an accumulation (`addf`/`addi`) whose old value is unobserved becomes a combining scatter, since adds commute up to rounding exactly as the atomic does. Anything else is left alone.

The test is the enzyme twin of `raising/atomic_add_scatter.mlir`, and raises to the same scatter.

Pairs with #3046, which produces this op; on its own this only widens what the raiser accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
