### PR TITLE
affine-cfg: only the loop's own yield says what it carries

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -6474,6 +6474,11 @@ struct AffineForReductionSink : public OpRewritePattern<affine::AffineForOp> {
         auto yldu = llvm::dyn_cast<AffineYieldOp>(u.getOwner());
         if (!yldu)
           continue;
+        // A yield of some other op nested in the body -- an affine.if, say --
+        // says nothing about what this loop carries, and its operand number
+        // does not index this loop's inits.
+        if (yldu->getParentOp() != forOp)
+          continue;
         if (yld) {
           legal = false;
           break;

--- a/test/lit_tests/affine_reduction_sink_foreign_yield.mlir
+++ b/test/lit_tests/affine_reduction_sink_foreign_yield.mlir
@@ -1,0 +1,18 @@
+// RUN: enzymexlamlir-opt %s --affine-cfg | FileCheck %s
+
+func.func @foreign_yield(%out: memref<1xf64>, %other: memref<1xf64>, %in: memref<8xf64>, %c: index) {
+  %cst = arith.constant 0.000000e+00 : f64
+  affine.for %i = 0 to 8 {
+    %v = affine.load %in[%i] : memref<8xf64>
+    %s = affine.if affine_set<()[s0] : (s0 - 1 >= 0)>()[%c] -> f64 {
+      affine.yield %v : f64
+    } else {
+      affine.yield %cst : f64
+    }
+    affine.store %v, %out[0] : memref<1xf64>
+    affine.store %s, %other[0] : memref<1xf64>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @foreign_yield


### PR DESCRIPTION
`AffineForReductionSink` finds the yield of a stored value by scanning that value's uses for any `affine.yield`. That includes the terminator of an `affine.if` nested in the loop body, which says nothing about what the loop carries. It then indexes `forOp.getInits()` with that yield's operand number: for a foreign yield the number does not index this loop's inits at all, and on a loop with no iter args it indexes an empty range, so `getDefiningOp()` runs on a garbage `Value` and segfaults.

On main today, `enzymexlamlir-opt %s --affine-cfg`:

```mlir
func.func @foreign_yield(%out: memref<1xf64>, %other: memref<1xf64>, %in: memref<8xf64>, %c: index) {
  %cst = arith.constant 0.000000e+00 : f64
  affine.for %i = 0 to 8 {
    %v = affine.load %in[%i] : memref<8xf64>
    %s = affine.if affine_set<()[s0] : (s0 - 1 >= 0)>()[%c] -> f64 {
      affine.yield %v : f64
    } else {
      affine.yield %cst : f64
    }
    affine.store %v, %out[0] : memref<1xf64>
    affine.store %s, %other[0] : memref<1xf64>
  }
  return
}
```

The two stores have to target different buffers, or the legality check rejects them before the pattern reaches this point.

Take only a yield whose parent is the loop.

This turned up as two MFEM translation units crashing (`fem/qinterp/grad_transpose`, `fem/quadinterpolator`) after #3056, which changed which values end up yielded where and so walked into the unguarded case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
