### PR TITLE
Fold the gep an affine atomic is taken through into its index

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -655,8 +655,12 @@ public:
 
   LogicalResult matchAndRewrite(T op,
                                 PatternRewriter &rewriter) const override {
+    // The accessed memref is the one this op names, whether or not the op
+    // itself spells out a type accessor for it.
+    auto accessedType = cast<MemRefType>(getMemref(op).getType());
+
     // FIXME: Only handle memref.load with single index for now
-    if (op.getMemRefType().getRank() != 1)
+    if (accessedType.getRank() != 1)
       return failure();
 
     // Match pointer2memref -> load pattern
@@ -666,7 +670,7 @@ public:
       return failure();
 
     // Get the element type and size of the final memref
-    Type elementType = op.getMemRefType().getElementType();
+    Type elementType = accessedType.getElementType();
     unsigned elementSize = elementType.isIntOrFloat()
                                ? elementType.getIntOrFloatBitWidth() / 8
                                : 0;
@@ -921,6 +925,42 @@ void LoadStorePointer2MemrefGEP<memref::AtomicRMWOp>::createNewOp(
       op, op.getKind(), op.getValue(), baseMemref, idxs);
 }
 
+template <>
+Value LoadStorePointer2MemrefGEP<enzyme::AffineAtomicRMWOp>::getMemref(
+    enzyme::AffineAtomicRMWOp op) const {
+  return op.getMemref();
+}
+
+template <>
+SmallVector<Value>
+LoadStorePointer2MemrefGEP<enzyme::AffineAtomicRMWOp>::newIndex(
+    enzyme::AffineAtomicRMWOp op, Value finalIndex,
+    PatternRewriter &rewriter) const {
+  auto apply = affine::AffineApplyOp::create(rewriter, op.getLoc(), op.getMap(),
+                                             op.getIndices());
+
+  SmallVector<Value> operands;
+  for (auto res : apply->getResults())
+    operands.push_back(res);
+  operands[0] =
+      arith::AddIOp::create(rewriter, op.getLoc(), operands[0], finalIndex);
+  return operands;
+}
+
+template <>
+void LoadStorePointer2MemrefGEP<enzyme::AffineAtomicRMWOp>::createNewOp(
+    enzyme::AffineAtomicRMWOp op, Value baseMemref, SmallVector<Value> idxs,
+    PatternRewriter &rewriter) const {
+  // As the affine load and store do, this leaves the non-affine form: the
+  // index it is given is a value, not a map. What the op says beyond the
+  // address -- its kind, its ordering, its alignment -- comes with it.
+  rewriter.replaceOpWithNewOp<enzyme::AtomicRMWOp>(
+      op, op.getResult().getType(), op.getKindAttr(),
+      enzyme::OrderingAttr::get(op.getContext(), op.getOrdering()),
+      op.getValue(), baseMemref, idxs, op.getAlignmentAttr(),
+      op.getFastmathAttr());
+}
+
 /// Simplify load (pointer2memref(x)) to llvm.load x
 template <typename Op>
 class MetaPointer2Memref final : public OpRewritePattern<Op> {
@@ -1163,6 +1203,7 @@ void Pointer2MemrefOp::getCanonicalizationPatterns(RewritePatternSet &results,
                  LoadStorePointer2MemrefGEP<affine::AffineStoreOp>,
                  LoadStorePointer2MemrefGEP<enzyme::AtomicRMWOp>,
                  LoadStorePointer2MemrefGEP<memref::AtomicRMWOp>,
+                 LoadStorePointer2MemrefGEP<enzyme::AffineAtomicRMWOp>,
                  HoistIfYieldConversion<scf::IfOp>,
                  HoistIfYieldConversion<affine::AffineIfOp>,
                  HoistSelectConversion>(context);

--- a/test/lit_tests/affine_atomic_gep_fold.mlir
+++ b/test/lit_tests/affine_atomic_gep_fold.mlir
@@ -1,0 +1,38 @@
+// RUN: enzymexlamlir-opt %s --canonicalize | FileCheck %s
+
+// The gep a view is taken through folds into the access index for the affine
+// atomic as for every other access, leaving the view on the gep's own base.
+// As the affine load and store do, it leaves the non-affine form, carrying
+// the kind, ordering and alignment the op named.
+
+module {
+  func.func @affine_atomic(%p: !llvm.ptr, %i: i64, %j: index, %v: f64) {
+    %g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xf64>
+    %old = enzyme.affine_atomic_rmw addf %v, %m, (affine_map<(d0) -> (d0)>)[%j] seq_cst {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+    return
+  }
+
+  // an element type the view does not share with the gep is left alone
+  func.func @element_type_differs(%p: !llvm.ptr, %i: i64, %j: index, %v: f64) {
+    %g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32, i32, i32)>
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xf64>
+    %old = enzyme.affine_atomic_rmw addf %v, %m, (affine_map<(d0) -> (d0)>)[%j] monotonic : (f64, memref<?xf64>) -> f64
+    return
+  }
+}
+
+// CHECK:  func.func @affine_atomic(%[[g1:.+]]: !llvm.ptr, %[[g2:.+]]: i64, %[[g3:.+]]: index, %[[g4:.+]]: f64) {
+// CHECK-NEXT:  %[[g5:.+]] = "enzymexla.pointer2memref"(%[[g1]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[g6:.+]] = arith.index_cast %[[g2]] : i64 to index
+// CHECK-NEXT:  %[[g7:.+]] = arith.addi %[[g3]], %[[g6]] : index
+// CHECK-NEXT:  %[[g8:.+]] = enzyme.atomic_rmw addf %[[g4]], %[[g5]][%[[g7]]] seq_cst {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @element_type_differs(%[[g1:.+]]: !llvm.ptr, %[[g2:.+]]: i64, %[[g3:.+]]: index, %[[g4:.+]]: f64) {
+// CHECK-NEXT:  %[[g5:.+]] = llvm.getelementptr inbounds %[[g1]][%[[g2]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32, i32, i32)>
+// CHECK-NEXT:  %[[g6:.+]] = "enzymexla.pointer2memref"(%[[g5]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  %[[g7:.+]] = enzyme.affine_atomic_rmw addf %[[g4]], %[[g6]], (#map) [%[[g3]]] monotonic : (f64, memref<?xf64>) -> f64
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }


### PR DESCRIPTION
`LoadStorePointer2MemrefGEP` rebases an access taken through a view of a gep onto a view of the gep's own base, with the offset joining the index. It covers the memref and affine loads and stores and, since #3045, both non-affine atomics — and missed `enzyme.affine_atomic_rmw`, which is the same access with the same addressing:

```mlir
%g = llvm.getelementptr inbounds %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, f64
%m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xf64>
%old = enzyme.affine_atomic_rmw addf %v, %m, (#map)[%j] seq_cst {alignment = 8 : i64} : (f64, memref<?xf64>) -> f64
```

becomes an atomic on `pointer2memref(%p)`, indexed by the map's result plus the gep's offset. As the affine load and store do, it leaves the non-affine form — the index it is handed is a value, not a map — and what the op says beyond the address comes with it: kind, ordering, alignment.

**One generalization to the pattern.** It asked ops for `getMemRefType()`, which only some of them declare — the affine atomic does not. It now takes the type from the memref the op names, which every op it handles has, so an op is not kept out of the rewrite by an accessor it happens not to spell out.

**Not gaps, having checked:** `PolygeistMem2Reg` classifies users through the MemoryEffects interface and both atomics declare `[MemRead, MemWrite]` on their memref, so they are already treated as writes rather than skipped. `MemrefLoadAffineApply`'s atomic counterpart is `MoveEnzymeRMWToAffine`, which exists for both forms. `LoadSelect` has no atomic twin on purpose: duplicating a side-effecting op into both arms of a select would perform two atomics, so it would need an `scf.if` rather than a select.

The test covers the fold and the rejection that was already there — a view whose element type the gep does not share. The full lit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
