### PR TITLE
canonicalize-scf-for: a pointer advanced a fixed distance is an induction variable

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -374,6 +374,102 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
         continue;
       }
 
+      // A pointer advanced by a fixed distance each iteration is an induction
+      // variable like any other: on iteration n it is the init advanced by n
+      // times that distance. The advance can be a chain of geps, and each
+      // step of it can be a value as long as the loop does not vary it. The
+      // arithmetic is the same as the integer case, done in the gep's index.
+      if (isa<LLVM::LLVMPointerType>(iterarg.getType())) {
+        SmallVector<LLVM::GEPOp> chain;
+        Value cur = yld;
+        while (cur != iterarg) {
+          auto g = cur.getDefiningOp<LLVM::GEPOp>();
+          if (!g || g.getIndices().size() != 1)
+            break;
+          chain.push_back(g);
+          cur = g.getBase();
+        }
+        if (cur != iterarg || chain.empty())
+          continue;
+        // Offsets only add up when they are in the same units.
+        Type elemTy = chain.front().getElemType();
+        if (llvm::any_of(chain, [&](LLVM::GEPOp g) {
+              return g.getElemType() != elemTy;
+            }))
+          continue;
+        int64_t constStride = 0;
+        SmallVector<Value> dynStrides;
+        bool ok = true;
+        for (auto g : chain) {
+          auto idx = g.getIndices()[0];
+          if (auto attr = dyn_cast<IntegerAttr>(idx)) {
+            constStride += attr.getInt();
+            continue;
+          }
+          Value v = cast<Value>(idx);
+          if (!forOp.isDefinedOutsideOfLoop(v)) {
+            ok = false;
+            break;
+          }
+          dynStrides.push_back(v);
+        }
+        if (!ok)
+          continue;
+        Location loc = forOp.getLoc();
+
+        auto advancedBy = [&](Value count) {
+          Value stride = nullptr;
+          for (Value v : dynStrides) {
+            Value c = castValue(rewriter, v, count, loc);
+            stride = stride
+                         ? AddIOp::create(rewriter, loc, stride, c).getResult()
+                         : c;
+          }
+          if (constStride || !stride) {
+            Value c = arith::ConstantOp::create(
+                rewriter, loc,
+                rewriter.getIntegerAttr(count.getType(), constStride));
+            stride = stride
+                         ? AddIOp::create(rewriter, loc, stride, c).getResult()
+                         : c.getDefiningOp()->getResult(0);
+          }
+          Value offset = MulIOp::create(rewriter, loc, count, stride);
+          // A gep index is a signless integer; loop arithmetic is often index.
+          if (isa<IndexType>(offset.getType()))
+            offset = IndexCastOp::create(rewriter, loc, rewriter.getI64Type(),
+                                         offset);
+          return LLVM::GEPOp::create(rewriter, loc, chain.back().getType(),
+                                     elemTy, outiter, ValueRange{offset},
+                                     chain.back().getNoWrapFlags())
+              .getResult();
+        };
+
+        if (!iterarg.use_empty()) {
+          rewriter.setInsertionPointToStart(&forOp.getRegion().front());
+          Value count = SubIOp::create(rewriter, loc, forOp.getInductionVar(),
+                                       forOp.getLowerBound());
+          count = DivUIOp::create(rewriter, loc, count, forOp.getStep());
+          Value replacement = advancedBy(count);
+          Value iterargCopy = iterarg;
+          rewriter.modifyOpInPlace(
+              forOp, [&] { iterargCopy.replaceAllUsesWith(replacement); });
+          canonicalize = true;
+        }
+
+        if (!res.use_empty()) {
+          rewriter.setInsertionPoint(forOp);
+          Value count = SubIOp::create(rewriter, loc, forOp.getUpperBound(),
+                                       forOp.getLowerBound());
+          count = DivUIOp::create(rewriter, loc, count, forOp.getStep());
+          Value replacement = advancedBy(count);
+          Value resCopy = res;
+          rewriter.modifyOpInPlace(
+              forOp, [&] { resCopy.replaceAllUsesWith(replacement); });
+          canonicalize = true;
+        }
+        continue;
+      }
+
       AddIOp addOp = yld.getDefiningOp<AddIOp>();
       if (!addOp)
         continue;

--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -458,9 +458,20 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
 
         if (!res.use_empty()) {
           rewriter.setInsertionPoint(forOp);
-          Value count = SubIOp::create(rewriter, loc, forOp.getUpperBound(),
-                                       forOp.getLowerBound());
-          count = DivUIOp::create(rewriter, loc, count, forOp.getStep());
+          // The trip count is a ceiling division: a range the step does not
+          // divide evenly still runs the iteration that starts inside it. A
+          // range the loop never enters runs none.
+          Value span = SubIOp::create(rewriter, loc, forOp.getUpperBound(),
+                                      forOp.getLowerBound());
+          Value zero = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getIntegerAttr(span.getType(), 0));
+          span = MaxSIOp::create(rewriter, loc, span, zero);
+          Value one = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getIntegerAttr(span.getType(), 1));
+          Value bump = SubIOp::create(rewriter, loc, forOp.getStep(), one);
+          Value count = DivUIOp::create(
+              rewriter, loc, AddIOp::create(rewriter, loc, span, bump),
+              forOp.getStep());
           Value replacement = advancedBy(count);
           Value resCopy = res;
           rewriter.modifyOpInPlace(

--- a/test/lit_tests/canonicalize_for_gep_induction.mlir
+++ b/test/lit_tests/canonicalize_for_gep_induction.mlir
@@ -97,3 +97,40 @@ func.func @varying_stride(%p: !llvm.ptr, %n: i64, %x: f64) {
 
 // CHAIN-LABEL: func.func @varying_stride(
 // CHAIN: iter_args
+
+// -----
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for --canonicalize | FileCheck %s --check-prefix=TRIP
+
+// 0 to 10 step 4 runs at 0, 4 and 8, so the result is the init advanced three
+// times: the trip count is a ceiling division, not a truncating one.
+func.func @ragged_trip_count(%p: !llvm.ptr, %x: f64) -> !llvm.ptr {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %c10 = arith.constant 10 : index
+  %r = scf.for %i = %c0 to %c10 step %c4 iter_args(%q = %p) -> (!llvm.ptr) {
+    llvm.store %x, %q : f64, !llvm.ptr
+    %next = llvm.getelementptr inbounds|nuw %q[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return %r : !llvm.ptr
+}
+
+// A loop that never runs advances nothing.
+func.func @never_runs(%p: !llvm.ptr, %x: f64) -> !llvm.ptr {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c5 = arith.constant 5 : index
+  %r = scf.for %i = %c5 to %c0 step %c1 iter_args(%q = %p) -> (!llvm.ptr) {
+    llvm.store %x, %q : f64, !llvm.ptr
+    %next = llvm.getelementptr inbounds|nuw %q[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return %r : !llvm.ptr
+}
+
+// TRIP-LABEL: func.func @ragged_trip_count(
+// TRIP: %[[r:.+]] = llvm.getelementptr inbounds|nuw %arg0[24]
+// TRIP: return %[[r]]
+
+// TRIP-LABEL: func.func @never_runs(
+// TRIP: return %arg0

--- a/test/lit_tests/canonicalize_for_gep_induction.mlir
+++ b/test/lit_tests/canonicalize_for_gep_induction.mlir
@@ -1,0 +1,99 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for | FileCheck %s
+
+// A pointer advanced by a constant gep each iteration is an induction
+// variable: on iteration n it is the init advanced by n times that offset.
+func.func @ptr_induction(%p: !llvm.ptr, %n: index, %x: f64) -> !llvm.ptr {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%q = %p) -> (!llvm.ptr) {
+    llvm.store %x, %q : f64, !llvm.ptr
+    %next = llvm.getelementptr inbounds|nuw %q[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return %r : !llvm.ptr
+}
+
+// A step of more than one divides into the count.
+func.func @strided(%p: !llvm.ptr, %n: index, %x: f64) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %r = scf.for %i = %c0 to %n step %c4 iter_args(%q = %p) -> (!llvm.ptr) {
+    llvm.store %x, %q : f64, !llvm.ptr
+    %next = llvm.getelementptr %q[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return
+}
+
+// An advance the loop does not vary is a fixed distance, even as a value.
+func.func @dynamic_advance(%p: !llvm.ptr, %n: index, %k: i64, %x: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%q = %p) -> (!llvm.ptr) {
+    llvm.store %x, %q : f64, !llvm.ptr
+    %next = llvm.getelementptr %q[%k] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return
+}
+
+// Advancing something other than the carried pointer is not an induction.
+func.func @other_base(%p: !llvm.ptr, %o: !llvm.ptr, %n: index, %x: f64) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%q = %p) -> (!llvm.ptr) {
+    llvm.store %x, %q : f64, !llvm.ptr
+    %next = llvm.getelementptr %o[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @ptr_induction(
+// CHECK-NOT: iter_args
+// CHECK: llvm.getelementptr inbounds|nuw %arg0[%{{.+}}]
+
+// CHECK-LABEL: func.func @strided(
+// CHECK-NOT: iter_args
+
+// CHECK-LABEL: func.func @dynamic_advance(
+// CHECK-NOT: iter_args
+
+// CHECK-LABEL: func.func @other_base(
+// CHECK: iter_args
+
+// -----
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for | FileCheck %s --check-prefix=CHAIN
+
+// The advance can be a chain, and a step of it can be a value the loop does
+// not vary.
+func.func @chained_invariant(%p: !llvm.ptr, %n: i64, %k: i64, %x: f64) {
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%q = %p) -> (!llvm.ptr) : i64 {
+    %mid = llvm.getelementptr inbounds|nuw %q[%k] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    llvm.store %x, %mid : f64, !llvm.ptr
+    %next = llvm.getelementptr inbounds|nuw %mid[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return
+}
+
+// A stride the loop varies is not a fixed distance: left alone.
+func.func @varying_stride(%p: !llvm.ptr, %n: i64, %x: f64) {
+  %c0 = arith.constant 0 : i64
+  %c1 = arith.constant 1 : i64
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%q = %p) -> (!llvm.ptr) : i64 {
+    %mid = llvm.getelementptr inbounds|nuw %q[%i] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    llvm.store %x, %mid : f64, !llvm.ptr
+    %next = llvm.getelementptr inbounds|nuw %mid[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return
+}
+
+// CHAIN-LABEL: func.func @chained_invariant(
+// CHAIN-NOT: iter_args
+
+// CHAIN-LABEL: func.func @varying_stride(
+// CHAIN: iter_args


### PR DESCRIPTION
`ForOpInductionReplacement` already rewrites an integer iter arg yielded as `addi(iterarg, k)` into the init plus `(iv - lb)/step` times `k`, so the loop stops carrying it. A pointer advanced by a gep each iteration is the same thing and had no case, so the loop kept carrying it and everything downstream had to cope with a pointer-typed iter arg.

```mlir
%r = scf.for %i = %c0 to %n step %c1 iter_args(%q = %p) -> (!llvm.ptr) {
  llvm.store %x, %q : f64, !llvm.ptr
  %next = llvm.getelementptr inbounds|nuw %q[8] : (!llvm.ptr) -> !llvm.ptr, i8
  scf.yield %next : !llvm.ptr
}
```

becomes

```mlir
%0 = arith.muli %arg1, %c8 : index
%1 = arith.index_cast %0 : index to i64
%2 = llvm.getelementptr inbounds|nuw %arg0[%1] : (!llvm.ptr, i64) -> !llvm.ptr, i8
scf.for %arg3 = %c0 to %arg1 step %c1 {
  %3 = arith.muli %arg3, %c8 : index
  %4 = arith.index_cast %3 : index to i64
  %5 = llvm.getelementptr inbounds|nuw %arg0[%4] : (!llvm.ptr, i64) -> !llvm.ptr, i8
  llvm.store %arg2, %5 : f64, !llvm.ptr
}
```

The advance can be a chain of geps, and each step of it can be a value rather than a constant as long as the loop does not vary it (`isDefinedOutsideOfLoop`) -- the rule is a fixed distance, not a constant one. Offsets only add up in the same units, so the chain has to agree on an element type. The result is the init advanced by the whole trip count, as in the integer case. A stride the loop varies, such as one indexed by the induction variable, is left alone.

This is a shape that reaches the raiser from mfem: a pointer walked one element per iteration and read at `[0]`, where the pointer is the induction variable and the loop carries no other state.

**What it does not cover.** In `fem/hybridization_ext.cpp` and `linalg/batched/native.cpp` the induction is nested:

```mlir
%81 = scf.for %arg8 = %c1_i64 to %80 iter_args(%arg9 = %78) -> ptr {
  %86 = scf.for %arg10 = %c1_i64 to %85 iter_args(%arg11 = %6) -> ptr {
    %89 = llvm.getelementptr %arg9[%88]
    %99 = llvm.getelementptr %89[8]
    scf.yield %99
  }
  scf.yield %86
}
```

The inner loop's own iter arg is dead in the body and the yielded chain roots at the enclosing loop's iter arg, so neither loop matches "my yield advances my own iter arg". Collapsing that needs an inner-loop invariant-yield result rule first, and then a zero-trip guard on the resulting select. So this shrinks what the raiser's `rewritePointerInduction` (#3011) has to handle but does not yet replace it; those two TUs still need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
