### PR TITLE
Size a viewed element with the data layout, not by asking for a bit width

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -669,11 +669,12 @@ public:
     if (!src)
       return failure();
 
-    // Get the element type and size of the final memref
+    // Get the element type and size of the final memref. Anything the data
+    // layout can size will do: a view of pointers is as foldable as a view of
+    // floats, and asking only int or float declines those for no reason.
     Type elementType = accessedType.getElementType();
-    unsigned elementSize = elementType.isIntOrFloat()
-                               ? elementType.getIntOrFloatBitWidth() / 8
-                               : 0;
+    DataLayout dl = DataLayout::closest(op);
+    unsigned elementSize = dl.getTypeSize(elementType);
     if (elementSize == 0)
       return failure();
 

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -669,10 +669,11 @@ public:
     if (!src)
       return failure();
 
-    // Get the element type and size of the final memref. Anything the data
-    // layout can size will do: a view of pointers is as foldable as a view of
-    // floats, and asking only int or float declines those for no reason.
+    // Get the element type and size of the final memref
     Type elementType = accessedType.getElementType();
+    if (!elementType.isIntOrFloat() &&
+        !isa<DataLayoutTypeInterface>(elementType))
+      return failure();
     DataLayout dl = DataLayout::closest(op);
     unsigned elementSize = dl.getTypeSize(elementType);
     if (elementSize == 0)

--- a/test/lit_tests/gep_fold_pointer_element.mlir
+++ b/test/lit_tests/gep_fold_pointer_element.mlir
@@ -14,9 +14,22 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
     %v = affine.load %m[0] : memref<?xf64>
     llvm.return %v : f64
   }
+
+  func.func @memref_element(%base: !llvm.ptr, %off: i64) -> memref<?xf32> {
+    %g = llvm.getelementptr inbounds|nuw %base[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xmemref<?xf32>>
+    %v = affine.load %m[0] : memref<?xmemref<?xf32>>
+    return %v : memref<?xf32>
+  }
+
+  llvm.func @func_element(%base: !llvm.ptr, %off: i64) -> !llvm.func<void ()> {
+    %g = llvm.getelementptr inbounds|nuw %base[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?x!llvm.func<void ()>>
+    %v = affine.load %m[0] : memref<?x!llvm.func<void ()>>
+    llvm.return %v : !llvm.func<void ()>
+  }
 }
 
-// A view of pointers folds the same way a view of floats does.
 // CHECK-LABEL: llvm.func @ptr_element(
 // CHECK-NOT: llvm.getelementptr
 // CHECK: "enzymexla.pointer2memref"(%arg0)
@@ -24,3 +37,11 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
 // CHECK-LABEL: llvm.func @float_element(
 // CHECK-NOT: llvm.getelementptr
 // CHECK: "enzymexla.pointer2memref"(%arg0)
+
+// CHECK-LABEL: func.func @memref_element(
+// CHECK: %[[g:.+]] = llvm.getelementptr inbounds|nuw %arg0[%arg1]
+// CHECK: "enzymexla.pointer2memref"(%[[g]])
+
+// CHECK-LABEL: llvm.func @func_element(
+// CHECK: %[[g:.+]] = llvm.getelementptr inbounds|nuw %arg0[%arg1]
+// CHECK: "enzymexla.pointer2memref"(%[[g]])

--- a/test/lit_tests/gep_fold_pointer_element.mlir
+++ b/test/lit_tests/gep_fold_pointer_element.mlir
@@ -1,0 +1,26 @@
+// RUN: enzymexlamlir-opt %s --canonicalize | FileCheck %s
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>>} {
+  llvm.func @ptr_element(%base: !llvm.ptr, %off: i64) -> !llvm.ptr {
+    %g = llvm.getelementptr inbounds|nuw %base[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %v = affine.load %m[0] : memref<?x!llvm.ptr>
+    llvm.return %v : !llvm.ptr
+  }
+
+  llvm.func @float_element(%base: !llvm.ptr, %off: i64) -> f64 {
+    %g = llvm.getelementptr inbounds|nuw %base[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+    %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?xf64>
+    %v = affine.load %m[0] : memref<?xf64>
+    llvm.return %v : f64
+  }
+}
+
+// A view of pointers folds the same way a view of floats does.
+// CHECK-LABEL: llvm.func @ptr_element(
+// CHECK-NOT: llvm.getelementptr
+// CHECK: "enzymexla.pointer2memref"(%arg0)
+
+// CHECK-LABEL: llvm.func @float_element(
+// CHECK-NOT: llvm.getelementptr
+// CHECK: "enzymexla.pointer2memref"(%arg0)


### PR DESCRIPTION
`LoadStorePointer2MemrefGEP` folds a gep into the access it feeds. To do that it needs the size of the element the view is of, and it asked for an int or float bit width:

```cpp
    unsigned elementSize = elementType.isIntOrFloat()
                               ? elementType.getIntOrFloatBitWidth() / 8
                               : 0;
    if (elementSize == 0)
      return failure();
```

So a view of anything else -- a view of pointers, most obviously -- was declined before the pattern ever looked at the access. Nothing about the fold needs the element to be a number; it needs its size. Asking the data layout gives that, and anything the layout cannot size still bails.

This is what leaves geps in mfem kernels before raising, and the reason is worth writing down because the shape looks like something else. In `fem/normal_deriv_restriction.cpp` a gep is taken through a conditional byte offset:

```mlir
%189 = arith.select %188, %c136_i64, %c104_i64 : i64
%190 = llvm.getelementptr inbounds|nuw %183[%189] : (!llvm.ptr, i64) -> !llvm.ptr, i8
```

The conditional offset is not the problem: every access through it whose view is of `i32` folds, and the select survives only as an index.

```mlir
%205 = arith.divsi %204, %c4 : index
%207 = memref.load %184[%206] : memref<?xi32>
```

What does not fold, and so holds the gep alive, is the load beside them:

```mlir
%202 = "enzymexla.pointer2memref"(%197) : (!llvm.ptr) -> memref<?x!llvm.ptr>
%203 = affine.load %202[0] : memref<?x!llvm.ptr>
```

The test covers a pointer-element view folding the same way a float-element one does, both through a gep with a runtime offset.

Whether this is enough to retire the raiser's own handling for those translation units (#3026) is not claimed here and is being measured separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
