### PR TITLE
Write a zeroing memset of an alloca as a loop of zero stores

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1,6 +1,7 @@
 #include "Passes.h"
 
 #include "Enzyme/MLIR/Dialect/Ops.h"
+#include "Enzyme/MLIR/Interfaces/AutoDiffTypeInterface.h"
 #include "mlir/Analysis/CallGraph.h"
 #include "mlir/Analysis/DataLayoutAnalysis.h"
 #include "mlir/Dialect/Affine/Analysis/AffineStructures.h"
@@ -1681,6 +1682,72 @@ static Value createVectorLoad(OpBuilder &b, Location loc, Type ty,
   llvm_unreachable("");
 }
 
+// A zeroing memset is a loop of stores of zero, and only in that form does an
+// allocation the conversion could take stop being blocked by it: the
+// conversion accepts views of an allocation and nothing else, and a memset
+// names the pointer itself. The element type is the one the allocation was
+// declared with, so the stores land on whole elements; a length that is not a
+// whole number of them is left alone.
+struct MemsetZeroToAffineFill : public OpRewritePattern<LLVM::MemsetOp> {
+  using OpRewritePattern<LLVM::MemsetOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::MemsetOp memset,
+                                PatternRewriter &rewriter) const override {
+    llvm::APInt val, len;
+    if (!matchPattern(memset.getVal(), m_ConstantInt(&val)) || !val.isZero())
+      return failure();
+    if (!matchPattern(memset.getLen(), m_ConstantInt(&len)))
+      return failure();
+    int64_t bytes = len.getSExtValue();
+    if (bytes <= 0)
+      return failure();
+    if (memset.getIsVolatile())
+      return failure();
+
+    Value base = memset.getDst();
+    while (true) {
+      if (auto gep = base.getDefiningOp<LLVM::GEPOp>())
+        base = gep.getBase();
+      else if (auto cast = base.getDefiningOp<LLVM::AddrSpaceCastOp>())
+        base = cast.getArg();
+      else
+        break;
+    }
+    auto alloca = base.getDefiningOp<LLVM::AllocaOp>();
+    if (!alloca)
+      return failure();
+    Type elTy = alloca.getElemType();
+    while (auto arr = dyn_cast<LLVM::LLVMArrayType>(elTy))
+      elTy = arr.getElementType();
+    auto adTy = dyn_cast<enzyme::AutoDiffTypeInterface>(elTy);
+    if (!adTy || !MemRefType::isValidElementType(elTy))
+      return failure();
+
+    DataLayout dl = DataLayout::closest(memset);
+    int64_t elSize = dl.getTypeSize(elTy);
+    if (elSize <= 0 || bytes % elSize != 0)
+      return failure();
+
+    Location loc = memset.getLoc();
+    auto ptrTy = cast<LLVM::LLVMPointerType>(memset.getDst().getType());
+    auto viewTy = MemRefType::get(
+        {ShapedType::kDynamic}, elTy, MemRefLayoutAttrInterface{},
+        rewriter.getIndexAttr(ptrTy.getAddressSpace()));
+    Value view = enzymexla::Pointer2MemrefOp::create(rewriter, loc, viewTy,
+                                                     memset.getDst());
+    Value zero = adTy.createNullValue(rewriter, loc);
+    auto loop = affine::AffineForOp::create(rewriter, loc, 0, bytes / elSize);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(loop.getBody());
+      affine::AffineStoreOp::create(rewriter, loc, zero, view,
+                                    ValueRange{loop.getInductionVar()});
+    }
+    rewriter.eraseOp(memset);
+    return success();
+  }
+};
+
 /// Fold constant dimensions into an alloc like operation.
 template <typename AllocLikeOp, bool gpu = false>
 struct SimplifyAllocConst : public OpRewritePattern<AllocLikeOp> {
@@ -2289,6 +2356,7 @@ convertLLVMToAffineAccess(Operation *op,
                     SimplifyInPlaceAlloc<memref::AllocaOp>,
                     SimplifyInPlaceAlloc<gpu::AllocOp>>(context,
                                                         dataLayoutAnalysis);
+    patterns.insert<MemsetZeroToAffineFill>(context);
     patterns.insert<IndexCastAddSub, MemrefLoadAffineApply, SelectCSE,
                     SelectAddrCast>(context);
     patterns.insert<SimplifyAllocConst<memref::AllocOp>,

--- a/test/lit_tests/memset_zero_fill.mlir
+++ b/test/lit_tests/memset_zero_fill.mlir
@@ -1,0 +1,76 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+module {
+  func.func @zerofill(%i: i64) {
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %a = llvm.alloca %c1 x !llvm.array<8 x f64> : (i32) -> !llvm.ptr
+    "llvm.intr.memset"(%a, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    %g = llvm.getelementptr inbounds %a[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<24 x i8>
+    "llvm.intr.memset"(%g, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    return
+  }
+  func.func @ptrs() {
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %a = llvm.alloca %c1 x !llvm.array<8 x ptr> : (i32) -> !llvm.ptr
+    "llvm.intr.memset"(%a, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    return
+  }
+  func.func @structs() {
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %a = llvm.alloca %c1 x !llvm.array<2 x struct<(f64, i64)>> : (i32) -> !llvm.ptr
+    "llvm.intr.memset"(%a, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    return
+  }
+  func.func @ragged() {
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i8
+    %c12 = arith.constant 12 : i64
+    %a = llvm.alloca %c1 x !llvm.array<8 x f64> : (i32) -> !llvm.ptr
+    "llvm.intr.memset"(%a, %c0, %c12) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    return
+  }
+}
+
+// CHECK:  func.func @zerofill(%[[m1:.+]]: i64) {
+// CHECK-NEXT:  %[[m2:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:  %[[m3:.+]] = arith.constant 1 : i32
+// CHECK-NEXT:  %[[m4:.+]] = llvm.alloca %[[m3]] x !llvm.array<8 x f64> : (i32) -> !llvm.ptr
+// CHECK-NEXT:  %[[m5:.+]] = "enzymexla.pointer2memref"(%[[m4]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  affine.for %arg1 = 0 to 3 {
+// CHECK-NEXT:  affine.store %[[m2]], %[[m5]][%arg1] : memref<?xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %[[m6:.+]] = llvm.getelementptr inbounds %[[m4]][%[[m1]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<24 x i8>
+// CHECK-NEXT:  %[[m7:.+]] = "enzymexla.pointer2memref"(%[[m6]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  affine.for %arg1 = 0 to 3 {
+// CHECK-NEXT:  affine.store %[[m2]], %[[m7]][%arg1] : memref<?xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @ptrs() {
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @structs() {
+// CHECK-NEXT:  %[[s1:.+]] = arith.constant 1 : i32
+// CHECK-NEXT:  %[[s2:.+]] = arith.constant 0 : i8
+// CHECK-NEXT:  %[[s3:.+]] = arith.constant 24 : i64
+// CHECK-NEXT:  %[[s4:.+]] = llvm.alloca %[[s1]] x !llvm.array<2 x struct<(f64, i64)>> : (i32) -> !llvm.ptr
+// CHECK-NEXT:  "llvm.intr.memset"(%[[s4]], %[[s2]], %[[s3]]) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func @ragged() {
+// CHECK-NEXT:  %[[m1:.+]] = arith.constant 1 : i32
+// CHECK-NEXT:  %[[m2:.+]] = arith.constant 0 : i8
+// CHECK-NEXT:  %[[m3:.+]] = arith.constant 12 : i64
+// CHECK-NEXT:  %[[m4:.+]] = llvm.alloca %[[m1]] x !llvm.array<8 x f64> : (i32) -> !llvm.ptr
+// CHECK-NEXT:  "llvm.intr.memset"(%[[m4]], %[[m2]], %[[m3]]) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+// CHECK-NEXT:  return
+// CHECK-NEXT:  }


### PR DESCRIPTION
An `llvm.alloca` becomes a `memref.alloca` only if every user is understood. A zeroing `llvm.intr.memset` is not, so one memset keeps an otherwise ordinary scratch buffer in pointer form for the rest of the pipeline -- and the accesses through it stay pointer-shaped too.

A zeroing memset of a whole number of elements is just a loop storing zeros, so this writes it as one, in `LLVMToAffineAccess` beside the alloca conversion it unblocks:

```mlir
llvm.intr.memset %alloca, %c0_i8, %c24 : !llvm.ptr, i8, i64
```

becomes

```mlir
%view = "enzymexla.pointer2memref"(%alloca) : (!llvm.ptr) -> memref<?xf64>
affine.for %i = 0 to 3 {
  affine.store %cst_zero, %view[%i] : memref<?xf64>
}
```

The pattern requires a constant zero fill value, a constant length, and a non-volatile memset. It walks the destination back through geps and addrspace casts to the `llvm.alloca`, peels nested `!llvm.array` to reach an element type, and applies only when the byte count divides evenly by that element's size -- a ragged length is left alone rather than guessed at, as the test covers.

The zero comes from `AutoDiffTypeInterface::createNullValue`, so this is not limited to int and float elements: a `!llvm.ptr` element fills with null pointers, and the test covers that buffer converting and then falling away as dead. The element must also be storable in a memref, which an `!llvm.struct` is not despite having a null value -- also covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
