### PR TITLE
Loop canonicalizations for a pointer walked across nested loops

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -292,6 +292,34 @@ static Value castValue(PatternRewriter &rewriter, Value value, Value target,
   }
 };
 
+// The ops needed to recompute `v` where the loop's own operands are available,
+// in block order. A value the loop does not vary can still be computed inside
+// it, so being defined outside is sufficient but not necessary.
+static bool collectLoopInvariantSlice(scf::ForOp forOp, Value v,
+                                      SmallVectorImpl<Operation *> &ops) {
+  SmallVector<Value> todo{v};
+  SmallPtrSet<Operation *, 8> seen;
+  while (!todo.empty()) {
+    Value cur = todo.pop_back_val();
+    if (forOp.isDefinedOutsideOfLoop(cur))
+      continue;
+    Operation *def = cur.getDefiningOp();
+    if (!def || def->getParentRegion() != &forOp.getRegion())
+      return false;
+    if (!isMemoryEffectFree(def) || def->getNumRegions())
+      return false;
+    if (!seen.insert(def).second)
+      continue;
+    if (ops.size() >= 8)
+      return false;
+    ops.push_back(def);
+    llvm::append_range(todo, def->getOperands());
+  }
+  llvm::sort(ops,
+             [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
+  return true;
+}
+
 struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
   using OpRewritePattern<scf::ForOp>::OpRewritePattern;
 
@@ -399,6 +427,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
           continue;
         int64_t constStride = 0;
         SmallVector<Value> dynStrides;
+        SmallVector<Operation *> strideSlice;
         bool ok = true;
         for (auto g : chain) {
           auto idx = g.getIndices()[0];
@@ -407,7 +436,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
             continue;
           }
           Value v = cast<Value>(idx);
-          if (!forOp.isDefinedOutsideOfLoop(v)) {
+          if (!collectLoopInvariantSlice(forOp, v, strideSlice)) {
             ok = false;
             break;
           }
@@ -418,8 +447,14 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
         Location loc = forOp.getLoc();
 
         auto advancedBy = [&](Value count) {
+          // The stride may be computed in the body, after the point this is
+          // inserted at, so recompute it here.
+          IRMapping map;
+          for (Operation *op : strideSlice)
+            rewriter.clone(*op, map);
           Value stride = nullptr;
-          for (Value v : dynStrides) {
+          for (Value orig : dynStrides) {
+            Value v = map.lookupOrDefault(orig);
             Value c = castValue(rewriter, v, count, loc);
             stride = stride
                          ? AddIOp::create(rewriter, loc, stride, c).getResult()
@@ -583,6 +618,96 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
     }
 
     return success(canonicalize);
+  }
+};
+
+// A result whose iter arg the body never reads does not accumulate anything:
+// it is just the yielded value of the last iteration. When that value varies
+// with the loop only through the induction variable, the last one can be
+// computed outside, at the last induction variable the loop reaches -- or the
+// init, when the loop never runs.
+//
+// mfem walks a pointer this way: `TC *c = Cdata;` advanced with `c++` in an
+// inner loop, so the enclosing loop carries it while the inner loop's own copy
+// is dead. Nothing recognizes the enclosing loop as an induction until this
+// inner result is out of the way.
+struct ForOpFinalValueOfDeadIterArg : public OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+
+  // The ops needed to recompute `v` outside the loop, in block order, or
+  // nothing when the loop varies it by more than the induction variable.
+  static bool collectSlice(scf::ForOp forOp, Value v,
+                           SmallVectorImpl<Operation *> &ops) {
+    SmallVector<Value> todo{v};
+    SmallPtrSet<Operation *, 8> seen;
+    while (!todo.empty()) {
+      Value cur = todo.pop_back_val();
+      if (cur == forOp.getInductionVar() || forOp.isDefinedOutsideOfLoop(cur))
+        continue;
+      Operation *def = cur.getDefiningOp();
+      if (!def || def->getParentRegion() != &forOp.getRegion())
+        return false;
+      if (!isMemoryEffectFree(def) || def->getNumRegions())
+        return false;
+      if (!seen.insert(def).second)
+        continue;
+      // Recomputing the whole body outside it is no canonicalization.
+      if (ops.size() >= 8)
+        return false;
+      ops.push_back(def);
+      llvm::append_range(todo, def->getOperands());
+    }
+    llvm::sort(
+        ops, [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
+    return true;
+  }
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    Location loc = forOp.getLoc();
+    bool changed = false;
+
+    for (auto [init, iterarg, res, yld] :
+         llvm::zip(forOp.getInits(), forOp.getRegionIterArgs(),
+                   forOp.getResults(), yieldOp.getOperands())) {
+      if (!iterarg.use_empty() || res.use_empty() || yld == iterarg)
+        continue;
+      SmallVector<Operation *> slice;
+      if (!collectSlice(forOp, yld, slice))
+        continue;
+
+      rewriter.setInsertionPoint(forOp);
+      Value lb = forOp.getLowerBound(), ub = forOp.getUpperBound(),
+            step = forOp.getStep();
+      // The last induction variable the loop reaches: lb +
+      // ((ub-lb-1)/step)*step.
+      Value one = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getIntegerAttr(lb.getType(), 1));
+      Value span = SubIOp::create(rewriter, loc, ub, lb);
+      Value zero = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getIntegerAttr(lb.getType(), 0));
+      Value clamped = MaxSIOp::create(rewriter, loc, span, zero);
+      Value back = SubIOp::create(rewriter, loc, clamped, one);
+      Value whole = MulIOp::create(
+          rewriter, loc, DivUIOp::create(rewriter, loc, back, step), step);
+      Value lastIV = AddIOp::create(rewriter, loc, lb, whole);
+
+      IRMapping map;
+      map.map(forOp.getInductionVar(), lastIV);
+      for (Operation *op : slice)
+        rewriter.clone(*op, map);
+      Value last = map.lookupOrDefault(yld);
+
+      Value ran = CmpIOp::create(rewriter, loc, CmpIPredicate::sgt, ub, lb);
+      Value replacement = SelectOp::create(rewriter, loc, ran, last, init);
+
+      Value resCopy = res;
+      rewriter.modifyOpInPlace(
+          forOp, [&] { resCopy.replaceAllUsesWith(replacement); });
+      changed = true;
+    }
+    return success(changed);
   }
 };
 
@@ -3902,7 +4027,8 @@ void CanonicalizeFor::runOnOperation() {
           RemoveUnusedForResults, RemoveUnusedArgs, MoveWhileToFor,
           RemoveWhileSelect, SelectTruncToTruncSelect, MaxSimplify,
           ForBoundUnSwitch, SelectI1Simplify, RemoveInductionVarRelated,
-          RotateWhileAnd, MoveWhileDown, MoveWhileDown2,
+          ForOpFinalValueOfDeadIterArg, RotateWhileAnd, MoveWhileDown,
+          MoveWhileDown2,
 
           ReplaceRedundantArgs,
 

--- a/test/lit_tests/canonicalize_for_final_value.mlir
+++ b/test/lit_tests/canonicalize_for_final_value.mlir
@@ -1,0 +1,76 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for --canonicalize | FileCheck %s
+
+// mfem walks a pointer as `TC *c = Cdata;` advanced with `c++` in an inner
+// loop, so the enclosing loop carries it while the inner loop's own copy is
+// dead. The inner result is the yielded value of the last iteration.
+func.func @walk(%init: !llvm.ptr, %dead: !llvm.ptr, %bw: i64, %aw: i64, %v: f64) {
+  %idx0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : i64
+  %cm1 = arith.constant -1 : i64
+  %c8 = arith.constant 8 : i64
+  %outer = scf.for %i = %c1 to %bw step %c1 iter_args(%c = %init) -> (!llvm.ptr) : i64 {
+    %inner = scf.for %j = %c1 to %aw step %c1 iter_args(%lag = %dead) -> (!llvm.ptr) : i64 {
+      %jm = arith.addi %j, %cm1 : i64
+      %off = arith.muli %jm, %c8 : i64
+      %at = llvm.getelementptr inbounds|nuw %c[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      %m = "enzymexla.pointer2memref"(%at) : (!llvm.ptr) -> memref<?xf64>
+      %old = memref.load %m[%idx0] : memref<?xf64>
+      %new = arith.addf %old, %v : f64
+      memref.store %new, %m[%idx0] : memref<?xf64>
+      %next = llvm.getelementptr inbounds|nuw %at[8] : (!llvm.ptr) -> !llvm.ptr, i8
+      scf.yield %next : !llvm.ptr
+    }
+    scf.yield %inner : !llvm.ptr
+  }
+  return
+}
+
+// With bounds the folder can settle, the guard goes too and the enclosing
+// loop stops carrying the pointer as well.
+func.func @walk_const(%init: !llvm.ptr, %dead: !llvm.ptr, %v: f64) {
+  %idx0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : i64
+  %cm1 = arith.constant -1 : i64
+  %c8 = arith.constant 8 : i64
+  %c5 = arith.constant 5 : i64
+  %c9 = arith.constant 9 : i64
+  %outer = scf.for %i = %c1 to %c9 step %c1 iter_args(%c = %init) -> (!llvm.ptr) : i64 {
+    %inner = scf.for %j = %c1 to %c5 step %c1 iter_args(%lag = %dead) -> (!llvm.ptr) : i64 {
+      %jm = arith.addi %j, %cm1 : i64
+      %off = arith.muli %jm, %c8 : i64
+      %at = llvm.getelementptr inbounds|nuw %c[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      %m = "enzymexla.pointer2memref"(%at) : (!llvm.ptr) -> memref<?xf64>
+      %old = memref.load %m[%idx0] : memref<?xf64>
+      %new = arith.addf %old, %v : f64
+      memref.store %new, %m[%idx0] : memref<?xf64>
+      %next = llvm.getelementptr inbounds|nuw %at[8] : (!llvm.ptr) -> !llvm.ptr, i8
+      scf.yield %next : !llvm.ptr
+    }
+    scf.yield %inner : !llvm.ptr
+  }
+  return
+}
+
+// An iter arg the body reads is accumulating something: left alone.
+func.func @live_iter_arg(%n: i64, %x: f64) -> f64 {
+  %c1 = arith.constant 1 : i64
+  %cst = arith.constant 0.0 : f64
+  %r = scf.for %i = %c1 to %n step %c1 iter_args(%acc = %cst) -> (f64) : i64 {
+    %s = arith.addf %acc, %x : f64
+    scf.yield %s : f64
+  }
+  return %r : f64
+}
+
+// CHECK-LABEL: func.func @walk(
+// The inner loop no longer carries a pointer; its result is the last value.
+// CHECK: arith.select
+// CHECK: scf.for
+// CHECK-NOT: iter_args
+
+// CHECK-LABEL: func.func @walk_const(
+// CHECK-NOT: iter_args
+// CHECK-NOT: arith.select
+
+// CHECK-LABEL: func.func @live_iter_arg(
+// CHECK: iter_args

--- a/test/lit_tests/canonicalizefor/doWhile.mlir
+++ b/test/lit_tests/canonicalizefor/doWhile.mlir
@@ -95,15 +95,13 @@ module @negative_step{
 // CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
 // CHECK-NEXT:     %c-4_i32 = arith.constant -4 : i32
 // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %0 = ub.poison : i32
-// CHECK-NEXT:     %1 = scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
-// CHECK-NEXT:       %2 = arith.addi %arg0, %c4_i32 : i32
-// CHECK-NEXT:       %3 = arith.muli %2, %c-1_i32 : i32
-// CHECK-NEXT:       "before.keepalive"(%3) : (i32) -> ()
-// CHECK-NEXT:       %4 = arith.addi %3, %c-1_i32 : i32
-// CHECK-NEXT:       scf.yield %4 : i32
+// CHECK-NEXT:     %c-5_i32 = arith.constant -5 : i32
+// CHECK-NEXT:     scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32  : i32 {
+// CHECK-NEXT:       %0 = arith.addi %arg0, %c4_i32 : i32
+// CHECK-NEXT:       %1 = arith.muli %0, %c-1_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%1) : (i32) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %1 : i32
+// CHECK-NEXT:     return %c-5_i32 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -168,15 +166,14 @@ module @execute_once{
 // CHECK-NEXT:   func.func @do_while() -> i32 {
 // CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
 // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %0 = ub.poison : i32
 // CHECK-NEXT:     %c11_i32 = arith.constant 11 : i32
-// CHECK-NEXT:     %1:2 = scf.for %arg0 = %c1_i32 to %c11_i32 step %c1_i32 iter_args(%arg1 = %c1_i32, %arg2 = %0) -> (i32, i32)  : i32 {
-// CHECK-NEXT:       %2 = arith.addi %arg0, %c-1_i32 : i32
-// CHECK-NEXT:       %3 = "before.keepalive"(%arg1, %2) : (i32, i32) -> i32
-// CHECK-NEXT:       %4 = arith.addi %2, %c1_i32 : i32
-// CHECK-NEXT:       scf.yield %3, %4 : i32, i32
+// CHECK-NEXT:     %c10_i32 = arith.constant 10 : i32
+// CHECK-NEXT:     %0 = scf.for %arg0 = %c1_i32 to %c11_i32 step %c1_i32 iter_args(%arg1 = %c1_i32) -> (i32)  : i32 {
+// CHECK-NEXT:       %1 = arith.addi %arg0, %c-1_i32 : i32
+// CHECK-NEXT:       %2 = "before.keepalive"(%arg1, %1) : (i32, i32) -> i32
+// CHECK-NEXT:       scf.yield %2 : i32
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %1#1 : i32
+// CHECK-NEXT:     return %c10_i32 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -242,15 +239,13 @@ module @cmpi_ne_neg{
 // CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
 // CHECK-NEXT:     %c-4_i32 = arith.constant -4 : i32
 // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %0 = ub.poison : i32
-// CHECK-NEXT:     %1 = scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
-// CHECK-NEXT:       %2 = arith.addi %arg0, %c4_i32 : i32
-// CHECK-NEXT:       %3 = arith.muli %2, %c-1_i32 : i32
-// CHECK-NEXT:       "before.keepalive"(%3) : (i32) -> ()
-// CHECK-NEXT:       %4 = arith.addi %3, %c-1_i32 : i32
-// CHECK-NEXT:       scf.yield %4 : i32
+// CHECK-NEXT:     %c-5_i32 = arith.constant -5 : i32
+// CHECK-NEXT:     scf.for %arg0 = %c-4_i32 to %c1_i32 step %c1_i32  : i32 {
+// CHECK-NEXT:       %0 = arith.addi %arg0, %c4_i32 : i32
+// CHECK-NEXT:       %1 = arith.muli %0, %c-1_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%1) : (i32) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %1 : i32
+// CHECK-NEXT:     return %c-5_i32 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -281,17 +276,15 @@ module @cmpi_ne_neg_step{
 // CHECK-NEXT:     %c49_i32 = arith.constant 49 : i32
 // CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
 // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %0 = ub.poison : i32
 // CHECK-NEXT:     %c50_i32 = arith.constant 50 : i32
-// CHECK-NEXT:     %1 = scf.for %arg0 = %c1_i32 to %c50_i32 step %c1_i32 iter_args(%arg1 = %0) -> (i32)  : i32 {
-// CHECK-NEXT:       %2 = arith.addi %arg0, %c-1_i32 : i32
-// CHECK-NEXT:       %3 = arith.muli %2, %c-1_i32 : i32
-// CHECK-NEXT:       %4 = arith.addi %3, %c49_i32 : i32
-// CHECK-NEXT:       "before.keepalive"(%4) : (i32) -> ()
-// CHECK-NEXT:       %5 = arith.addi %4, %c-1_i32 : i32
-// CHECK-NEXT:       scf.yield %5 : i32
+// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:     scf.for %arg0 = %c1_i32 to %c50_i32 step %c1_i32  : i32 {
+// CHECK-NEXT:       %0 = arith.addi %arg0, %c-1_i32 : i32
+// CHECK-NEXT:       %1 = arith.muli %0, %c-1_i32 : i32
+// CHECK-NEXT:       %2 = arith.addi %1, %c49_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%2) : (i32) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %1 : i32
+// CHECK-NEXT:     return %c0_i32 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -351,14 +344,16 @@ module @test_dynamic_ub {
 
 // CHECK-LABEL: module @test_dynamic_ub {
 // CHECK-NEXT:   func.func @do_while(%arg0: index) -> index {
+// CHECK-NEXT:     %c0 = arith.constant 0 : index
 // CHECK-NEXT:     %c1 = arith.constant 1 : index
 // CHECK-NEXT:     %0 = arith.maxsi %arg0, %c1 : index
 // CHECK-NEXT:     %1 = arith.addi %0, %c1 : index
+// CHECK-NEXT:     %2 = arith.maxsi %0, %c0 : index
 // CHECK-NEXT:     scf.for %arg1 = %c1 to %1 step %c1 {
-// CHECK-NEXT:       %2 = arith.subi %arg1, %c1 : index
-// CHECK-NEXT:       "before.keepalive"(%2) : (index) -> ()
+// CHECK-NEXT:       %3 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:       "before.keepalive"(%3) : (index) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %0 : index
+// CHECK-NEXT:     return %2 : index
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -384,19 +379,22 @@ module @test_fully_dynamic {
 
 // CHECK-LABEL: module @test_fully_dynamic {
 // CHECK-NEXT:   func.func @do_while(%arg0: index, %arg1: index) -> index {
-// CHECK-NEXT:     %0 = ub.poison : index
+// CHECK-NEXT:     %c0 = arith.constant 0 : index
 // CHECK-NEXT:     %c1 = arith.constant 1 : index
-// CHECK-NEXT:     %1 = arith.addi %arg0, %c1 : index
-// CHECK-NEXT:     %2 = arith.maxsi %arg1, %1 : index
-// CHECK-NEXT:     %3 = arith.addi %2, %c1 : index
-// CHECK-NEXT:     %4 = scf.for %arg2 = %1 to %3 step %c1 iter_args(%arg3 = %0) -> (index) {
-// CHECK-NEXT:       %5 = arith.subi %arg2, %1 : index
-// CHECK-NEXT:       %6 = arith.addi %arg0, %5 : index
-// CHECK-NEXT:       "before.keepalive"(%6) : (index) -> ()
-// CHECK-NEXT:       %7 = arith.addi %6, %c1 : index
-// CHECK-NEXT:       scf.yield %7 : index
+// CHECK-NEXT:     %0 = arith.addi %arg0, %c1 : index
+// CHECK-NEXT:     %1 = arith.maxsi %arg1, %0 : index
+// CHECK-NEXT:     %2 = arith.addi %1, %c1 : index
+// CHECK-NEXT:     %3 = arith.subi %2, %0 : index
+// CHECK-NEXT:     %4 = arith.maxsi %3, %c0 : index
+// CHECK-NEXT:     %5 = arith.subi %4, %c1 : index
+// CHECK-NEXT:     %6 = arith.addi %arg0, %5 : index
+// CHECK-NEXT:     %7 = arith.addi %6, %c1 : index
+// CHECK-NEXT:     scf.for %arg2 = %0 to %2 step %c1 {
+// CHECK-NEXT:       %8 = arith.subi %arg2, %0 : index
+// CHECK-NEXT:       %9 = arith.addi %arg0, %8 : index
+// CHECK-NEXT:       "before.keepalive"(%9) : (index) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %4 : index
+// CHECK-NEXT:     return %7 : index
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -423,22 +421,26 @@ module @test_negative_step_dynamic_ub {
 
 // CHECK-LABEL: module @test_negative_step_dynamic_ub {
 // CHECK-NEXT:   func.func @do_while(%arg0: i32) -> i32 {
-// CHECK-NEXT:     %0 = ub.poison : i32
+// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT:     %c10_i32 = arith.constant 10 : i32
 // CHECK-NEXT:     %c-1_i32 = arith.constant -1 : i32
 // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %1 = arith.addi %arg0, %c1_i32 : i32
-// CHECK-NEXT:     %2 = arith.maxsi %1, %c10_i32 : i32
-// CHECK-NEXT:     %3 = arith.addi %2, %c1_i32 : i32
-// CHECK-NEXT:     %4 = scf.for %arg1 = %1 to %3 step %c1_i32 iter_args(%arg2 = %0) -> (i32)  : i32 {
-// CHECK-NEXT:       %5 = arith.subi %arg1, %1 : i32
-// CHECK-NEXT:       %6 = arith.muli %5, %c-1_i32 : i32
-// CHECK-NEXT:       %7 = arith.addi %6, %c10_i32 : i32
-// CHECK-NEXT:       "before.keepalive"(%7) : (i32) -> ()
-// CHECK-NEXT:       %8 = arith.addi %7, %c-1_i32 : i32
-// CHECK-NEXT:       scf.yield %8 : i32
+// CHECK-NEXT:     %0 = arith.addi %arg0, %c1_i32 : i32
+// CHECK-NEXT:     %1 = arith.maxsi %0, %c10_i32 : i32
+// CHECK-NEXT:     %2 = arith.addi %1, %c1_i32 : i32
+// CHECK-NEXT:     %3 = arith.subi %2, %0 : i32
+// CHECK-NEXT:     %4 = arith.maxsi %3, %c0_i32 : i32
+// CHECK-NEXT:     %5 = arith.addi %4, %c-1_i32 : i32
+// CHECK-NEXT:     %6 = arith.muli %5, %c-1_i32 : i32
+// CHECK-NEXT:     %7 = arith.addi %6, %c10_i32 : i32
+// CHECK-NEXT:     %8 = arith.addi %7, %c-1_i32 : i32
+// CHECK-NEXT:     scf.for %arg1 = %0 to %2 step %c1_i32  : i32 {
+// CHECK-NEXT:       %9 = arith.subi %arg1, %0 : i32
+// CHECK-NEXT:       %10 = arith.muli %9, %c-1_i32 : i32
+// CHECK-NEXT:       %11 = arith.addi %10, %c10_i32 : i32
+// CHECK-NEXT:       "before.keepalive"(%11) : (i32) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %4 : i32
+// CHECK-NEXT:     return %8 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -467,20 +469,23 @@ module @test_multiple_args_dynamic {
 
 // CHECK-LABEL: module @test_multiple_args_dynamic {
 // CHECK-NEXT:   func.func @do_while(%arg0: index) -> (index, index) {
+// CHECK-NEXT:     %c0 = arith.constant 0 : index
 // CHECK-NEXT:     %c1 = arith.constant 1 : index
 // CHECK-NEXT:     %c2 = arith.constant 2 : index
-// CHECK-NEXT:     %0 = ub.poison : index
-// CHECK-NEXT:     %1 = arith.maxsi %arg0, %c1 : index
-// CHECK-NEXT:     %2 = arith.addi %1, %c1 : index
-// CHECK-NEXT:     %3 = scf.for %arg1 = %c1 to %2 step %c1 iter_args(%arg2 = %0) -> (index) {
-// CHECK-NEXT:       %4 = arith.subi %arg1, %c1 : index
-// CHECK-NEXT:       %5 = arith.muli %4, %c2 : index
-// CHECK-NEXT:       %6 = arith.subi %arg1, %c1 : index
-// CHECK-NEXT:       "before.keepalive"(%6, %5) : (index, index) -> ()
-// CHECK-NEXT:       %7 = arith.addi %5, %c2 : index
-// CHECK-NEXT:       scf.yield %7 : index
+// CHECK-NEXT:     %0 = arith.maxsi %arg0, %c1 : index
+// CHECK-NEXT:     %1 = arith.addi %0, %c1 : index
+// CHECK-NEXT:     %2 = arith.maxsi %0, %c0 : index
+// CHECK-NEXT:     %3 = arith.maxsi %0, %c0 : index
+// CHECK-NEXT:     %4 = arith.subi %3, %c1 : index
+// CHECK-NEXT:     %5 = arith.muli %4, %c2 : index
+// CHECK-NEXT:     %6 = arith.addi %5, %c2 : index
+// CHECK-NEXT:     scf.for %arg1 = %c1 to %1 step %c1 {
+// CHECK-NEXT:       %7 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:       %8 = arith.muli %7, %c2 : index
+// CHECK-NEXT:       %9 = arith.subi %arg1, %c1 : index
+// CHECK-NEXT:       "before.keepalive"(%9, %8) : (index, index) -> ()
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return %1, %3 : index, index
+// CHECK-NEXT:     return %2, %6 : index, index
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 


### PR DESCRIPTION
Three loop canonicalizations that between them make the raiser's own pointer-induction pass unnecessary for the mfem translation units that needed it (#3011).

The shape comes from `kernels::AddMultAtB` (`linalg/kernels.hpp:486`), where a raw pointer is declared outside two loops and walked in the inner one:

```cpp
   TC *c = Cdata;
   for (int i = 0; i < Bwidth; ++i)
      for (int j = 0; j < Awidth; ++j)
      {
         ...
         *c += val;
         c++;
      }
```

After rotation that reaches the raiser as a pointer the enclosing loop carries, with the inner loop keeping a dead copy of it:

```mlir
%81 = scf.for %arg8 = %c1_i64 to %80 iter_args(%arg9 = %78) -> (!llvm.ptr) : i64 {
  %86 = scf.for %arg10 = %c1_i64 to %85 iter_args(%arg11 = %6) -> (!llvm.ptr) : i64 {
    %89 = llvm.getelementptr %arg9[%88]   // rooted at the enclosing iter arg
    %99 = llvm.getelementptr %89[8]
    scf.yield %99
  }
  scf.yield %86
}
```

**`ForOpFinalValueOfDeadIterArg`.** An iter arg the body never reads accumulates nothing, so the result is the yielded value of the last iteration. When that value varies with the loop only through the induction variable, it can be computed outside at the last induction variable the loop reaches, selected against the init on whether the loop ran. The slice it recomputes must be pure, region-free and under eight ops, since recomputing a whole body outside it would not be a canonicalization. Nothing about this is pointer-specific; converted do-whiles hit it with an `ub.poison` init, which is why eight blocks in `canonicalizefor/doWhile.mlir` now expect simpler output. Each was checked against its source: `@negative_step` returns -5, `@execute_once` returns 1, `@multiple_iter_args_2` returns 10 and keeps its live arg, `@test_fully_dynamic` returns `max(lb+1, ub)`.

**A stride the loop does not vary.** #3060 wanted every step of the advance defined outside the loop. That is sufficient but not necessary: mfem computes the distance in the body from values the loop does not vary, as `(max(%68,1) - 1) * 8`. The test is now whether the loop varies the value, by walking its slice back to operands from outside; the slice is recomputed where the replacement goes, since the original definition sits further down the body.

Together with #3060's induction rewrite, pointer-carrying loops in `linalg/batched/native.cpp` before raising go from 5 `scf.for` and 3 `affine.for` to none.

Measured with the raiser's `rewritePointerInduction` disabled: `fem/hybridization_ext.cpp` and `linalg/batched/native.cpp` both compile, and the full 122-TU mfem sweep is `real_red=0`. So #3011 can be closed rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
