### PR TITLE
Stop the barrier effect walk at a function boundary

### DIFF
--- a/src/enzyme_ad/jax/Utils.cpp
+++ b/src/enzyme_ad/jax/Utils.cpp
@@ -264,12 +264,21 @@ bool getEffectsBefore(Operation *op,
 
   bool conservative = false;
 
-  if (isa<scf::ParallelOp, affine::AffineParallelOp>(op->getParentOp()))
+  Operation *parent = op->getParentOp();
+  if (isa<scf::ParallelOp, affine::AffineParallelOp>(parent))
     return true;
+
+  if (isa<FunctionOpInterface>(parent)) {
+    effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Read>());
+    effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Write>());
+    effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Allocate>());
+    effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Free>());
+    return false;
+  }
 
   // As we didn't hit another barrier, we must check the predecessors of this
   // operation.
-  if (!getEffectsBefore(op->getParentOp(), effects, stopAtBarrier)) {
+  if (!getEffectsBefore(parent, effects, stopAtBarrier)) {
     return false;
   }
   // If the parent operation is not guaranteed to execute its (single-block)
@@ -304,12 +313,21 @@ bool getEffectsAfter(Operation *op,
 
   bool conservative = false;
 
-  if (isa<scf::ParallelOp, affine::AffineParallelOp>(op->getParentOp()))
+  Operation *parent = op->getParentOp();
+  if (isa<scf::ParallelOp, affine::AffineParallelOp>(parent))
     return true;
+
+  if (isa<FunctionOpInterface>(parent)) {
+    effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Read>());
+    effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Write>());
+    effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Allocate>());
+    effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Free>());
+    return false;
+  }
 
   // As we didn't hit another barrier, we must check the predecessors of this
   // operation.
-  if (!getEffectsAfter(op->getParentOp(), effects, stopAtBarrier))
+  if (!getEffectsAfter(parent, effects, stopAtBarrier))
     return false;
 
   // If the parent operation is not guaranteed to execute its (single-block)

--- a/test/lit_tests/barrier-outside-parallel.mlir
+++ b/test/lit_tests/barrier-outside-parallel.mlir
@@ -1,0 +1,19 @@
+// RUN: enzymexlamlir-opt %s --canonicalize | FileCheck %s
+
+// A barrier's effects are read by walking outwards from it, and the walk stops
+// at an enclosing parallel op. A barrier outside any parallel op has no such
+// stopping point, so the climb runs to the function boundary, where what came
+// before is whatever called it.
+
+module {
+  func.func @f(%m : memref<10xf32>, %v: f32, %i: index) {
+    memref.store %v, %m[%i] : memref<10xf32>
+    "enzymexla.barrier"(%i) : (index) -> ()
+    return
+  }
+}
+
+// The effects are unknown rather than empty, so the barrier is not dead.
+// CHECK-LABEL: func.func @f
+// CHECK-NEXT: memref.store
+// CHECK-NEXT: "enzymexla.barrier"


### PR DESCRIPTION
A barrier's effects are read by walking outwards from it, and the climb stops at an enclosing parallel op. A barrier outside any parallel op has no such stopping point, so the climb runs past the enclosing function up to the top-level operation, whose `getBlock()` is null.

Nothing prevents that IR: `BarrierOp` has no verifier and no `ParentOneOf`, so the "barrier for parallel loops" summary is documentation rather than a constraint. On main today:

```mlir
func.func @f(%m : memref<10xf32>, %v: f32, %i: index) {
  memref.store %v, %m[%i] : memref<10xf32>
  "enzymexla.barrier"(%i) : (index) -> ()
  return
}
```

`enzymexlamlir-opt %s --canonicalize` segfaults, since canonicalization asks `wouldOpBeTriviallyDead` about the barrier.

The climb now stops at a function boundary: what runs before or after a function is whatever called it, which cannot be enumerated from here. Nothing encloses a function that this could read, so it answers conservatively there, as `collectEffects` does for an op it cannot read -- append read/write/allocate/free and return `false`. The appending is the point, since `BarrierElim` ignores the result and reads only the effect list: an empty list would read as "nothing conflicts here" and erase the barrier. With unknown effects the barrier is kept, which is what the added test checks.

This also replaces what the walk did before at that boundary, which was to climb into the module and `walk()` every operation in it.

Note that `getEffectsBeforeForLoopDistribute` in ParallelLoopDistribute.cpp is a copy of this walk with the same unbounded climb; it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
