### PR TITLE
canonicalize-parallel: a branch between a base and a step off it

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -88,6 +88,16 @@ struct SelectOfSameBaseGEPs : public OpRewritePattern<arith::SelectOp> {
       return failure();
     auto gepT = sel.getTrueValue().getDefiningOp<LLVM::GEPOp>();
     auto gepF = sel.getFalseValue().getDefiningOp<LLVM::GEPOp>();
+    // A side that is the base itself stepped zero elements of the other's
+    // type.
+    int bare = -1;
+    if (!gepT && gepF && sel.getTrueValue() == gepF.getBase()) {
+      gepT = gepF;
+      bare = 0;
+    } else if (!gepF && gepT && sel.getFalseValue() == gepT.getBase()) {
+      gepF = gepT;
+      bare = 1;
+    }
     if (!gepT || !gepF)
       return failure();
     if (gepT.getBase() != gepF.getBase() ||
@@ -111,17 +121,19 @@ struct SelectOfSameBaseGEPs : public OpRewritePattern<arith::SelectOp> {
       idxTy = rewriter.getI64Type();
     }
 
-    auto materialize = [&](LLVM::GEPOp gep, Value dyn) -> Value {
-      if (dyn)
+    auto materialize = [&](LLVM::GEPOp gep, Value dyn, bool zero) -> Value {
+      if (dyn && !zero)
         return dyn;
-      auto attr = cast<IntegerAttr>(gep.getIndices()[0]);
-      Value c = arith::ConstantOp::create(
-          rewriter, gep.getLoc(),
-          IntegerAttr::get(idxTy, attr.getValue().getSExtValue()));
+      int64_t v = zero ? 0
+                       : cast<IntegerAttr>(gep.getIndices()[0])
+                             .getValue()
+                             .getSExtValue();
+      Value c = arith::ConstantOp::create(rewriter, gep.getLoc(),
+                                          IntegerAttr::get(idxTy, v));
       return c;
     };
-    Value idxT = materialize(gepT, dynT);
-    Value idxF = materialize(gepF, dynF);
+    Value idxT = materialize(gepT, dynT, bare == 0);
+    Value idxF = materialize(gepF, dynF, bare == 1);
     Value idx = arith::SelectOp::create(rewriter, sel.getLoc(),
                                         sel.getCondition(), idxT, idxF);
     rewriter.replaceOpWithNewOp<LLVM::GEPOp>(
@@ -275,6 +287,9 @@ template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
     SmallVector<LLVM::GEPOp> tmpl(ifOp->getNumResults(), nullptr);
     SmallVector<LLVM::GEPOp> other(ifOp->getNumResults(), nullptr);
     SmallVector<char> inBytes(ifOp->getNumResults(), 0);
+    // Which arm, if any, yields the base itself: that arm stepped zero
+    // elements of the other's type.
+    SmallVector<int> bare(ifOp->getNumResults(), -1);
     bool any = false;
     for (auto [i, res] : llvm::enumerate(ifOp->getResults())) {
       newTypes.push_back(res.getType());
@@ -282,6 +297,13 @@ template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
           thenY->getOperand(i).getDefiningOp());
       auto f = dyn_cast_if_present<LLVM::GEPOp>(
           elseY->getOperand(i).getDefiningOp());
+      if (!t && f && thenY->getOperand(i) == f.getBase()) {
+        t = f;
+        bare[i] = 0;
+      } else if (!f && t && elseY->getOperand(i) == t.getBase()) {
+        f = t;
+        bare[i] = 1;
+      }
       if (!t || !f || t.getBase() != f.getBase() ||
           t.getType() != f.getType() || t.getIndices().size() != 1 ||
           f.getIndices().size() != 1)
@@ -321,10 +343,17 @@ template <typename IfT> struct IfOfSameBaseGEPs : public OpRewritePattern<IfT> {
       for (auto [i, g] : llvm::enumerate(tmpl)) {
         if (!g)
           continue;
-        auto gep = cast<LLVM::GEPOp>(ops[i].getDefiningOp());
-        auto idx = gep.getIndices()[0];
         OpBuilder::InsertionGuard guard(rewriter);
         rewriter.setInsertionPoint(y);
+        if (bare[i] == (int)r) {
+          ops[i] =
+              arith::ConstantOp::create(rewriter, ifOp.getLoc(), newTypes[i],
+                                        rewriter.getIntegerAttr(newTypes[i], 0))
+                  .getResult();
+          continue;
+        }
+        auto gep = cast<LLVM::GEPOp>(ops[i].getDefiningOp());
+        auto idx = gep.getIndices()[0];
         int64_t scale = inBytes[i]
                             ? (int64_t)DataLayout::closest(gep).getTypeSize(
                                   gep.getElemType())

--- a/test/lit_tests/canonicalize_parallel_base_or_gep.mlir
+++ b/test/lit_tests/canonicalize_parallel_base_or_gep.mlir
@@ -1,0 +1,59 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel | FileCheck %s
+
+// A coefficient ternary that steps the pointer on one side only: the arm
+// yielding the base itself stepped zero elements of the other's type.
+// CHECK-LABEL: func.func @affine_if_bare_then
+// CHECK-SAME: (%[[p:.+]]: !llvm.ptr<1>, %[[n:.+]]: index)
+// CHECK: %[[i:.+]] = affine.if #{{.+}}()[%[[n]]] -> i64 {
+// CHECK-NEXT:   affine.yield %c0_i64 : i64
+// CHECK-NEXT: } else {
+// CHECK-NEXT:   affine.yield %c16_i64 : i64
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[g:.+]] = llvm.getelementptr inbounds %[[p]][%[[i]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, f64
+// CHECK-NEXT: return %[[g]]
+func.func @affine_if_bare_then(%p: !llvm.ptr<1>, %n: index) -> !llvm.ptr<1> {
+  %sel = affine.if affine_set<()[s0] : (s0 - 1 >= 0)>()[%n] -> !llvm.ptr<1> {
+    affine.yield %p : !llvm.ptr<1>
+  } else {
+    %g = llvm.getelementptr inbounds %p[16] : (!llvm.ptr<1>) -> !llvm.ptr<1>, f64
+    affine.yield %g : !llvm.ptr<1>
+  }
+  return %sel : !llvm.ptr<1>
+}
+
+// The gep side may index dynamically; the bare side then chooses a zero of
+// that index's type.
+// CHECK-LABEL: func.func @scf_if_bare_else
+// CHECK-SAME: (%[[p:.+]]: !llvm.ptr, %[[c:.+]]: i1, %[[k:.+]]: i32)
+// CHECK: %[[i:.+]] = arith.select %[[c]], %[[k]], %c0_i32 : i32
+// CHECK-NEXT: %[[g:.+]] = llvm.getelementptr %[[p]][%[[i]]] : (!llvm.ptr, i32) -> !llvm.ptr, f32
+// CHECK-NEXT: return %[[g]]
+func.func @scf_if_bare_else(%p: !llvm.ptr, %c: i1, %k: i32) -> !llvm.ptr {
+  %sel = scf.if %c -> !llvm.ptr {
+    %g = llvm.getelementptr %p[%k] : (!llvm.ptr, i32) -> !llvm.ptr, f32
+    scf.yield %g : !llvm.ptr
+  } else {
+    scf.yield %p : !llvm.ptr
+  }
+  return %sel : !llvm.ptr
+}
+
+// CHECK-LABEL: func.func @select_bare
+// CHECK-SAME: (%[[p:.+]]: !llvm.ptr, %[[c:.+]]: i1)
+// CHECK: %[[i:.+]] = arith.select %[[c]], %c0_i64, %c3_i64 : i64
+// CHECK-NEXT: %[[g:.+]] = llvm.getelementptr %[[p]][%[[i]]] : (!llvm.ptr, i64) -> !llvm.ptr, f64
+// CHECK-NEXT: return %[[g]]
+func.func @select_bare(%p: !llvm.ptr, %c: i1) -> !llvm.ptr {
+  %g = llvm.getelementptr %p[3] : (!llvm.ptr) -> !llvm.ptr, f64
+  %sel = arith.select %c, %p, %g : !llvm.ptr
+  return %sel : !llvm.ptr
+}
+
+// Two different pointers are not a base and a step off it.
+// CHECK-LABEL: func.func @select_unrelated
+// CHECK: arith.select %{{.+}}, %{{.+}}, %{{.+}} : !llvm.ptr
+func.func @select_unrelated(%p: !llvm.ptr, %q: !llvm.ptr, %c: i1) -> !llvm.ptr {
+  %g = llvm.getelementptr %q[3] : (!llvm.ptr) -> !llvm.ptr, f64
+  %sel = arith.select %c, %p, %g : !llvm.ptr
+  return %sel : !llvm.ptr
+}

--- a/test/lit_tests/raising/raise_if_base_or_gep.mlir
+++ b/test/lit_tests/raising/raise_if_base_or_gep.mlir
@@ -1,0 +1,30 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel --llvm-to-affine-access --canonicalize-parallel --raise-affine-to-stablehlo | FileCheck %s
+
+// A coefficient ternary yields either a pointer or a step off it from an
+// affine.if; the branch becomes a choice of index and the access raises.
+
+// CHECK-LABEL: @ifptr_raised
+// CHECK: stablehlo.select
+// CHECK: stablehlo.gather
+// CHECK-NOT: affine.if
+// CHECK-NOT: llvm.getelementptr
+
+module {
+  func.func private @ifptr(%out: memref<16xf64, 1>, %in: memref<64xf64, 1>, %cbuf: memref<1xi32, 1>) {
+    %n = affine.load %cbuf[0] : memref<1xi32, 1>
+    %ni = arith.index_cast %n : i32 to index
+    %p = "enzymexla.memref2pointer"(%in) : (memref<64xf64, 1>) -> !llvm.ptr<1>
+    affine.parallel (%t) = (0) to (16) {
+      %sel = affine.if affine_set<()[s0] : (s0 - 1 >= 0)>()[%ni] -> !llvm.ptr<1> {
+        affine.yield %p : !llvm.ptr<1>
+      } else {
+        %g = llvm.getelementptr %p[16] : (!llvm.ptr<1>) -> !llvm.ptr<1>, f64
+        affine.yield %g : !llvm.ptr<1>
+      }
+      %view = "enzymexla.pointer2memref"(%sel) : (!llvm.ptr<1>) -> memref<?xf64, 1>
+      %v = affine.load %view[%t] : memref<?xf64, 1>
+      affine.store %v, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}


### PR DESCRIPTION
Part of #2968.

`IfOfSameBaseGEPs` and `SelectOfSameBaseGEPs` take a branch whose arms both gep off one base and make the branch choose the index instead, so the pointer never has to survive as a branch result. MFEM's coefficient ternaries step the pointer on one side only, so one arm yields the base itself:

```mlir
%sel = affine.if #set()[%n] -> !llvm.ptr<1> {
  affine.yield %p : !llvm.ptr<1>
} else {
  %g = llvm.getelementptr %p[16] : (!llvm.ptr<1>) -> !llvm.ptr<1>, f64
  affine.yield %g : !llvm.ptr<1>
}
```

and neither pattern fires. This teaches both to read a bare arm as index zero of the other arm's element type (materializing a `gep %p[0]` in the arm instead would not do: the LLVM dialect folds a zero gep straight back to its base). With it the branch above becomes `affine.if -> index { 0 } else { 16 }` feeding one gep, `llvm-to-affine-access` turns that into an offset access, and the kernel raises (`stablehlo.select` over the offset, then a gather); the end-to-end case is `test/lit_tests/raising/raise_if_base_or_gep.mlir`.

This is the general form of the affine.if pointer-yield expansion in #3016's first commit, which pushed each viewing access into a clone of the branch inside the raiser; that piece is dropped from #3016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
