### PR TITLE
Fold the gep an atomic is taken through into its index

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Ops.h"
+#include "Enzyme/MLIR/Dialect/Ops.h"
 #include "Dialect.h"
 #include "Interfaces/AutoDiffTypeInterface.h"
+#include "Ops.h"
 #include "src/enzyme_ad/jax/Dialect/Canonicalizers.h"
 #include "src/enzyme_ad/jax/Dialect/Utils.h"
 #include "src/enzyme_ad/jax/Utils.h"
@@ -872,6 +873,54 @@ void LoadStorePointer2MemrefGEP<affine::AffineStoreOp>::createNewOp(
                                                idxs);
 }
 
+template <>
+Value LoadStorePointer2MemrefGEP<enzyme::AtomicRMWOp>::getMemref(
+    enzyme::AtomicRMWOp op) const {
+  return op.getMemref();
+}
+
+template <>
+SmallVector<Value> LoadStorePointer2MemrefGEP<enzyme::AtomicRMWOp>::newIndex(
+    enzyme::AtomicRMWOp op, Value finalIndex, PatternRewriter &rewriter) const {
+  auto operands = llvm::to_vector(op.getIndices());
+  operands[0] =
+      arith::AddIOp::create(rewriter, op.getLoc(), operands[0], finalIndex);
+  return operands;
+}
+
+template <>
+void LoadStorePointer2MemrefGEP<enzyme::AtomicRMWOp>::createNewOp(
+    enzyme::AtomicRMWOp op, Value baseMemref, SmallVector<Value> idxs,
+    PatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<enzyme::AtomicRMWOp>(
+      op, op.getResult().getType(), op.getKindAttr(), op.getOrderingAttr(),
+      op.getValue(), baseMemref, idxs, op.getAlignmentAttr(),
+      op.getFastmathAttr());
+}
+
+template <>
+Value LoadStorePointer2MemrefGEP<memref::AtomicRMWOp>::getMemref(
+    memref::AtomicRMWOp op) const {
+  return op.getMemref();
+}
+
+template <>
+SmallVector<Value> LoadStorePointer2MemrefGEP<memref::AtomicRMWOp>::newIndex(
+    memref::AtomicRMWOp op, Value finalIndex, PatternRewriter &rewriter) const {
+  auto operands = llvm::to_vector(op.getIndices());
+  operands[0] =
+      arith::AddIOp::create(rewriter, op.getLoc(), operands[0], finalIndex);
+  return operands;
+}
+
+template <>
+void LoadStorePointer2MemrefGEP<memref::AtomicRMWOp>::createNewOp(
+    memref::AtomicRMWOp op, Value baseMemref, SmallVector<Value> idxs,
+    PatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<memref::AtomicRMWOp>(
+      op, op.getKind(), op.getValue(), baseMemref, idxs);
+}
+
 /// Simplify load (pointer2memref(x)) to llvm.load x
 template <typename Op>
 class MetaPointer2Memref final : public OpRewritePattern<Op> {
@@ -1112,6 +1161,8 @@ void Pointer2MemrefOp::getCanonicalizationPatterns(RewritePatternSet &results,
                  LoadStorePointer2MemrefGEP<affine::AffineLoadOp>,
                  LoadStorePointer2MemrefGEP<memref::StoreOp>,
                  LoadStorePointer2MemrefGEP<affine::AffineStoreOp>,
+                 LoadStorePointer2MemrefGEP<enzyme::AtomicRMWOp>,
+                 LoadStorePointer2MemrefGEP<memref::AtomicRMWOp>,
                  HoistIfYieldConversion<scf::IfOp>,
                  HoistIfYieldConversion<affine::AffineIfOp>,
                  HoistSelectConversion>(context);

--- a/test/lit_tests/atomic_gep_fold.mlir
+++ b/test/lit_tests/atomic_gep_fold.mlir
@@ -1,0 +1,54 @@
+// RUN: enzymexlamlir-opt %s --canonicalize | FileCheck %s
+
+// The gep an access is taken through folds into its index, for an atomic as
+// for a load or a store: the view is then taken of the base, which is what
+// lets a kernel's pointer argument have nothing but a view reading it.
+
+module {
+  func.func @enzyme_atomic(%p: !llvm.ptr, %i: i64, %v: f64) {
+    %g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xf64>
+    %c0 = arith.constant 0 : index
+    %old = enzyme.atomic_rmw addf %v, %m[%c0] monotonic {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+    return
+  }
+
+  func.func @memref_atomic(%p: !llvm.ptr, %i: i64, %v: i32) {
+    %g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xi32>
+    %c0 = arith.constant 0 : index
+    %old = memref.atomic_rmw addi %v, %m[%c0] : (i32, memref<?xi32>) -> i32
+    return
+  }
+
+  // an element type the view does not share with the gep is left alone
+  func.func @element_type_differs(%p: !llvm.ptr, %i: i64, %v: f64) {
+    %g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32, i32, i32)>
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xf64>
+    %c0 = arith.constant 0 : index
+    %old = enzyme.atomic_rmw addf %v, %m[%c0] monotonic : (f64, memref<?xf64>) -> f64
+    return
+  }
+}
+
+// CHECK:  func.func @enzyme_atomic(%[[a1:.+]]: !llvm.ptr, %[[a2:.+]]: i64, %[[a3:.+]]: f64) {
+// CHECK-NEXT:  %[[a4:.+]] = "enzymexla.pointer2memref"(%[[a1]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[a5:.+]] = arith.index_cast %[[a2]] : i64 to index
+// CHECK-NEXT:  %[[a6:.+]] = enzyme.atomic_rmw addf %[[a3]], %[[a4]][%[[a5]]] monotonic {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @memref_atomic(%[[a1:.+]]: !llvm.ptr, %[[a2:.+]]: i64, %[[a3:.+]]: i32) {
+// CHECK-NEXT:  %[[a4:.+]] = "enzymexla.pointer2memref"(%[[a1]]) : (!llvm.ptr) -> memref<?xi32>
+// CHECK-NEXT:  %[[a5:.+]] = arith.index_cast %[[a2]] : i64 to index
+// CHECK-NEXT:  %[[a6:.+]] = memref.atomic_rmw addi %[[a3]], %[[a4]][%[[a5]]] : (i32, memref<?xi32>) -> i32
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @element_type_differs(%[[a1:.+]]: !llvm.ptr, %[[a2:.+]]: i64, %[[a3:.+]]: f64) {
+// CHECK-NEXT:  %[[a4:.+]] = arith.constant 0 : index
+// CHECK-NEXT:  %[[a5:.+]] = llvm.getelementptr inbounds %[[a1]][%[[a2]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32, i32, i32)>
+// CHECK-NEXT:  %[[a6:.+]] = "enzymexla.pointer2memref"(%[[a5]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[a7:.+]] = enzyme.atomic_rmw addf %[[a3]], %[[a6]][%[[a4]]] monotonic : (f64, memref<?xf64>) -> f64
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }


### PR DESCRIPTION
`LoadStorePointer2MemrefGEP` rebases a load or a store taken through a view of a gep onto a view of the gep's own base, with the offset joining the index:

```mlir
%g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f64
%m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xf64>
%old = enzyme.atomic_rmw addf %v, %m[%c0] monotonic : (f64, memref<?xf64>) -> f64
```

becomes an atomic on `pointer2memref(%p)` at `%i`. An atomic is the same access with the same addressing, so it takes the same rewrite — in both the enzyme and the memref form, since the raiser's own gep conversion produces the latter.

**Why it matters.** A gep is a use of the pointer it walks from, and the raiser maps a kernel's pointer argument to a tensor only when a view is all that reads it — `non pointermemref user of pointer arg in kernel`. An atomic left addressed through a gep is what keeps that from being true in MFEM's `derefmat_op.cpp` and `pderefmat_op.cpp`.

The test covers both atomic forms and the rejection that was already there: a view whose element type the gep does not share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
