### PR TITLE
Read an atomic through a view, beside the loads and stores

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1,5 +1,6 @@
 #include "Passes.h"
 
+#include "Enzyme/MLIR/Dialect/Ops.h"
 #include "mlir/Analysis/CallGraph.h"
 #include "mlir/Analysis/DataLayoutAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/AffineStructures.h"
@@ -1926,6 +1927,10 @@ convertLLVMToAffineAccess(Operation *op,
     PtrVal addr = store.getAddr();
     handleOp(store, addr);
   });
+  op->walk([&](LLVM::AtomicRMWOp rmw) {
+    PtrVal addr = rmw.getPtr();
+    handleOp(rmw, addr);
+  });
   op->walk([&](LLVM::LoadOp load) {
     PtrVal addr = load.getAddr();
     handleOp(load, addr);
@@ -2158,6 +2163,120 @@ convertLLVMToAffineAccess(Operation *op,
         else
           newStore->setAttr(attr.getName(), attr.getValue());
       }
+    } else if (auto rmw = dyn_cast<LLVM::AtomicRMWOp>(aab.user)) {
+      IRRewriter rewriter(rmw);
+
+      // The enzyme atomic rather than the memref one: it is the only form
+      // with somewhere to put the ordering the llvm op carries.
+      arith::AtomicRMWKind kind;
+      switch (rmw.getBinOp()) {
+      case LLVM::AtomicBinOp::xchg:
+        kind = arith::AtomicRMWKind::assign;
+        break;
+      case LLVM::AtomicBinOp::add:
+        kind = arith::AtomicRMWKind::addi;
+        break;
+      case LLVM::AtomicBinOp::_and:
+        kind = arith::AtomicRMWKind::andi;
+        break;
+      case LLVM::AtomicBinOp::_or:
+        kind = arith::AtomicRMWKind::ori;
+        break;
+      case LLVM::AtomicBinOp::max:
+        kind = arith::AtomicRMWKind::maxs;
+        break;
+      case LLVM::AtomicBinOp::min:
+        kind = arith::AtomicRMWKind::mins;
+        break;
+      case LLVM::AtomicBinOp::umax:
+        kind = arith::AtomicRMWKind::maxu;
+        break;
+      case LLVM::AtomicBinOp::umin:
+        kind = arith::AtomicRMWKind::minu;
+        break;
+      case LLVM::AtomicBinOp::fadd:
+        kind = arith::AtomicRMWKind::addf;
+        break;
+      case LLVM::AtomicBinOp::fmax:
+        kind = arith::AtomicRMWKind::maximumf;
+        break;
+      case LLVM::AtomicBinOp::fmin:
+        kind = arith::AtomicRMWKind::minimumf;
+        break;
+      default:
+        // The rest -- sub, nand, xor, the wrapping and saturating ones --
+        // name no arith kind to carry them.
+        continue;
+      }
+      if (rmw.getVolatile_())
+        continue;
+
+      Type ty = rmw.getVal().getType();
+      auto tySize = dl.getTypeSize(ty);
+      // See the load path above.
+      if (llvm::alignTo(static_cast<uint64_t>(tySize),
+                        dl.getTypeABIAlignment(ty)) != tySize)
+        continue;
+      // The two orderings agree case for case, so the llvm one names the
+      // enzyme one directly.
+      auto ordering = static_cast<enzyme::Ordering>(rmw.getOrdering());
+
+      if (MemRefType::isValidElementType(ty) && aab.isLegal() && aab.base &&
+          canMaterializeAfterValue(aab.base) &&
+          llvm::all_of(aab.getMap().operands, canMaterializeAfterValue)) {
+        auto memref0 = mc(aab.base);
+        Value memref = memref0;
+        auto memrefTy = memref0.getType();
+        if (memrefTy.getElementType() != ty) {
+          if (auto p2m = memref.getDefiningOp<enzymexla::Pointer2MemrefOp>())
+            memref = p2m.getOperand();
+          else
+            memref = enzymexla::Memref2PointerOp::create(
+                rewriter, rmw.getLoc(),
+                LLVM::LLVMPointerType::get(ty.getContext()), memref);
+          memref = enzymexla::Pointer2MemrefOp::create(
+                       rewriter, rmw.getLoc(),
+                       MemRefType::get(memrefTy.getShape(), ty,
+                                       MemRefLayoutAttrInterface{},
+                                       memrefTy.getMemorySpace()),
+                       memref)
+                       .getResult();
+        }
+
+        auto mao = aab.getMap();
+        if (mao.map.getResult(0).isMultipleOf(tySize) ||
+            isAligned(rmw, tySize)) {
+          auto expr = mao.map.getResult(0).floorDiv(tySize);
+          // The affine form, as the load and the store here take theirs: the
+          // access keeps its map rather than an index applied ahead of it.
+          auto newRMW = enzyme::AffineAtomicRMWOp::create(
+              rewriter, rmw.getLoc(), ty, kind, ordering, rmw.getVal(), memref,
+              ic(mao.operands),
+              AffineMap::get(mao.map.getNumDims(), mao.map.getNumSymbols(),
+                             expr),
+              rmw.getAlignmentAttr());
+          for (auto &a2 : accessBuilders)
+            a2->maybeReplaceBase(rmw, newRMW);
+          mc.replace(rmw, newRMW);
+          ic.replace(rmw, newRMW);
+          rewriter.replaceOp(rmw, newRMW);
+          continue;
+        }
+      }
+
+      Value idxs[1] = {
+          arith::ConstantIndexOp::create(rewriter, rmw.getLoc(), 0)};
+      auto newRMW = enzyme::AtomicRMWOp::create(
+          rewriter, rmw.getLoc(), ty, kind, ordering, rmw.getVal(),
+          enzymexla::Pointer2MemrefOp::create(
+              rewriter, rmw.getLoc(),
+              MemRefType::get({ShapedType::kDynamic}, ty,
+                              MemRefLayoutAttrInterface{},
+                              rewriter.getIndexAttr(
+                                  rmw.getPtr().getType().getAddressSpace())),
+              rmw.getPtr()),
+          idxs, rmw.getAlignmentAttr());
+      rewriter.replaceOp(rmw, newRMW);
     } else {
       llvm_unreachable("Unknown operation to raise");
     }

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -950,13 +950,11 @@ def EnzymeLiftControlFlowToSCFPass : Pass<"enzyme-lift-cf-to-scf"> {
 
 def LLVMToAffineAccessPass : Pass<"llvm-to-affine-access"> {
   let summary = "";
-  let dependentDialects = [
-    "LLVM::LLVMDialect",
-    "memref::MemRefDialect",
-    "affine::AffineDialect",
-    "vector::VectorDialect",
-    "enzymexla::EnzymeXLADialect",
-    "vector::VectorDialect",
+  let dependentDialects = ["LLVM::LLVMDialect", "enzyme::EnzymeDialect",
+                           "memref::MemRefDialect", "affine::AffineDialect",
+                           "vector::VectorDialect",
+                           "enzymexla::EnzymeXLADialect",
+                           "vector::VectorDialect",
   ];
 }
 

--- a/test/lit_tests/llvm_to_affine_access_atomic.mlir
+++ b/test/lit_tests/llvm_to_affine_access_atomic.mlir
@@ -1,0 +1,66 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+// An atomic read-modify-write becomes an access on a view of its pointer,
+// beside the loads and stores this pass rewrites. The enzyme atomic rather
+// than the memref one: it is the only form with somewhere to put the
+// ordering, and the alignment, that the llvm op carried.
+
+module {
+  func.func @fadd(%p: !llvm.ptr, %v: f64) {
+    %old = llvm.atomicrmw fadd %p, %v monotonic {alignment = 8 : i64} : !llvm.ptr, f64
+    return
+  }
+
+  func.func @add_seq_cst(%p: !llvm.ptr, %v: i32) {
+    %old = llvm.atomicrmw add %p, %v seq_cst : !llvm.ptr, i32
+    return
+  }
+
+  func.func @umax_in_shared(%p: !llvm.ptr<3>, %v: i32) {
+    %old = llvm.atomicrmw umax %p, %v acquire : !llvm.ptr<3>, i32
+    return
+  }
+
+  // a kind no arith one names is left alone
+  func.func @nand(%p: !llvm.ptr, %v: i32) {
+    %old = llvm.atomicrmw _xor %p, %v monotonic : !llvm.ptr, i32
+    return
+  }
+  // the address arithmetic joins the index, as it does for a load
+  func.func @through_gep(%p: !llvm.ptr, %i: i64, %v: f64) {
+    %g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    %old = llvm.atomicrmw fadd %g, %v monotonic {alignment = 8 : i64} : !llvm.ptr, f64
+    return
+  }
+
+}
+
+// CHECK:  func.func @fadd(%[[c1:.+]]: !llvm.ptr, %[[c2:.+]]: f64) {
+// CHECK-NEXT:  %[[c3:.+]] = "enzymexla.pointer2memref"(%[[c1]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[c4:.+]] = enzyme.affine_atomic_rmw addf %[[c2]], %[[c3]], (#map) [] monotonic {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @add_seq_cst(%[[c1:.+]]: !llvm.ptr, %[[c2:.+]]: i32) {
+// CHECK-NEXT:  %[[c3:.+]] = "enzymexla.pointer2memref"(%[[c1]]) : (!llvm.ptr) -> memref<?xi32>
+// CHECK-NEXT:  %[[c4:.+]] = enzyme.affine_atomic_rmw addi %[[c2]], %[[c3]], (#map) [] seq_cst : (i32, memref<?xi32>) -> i32
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @umax_in_shared(%[[c1:.+]]: !llvm.ptr<3>, %[[c2:.+]]: i32) {
+// CHECK-NEXT:  %[[c3:.+]] = "enzymexla.pointer2memref"(%[[c1]]) : (!llvm.ptr<3>) -> memref<?xi32, 3>
+// CHECK-NEXT:  %[[c4:.+]] = enzyme.affine_atomic_rmw maxu %[[c2]], %[[c3]], (#map) [] acquire : (i32, memref<?xi32, 3>) -> i32
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @nand(%[[c1:.+]]: !llvm.ptr, %[[c2:.+]]: i32) {
+// CHECK-NEXT:  %[[c3:.+]] = llvm.atomicrmw _xor %[[c1]], %[[c2]] monotonic : !llvm.ptr, i32
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @through_gep(%[[c1:.+]]: !llvm.ptr, %[[c2:.+]]: i64, %[[c3:.+]]: f64) {
+// CHECK-NEXT:  %[[c4:.+]] = arith.index_cast %[[c2]] : i64 to index
+// CHECK-NEXT:  %[[c5:.+]] = "enzymexla.pointer2memref"(%[[c1]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[c6:.+]] = enzyme.affine_atomic_rmw addf %[[c3]], %[[c5]], (#map1) [%[[c4]]] monotonic {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }


### PR DESCRIPTION
`llvm-to-affine-access` rewrites a load and a store on a raw pointer into an access on a view of it, and left an atomic read-modify-write alone — so the atomic's address stayed in llvm form, as a gep on whatever it walked from. A gep is a use of the pointer it walks from, and the raiser maps a kernel's pointer argument to a tensor only when a view is all that reads it (`non pointermemref user of pointer arg in kernel`).

The atomic is now rewritten in the same place, by the same walk, and in the same two shapes as a load — the affine one where the access map is legal, the view-of-the-pointer one where it is not:

```mlir
%g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f64
%old = llvm.atomicrmw fadd %g, %v monotonic {alignment = 8 : i64} : !llvm.ptr, f64
```
becomes
```mlir
%0 = arith.index_cast %i : i64 to index
%1 = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
%2 = enzyme.affine_atomic_rmw addf %v, %1, (#map)[%0] monotonic {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
```

so the address lives in the map, as a load's does, rather than being applied ahead of the access. Where no legal map exists the view is of the pointer itself, indexed at zero, in the non-affine form.

**The enzyme atomics, not `memref.atomic_rmw`**: the memref op has nowhere to put the ordering, so it would be dropped silently. The affine form could only be used once #3047 gave it an ordering of its own. Address space rides along in the view's type, so a shared-memory atomic stays in space 3.

Kinds are taken as far as arith names them — exchange, add, and, or, the signed and unsigned extremes, and the floating add and extremes. `sub`, `nand`, `xor` and the wrapping and saturating kinds name no arith kind and are left alone, as are volatile atomics and the sub-ABI-stride types the load path already declines.

Both forms raise: #3044 gave the raiser the non-affine enzyme atomic, #3047 the affine one. #3048 folds the gep for affine atomics that arrive from elsewhere; this pass keeps the gep out of the ones it converts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
