### PR TITLE
canonicalize-scf-for: a stride the loop does not vary may be computed inside it

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -292,6 +292,34 @@ static Value castValue(PatternRewriter &rewriter, Value value, Value target,
   }
 };
 
+// The ops needed to recompute `v` where the loop's own operands are available,
+// in block order. A value the loop does not vary can still be computed inside
+// it, so being defined outside is sufficient but not necessary.
+static bool collectLoopInvariantSlice(scf::ForOp forOp, Value v,
+                                      SmallVectorImpl<Operation *> &ops) {
+  SmallVector<Value> todo{v};
+  SmallPtrSet<Operation *, 8> seen;
+  while (!todo.empty()) {
+    Value cur = todo.pop_back_val();
+    if (forOp.isDefinedOutsideOfLoop(cur))
+      continue;
+    Operation *def = cur.getDefiningOp();
+    if (!def || def->getParentRegion() != &forOp.getRegion())
+      return false;
+    if (!isMemoryEffectFree(def) || def->getNumRegions())
+      return false;
+    if (!seen.insert(def).second)
+      continue;
+    if (ops.size() >= 8)
+      return false;
+    ops.push_back(def);
+    llvm::append_range(todo, def->getOperands());
+  }
+  llvm::sort(ops,
+             [](Operation *a, Operation *b) { return a->isBeforeInBlock(b); });
+  return true;
+}
+
 struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
   using OpRewritePattern<scf::ForOp>::OpRewritePattern;
 
@@ -399,6 +427,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
           continue;
         int64_t constStride = 0;
         SmallVector<Value> dynStrides;
+        SmallVector<Operation *> strideSlice;
         bool ok = true;
         for (auto g : chain) {
           auto idx = g.getIndices()[0];
@@ -407,7 +436,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
             continue;
           }
           Value v = cast<Value>(idx);
-          if (!forOp.isDefinedOutsideOfLoop(v)) {
+          if (!collectLoopInvariantSlice(forOp, v, strideSlice)) {
             ok = false;
             break;
           }
@@ -418,8 +447,14 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
         Location loc = forOp.getLoc();
 
         auto advancedBy = [&](Value count) {
+          // The stride may be computed in the body, after the point this is
+          // inserted at, so recompute it here.
+          IRMapping map;
+          for (Operation *op : strideSlice)
+            rewriter.clone(*op, map);
           Value stride = nullptr;
-          for (Value v : dynStrides) {
+          for (Value orig : dynStrides) {
+            Value v = map.lookupOrDefault(orig);
             Value c = castValue(rewriter, v, count, loc);
             stride = stride
                          ? AddIOp::create(rewriter, loc, stride, c).getResult()

--- a/test/lit_tests/canonicalize_for_gep_induction.mlir
+++ b/test/lit_tests/canonicalize_for_gep_induction.mlir
@@ -134,3 +134,42 @@ func.func @never_runs(%p: !llvm.ptr, %x: f64) -> !llvm.ptr {
 
 // TRIP-LABEL: func.func @never_runs(
 // TRIP: return %arg0
+
+// -----
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for | FileCheck %s --check-prefix=INSIDE
+
+// A distance the loop does not vary can still be computed inside it.
+func.func @stride_computed_inside(%p: !llvm.ptr, %n: i64, %k: i64, %x: f64) -> !llvm.ptr {
+  %c1 = arith.constant 1 : i64
+  %c8 = arith.constant 8 : i64
+  %r = scf.for %i = %c1 to %n step %c1 iter_args(%q = %p) -> (!llvm.ptr) : i64 {
+    %m = arith.maxsi %k, %c1 : i64
+    %off = arith.muli %m, %c8 : i64
+    %at = llvm.getelementptr inbounds|nuw %q[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    llvm.store %x, %at : f64, !llvm.ptr
+    %next = llvm.getelementptr inbounds|nuw %at[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return %r : !llvm.ptr
+}
+
+// A distance read from memory inside the loop is not one the loop leaves
+// alone: left carried.
+func.func @stride_loaded_inside(%p: !llvm.ptr, %n: i64, %src: memref<?xi64>, %x: f64) -> !llvm.ptr {
+  %c1 = arith.constant 1 : i64
+  %i0 = arith.constant 0 : index
+  %r = scf.for %i = %c1 to %n step %c1 iter_args(%q = %p) -> (!llvm.ptr) : i64 {
+    %off = memref.load %src[%i0] : memref<?xi64>
+    %at = llvm.getelementptr inbounds|nuw %q[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    llvm.store %x, %at : f64, !llvm.ptr
+    %next = llvm.getelementptr inbounds|nuw %at[8] : (!llvm.ptr) -> !llvm.ptr, i8
+    scf.yield %next : !llvm.ptr
+  }
+  return %r : !llvm.ptr
+}
+
+// INSIDE-LABEL: func.func @stride_computed_inside(
+// INSIDE-NOT: iter_args
+
+// INSIDE-LABEL: func.func @stride_loaded_inside(
+// INSIDE: iter_args


### PR DESCRIPTION
#3060 asks that every step of a pointer's advance be defined outside the loop. That is sufficient but not necessary: the distance can be computed in the body out of values the loop leaves alone, and then the pattern declines a loop that is an induction after all.

mfem does exactly that. After the surrounding rotation, `linalg/batched/native.cpp` reaches the raiser with

```mlir
%83 = arith.maxsi %68, %c1_i64 : i64      // %68 comes from outside the loop
%86 = arith.addi %85, %c-1_i64 : i64
%87 = arith.muli %86, %c8_i64 : i64
%88 = llvm.getelementptr inbounds|nuw %arg9[%87] : (!llvm.ptr, i64) -> !llvm.ptr, i8
%89 = llvm.getelementptr inbounds|nuw %88[8] : (!llvm.ptr) -> !llvm.ptr, i8
scf.yield %89 : !llvm.ptr
```

`%87` is the same on every iteration; it is simply computed in the body.

The test is now whether the loop varies the value, by walking its slice back to operands from outside. The slice must be pure, region-free and under eight ops, and it is recomputed where the replacement goes -- the replacement is inserted at the top of the body, above where the stride is originally defined. A distance the loop actually reaches for, such as one loaded from memory each iteration, is still left carried, which the second test covers.

Split out of #3061. On its own this does not change any mfem translation unit; it is one of the two halves that together let the raiser drop its own pointer-induction pass, the other being the final-value substitution in that PR's sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
