### PR TITLE
CuDNNHLOOpt: don't fuse a dot_general with no contracting dimensions

### DIFF
--- a/src/enzyme_ad/jax/Passes/CuDNNHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/CuDNNHLOOpt.cpp
@@ -82,6 +82,16 @@ struct DotGeneralElementwiseToCuDNNFusion
     if (!dotGeneral->hasOneUse())
       return failure();
 
+    // cuDNN's matmul engine needs an actual contraction. A dot_general with no
+    // contracting dimensions is a batched outer product, and cuDNN has no
+    // candidate for it: the fusion is built, and the GPU compiler then fails
+    // the whole module with "No candidates could be compiled".
+    if (dotGeneral.getDotDimensionNumbers()
+            .getLhsContractingDimensions()
+            .empty())
+      return rewriter.notifyMatchFailure(
+          elemOp, "dot_general has no contracting dimensions");
+
     ModuleOp mod = elemOp->template getParentOfType<ModuleOp>();
     if (!mod)
       return rewriter.notifyMatchFailure(elemOp, "No module found");

--- a/test/lit_tests/cudnn/fusion.mlir
+++ b/test/lit_tests/cudnn/fusion.mlir
@@ -36,3 +36,20 @@ module {
 // CHECK-NEXT:    %0 = stablehlo.custom_call @__cudnn$fusion(%arg0, %arg1, %arg2) {called_computations = [@__cudnn_fused_elementwise_dot_0]} : (tensor<4x16x16xbf16>, tensor<4x16x16xbf16>, tensor<4x16x16xbf16>) -> tensor<4x16x16xbf16>
 // CHECK-NEXT:    return %0 : tensor<4x16x16xbf16>
 // CHECK-NEXT:  }
+
+// A dot_general with no contracting dimensions is a batched outer product.
+// cuDNN has no candidate for it ("No candidates could be compiled"), so it must
+// be left alone rather than wrapped in a fusion.
+module {
+    func.func @outer_product(%arg0: tensor<4x16xbf16>, %arg1: tensor<8x4x16xbf16>, %arg2: tensor<4x16x8xbf16>) -> (tensor<4x16x8xbf16>) {
+        %1 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0, 1] x [1, 2], contracting_dims = [] x [] : (tensor<4x16xbf16>, tensor<8x4x16xbf16>) -> tensor<4x16x8xbf16>
+        %2 = stablehlo.multiply %1, %arg2 : tensor<4x16x8xbf16>
+        return %2 : tensor<4x16x8xbf16>
+    }
+}
+
+// CHECK:      func.func @outer_product
+// CHECK-NOT:    stablehlo.custom_call @__cudnn$fusion
+// CHECK:        stablehlo.dot_general
+// CHECK-NEXT:   stablehlo.multiply
+


### PR DESCRIPTION
Fixes #3058.

A `dot_general` with empty `contracting_dims` is a batched outer product, not a matmul, and cuDNN has no candidate for it: the fusion is built and the GPU compiler then fails the whole module with `No candidates could be compiled`. The pattern matched any dot feeding an elementwise op without checking.

On a depth-12 bf16 training step this accounted for 49 of the 61 emitted fusions; the 12 with a real contraction all compiled.

Verified locally: `bazel test //test/lit_tests/...` is 1214/1214, and the added lit case asserts the outer product comes out unfused.