### PR TITLE
Fill a zeroing memset of a select between allocations

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1682,12 +1682,42 @@ static Value createVectorLoad(OpBuilder &b, Location loc, Type ty,
   llvm_unreachable("");
 }
 
+// The one element type every typed view derived from `root` uses, or null
+// when there is none or they disagree.
+static Type viewedElementType(Value root) {
+  Type elTy;
+  SmallVector<Value> todo{root};
+  DenseSet<Value> seen;
+  while (!todo.empty()) {
+    Value v = todo.pop_back_val();
+    if (!seen.insert(v).second)
+      continue;
+    for (Operation *user : v.getUsers()) {
+      if (auto gep = dyn_cast<LLVM::GEPOp>(user)) {
+        if (gep.getBase() == v)
+          todo.push_back(gep.getResult());
+      } else if (isa<LLVM::AddrSpaceCastOp, arith::SelectOp>(user)) {
+        todo.push_back(user->getResult(0));
+      } else if (auto view = dyn_cast<enzymexla::Pointer2MemrefOp>(user)) {
+        Type t = cast<MemRefType>(view.getType()).getElementType();
+        if (elTy && elTy != t)
+          return nullptr;
+        elTy = t;
+      }
+    }
+  }
+  return elTy;
+}
+
 // A zeroing memset is a loop of stores of zero, and only in that form does an
 // allocation the conversion could take stop being blocked by it: the
 // conversion accepts views of an allocation and nothing else, and a memset
 // names the pointer itself. The element type is the one the allocation was
-// declared with, so the stores land on whole elements; a length that is not a
-// whole number of them is left alone.
+// declared with (every allocation a select could pick must agree), so the
+// stores land on whole elements; a length that is not a whole number of them
+// is left alone. Inside a kernel every memset has to go, since the raising
+// has no lowering for one, so there a base that is not an allocation may take
+// its type from the views the kernel already accesses it through.
 struct MemsetZeroToAffineFill : public OpRewritePattern<LLVM::MemsetOp> {
   using OpRewritePattern<LLVM::MemsetOp>::OpRewritePattern;
 
@@ -1704,21 +1734,34 @@ struct MemsetZeroToAffineFill : public OpRewritePattern<LLVM::MemsetOp> {
     if (memset.getIsVolatile())
       return failure();
 
-    Value base = memset.getDst();
-    while (true) {
+    bool inKernel =
+        memset->getParentOfType<enzymexla::GPUWrapperOp>() != nullptr;
+    Type elTy;
+    auto merge = [&](Type t) {
+      if (!t || (elTy && elTy != t))
+        return failure();
+      elTy = t;
+      return success();
+    };
+    SmallVector<Value> todo{memset.getDst()};
+    while (!todo.empty()) {
+      Value base = todo.pop_back_val();
       if (auto gep = base.getDefiningOp<LLVM::GEPOp>())
-        base = gep.getBase();
+        todo.push_back(gep.getBase());
       else if (auto cast = base.getDefiningOp<LLVM::AddrSpaceCastOp>())
-        base = cast.getArg();
-      else
-        break;
+        todo.push_back(cast.getArg());
+      else if (auto sel = base.getDefiningOp<arith::SelectOp>()) {
+        todo.push_back(sel.getTrueValue());
+        todo.push_back(sel.getFalseValue());
+      } else if (auto alloca = base.getDefiningOp<LLVM::AllocaOp>()) {
+        Type t = alloca.getElemType();
+        while (auto arr = dyn_cast<LLVM::LLVMArrayType>(t))
+          t = arr.getElementType();
+        if (failed(merge(t)))
+          return failure();
+      } else if (!inKernel || failed(merge(viewedElementType(base))))
+        return failure();
     }
-    auto alloca = base.getDefiningOp<LLVM::AllocaOp>();
-    if (!alloca)
-      return failure();
-    Type elTy = alloca.getElemType();
-    while (auto arr = dyn_cast<LLVM::LLVMArrayType>(elTy))
-      elTy = arr.getElementType();
     auto adTy = dyn_cast<enzyme::AutoDiffTypeInterface>(elTy);
     if (!adTy || !MemRefType::isValidElementType(elTy))
       return failure();

--- a/test/lit_tests/memset_zero_fill_viewed.mlir
+++ b/test/lit_tests/memset_zero_fill_viewed.mlir
@@ -1,0 +1,132 @@
+// RUN: enzymexlamlir-opt %s --llvm-to-affine-access | FileCheck %s
+
+module {
+  func.func @chosen(%c: i1, %i: i64) {
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %a = llvm.alloca %c1 x !llvm.array<8 x f64> : (i32) -> !llvm.ptr
+    %b = llvm.alloca %c1 x !llvm.array<4 x f64> : (i32) -> !llvm.ptr
+    %ga = llvm.getelementptr %a[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+    %gb = llvm.getelementptr %b[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+    %s = arith.select %c, %ga, %gb : !llvm.ptr
+    "llvm.intr.memset"(%s, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    return
+  }
+  func.func @cast(%c: i1) {
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %a = llvm.alloca %c1 x !llvm.array<8 x f64> : (i32) -> !llvm.ptr
+    %b = llvm.alloca %c1 x !llvm.array<4 x f64> : (i32) -> !llvm.ptr
+    %ca = llvm.addrspacecast %a : !llvm.ptr to !llvm.ptr<3>
+    %cb = llvm.addrspacecast %b : !llvm.ptr to !llvm.ptr<3>
+    %s = arith.select %c, %ca, %cb : !llvm.ptr<3>
+    "llvm.intr.memset"(%s, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr<3>, i8, i64) -> ()
+    return
+  }
+  func.func @mismatched(%c: i1) {
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %a = llvm.alloca %c1 x !llvm.array<8 x f64> : (i32) -> !llvm.ptr
+    %b = llvm.alloca %c1 x !llvm.array<8 x i32> : (i32) -> !llvm.ptr
+    %s = arith.select %c, %a, %b : !llvm.ptr
+    "llvm.intr.memset"(%s, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    return
+  }
+  func.func @argument(%a: !llvm.ptr, %c: i1) {
+    %c1 = arith.constant 1 : i32
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %b = llvm.alloca %c1 x !llvm.array<8 x f64> : (i32) -> !llvm.ptr
+    %s = arith.select %c, %a, %b : !llvm.ptr
+    "llvm.intr.memset"(%s, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    return
+  }
+  func.func @kernel_viewed(%p: !llvm.ptr, %i: i64, %x: f64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+      %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+      affine.store %x, %v[0] : memref<?xf64>
+      %g = llvm.getelementptr %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+      "llvm.intr.memset"(%g, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+  func.func @host_viewed(%p: !llvm.ptr, %i: i64, %x: f64) {
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+    affine.store %x, %v[0] : memref<?xf64>
+    %g = llvm.getelementptr %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+    "llvm.intr.memset"(%g, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    return
+  }
+  func.func @kernel_unviewed(%p: !llvm.ptr, %i: i64) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+      %g = llvm.getelementptr %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+      "llvm.intr.memset"(%g, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+  func.func @kernel_disagreeing_views(%p: !llvm.ptr, %i: i64, %x: f64, %y: i32) {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+      %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+      affine.store %x, %v[0] : memref<?xf64>
+      %w = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xi32>
+      affine.store %y, %w[0] : memref<?xi32>
+      %g = llvm.getelementptr %p[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+      "llvm.intr.memset"(%g, %c0, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
+}
+
+// CHECK-LABEL:  func.func @chosen(
+// CHECK-NOT:  llvm.intr.memset
+// CHECK:  %[[sel:.+]] = arith.select %arg0, %{{.*}}, %{{.*}} : memref<?xf64>
+// CHECK-NEXT:  affine.for %[[iv:.+]] = 0 to 3 {
+// CHECK-NEXT:  affine.store %{{.*}}, %[[sel]][%[[iv]]] : memref<?xf64>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL:  func.func @cast(
+// CHECK-NOT:  llvm.intr.memset
+// CHECK:  %[[sel:.+]] = arith.select %arg0, %{{.*}}, %{{.*}} : memref<?xf64, 3 : index>
+// CHECK-NEXT:  affine.for %[[iv:.+]] = 0 to 3 {
+// CHECK-NEXT:  affine.store %{{.*}}, %[[sel]][%[[iv]]] : memref<?xf64, 3 : index>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL:  func.func @mismatched(
+// CHECK:  llvm.intr.memset
+
+// CHECK-LABEL:  func.func @argument(
+// CHECK:  llvm.intr.memset
+
+// CHECK-LABEL:  func.func @kernel_viewed(
+// CHECK-NOT:  llvm.intr.memset
+// CHECK:  %[[gep:.+]] = llvm.getelementptr %arg0[%arg1]
+// CHECK-NEXT:  %[[view:.+]] = "enzymexla.pointer2memref"(%[[gep]]) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:  affine.for %[[iv:.+]] = 0 to 3 {
+// CHECK-NEXT:  affine.store %{{.*}}, %[[view]][%[[iv]]] : memref<?xf64>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL:  func.func @host_viewed(
+// CHECK:  llvm.intr.memset
+
+// CHECK-LABEL:  func.func @kernel_unviewed(
+// CHECK:  llvm.intr.memset
+
+// CHECK-LABEL:  func.func @kernel_disagreeing_views(
+// CHECK:  llvm.intr.memset


### PR DESCRIPTION
Follow-up to #3054. That fill needed the memset's destination to trace back, through geps and address-space casts, to a single `llvm.alloca`, since the allocation's declared element type is what sizes the stores. A destination that is a select between two buffers,

```
%1588 = arith.select %386, %1586, %1587 : !llvm.ptr
"llvm.intr.memset"(%1588, %c0_i8, %c24_i64)
```

was left alone.

Walk the destination with a worklist instead: a gep or address-space cast pushes its base, a select pushes both arms, an `llvm.alloca` supplies its element type (arrays peeled), and every allocation the walk reaches must agree on that type; any other base means no fill.

Inside a `gpu_wrapper` every memset has to go, since the raising has no lowering for one, so there a base that is not an allocation takes its type from the `pointer2memref` views the kernel already accesses it through (again requiring them to agree). This is the mfem `DeviceTensor` shape in `bilininteg_dgdiffusion_pa.cpp`, where the memset's base is the kernel's `Write()` pointer, viewed as `memref<?xf64>` by every other access in the wrapper. Outside a kernel a non-allocation base still leaves the memset alone.

The test covers a select of two allocations through geps, through address-space casts, two allocations of different element types, a select against a function argument, and the in-kernel view-typed cases: a viewed base inside a wrapper (filled), the same outside a wrapper (kept), an unviewed base inside a wrapper (kept), and disagreeing views (kept).

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
