### PR TITLE
Revert "refactor MPI constant binding with a generic API (#3052)"

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -119,7 +119,6 @@ cc_library(
     deps = [
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/strings:str_format",
-        "@llvm-project//llvm:Support",
         "@xla//xla/ffi:ffi_api",
         "@xla//xla/ffi/api:c_api",
         "@xla//xla/ffi/api:ffi",
@@ -1378,8 +1377,8 @@ cc_library(
         "@llvm-project//mlir:InliningUtils",
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",
-        "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:LoopLikeInterface",
+        "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MathToLLVM",
         "@llvm-project//mlir:MathToLibm",

--- a/src/enzyme_ad/jax/xla_ffi/host/mpi.cc
+++ b/src/enzyme_ad/jax/xla_ffi/host/mpi.cc
@@ -1,8 +1,5 @@
 #include <string_view>
-#include <tuple>
 #include <type_traits>
-
-#include "llvm/ADT/StringMap.h"
 
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/api/ffi.h"
@@ -26,47 +23,41 @@ int mpi_unimplemented_stub(...) {
 
 #define EXLA_FFI_PREFIX enzymexla_ffi
 
-// value is a pointer to the constant, boolean indicates whether to deref the
-// pointer (on true) or cast the pointer to the type (on false)
-llvm::StringMap<std::tuple<bool, void *>> mpi_constants_map;
-
-extern "C" MLIR_CAPI_EXPORTED void
-enzymexla_set_mpi_constant(const char *name, void *value, int isptr) {
-  mpi_constants_map[name] = std::make_tuple(static_cast<bool>(isptr), value);
-}
-
-extern "C" MLIR_CAPI_EXPORTED int
-enzymexla_get_mpi_constant(const char *name, void **value, int *isptr) {
-  auto it = mpi_constants_map.find(name);
-  if (it == mpi_constants_map.end()) {
-    return -1;
-  }
-  *isptr = std::get<0>(it->second);
-  *value = std::get<1>(it->second);
-  return 0;
-}
-
-template <typename T> xla::ffi::ErrorOr<T> getMpiConstant(const char *name) {
-  void *value;
-  int isptr;
-  auto notfound = enzymexla_get_mpi_constant(name, &value, &isptr);
-  if (notfound) {
-    return xla::ffi::Error::InvalidArgument(
-        absl::StrFormat("MPI constant `%s` not found", name));
+// generates a global variable for `FNAME` that defaults to the value by
+// MPItrampoline by default and a exported C function for setting the value
+// dynamically NOTE this should not be required once MPI v5 ABI is used as
+// minimum version
+#define EXLA_FFI_MPI_CONSTANT_BINDING(T, FNAME)                                \
+  T EXLA_##FNAME = FNAME;                                                      \
+  extern "C" MLIR_CAPI_EXPORTED void EXLA_FFI_PREFIX##_set_##FNAME(T val) {    \
+    EXLA_##FNAME = val;                                                        \
+  }                                                                            \
+  extern "C" MLIR_CAPI_EXPORTED T EXLA_FFI_PREFIX##_get_##FNAME() {            \
+    return EXLA_##FNAME;                                                       \
   }
 
-  if (isptr) {
-    if constexpr (std::is_pointer_v<T>) {
-      return reinterpret_cast<T>(value);
-    } else if constexpr (std::is_integral_v<T>) {
-      return static_cast<T>(reinterpret_cast<std::uintptr_t>(value));
-    } else {
-      return reinterpret_cast<T>(value);
-    }
-  } else {
-    return *static_cast<T *>(value);
-  }
-}
+EXLA_FFI_MPI_CONSTANT_BINDING(int, MPI_STATUS_SIZE)
+EXLA_FFI_MPI_CONSTANT_BINDING(int, MPI_SUCCESS)
+EXLA_FFI_MPI_CONSTANT_BINDING(int, MPI_MAX_ERROR_STRING)
+
+#define GENERATE_MPI_OP_LIST(X)                                                \
+  X(MPI_Op, MPI_OP_NULL)                                                       \
+  X(MPI_Op, MPI_SUM)                                                           \
+  X(MPI_Op, MPI_MIN)                                                           \
+  X(MPI_Op, MPI_MAX)                                                           \
+  X(MPI_Op, MPI_PROD)                                                          \
+  X(MPI_Op, MPI_BAND)                                                          \
+  X(MPI_Op, MPI_BOR)                                                           \
+  X(MPI_Op, MPI_BXOR)                                                          \
+  X(MPI_Op, MPI_LAND)                                                          \
+  X(MPI_Op, MPI_LOR)                                                           \
+  X(MPI_Op, MPI_LXOR)                                                          \
+  X(MPI_Op, MPI_MINLOC)                                                        \
+  X(MPI_Op, MPI_MAXLOC)                                                        \
+  X(MPI_Op, MPI_REPLACE)                                                       \
+  X(MPI_Op, MPI_NO_OP)
+
+GENERATE_MPI_OP_LIST(EXLA_FFI_MPI_CONSTANT_BINDING)
 
 namespace enzymexla::ffi_internal {
 namespace ffi = xla::ffi;
@@ -87,28 +78,16 @@ using MpiRequestBuffer = PtrBuffer;
 using MpiStatusBuffer = Buffer<ffi::U8, 1>;
 
 ffi::Error checkMpiStatusSize(const MpiStatusBuffer &buf) {
-  auto mpi_status_size = getMpiConstant<int>("MPI_STATUS_SIZE");
-  if (mpi_status_size.has_error())
-    return mpi_status_size.error();
-
-  if (buf.element_count() != mpi_status_size) {
+  if (buf.element_count() != EXLA_MPI_STATUS_SIZE) {
     return ffi::Error::InvalidArgument(
         absl::StrFormat("MPI_Status buffer must have %d elements, got %d",
-                        mpi_status_size, buf.element_count()));
+                        EXLA_MPI_STATUS_SIZE, buf.element_count()));
   }
   return ffi::Error::Success();
 }
 
 ffi::Error checkMpiError(const char *fname, const int err) {
-  auto mpi_success = getMpiConstant<int>("MPI_SUCCESS");
-  if (mpi_success.has_error())
-    return mpi_success.error();
-
-  auto mpi_max_error_string = getMpiConstant<int>("MPI_MAX_ERROR_STRING");
-  if (mpi_max_error_string.has_error())
-    return mpi_max_error_string.error();
-
-  if (err == mpi_success)
+  if (err == EXLA_MPI_SUCCESS)
     return ffi::Error::Success();
 
   auto *fptr = reinterpret_cast<decltype(MPI_Error_string) *>(
@@ -116,7 +95,7 @@ ffi::Error checkMpiError(const char *fname, const int err) {
   if (fptr == nullptr)
     return ffi::Error::Internal("MPI_Error_string symbol not found");
 
-  std::vector<char> cstr(mpi_max_error_string);
+  std::vector<char> cstr(EXLA_MPI_MAX_ERROR_STRING);
   int len;
 
   fptr(err, cstr.data(), &len);
@@ -127,49 +106,52 @@ ffi::Error checkMpiError(const char *fname, const int err) {
 }
 
 // clang-format off
+std::optional<MPI_Op> symbolizeMpiOp(std::string_view op) {
+  #define X(_, NAME) if (op == #NAME) return EXLA_##NAME;
+  GENERATE_MPI_OP_LIST(X)
+  #undef X
+  return std::nullopt;
+}
+// clang-format on
+
+// clang-format off
 std::optional<MPI_Datatype>
 convertPrimitiveTypeToMpiDatatype(ffi::DataType type, bool allow_cast = false) {
-  const char* name;
   switch (type) {
-    // case ffi::DataType::INVALID: name = std::nullopt;
-    case ffi::DataType::PRED: name = "MPI_C_BOOL";
-    // case ffi::DataType::S1: name = std::nullopt;
-    // case ffi::DataType::S2: name = std::nullopt;
-    // case ffi::DataType::S4: name = std::nullopt;
-    case ffi::DataType::S8: name = "MPI_INT8_T";
-    case ffi::DataType::S16: name = "MPI_INT16_T";
-    case ffi::DataType::S32: name = "MPI_INT32_T";
-    case ffi::DataType::S64: name = "MPI_INT64_T";
-    // case ffi::DataType::U1: name = std::nullopt;
-    // case ffi::DataType::U2: name = std::nullopt;
-    // case ffi::DataType::U4: name = std::nullopt;
-    case ffi::DataType::U8: name = "MPI_UINT8_T";
-    case ffi::DataType::U16: name = "MPI_UINT16_T";
-    case ffi::DataType::U32: name = "MPI_UINT32_T";
-    case ffi::DataType::U64: name = "MPI_UINT64_T";
-    case ffi::DataType::F16: name = (allow_cast ? "MPI_UINT16_T" : nullptr);
-    case ffi::DataType::F32: name = "MPI_FLOAT";
-    case ffi::DataType::F64: name = "MPI_DOUBLE";
-    case ffi::DataType::BF16: name = (allow_cast ? "MPI_UINT16_T" : nullptr);
-    case ffi::DataType::C64: name = "MPI_C_FLOAT_COMPLEX";
-    case ffi::DataType::C128: name = "MPI_C_DOUBLE_COMPLEX";
-    // case ffi::DataType::TOKEN: name = std::nullopt;
-    case ffi::DataType::F8E5M2: name = (allow_cast ? "MPI_UINT8_T" : nullptr);
-    case ffi::DataType::F8E4M3: name = (allow_cast ? "MPI_UINT8_T" : nullptr);
-    case ffi::DataType::F8E4M3FN: name = (allow_cast ? "MPI_UINT8_T" : nullptr);
-    case ffi::DataType::F8E4M3B11FNUZ: name = (allow_cast ? "MPI_UINT8_T" : nullptr);
-    case ffi::DataType::F8E5M2FNUZ: name = (allow_cast ? "MPI_UINT8_T" : nullptr);
-    case ffi::DataType::F8E4M3FNUZ: name = (allow_cast ? "MPI_UINT8_T" : nullptr);
-    case ffi::DataType::F8E3M4: name = (allow_cast ? "MPI_UINT8_T" : nullptr);
-    // case ffi::DataType::F4E2M1FN: name = std::nullopt;
-    case ffi::DataType::F8E8M0FNU: name = (allow_cast ? "MPI_UINT8_T" : nullptr);
+    case ffi::DataType::INVALID: return std::nullopt;
+    case ffi::DataType::PRED: return MPI_C_BOOL;
+    case ffi::DataType::S1: return std::nullopt;
+    case ffi::DataType::S2: return std::nullopt;
+    case ffi::DataType::S4: return std::nullopt;
+    case ffi::DataType::S8: return MPI_INT8_T;
+    case ffi::DataType::S16: return MPI_INT16_T;
+    case ffi::DataType::S32: return MPI_INT32_T;
+    case ffi::DataType::S64: return MPI_INT64_T;
+    case ffi::DataType::U1: return std::nullopt;
+    case ffi::DataType::U2: return std::nullopt;
+    case ffi::DataType::U4: return std::nullopt;
+    case ffi::DataType::U8: return MPI_UINT8_T;
+    case ffi::DataType::U16: return MPI_UINT16_T;
+    case ffi::DataType::U32: return MPI_UINT32_T;
+    case ffi::DataType::U64: return MPI_UINT64_T;
+    case ffi::DataType::F16: return std::nullopt; // allow_cast ? MPI_UINT16_T : std::nullopt;
+    case ffi::DataType::F32: return MPI_FLOAT;
+    case ffi::DataType::F64: return MPI_DOUBLE;
+    case ffi::DataType::BF16: return std::nullopt; // allow_cast ? MPI_UINT16_T : std::nullopt;
+    case ffi::DataType::C64: return MPI_C_FLOAT_COMPLEX;
+    case ffi::DataType::C128: return MPI_C_DOUBLE_COMPLEX;
+    case ffi::DataType::TOKEN: return std::nullopt;
+    case ffi::DataType::F8E5M2: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
+    case ffi::DataType::F8E4M3: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
+    case ffi::DataType::F8E4M3FN: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
+    case ffi::DataType::F8E4M3B11FNUZ: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
+    case ffi::DataType::F8E5M2FNUZ: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
+    case ffi::DataType::F8E4M3FNUZ: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
+    case ffi::DataType::F8E3M4: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
+    case ffi::DataType::F4E2M1FN: return std::nullopt;
+    case ffi::DataType::F8E8M0FNU: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
     default: return std::nullopt;
   }
-
-  auto datatype = getMpiConstant<MPI_Datatype>(name);
-  if (datatype.has_error())
-    return std::nullopt;
-  return datatype.value();
 }
 // clang-format on
 
@@ -477,10 +459,11 @@ ffi::Error MpiAllreduceImpl(ffi::AnyBuffer sendbuf, std::string_view op_str,
     return ffi::Error::InvalidArgument(
         absl::StrFormat("MPI_Allreduce: unsupported datatype %s", oss.str()));
   }
-  auto op = getMpiConstant<MPI_Op>(op_str.data());
-  if (op.has_error())
-    return op.error();
-
+  auto op = symbolizeMpiOp(op_str);
+  if (!op.has_value()) {
+    return ffi::Error::InvalidArgument(
+        absl::StrFormat("MPI_Allreduce: invalid operation %s", op_str));
+  }
   int count = sendbuf.element_count();
   int err = fptr(sendbuf.untyped_data(), recvbuf->untyped_data(), count,
                  datatype.value(), op.value(), comm);

--- a/src/enzyme_ad/jax/xla_ffi/host/mpi.cc
+++ b/src/enzyme_ad/jax/xla_ffi/host/mpi.cc
@@ -8,6 +8,11 @@
 #include "../export_macro.h"
 
 // from LowerJIT
+// - function pointers should be registered normally
+// - handle constants (communicators, ops and datatypes) should also be
+// registered normally (as they are encoded as pointers)
+// - integer constants (MPI_SUCCESS, MPI_STATUS_SIZE, ...) should be registered
+// as pointers to int
 extern "C" void *EnzymeJaXLookupSymbol(const char *name);
 
 #if defined(_WIN32)
@@ -15,49 +20,6 @@ void registerEnzymeJaXXLAHostMPIFFI() {}
 #else
 
 #include "mpi.h"
-
-int mpi_unimplemented_stub(...) {
-  abort();
-  return -1;
-}
-
-#define EXLA_FFI_PREFIX enzymexla_ffi
-
-// generates a global variable for `FNAME` that defaults to the value by
-// MPItrampoline by default and a exported C function for setting the value
-// dynamically NOTE this should not be required once MPI v5 ABI is used as
-// minimum version
-#define EXLA_FFI_MPI_CONSTANT_BINDING(T, FNAME)                                \
-  T EXLA_##FNAME = FNAME;                                                      \
-  extern "C" MLIR_CAPI_EXPORTED void EXLA_FFI_PREFIX##_set_##FNAME(T val) {    \
-    EXLA_##FNAME = val;                                                        \
-  }                                                                            \
-  extern "C" MLIR_CAPI_EXPORTED T EXLA_FFI_PREFIX##_get_##FNAME() {            \
-    return EXLA_##FNAME;                                                       \
-  }
-
-EXLA_FFI_MPI_CONSTANT_BINDING(int, MPI_STATUS_SIZE)
-EXLA_FFI_MPI_CONSTANT_BINDING(int, MPI_SUCCESS)
-EXLA_FFI_MPI_CONSTANT_BINDING(int, MPI_MAX_ERROR_STRING)
-
-#define GENERATE_MPI_OP_LIST(X)                                                \
-  X(MPI_Op, MPI_OP_NULL)                                                       \
-  X(MPI_Op, MPI_SUM)                                                           \
-  X(MPI_Op, MPI_MIN)                                                           \
-  X(MPI_Op, MPI_MAX)                                                           \
-  X(MPI_Op, MPI_PROD)                                                          \
-  X(MPI_Op, MPI_BAND)                                                          \
-  X(MPI_Op, MPI_BOR)                                                           \
-  X(MPI_Op, MPI_BXOR)                                                          \
-  X(MPI_Op, MPI_LAND)                                                          \
-  X(MPI_Op, MPI_LOR)                                                           \
-  X(MPI_Op, MPI_LXOR)                                                          \
-  X(MPI_Op, MPI_MINLOC)                                                        \
-  X(MPI_Op, MPI_MAXLOC)                                                        \
-  X(MPI_Op, MPI_REPLACE)                                                       \
-  X(MPI_Op, MPI_NO_OP)
-
-GENERATE_MPI_OP_LIST(EXLA_FFI_MPI_CONSTANT_BINDING)
 
 namespace enzymexla::ffi_internal {
 namespace ffi = xla::ffi;
@@ -78,16 +40,23 @@ using MpiRequestBuffer = PtrBuffer;
 using MpiStatusBuffer = Buffer<ffi::U8, 1>;
 
 ffi::Error checkMpiStatusSize(const MpiStatusBuffer &buf) {
-  if (buf.element_count() != EXLA_MPI_STATUS_SIZE) {
+  int mpi_status_size =
+      *reinterpret_cast<int *>(EnzymeJaXLookupSymbol("MPI_STATUS_SIZE"));
+  if (buf.element_count() != mpi_status_size) {
     return ffi::Error::InvalidArgument(
         absl::StrFormat("MPI_Status buffer must have %d elements, got %d",
-                        EXLA_MPI_STATUS_SIZE, buf.element_count()));
+                        mpi_status_size, buf.element_count()));
   }
   return ffi::Error::Success();
 }
 
 ffi::Error checkMpiError(const char *fname, const int err) {
-  if (err == EXLA_MPI_SUCCESS)
+  int mpi_success =
+      *reinterpret_cast<int *>(EnzymeJaXLookupSymbol("MPI_SUCCESS"));
+  int mpi_max_error_string =
+      *reinterpret_cast<int *>(EnzymeJaXLookupSymbol("MPI_MAX_ERROR_STRING"));
+
+  if (err == mpi_success)
     return ffi::Error::Success();
 
   auto *fptr = reinterpret_cast<decltype(MPI_Error_string) *>(
@@ -95,7 +64,7 @@ ffi::Error checkMpiError(const char *fname, const int err) {
   if (fptr == nullptr)
     return ffi::Error::Internal("MPI_Error_string symbol not found");
 
-  std::vector<char> cstr(EXLA_MPI_MAX_ERROR_STRING);
+  std::vector<char> cstr(mpi_max_error_string);
   int len;
 
   fptr(err, cstr.data(), &len);
@@ -106,54 +75,64 @@ ffi::Error checkMpiError(const char *fname, const int err) {
 }
 
 // clang-format off
-std::optional<MPI_Op> symbolizeMpiOp(std::string_view op) {
-  #define X(_, NAME) if (op == #NAME) return EXLA_##NAME;
-  GENERATE_MPI_OP_LIST(X)
-  #undef X
-  return std::nullopt;
-}
-// clang-format on
-
-// clang-format off
-std::optional<MPI_Datatype>
-convertPrimitiveTypeToMpiDatatype(ffi::DataType type, bool allow_cast = false) {
+const char *
+convertPrimitiveTypeToMpiDatatypeName(ffi::DataType type, bool allow_cast = false) {
   switch (type) {
-    case ffi::DataType::INVALID: return std::nullopt;
-    case ffi::DataType::PRED: return MPI_C_BOOL;
-    case ffi::DataType::S1: return std::nullopt;
-    case ffi::DataType::S2: return std::nullopt;
-    case ffi::DataType::S4: return std::nullopt;
-    case ffi::DataType::S8: return MPI_INT8_T;
-    case ffi::DataType::S16: return MPI_INT16_T;
-    case ffi::DataType::S32: return MPI_INT32_T;
-    case ffi::DataType::S64: return MPI_INT64_T;
-    case ffi::DataType::U1: return std::nullopt;
-    case ffi::DataType::U2: return std::nullopt;
-    case ffi::DataType::U4: return std::nullopt;
-    case ffi::DataType::U8: return MPI_UINT8_T;
-    case ffi::DataType::U16: return MPI_UINT16_T;
-    case ffi::DataType::U32: return MPI_UINT32_T;
-    case ffi::DataType::U64: return MPI_UINT64_T;
-    case ffi::DataType::F16: return std::nullopt; // allow_cast ? MPI_UINT16_T : std::nullopt;
-    case ffi::DataType::F32: return MPI_FLOAT;
-    case ffi::DataType::F64: return MPI_DOUBLE;
-    case ffi::DataType::BF16: return std::nullopt; // allow_cast ? MPI_UINT16_T : std::nullopt;
-    case ffi::DataType::C64: return MPI_C_FLOAT_COMPLEX;
-    case ffi::DataType::C128: return MPI_C_DOUBLE_COMPLEX;
-    case ffi::DataType::TOKEN: return std::nullopt;
-    case ffi::DataType::F8E5M2: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
-    case ffi::DataType::F8E4M3: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
-    case ffi::DataType::F8E4M3FN: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
-    case ffi::DataType::F8E4M3B11FNUZ: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
-    case ffi::DataType::F8E5M2FNUZ: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
-    case ffi::DataType::F8E4M3FNUZ: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
-    case ffi::DataType::F8E3M4: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
-    case ffi::DataType::F4E2M1FN: return std::nullopt;
-    case ffi::DataType::F8E8M0FNU: return std::nullopt; // allow_cast ? MPI_UINT8_T : std::nullopt;
-    default: return std::nullopt;
+    // case ffi::DataType::INVALID: return nullptr;
+    case ffi::DataType::PRED: return "MPI_C_BOOL";
+    // case ffi::DataType::S1: return nullptr;
+    // case ffi::DataType::S2: return nullptr;
+    // case ffi::DataType::S4: return nullptr;
+    case ffi::DataType::S8: return "MPI_INT8_T";
+    case ffi::DataType::S16: return "MPI_INT16_T";
+    case ffi::DataType::S32: return "MPI_INT32_T";
+    case ffi::DataType::S64: return "MPI_INT64_T";
+    // case ffi::DataType::U1: return nullptr;
+    // case ffi::DataType::U2: return nullptr;
+    // case ffi::DataType::U4: return nullptr;
+    case ffi::DataType::U8: return "MPI_UINT8_T";
+    case ffi::DataType::U16: return "MPI_UINT16_T";
+    case ffi::DataType::U32: return "MPI_UINT32_T";
+    case ffi::DataType::U64: return "MPI_UINT64_T";
+    case ffi::DataType::F16: return (allow_cast ? "MPI_UINT16_T" : nullptr);
+    case ffi::DataType::F32: return "MPI_FLOAT";
+    case ffi::DataType::F64: return "MPI_DOUBLE";
+    case ffi::DataType::BF16: return (allow_cast ? "MPI_UINT16_T" : nullptr);
+    case ffi::DataType::C64: return "MPI_C_FLOAT_COMPLEX";
+    case ffi::DataType::C128: return "MPI_C_DOUBLE_COMPLEX";
+    // case ffi::DataType::TOKEN: return nullptr;
+    case ffi::DataType::F8E5M2: return (allow_cast ? "MPI_UINT8_T" : nullptr);
+    case ffi::DataType::F8E4M3: return (allow_cast ? "MPI_UINT8_T" : nullptr);
+    case ffi::DataType::F8E4M3FN: return (allow_cast ? "MPI_UINT8_T" : nullptr);
+    case ffi::DataType::F8E4M3B11FNUZ: return (allow_cast ? "MPI_UINT8_T" : nullptr);
+    case ffi::DataType::F8E5M2FNUZ: return (allow_cast ? "MPI_UINT8_T" : nullptr);
+    case ffi::DataType::F8E4M3FNUZ: return (allow_cast ? "MPI_UINT8_T" : nullptr);
+    case ffi::DataType::F8E3M4: return (allow_cast ? "MPI_UINT8_T" : nullptr);
+    // case ffi::DataType::F4E2M1FN: return nullptr;
+    case ffi::DataType::F8E8M0FNU: return (allow_cast ? "MPI_UINT8_T" : nullptr);
+    default: return nullptr;
   }
 }
 // clang-format on
+
+ffi::ErrorOr<MPI_Datatype>
+convertPrimitiveTypeToMpiDatatype(ffi::DataType type, bool allow_cast = false) {
+  const char *name = convertPrimitiveTypeToMpiDatatypeName(type, allow_cast);
+  if (name == nullptr) {
+    std::ostringstream oss;
+    oss << type;
+    return ffi::Error::InvalidArgument(
+        absl::StrFormat("MPI: unsupported datatype `%s`", oss.str()));
+  }
+
+  auto dt = reinterpret_cast<MPI_Datatype>(EnzymeJaXLookupSymbol(name));
+  if (dt == nullptr) {
+    return ffi::Error::Internal(
+        absl::StrFormat("MPI: symbol `%s` not found", name));
+  }
+
+  return dt;
+}
 
 ffi::Error MpiCommRankImpl(MpiCommBuffer comm_ptr, Result<IntBuffer> rank_ptr) {
   auto *fptr = reinterpret_cast<decltype(MPI_Comm_rank) *>(
@@ -234,12 +213,9 @@ ffi::Error MpiSendImpl(ffi::AnyBuffer buf, IntBuffer dest_ptr,
   int tag = *tag_ptr.typed_data();
   int count = buf.element_count();
   auto datatype = convertPrimitiveTypeToMpiDatatype(buf.element_type());
-  if (!datatype.has_value()) {
-    std::ostringstream oss;
-    oss << buf.element_type();
-    return ffi::Error::InvalidArgument(
-        absl::StrFormat("MPI_Send: unsupported datatype %s", oss.str()));
-  }
+  if (datatype.has_error())
+    return datatype.error();
+
   int err = fptr(buf.untyped_data(), count, datatype.value(), dest, tag, comm);
   return checkMpiError("MPI_Send", err);
 }
@@ -260,12 +236,9 @@ ffi::Error MpiIsendImpl(ffi::AnyBuffer buf, IntBuffer dest_ptr,
   if (fptr == nullptr)
     return ffi::Error::Internal("MPI_Isend symbol not found");
   auto datatype = convertPrimitiveTypeToMpiDatatype(buf.element_type());
-  if (!datatype.has_value()) {
-    std::ostringstream oss;
-    oss << buf.element_type();
-    return ffi::Error::InvalidArgument(
-        absl::StrFormat("MPI_Isend: unsupported datatype %s", oss.str()));
-  }
+  if (datatype.has_error())
+    return datatype.error();
+
   MPI_Comm comm = *reinterpret_cast<MPI_Comm *>(comm_ptr.typed_data());
   int dest = *dest_ptr.typed_data();
   int tag = *tag_ptr.typed_data();
@@ -298,12 +271,9 @@ ffi::Error MpiRecvImpl(IntBuffer source_ptr, IntBuffer tag_ptr,
   }
   MPI_Comm comm = *reinterpret_cast<MPI_Comm *>(comm_ptr.typed_data());
   auto datatype = convertPrimitiveTypeToMpiDatatype(buf->element_type());
-  if (!datatype.has_value()) {
-    std::ostringstream oss;
-    oss << buf->element_type();
-    return ffi::Error::InvalidArgument(
-        absl::StrFormat("MPI_Recv: unsupported datatype %s", oss.str()));
-  }
+  if (datatype.has_error())
+    return datatype.error();
+
   int source = *source_ptr.typed_data();
   int tag = *tag_ptr.typed_data();
   int count = buf->element_count();
@@ -331,12 +301,9 @@ ffi::Error MpiIrecvImpl(IntBuffer source_ptr, IntBuffer tag_ptr,
     return ffi::Error::Internal("MPI_Irecv symbol not found");
   MPI_Comm comm = *reinterpret_cast<MPI_Comm *>(comm_ptr.typed_data());
   auto datatype = convertPrimitiveTypeToMpiDatatype(buf->element_type());
-  if (!datatype.has_value()) {
-    std::ostringstream oss;
-    oss << buf->element_type();
-    return ffi::Error::InvalidArgument(
-        absl::StrFormat("MPI_Irecv: unsupported datatype %s", oss.str()));
-  }
+  if (datatype.has_error())
+    return datatype.error();
+
   int source = *source_ptr.typed_data();
   int tag = *tag_ptr.typed_data();
   int count = buf->element_count();
@@ -453,20 +420,18 @@ ffi::Error MpiAllreduceImpl(ffi::AnyBuffer sendbuf, std::string_view op_str,
   }
   MPI_Comm comm = *reinterpret_cast<MPI_Comm *>(comm_ptr.typed_data());
   auto datatype = convertPrimitiveTypeToMpiDatatype(sendbuf.element_type());
-  if (!datatype.has_value()) {
-    std::ostringstream oss;
-    oss << sendbuf.element_type();
+  if (datatype.has_error())
+    return datatype.error();
+
+  auto op = static_cast<MPI_Op>(EnzymeJaXLookupSymbol(op_str.data()));
+  if (op == nullptr) {
     return ffi::Error::InvalidArgument(
-        absl::StrFormat("MPI_Allreduce: unsupported datatype %s", oss.str()));
+        absl::StrFormat("MPI_Allreduce: symbol `%s`", op_str));
   }
-  auto op = symbolizeMpiOp(op_str);
-  if (!op.has_value()) {
-    return ffi::Error::InvalidArgument(
-        absl::StrFormat("MPI_Allreduce: invalid operation %s", op_str));
-  }
+
   int count = sendbuf.element_count();
   int err = fptr(sendbuf.untyped_data(), recvbuf->untyped_data(), count,
-                 datatype.value(), op.value(), comm);
+                 datatype.value(), op, comm);
   return checkMpiError("MPI_Allreduce", err);
 }
 
@@ -486,11 +451,8 @@ ffi::Error MpiBcastImpl(ffi::AnyBuffer buf, IntBuffer root_ptr,
     return ffi::Error::Internal("MPI_Bcast symbol not found");
   MPI_Comm comm = *reinterpret_cast<MPI_Comm *>(comm_ptr.typed_data());
   auto datatype = convertPrimitiveTypeToMpiDatatype(buf.element_type());
-  if (!datatype.has_value()) {
-    std::ostringstream oss;
-    oss << buf.element_type();
-    return ffi::Error::InvalidArgument(
-        absl::StrFormat("MPI_Bcast: unsupported datatype %s", oss.str()));
+  if (datatype.has_error()) {
+    return datatype.error();
   }
   int root = *root_ptr.typed_data();
   int count = buf.element_count();


### PR DESCRIPTION
This reverts commit 0dfd10e9b6187a376a46095cb64639abf19d0077.

It gives some linking errors when running `enzymexlamlir-opt` on some situations (i.e. using it in LowerComm pass for the new `comm.mpi.constant` op) because it depends on whether you build the XLA FFI or not.

I also agreed with @romanlee to continue using the JIT registry mechanism and we will revisit this after all MPI / NCCL works. Probably, with a better and more general mechanism.