### PR TITLE
Put the shape cast last in the pointer round trip view

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -268,21 +268,21 @@ public:
         smt.getRank() != omt.getRank())
       return failure();
 
-    // The shapes adapt in the source's own space, so a memory space cast
-    // lands last, closest to the accesses, where it can sink into them.
-    auto inSrcSpace =
-        MemRefType::get(omt.getShape(), omt.getElementType(),
-                        MemRefLayoutAttrInterface{}, smt.getMemorySpace());
+    // The memory space changes on the source's own shape, so the shape cast
+    // lands last, closest to the accesses, where it folds into them.
+    auto inDstSpace =
+        MemRefType::get(smt.getShape(), smt.getElementType(),
+                        MemRefLayoutAttrInterface{}, omt.getMemorySpace());
+    if (inDstSpace != omt &&
+        !memref::CastOp::areCastCompatible(inDstSpace, omt))
+      return failure();
     Value v = src.getSource();
-    if (inSrcSpace != smt) {
-      if (!memref::CastOp::areCastCompatible(smt, inSrcSpace))
-        return failure();
-      v = memref::CastOp::create(rewriter, op.getLoc(), inSrcSpace, v)
-              .getResult();
-    }
     if (smt.getMemorySpace() != omt.getMemorySpace())
-      v = memref::MemorySpaceCastOp::create(rewriter, op.getLoc(), omt, v)
+      v = memref::MemorySpaceCastOp::create(rewriter, op.getLoc(), inDstSpace,
+                                            v)
               .getResult();
+    if (inDstSpace != omt)
+      v = memref::CastOp::create(rewriter, op.getLoc(), omt, v).getResult();
     rewriter.replaceOp(op, v);
     return success();
   }

--- a/test/lit_tests/memref2pointer2memref.mlir
+++ b/test/lit_tests/memref2pointer2memref.mlir
@@ -1,8 +1,9 @@
 // RUN: enzymexlamlir-opt %s --canonicalize --split-input-file | FileCheck %s
 
-// A pointer round trip is a view of the source buffer. The shapes adapt in
-// the source's own space and the memory space cast lands last, next to the
-// accesses, where the raising preprocessing strips it.
+// A pointer round trip is a view of the source buffer. The memory space
+// changes on the source's own shape and the shape cast lands last, next to
+// the accesses, where it folds into them; the space cast left directly on
+// the access is what the raising preprocessing strips.
 
 func.func private @space(%m: memref<30xf64>, %i: index) -> f64 {
   %p = "enzymexla.memref2pointer"(%m) : (memref<30xf64>) -> !llvm.ptr<3>
@@ -12,9 +13,34 @@ func.func private @space(%m: memref<30xf64>, %i: index) -> f64 {
 }
 
 // CHECK:  func.func private @space(%[[m:.+]]: memref<30xf64>, %[[i:.+]]: index) -> f64 {
-// CHECK-NEXT:  %[[cast:.+]] = memref.cast %[[m]] : memref<30xf64> to memref<?xf64>
-// CHECK-NEXT:  %[[sp:.+]] = memref.memory_space_cast %[[cast]] : memref<?xf64> to memref<?xf64, 3>
-// CHECK-NEXT:  %[[x:.+]] = memref.load %[[sp]][%[[i]]] : memref<?xf64, 3>
+// CHECK-NEXT:  %[[sp:.+]] = memref.memory_space_cast %[[m]] : memref<30xf64> to memref<30xf64, 3>
+// CHECK-NEXT:  %[[x:.+]] = memref.load %[[sp]][%[[i]]] : memref<30xf64, 3>
+// CHECK-NEXT:  return %[[x]] : f64
+// CHECK-NEXT:  }
+
+// -----
+
+// The same through affine accesses of a static scratch buffer, the shape
+// MFEM's shared-memory tensors take after llvm-to-affine-access.
+
+func.func private @space_affine(%i: index) -> f64 {
+  %m = memref.alloca() : memref<64xf64>
+  %c = arith.constant 1.0 : f64
+  memref.store %c, %m[%i] : memref<64xf64>
+  %p = "enzymexla.memref2pointer"(%m) : (memref<64xf64>) -> !llvm.ptr<3>
+  %v = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64, 3>
+  affine.store %c, %v[%i] : memref<?xf64, 3>
+  %x = affine.load %v[%i + 1] : memref<?xf64, 3>
+  return %x : f64
+}
+
+// CHECK:  func.func private @space_affine(%[[i:.+]]: index) -> f64 {
+// CHECK-DAG:  %[[c:.+]] = arith.constant 1.000000e+00 : f64
+// CHECK-DAG:  %[[m:.+]] = memref.alloca() : memref<64xf64>
+// CHECK:  memref.store %[[c]], %[[m]][%[[i]]] : memref<64xf64>
+// CHECK-NEXT:  %[[sp:.+]] = memref.memory_space_cast %[[m]] : memref<64xf64> to memref<64xf64, 3>
+// CHECK-NEXT:  affine.store %[[c]], %[[sp]][symbol(%[[i]])] : memref<64xf64, 3>
+// CHECK-NEXT:  %[[x:.+]] = affine.load %[[sp]][symbol(%[[i]]) + 1] : memref<64xf64, 3>
 // CHECK-NEXT:  return %[[x]] : f64
 // CHECK-NEXT:  }
 

--- a/test/lit_tests/raising/raise_space_cast_roundtrip.mlir
+++ b/test/lit_tests/raising/raise_space_cast_roundtrip.mlir
@@ -1,0 +1,24 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel --raise-affine-to-stablehlo | FileCheck %s
+
+// A pointer round trip into shared memory of a static scratch buffer: the
+// shape cast folds into the accesses under canonicalization, leaving only the
+// memory space cast, which the raising strips.
+func.func @roundtrip(%out: memref<10xf64, 1>) {
+  %tmp = memref.alloca() : memref<10xf64>
+  %p = "enzymexla.memref2pointer"(%tmp) : (memref<10xf64>) -> !llvm.ptr<3>
+  %view = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64, 3>
+  affine.parallel (%i) = (0) to (10) {
+    %c = arith.constant 2.0 : f64
+    affine.store %c, %view[%i] : memref<?xf64, 3>
+    %v = affine.load %view[9 - %i] : memref<?xf64, 3>
+    affine.store %v, %out[%i] : memref<10xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @roundtrip_raised(
+// CHECK-NOT: memref.cast
+// CHECK-NOT: memory_space_cast
+// CHECK-DAG: stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-DAG: stablehlo.constant dense<0.000000e+00> : tensor<10xf64>
+// CHECK: stablehlo.reverse

--- a/test/lit_tests/raising/raise_space_cast_roundtrip.mlir
+++ b/test/lit_tests/raising/raise_space_cast_roundtrip.mlir
@@ -1,24 +1,22 @@
-// RUN: enzymexlamlir-opt %s --canonicalize-parallel --raise-affine-to-stablehlo | FileCheck %s
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel,raise-affine-to-stablehlo,enzyme-hlo-opt{max_constant_expansion=0})" | FileCheck %s
 
 // A pointer round trip into shared memory of a static scratch buffer: the
 // shape cast folds into the accesses under canonicalization, leaving only the
 // memory space cast, which the raising strips.
-func.func @roundtrip(%out: memref<10xf64, 1>) {
+func.func @roundtrip(%in: memref<10xf64, 1>, %out: memref<10xf64, 1>) {
   %tmp = memref.alloca() : memref<10xf64>
   %p = "enzymexla.memref2pointer"(%tmp) : (memref<10xf64>) -> !llvm.ptr<3>
   %view = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64, 3>
   affine.parallel (%i) = (0) to (10) {
-    %c = arith.constant 2.0 : f64
-    affine.store %c, %view[%i] : memref<?xf64, 3>
-    %v = affine.load %view[9 - %i] : memref<?xf64, 3>
-    affine.store %v, %out[%i] : memref<10xf64, 1>
+    %v = affine.load %in[%i] : memref<10xf64, 1>
+    affine.store %v, %view[%i] : memref<?xf64, 3>
+    %r = affine.load %view[9 - %i] : memref<?xf64, 3>
+    affine.store %r, %out[%i] : memref<10xf64, 1>
   }
   return
 }
 
-// CHECK-LABEL: func.func private @roundtrip_raised(
-// CHECK-NOT: memref.cast
-// CHECK-NOT: memory_space_cast
-// CHECK-DAG: stablehlo.constant dense<2.000000e+00> : tensor<f64>
-// CHECK-DAG: stablehlo.constant dense<0.000000e+00> : tensor<10xf64>
-// CHECK: stablehlo.reverse
+// CHECK:  func.func private @roundtrip_raised(%arg0: tensor<10xf64>, %arg1: tensor<10xf64>) -> (tensor<10xf64>, tensor<10xf64>) {
+// CHECK-NEXT:    %0 = stablehlo.reverse %arg0, dims = [0] : tensor<10xf64>
+// CHECK-NEXT:    return %arg0, %0 : tensor<10xf64>, tensor<10xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
`Memref2Pointer2MemrefCast` rewrites a pointer round trip that changes memory space into `memory_space_cast(memref.cast(x))`. The `memref.cast` would fold into its affine/memref accesses, but the `memory_space_cast` sitting between blocks that fold, and the raising preprocessing (`stripAccessMemorySpaceCasts`) only strips a `memory_space_cast` that sits directly on an access. So the shape cast survived into the raising and stopped it:

```
%377 = memref.cast %262 : memref<100xf64> to memref<?xf64>
%378 = memref.memory_space_cast %377 : memref<?xf64> to memref<?xf64, 3>
affine.load %378[...]
error: cannot raise op to stablehlo %377 = "memref.cast"(%262)
```

This is what stopped MFEM's shared-memory scratch in quadinterpolator, quadinterpolator_face, batchitrans, mass_kernels, diffusion_kernels, vectorfemass_pa, dgdiffusion_pa, normal_deriv_restriction, diag2, diag2_limit, linalg/batched, linalg/vector and tmop/tools/discrete (13 TUs of the #2968 sweep).

Change the space on the source's own shape and cast the shape last — the order `llvm-to-affine-access` already uses when it types an alloca — so the shape cast folds into the accesses in the same canonicalization run and the `memory_space_cast` left directly on them is what the raising strips. No raiser change needed; this replaces the shape-cast half of the union branch's `stripAccessMemorySpaceCasts`.

Tests: `memref2pointer2memref.mlir` updated for the new order plus an affine case; `raising/raise_space_cast_roundtrip.mlir` runs `canonicalize-parallel, raise-affine-to-stablehlo` on the round trip and fails on main with exactly the error above.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
