### PR TITLE
canonicalize-parallel: unroll whiles that cannot iterate a third time

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -19,6 +19,7 @@
 #include "Enzyme/MLIR/Dialect/Ops.h"
 #include "Enzyme/MLIR/Interfaces/AutoDiffOpInterface.h"
 #include "mlir/Analysis/DataLayoutAnalysis.h"
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -32,6 +33,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
+#include "llvm/Support/KnownBits.h"
 
 namespace mlir {
 namespace enzyme {
@@ -41,6 +43,7 @@ namespace enzyme {
 } // namespace mlir
 
 using namespace mlir;
+using llvm::KnownBits;
 
 namespace {
 
@@ -766,6 +769,358 @@ struct StoreOfUndef
   }
 };
 
+// The loop-carried arguments a value is a pure function of, or nullopt when
+// the dependence passes through a region or a side effect. getBackwardSlice
+// collects every operation inside the loop the value depends on; the block
+// arguments among their operands are then read directly, an after-region
+// argument standing for the condition operand forwarded to it. With
+// `anyIsEnough` the walk stops at the first carried argument found.
+static std::optional<SetVector<BlockArgument>>
+carriedArguments(scf::WhileOp whileOp, Value root, bool anyIsEnough = false) {
+  Block &before = whileOp.getBefore().front();
+  Block &after = whileOp.getAfter().front();
+  scf::ConditionOp conditionOp = whileOp.getConditionOp();
+  SetVector<BlockArgument> carried;
+  BackwardSliceOptions options;
+  options.inclusive = true;
+  options.omitBlockArguments = true;
+  options.filter = [&](Operation *op) { return whileOp->isAncestor(op); };
+  SmallVector<Value> roots{root};
+  DenseSet<Value> visited;
+  while (!roots.empty()) {
+    Value value = roots.pop_back_val();
+    if (!visited.insert(value).second)
+      continue;
+    SmallVector<Value> operands{value};
+    if (Operation *definingOp = value.getDefiningOp();
+        definingOp && whileOp->isAncestor(definingOp)) {
+      SetVector<Operation *> slice;
+      if (failed(getBackwardSlice(definingOp, &slice, options)))
+        return std::nullopt;
+      for (Operation *op : slice) {
+        if (op->getNumRegions() || !isMemoryEffectFree(op))
+          return std::nullopt;
+        operands.append(op->operand_begin(), op->operand_end());
+      }
+    }
+    for (Value operand : operands) {
+      auto blockArg = dyn_cast<BlockArgument>(operand);
+      if (!blockArg)
+        continue;
+      Block *owner = blockArg.getOwner();
+      if (owner == &before) {
+        carried.insert(blockArg);
+        if (anyIsEnough)
+          return carried;
+      } else if (owner == &after) {
+        roots.push_back(conditionOp.getArgs()[blockArg.getArgNumber()]);
+      } else if (whileOp->isAncestor(owner->getParentOp())) {
+        return std::nullopt;
+      }
+    }
+  }
+  return carried;
+}
+
+// Whether a value is a pure function of values from outside the loop.
+static bool isInvariant(scf::WhileOp whileOp, Value value) {
+  auto carried = carriedArguments(whileOp, value, /*anyIsEnough=*/true);
+  return carried && carried->empty();
+}
+
+// The evaluation of the loop a value is asked about: Outside for a value
+// defined outside the loop, First for the before region fed by the inits,
+// Second for the before region fed by the first evaluation's yields.
+enum class Evaluation { Outside, First, Second };
+using KnownKey = std::pair<Value, Evaluation>;
+// The bits known of an integer value; nullopt for a value of another type.
+using Known = std::optional<KnownBits>;
+
+static unsigned integerWidth(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type))
+    return intType.getWidth();
+  if (isa<IndexType>(type))
+    return IndexType::kInternalStorageBitWidth;
+  return 0;
+}
+
+static KnownKey knownKey(scf::WhileOp whileOp, Value value,
+                         Evaluation evaluation) {
+  auto blockArg = dyn_cast<BlockArgument>(value);
+  Operation *definingOp = value.getDefiningOp();
+  if (!whileOp->isAncestor(blockArg ? blockArg.getOwner()->getParentOp()
+                                    : definingOp))
+    evaluation = Evaluation::Outside;
+  return {value, evaluation};
+}
+
+// The keys whose bits decide the bits of a key inside the loop. For an
+// scf.if result they are the condition and the values its two regions yield.
+static SmallVector<KnownKey> knownInputKeys(scf::WhileOp whileOp,
+                                            KnownKey key) {
+  auto [value, evaluation] = key;
+  assert(evaluation != Evaluation::Outside);
+  if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+    unsigned argNumber = blockArg.getArgNumber();
+    if (blockArg.getOwner() == &whileOp.getBefore().front()) {
+      if (evaluation == Evaluation::First)
+        return {knownKey(whileOp, whileOp.getInits()[argNumber],
+                         Evaluation::Outside)};
+      assert(evaluation == Evaluation::Second);
+      return {knownKey(whileOp, whileOp.getYieldOp().getOperand(argNumber),
+                       Evaluation::First)};
+    }
+    assert(blockArg.getOwner() == &whileOp.getAfter().front());
+    return {knownKey(whileOp, whileOp.getConditionOp().getArgs()[argNumber],
+                     evaluation)};
+  }
+  Operation *definingOp = value.getDefiningOp();
+  SmallVector<KnownKey> keys;
+  if (auto ifOp = dyn_cast<scf::IfOp>(definingOp)) {
+    unsigned resultNumber = cast<OpResult>(value).getResultNumber();
+    keys.push_back(knownKey(whileOp, ifOp.getCondition(), evaluation));
+    keys.push_back(knownKey(whileOp, ifOp.thenYield().getOperand(resultNumber),
+                            evaluation));
+    keys.push_back(knownKey(whileOp, ifOp.elseYield().getOperand(resultNumber),
+                            evaluation));
+    return keys;
+  }
+  for (Value operand : definingOp->getOperands())
+    keys.push_back(knownKey(whileOp, operand, evaluation));
+  return keys;
+}
+
+// The bits known of a key from the bits known of its input keys.
+static Known knownBitsFrom(KnownKey key, ArrayRef<Known> inputs) {
+  auto [value, evaluation] = key;
+  unsigned width = integerWidth(value.getType());
+  if (isa<BlockArgument>(value))
+    return inputs[0];
+  APInt constant;
+  if (matchPattern(value, m_ConstantInt(&constant)))
+    return KnownBits::makeConstant(constant);
+  if (llvm::any_of(inputs, [](const Known &bits) { return !bits; }))
+    return KnownBits(width);
+  Operation *definingOp = value.getDefiningOp();
+  // An scf.if or a select has the bits of the side its condition picks, or
+  // the bits both sides agree on.
+  if (isa<scf::IfOp, arith::SelectOp>(definingOp)) {
+    const KnownBits &condition = *inputs[0], &thenBits = *inputs[1],
+                    &elseBits = *inputs[2];
+    if (condition.isConstant())
+      return condition.isZero() ? elseBits : thenBits;
+    return thenBits.intersectWith(elseBits);
+  }
+  if (auto cmp = dyn_cast<arith::CmpIOp>(definingOp)) {
+    const KnownBits &lhs = *inputs[0], &rhs = *inputs[1];
+    std::optional<bool> result;
+    switch (cmp.getPredicate()) {
+    case arith::CmpIPredicate::eq:
+      result = KnownBits::eq(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::ne:
+      result = KnownBits::ne(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::slt:
+      result = KnownBits::slt(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::sle:
+      result = KnownBits::sle(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::sgt:
+      result = KnownBits::sgt(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::sge:
+      result = KnownBits::sge(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::ult:
+      result = KnownBits::ult(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::ule:
+      result = KnownBits::ule(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::ugt:
+      result = KnownBits::ugt(lhs, rhs);
+      break;
+    case arith::CmpIPredicate::uge:
+      result = KnownBits::uge(lhs, rhs);
+      break;
+    }
+    if (result)
+      return KnownBits::makeConstant(APInt(1, *result));
+    return KnownBits(width);
+  }
+  if (inputs.size() == 2) {
+    const KnownBits &lhs = *inputs[0], &rhs = *inputs[1];
+    if (isa<arith::AddIOp>(definingOp))
+      return KnownBits::add(lhs, rhs);
+    if (isa<arith::SubIOp>(definingOp))
+      return KnownBits::sub(lhs, rhs);
+    if (isa<arith::MulIOp>(definingOp))
+      return KnownBits::mul(lhs, rhs);
+    if (isa<arith::AndIOp>(definingOp))
+      return lhs & rhs;
+    if (isa<arith::OrIOp>(definingOp))
+      return lhs | rhs;
+    if (isa<arith::XOrIOp>(definingOp))
+      return lhs ^ rhs;
+    if (isa<arith::ShLIOp>(definingOp))
+      return KnownBits::shl(lhs, rhs);
+    if (isa<arith::ShRUIOp>(definingOp))
+      return KnownBits::lshr(lhs, rhs);
+    if (isa<arith::ShRSIOp>(definingOp))
+      return KnownBits::ashr(lhs, rhs);
+    if (isa<arith::DivUIOp>(definingOp))
+      return KnownBits::udiv(lhs, rhs);
+    if (isa<arith::DivSIOp>(definingOp))
+      return KnownBits::sdiv(lhs, rhs);
+    if (isa<arith::RemUIOp>(definingOp))
+      return KnownBits::urem(lhs, rhs);
+    if (isa<arith::RemSIOp>(definingOp))
+      return KnownBits::srem(lhs, rhs);
+  }
+  if (inputs.size() == 1) {
+    const KnownBits &input = *inputs[0];
+    if (isa<arith::ExtUIOp, arith::IndexCastUIOp>(definingOp))
+      return input.zextOrTrunc(width);
+    if (isa<arith::ExtSIOp, arith::IndexCastOp>(definingOp))
+      return input.sextOrTrunc(width);
+    if (isa<arith::TruncIOp>(definingOp))
+      return input.trunc(width);
+  }
+  return KnownBits(width);
+}
+
+// The bits known of a value in one evaluation of the loop, memoized in
+// `known`; a key is computed once its input keys are known.
+static Known knownBitsIn(scf::WhileOp whileOp, DenseMap<KnownKey, Known> &known,
+                         Value value, Evaluation evaluation) {
+  KnownKey root = knownKey(whileOp, value, evaluation);
+  SmallVector<KnownKey> worklist{root};
+  DenseSet<KnownKey> pending;
+  while (!worklist.empty()) {
+    KnownKey key = worklist.back();
+    if (known.contains(key)) {
+      worklist.pop_back();
+      continue;
+    }
+    unsigned width = integerWidth(key.first.getType());
+    if (!width) {
+      known[key] = std::nullopt;
+      worklist.pop_back();
+      continue;
+    }
+    // Of a value from outside the loop only a constant says anything.
+    if (key.second == Evaluation::Outside) {
+      APInt constant;
+      known[key] = matchPattern(key.first, m_ConstantInt(&constant))
+                       ? KnownBits::makeConstant(constant)
+                       : KnownBits(width);
+      worklist.pop_back();
+      continue;
+    }
+    SmallVector<KnownKey> inputs = knownInputKeys(whileOp, key);
+    SmallVector<KnownKey> missing;
+    for (const KnownKey &input : inputs)
+      if (!known.contains(input))
+        missing.push_back(input);
+    if (missing.empty()) {
+      SmallVector<Known> bits;
+      for (const KnownKey &input : inputs)
+        bits.push_back(known[input]);
+      known[key] = knownBitsFrom(key, bits);
+      pending.erase(key);
+      worklist.pop_back();
+      continue;
+    }
+    // Asked again before its inputs settle, a value is on a cycle within
+    // one evaluation; nothing is known of it.
+    if (!pending.insert(key).second) {
+      known[key] = KnownBits(width);
+      worklist.pop_back();
+      continue;
+    }
+    worklist.append(missing);
+  }
+  return known[root];
+}
+
+// A while loop whose exit test cannot come out differently on a third
+// evaluation runs its before region at most twice and its after region at
+// most once, so it unrolls to
+//   before(inits); if (condition) { after; before(yields) }
+// The test is decided by then when it is a pure function of the loop-carried
+// arguments and each of those is yielded a loop-invariant value: the second
+// evaluation already sees what every later one would. It is also decided when
+// the bits known of the values feeding the second evaluation settle it, as
+// for a trip flag yielded as a constant or a counter whose low bit it reads.
+struct UnrollInvariantYieldWhile : public OpRewritePattern<scf::WhileOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::WhileOp whileOp,
+                                PatternRewriter &rewriter) const override {
+    Block &before = whileOp.getBefore().front();
+    Block &after = whileOp.getAfter().front();
+    scf::ConditionOp conditionOp = whileOp.getConditionOp();
+    scf::YieldOp yieldOp = whileOp.getYieldOp();
+
+    bool decided = false;
+    if (auto carried = carriedArguments(whileOp, conditionOp.getCondition()))
+      decided = llvm::all_of(*carried, [&](BlockArgument blockArg) {
+        return isInvariant(whileOp,
+                           yieldOp.getOperand(blockArg.getArgNumber()));
+      });
+    if (!decided) {
+      DenseMap<KnownKey, Known> known;
+      Known condition = knownBitsIn(whileOp, known, conditionOp.getCondition(),
+                                    Evaluation::Second);
+      decided = condition && condition->isZero();
+    }
+    if (!decided)
+      return failure();
+
+    Location loc = whileOp.getLoc();
+    IRMapping firstEvaluation;
+    for (auto [blockArg, init] :
+         llvm::zip(before.getArguments(), whileOp.getInits()))
+      firstEvaluation.map(blockArg, init);
+    for (Operation &op : before.without_terminator())
+      rewriter.clone(op, firstEvaluation);
+    Value firstCondition =
+        firstEvaluation.lookupOrDefault(conditionOp.getCondition());
+    SmallVector<Value> firstForwarded;
+    for (Value value : conditionOp.getArgs())
+      firstForwarded.push_back(firstEvaluation.lookupOrDefault(value));
+
+    auto ifOp = scf::IfOp::create(
+        rewriter, loc, firstCondition,
+        [&](OpBuilder &builder, Location loc) {
+          IRMapping secondEvaluation;
+          for (auto [afterArg, forwarded] :
+               llvm::zip(after.getArguments(), firstForwarded))
+            secondEvaluation.map(afterArg, forwarded);
+          for (Operation &op : after.without_terminator())
+            builder.clone(op, secondEvaluation);
+          for (auto [blockArg, yielded] :
+               llvm::zip(before.getArguments(), yieldOp.getOperands()))
+            secondEvaluation.map(blockArg,
+                                 secondEvaluation.lookupOrDefault(
+                                     firstEvaluation.lookupOrDefault(yielded)));
+          for (Operation &op : before.without_terminator())
+            builder.clone(op, secondEvaluation);
+          SmallVector<Value> secondForwarded;
+          for (Value value : conditionOp.getArgs())
+            secondForwarded.push_back(secondEvaluation.lookupOrDefault(value));
+          scf::YieldOp::create(builder, loc, secondForwarded);
+        },
+        [&](OpBuilder &builder, Location loc) {
+          scf::YieldOp::create(builder, loc, firstForwarded);
+        });
+    rewriter.replaceOp(whileOp, ifOp.getResults());
+    return success();
+  }
+};
+
 struct CanonicalizeParallelPass
     : public enzyme::impl::CanonicalizeParallelPassBase<
           CanonicalizeParallelPass> {
@@ -803,7 +1158,7 @@ struct CanonicalizeParallelPass
         SinkThroughSelectOfConstants<arith::AddIOp>,
         SinkThroughSelectOfConstants<arith::MulIOp>, SelectOfNullPointer,
         IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>,
-        FlattenAggregateAlloca, StoreOfUndef>(ctx);
+        FlattenAggregateAlloca, StoreOfUndef, UnrollInvariantYieldWhile>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_while_unroll.mlir
+++ b/test/lit_tests/canonicalize_parallel_while_unroll.mlir
@@ -1,0 +1,310 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel --allow-unregistered-dialect | FileCheck %s
+
+// The strided copy loop after the range analysis folded k += stride to a
+// constant: every yield is loop-invariant, so the loop runs at most twice.
+// CHECK-LABEL: func.func @strided
+// CHECK-SAME: (%[[buf:.+]]: memref<32xf64>, %[[n:.+]]: i32)
+// CHECK: affine.parallel (%[[i:.+]]) = (0) to (16) {
+// CHECK-NEXT:   %[[k:.+]] = arith.index_cast %[[i]] : index to i32
+// CHECK-NEXT:   %[[idx:.+]] = arith.index_cast %[[k]] : i32 to index
+// CHECK-NEXT:   memref.store %{{.+}}, %[[buf]][%[[idx]]] : memref<32xf64>
+// CHECK-NEXT:   %[[c1:.+]] = arith.cmpi ult, %[[k]], %[[n]] : i32
+// CHECK-NEXT:   scf.if %[[c1]] {
+// CHECK-NEXT:     memref.store %{{.+}}, %[[buf]][%[[c16:.+]]] : memref<32xf64>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NOT: scf.while
+func.func @strided(%buf: memref<32xf64>, %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %v = arith.constant 2.0 : f64
+  affine.parallel (%i) = (0) to (16) {
+    %k = arith.index_cast %i : index to i32
+    %r = scf.while (%arg = %k) : (i32) -> i32 {
+      %idx = arith.index_cast %arg : i32 to index
+      memref.store %v, %buf[%idx] : memref<32xf64>
+      %cond = arith.cmpi ult, %arg, %n : i32
+      scf.condition(%cond) %arg : i32
+    } do {
+    ^bb0(%arg: i32):
+      scf.yield %c16 : i32
+    }
+  }
+  return
+}
+
+// A pass-through of a forwarded value only counts as invariant when the
+// forwarded value itself is.
+// CHECK-LABEL: func.func @forwarded_invariant
+// CHECK-NOT: scf.while
+// CHECK: scf.if
+// CHECK-NOT: scf.while
+func.func @forwarded_invariant(%buf: memref<32xf64>, %n: i32, %j: i32) {
+  %v = arith.constant 2.0 : f64
+  affine.parallel (%i) = (0) to (16) {
+    %k = arith.index_cast %i : index to i32
+    scf.while (%arg = %k) : (i32) -> i32 {
+      %idx = arith.index_cast %arg : i32 to index
+      memref.store %v, %buf[%idx] : memref<32xf64>
+      %cond = arith.cmpi ult, %arg, %n : i32
+      scf.condition(%cond) %j : i32
+    } do {
+    ^bb0(%arg: i32):
+      scf.yield %arg : i32
+    }
+  }
+  return
+}
+
+// The done flag: the after region's side effect lands between the two copies
+// of the before region, and the constant condition then dissolves the if.
+// CHECK-LABEL: func.func @sideflag
+// CHECK-SAME: (%[[buf:.+]]: memref<8xf64>)
+// CHECK-NOT: scf.while
+// CHECK: affine.store %{{.+}}, %[[buf]][0] : memref<8xf64>
+// CHECK-NEXT: affine.store %{{.+}}, %[[buf]][1] : memref<8xf64>
+// CHECK-NEXT: affine.store %{{.+}}, %[[buf]][0] : memref<8xf64>
+// CHECK-NEXT: return
+func.func @sideflag(%buf: memref<8xf64>) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %v = arith.constant 2.0 : f64
+  %w = arith.constant 3.0 : f64
+  scf.while (%flag = %true) : (i1) -> () {
+    affine.store %v, %buf[0] : memref<8xf64>
+    scf.condition(%flag)
+  } do {
+    affine.store %w, %buf[1] : memref<8xf64>
+    scf.yield %false : i1
+  }
+  return
+}
+
+// A real strided loop: the yield varies with the carried state.
+// CHECK-LABEL: func.func @varying
+// CHECK: scf.while
+func.func @varying(%buf: memref<32xf64>, %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %v = arith.constant 2.0 : f64
+  affine.parallel (%i) = (0) to (16) {
+    %k = arith.index_cast %i : index to i32
+    scf.while (%arg = %k) : (i32) -> i32 {
+      %idx = arith.index_cast %arg : i32 to index
+      memref.store %v, %buf[%idx] : memref<32xf64>
+      %cond = arith.cmpi ult, %arg, %n : i32
+      %next = arith.addi %arg, %c16 : i32
+      scf.condition(%cond) %next : i32
+    } do {
+    ^bb0(%arg: i32):
+      scf.yield %arg : i32
+    }
+  }
+  return
+}
+
+// The exit test reads memory the body writes, so the second iteration's
+// decision is not the third's.
+// CHECK-LABEL: func.func @cond_reads_memory
+// CHECK: scf.while
+func.func @cond_reads_memory(%buf: memref<32xf64>, %flags: memref<32xi1>) {
+  %c16 = arith.constant 16 : i32
+  %v = arith.constant 2.0 : f64
+  affine.parallel (%i) = (0) to (16) {
+    %k = arith.index_cast %i : index to i32
+    scf.while (%arg = %k) : (i32) -> i32 {
+      %idx = arith.index_cast %arg : i32 to index
+      memref.store %v, %buf[%idx] : memref<32xf64>
+      %cond = memref.load %flags[%idx] : memref<32xi1>
+      scf.condition(%cond) %arg : i32
+    } do {
+    ^bb0(%arg: i32):
+      scf.yield %c16 : i32
+    }
+  }
+  return
+}
+
+// The yield is computed in the after region from a value that varies.
+// CHECK-LABEL: func.func @after_varying
+// CHECK: scf.while
+func.func @after_varying(%buf: memref<32xf64>, %n: i32) {
+  %c16 = arith.constant 16 : i32
+  %v = arith.constant 2.0 : f64
+  affine.parallel (%i) = (0) to (16) {
+    %k = arith.index_cast %i : index to i32
+    scf.while (%arg = %k) : (i32) -> i32 {
+      %idx = arith.index_cast %arg : i32 to index
+      memref.store %v, %buf[%idx] : memref<32xf64>
+      %cond = arith.cmpi ult, %arg, %n : i32
+      scf.condition(%cond) %arg : i32
+    } do {
+    ^bb0(%arg: i32):
+      %next = arith.addi %arg, %c16 : i32
+      scf.yield %next : i32
+    }
+  }
+  return
+}
+
+// The accumulator is carried along, but the exit test reads only the counter,
+// whose next value is invariant.
+// CHECK-LABEL: func.func @accumulating
+// CHECK-SAME: (%[[buf:.+]]: memref<32xf64>, %[[n:.+]]: i32, %[[k0:.+]]: i32)
+// CHECK: %[[i0:.+]] = arith.index_cast %[[k0]] : i32 to index
+// CHECK-NEXT: %[[v0:.+]] = memref.load %[[buf]][%[[i0]]] : memref<32xf64>
+// CHECK-NEXT: %[[s0:.+]] = arith.addf %[[v0]], %{{.+}} : f64
+// CHECK-NEXT: %[[c0:.+]] = arith.cmpi ult, %[[k0]], %[[n]] : i32
+// CHECK-NEXT: %[[r:.+]] = scf.if %[[c0]] -> (f64) {
+// CHECK-NEXT:   %[[v1:.+]] = memref.load %[[buf]][%[[c16:.+]]] : memref<32xf64>
+// CHECK-NEXT:   %[[s1:.+]] = arith.addf %[[s0]], %[[v1]] : f64
+// CHECK-NEXT:   scf.yield %[[s1]] : f64
+// CHECK-NEXT: } else {
+// CHECK-NEXT:   scf.yield %[[s0]] : f64
+// CHECK-NEXT: }
+// CHECK-NEXT: return %[[r]] : f64
+func.func @accumulating(%buf: memref<32xf64>, %n: i32, %k0: i32) -> f64 {
+  %c16 = arith.constant 16 : i32
+  %zero = arith.constant 0.0 : f64
+  %r = scf.while (%k = %k0, %acc = %zero) : (i32, f64) -> f64 {
+    %idx = arith.index_cast %k : i32 to index
+    %v = memref.load %buf[%idx] : memref<32xf64>
+    %sum = arith.addf %acc, %v : f64
+    %cond = arith.cmpi ult, %k, %n : i32
+    scf.condition(%cond) %sum : f64
+  } do {
+  ^bb0(%sum: f64):
+    scf.yield %c16, %sum : i32, f64
+  }
+  return %r : f64
+}
+
+// The exit test reads the carried accumulator, which varies.
+// CHECK-LABEL: func.func @cond_reads_carried
+// CHECK: scf.while
+func.func @cond_reads_carried(%buf: memref<32xf64>, %n: i32, %k0: i32) -> f64 {
+  %c16 = arith.constant 16 : i32
+  %zero = arith.constant 0.0 : f64
+  %lim = arith.constant 1.0 : f64
+  %r = scf.while (%k = %k0, %acc = %zero) : (i32, f64) -> f64 {
+    %idx = arith.index_cast %k : i32 to index
+    %v = memref.load %buf[%idx] : memref<32xf64>
+    %sum = arith.addf %acc, %v : f64
+    %cond = arith.cmpf olt, %sum, %lim : f64
+    scf.condition(%cond) %sum : f64
+  } do {
+  ^bb0(%sum: f64):
+    scf.yield %c16, %sum : i32, f64
+  }
+  return %r : f64
+}
+
+// A rotated single-trip loop: the flag is yielded false, and on it the exit
+// test folds to false whatever the body reads; the second body then folds
+// away entirely.
+// CHECK-LABEL: func.func @trip_flag
+// CHECK-SAME: (%[[buf:.+]]: memref<32xf64>, %[[flags:.+]]: memref<32xi1>, %[[go:.+]]: i1)
+// CHECK-NOT: scf.while
+// CHECK: scf.if %[[go]] {
+// CHECK-NEXT:   memref.store %{{.+}}, %[[buf]][%{{.+}}] : memref<32xf64>
+// CHECK-NEXT: }
+// CHECK-NEXT: return
+func.func @trip_flag(%buf: memref<32xf64>, %flags: memref<32xi1>, %go: i1) {
+  %false = arith.constant false
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %v = arith.constant 2.0 : f64
+  scf.while (%run = %go, %i = %c0) : (i1, i32) -> i32 {
+    %r:2 = scf.if %run -> (i1, i32) {
+      %idx = arith.index_cast %i : i32 to index
+      memref.store %v, %buf[%idx] : memref<32xf64>
+      %again = memref.load %flags[%idx] : memref<32xi1>
+      %next = arith.addi %i, %c1 : i32
+      scf.yield %again, %next : i1, i32
+    } else {
+      scf.yield %false, %i : i1, i32
+    }
+    scf.condition(%r#0) %r#1 : i32
+  } do {
+  ^bb0(%i: i32):
+    scf.yield %false, %i : i1, i32
+  }
+  return
+}
+
+// The flag is yielded true, so the exit test stays with the body's reads.
+// CHECK-LABEL: func.func @trip_flag_true
+// CHECK: scf.while
+func.func @trip_flag_true(%buf: memref<32xf64>, %flags: memref<32xi1>, %go: i1) {
+  %false = arith.constant false
+  %true = arith.constant true
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %v = arith.constant 2.0 : f64
+  scf.while (%run = %go, %i = %c0) : (i1, i32) -> i32 {
+    %r:2 = scf.if %run -> (i1, i32) {
+      %idx = arith.index_cast %i : i32 to index
+      memref.store %v, %buf[%idx] : memref<32xf64>
+      %again = memref.load %flags[%idx] : memref<32xi1>
+      %next = arith.addi %i, %c1 : i32
+      scf.yield %again, %next : i1, i32
+    } else {
+      scf.yield %false, %i : i1, i32
+    }
+    scf.condition(%r#0) %r#1 : i32
+  } do {
+  ^bb0(%i: i32):
+    scf.yield %true, %i : i1, i32
+  }
+  return
+}
+
+// The counter starts at zero and steps by one, and the exit test ors it with
+// another value before comparing to zero: the second iteration's counter has
+// its low bit set, so there is no third.
+// CHECK-LABEL: func.func @low_bit_set
+// CHECK-NOT: scf.while
+// CHECK: %[[c1:.+]] = arith.constant 1 : index
+// CHECK: %[[go:.+]] = arith.cmpi eq, %{{.+}}, %[[c0:.+]] : i32
+// CHECK: scf.if %[[go]] -> (f64) {
+// CHECK: memref.load %{{.+}}[%[[c1]]] : memref<8xf64>
+// CHECK: } else {
+// CHECK: return
+func.func @low_bit_set(%buf: memref<8xf64>, %odd: i32) -> f64 {
+  %zero = arith.constant 0.0 : f64
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r:2 = scf.while (%acc = %zero, %k = %c0) : (f64, i32) -> (f64, i32) {
+    %idx = arith.index_cast %k : i32 to index
+    %x = memref.load %buf[%idx] : memref<8xf64>
+    %sum = arith.addf %acc, %x : f64
+    %next = arith.addi %k, %c1 : i32
+    %bits = arith.ori %k, %odd : i32
+    %again = arith.cmpi eq, %bits, %c0 : i32
+    scf.condition(%again) %sum, %next : f64, i32
+  } do {
+  ^bb0(%acc: f64, %k: i32):
+    scf.yield %acc, %k : f64, i32
+  }
+  return %r#0 : f64
+}
+
+// Masking the counter instead may leave it zero, so the loop may run on.
+// CHECK-LABEL: func.func @low_bit_masked
+// CHECK: scf.while
+func.func @low_bit_masked(%buf: memref<8xf64>, %mask: i32) -> f64 {
+  %zero = arith.constant 0.0 : f64
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %r:2 = scf.while (%acc = %zero, %k = %c0) : (f64, i32) -> (f64, i32) {
+    %idx = arith.index_cast %k : i32 to index
+    %x = memref.load %buf[%idx] : memref<8xf64>
+    %sum = arith.addf %acc, %x : f64
+    %next = arith.addi %k, %c1 : i32
+    %bits = arith.andi %k, %mask : i32
+    %again = arith.cmpi eq, %bits, %c0 : i32
+    scf.condition(%again) %sum, %next : f64, i32
+  } do {
+  ^bb0(%acc: f64, %k: i32):
+    scf.yield %acc, %k : f64, i32
+  }
+  return %r#0 : f64
+}


### PR DESCRIPTION
Part of #2968.

A `scf.while` cannot iterate a third time in two cases, and then unrolls (under the forward-progress guarantee) to

```
body(init); if (cond) { after; body(next) }
```

1. The exit test is a pure function of carried state whose next-iteration values are loop-invariant: a third iteration would start from exactly the second's state and take the same exit decision, so the loop would never terminate. Only the state the exit test reads needs invariant yields; an accumulator can be carried alongside (`bilininteg_curlcurl_pa.cpp`'s `scf.while (%k, %acc)` sums with `%k` yielded as a constant and `%acc` passed through).
2. The bits known of the second iteration's state decide the exit test. They are computed with `llvm::KnownBits` from the initial operands through the first iteration's condition operands and yields, and through the `arith` ops, `arith.select`s and `scf.if`s on the way (an `scf.if` with an unknown condition intersects its two yields).

MFEM's strided copy loops (`k = tid; do { copy(k); k += stride; } while (k < n)`) reach us the first way once the range analysis folds the increment to a constant, e.g. in `bilininteg_curlcurl_pa.cpp`:

```
scf.while (%arg23 = %102) { ... %113 = arith.cmpi ult, %arg23, %80; scf.condition(%113) } do { scf.yield %c4_i32 }
```

The second way covers clang's done-flag loops, e.g. `tmop_pa_h3d.cpp` (assemble diag):

```
scf.while (%arg13 = %true, %arg14 = %59, %arg15 = %58) { ... scf.condition(%arg13) } do { scf.yield %false, %61, %62 }
```

the rotated single-trip loop around `bilininteg_batchitrans.cpp`'s team solve, whose trip flag is the result of an `scf.if` on the previous flag and is yielded `false`, and the reduction over a leading dimension of one or two in `bilininteg_vectorfemass_pa.cpp`:

```
scf.while (%acc = %cst, %k = %c0_i32) { ... %next = arith.addi %k, %c1; %bits = arith.ori %k, %odd; %again = arith.cmpi eq, %bits, %c0; scf.condition(%again) %sum, %next } do { scf.yield }
```

where the second iteration's `%k` is 1, so `%k | %odd` has its low bit set whatever `%odd` is.

The `tmop_pa_h3d.cpp` loop carries an `llvm.alloca` (`%58`, a nested `mfem::future::tensor` struct) through the loop as an iter arg, which keeps `ConvertLLVMAllocaToMemrefAlloca` from converting it; that TU then fails raising on the surviving `llvm.alloca`. Running the unroll as a `canonicalize-parallel` pattern, i.e. before the final `llvm-to-affine-access`, lets the alloca convert normally (with #3064's gep fold for the 8-byte offset). Replaying that TU's imported module through the full pipeline with this branch, the `llvm.alloca` failure is gone and raising proceeds to the next (independent) blocker, a lane-private `memref<9xf64>` scratch (#2996's scope); the union's `flattenLLVMArrayAllocas` helper is not needed for it.

This supersedes #3013's raiser-local `unrollInvariantYieldWhiles`, with one soundness correction: #3013 accepted any pass-through of a value forwarded by `scf.condition` as invariant, and its own `@dowhile` test (`%next = %k + 16`, `scf.condition(%cond) %next`, `scf.yield %j`) is a genuine multi-iteration loop that it unrolled to two iterations. Here after-block arguments resolve through the forwarded condition operands, and the exit condition must be pure over loop-external values and the before-block arguments (no memory reads, since the body may write what the test reads). The negative cases in the test cover the varying pass-through against an unknown bound, a condition that loads memory, a yield computed in the after region from the carried state, an exit test that reads the accumulator, a trip flag yielded `true`, and a masked (`andi`) counter whose second value is not decided.

Test: `test/lit_tests/canonicalize_parallel_while_unroll.mlir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
