### PR TITLE
canonicalize-parallel: flatten an aggregate-typed alloca that is only ever cast to a pointer

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -683,6 +683,71 @@ template <typename IfT> struct IfOfNullPointer : public OpRewritePattern<IfT> {
   }
 };
 
+// How many scalars an LLVM aggregate holds when every leaf is the same scalar
+// type, or -1.
+static int64_t homogeneousLeafCount(Type t, Type &leaf) {
+  if (auto at = dyn_cast<LLVM::LLVMArrayType>(t)) {
+    int64_t n = homogeneousLeafCount(at.getElementType(), leaf);
+    return n < 0 ? -1 : n * at.getNumElements();
+  }
+  if (auto st = dyn_cast<LLVM::LLVMStructType>(t)) {
+    if (st.isOpaque())
+      return -1;
+    int64_t tot = 0;
+    for (Type f : st.getBody()) {
+      int64_t n = homogeneousLeafCount(f, leaf);
+      if (n < 0)
+        return -1;
+      tot += n;
+    }
+    return tot;
+  }
+  if (t.isIntOrFloat()) {
+    if (!leaf)
+      leaf = t;
+    return leaf == t ? 1 : -1;
+  }
+  return -1;
+}
+
+// Scratch declared as one aggregate value (a union wrapping a register array)
+// reaches the memref world as a memref of an LLVM struct whose only consumers
+// cast it straight back to a pointer. Padding-free and single-leaf-typed, that
+// is flat scalar scratch, and the pointer round trip then folds to a view.
+struct FlattenAggregateAlloca : public OpRewritePattern<memref::AllocaOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::AllocaOp alloca,
+                                PatternRewriter &rewriter) const override {
+    MemRefType MT = alloca.getType();
+    if (!isa<LLVM::LLVMStructType, LLVM::LLVMArrayType>(MT.getElementType()) ||
+        !MT.hasStaticShape() || !MT.getLayout().isIdentity())
+      return failure();
+    Type leaf;
+    int64_t leaves = homogeneousLeafCount(MT.getElementType(), leaf);
+    if (leaves <= 0)
+      return failure();
+    DataLayout dl = DataLayout::closest(alloca);
+    if (dl.getTypeSize(MT.getElementType()) != leaves * dl.getTypeSize(leaf))
+      return failure();
+    if (!llvm::all_of(alloca->getUsers(),
+                      llvm::IsaPred<enzymexla::Memref2PointerOp>))
+      return failure();
+
+    auto NT = MemRefType::get({leaves * MT.getNumElements()}, leaf,
+                              MemRefLayoutAttrInterface{}, MT.getMemorySpace());
+    auto flat = memref::AllocaOp::create(rewriter, alloca.getLoc(), NT,
+                                         alloca.getAlignmentAttr());
+    for (Operation *user : llvm::make_early_inc_range(alloca->getUsers())) {
+      rewriter.setInsertionPoint(user);
+      rewriter.replaceOpWithNewOp<enzymexla::Memref2PointerOp>(
+          user, user->getResult(0).getType(), flat);
+    }
+    rewriter.eraseOp(alloca);
+    return success();
+  }
+};
+
 struct CanonicalizeParallelPass
     : public enzyme::impl::CanonicalizeParallelPassBase<
           CanonicalizeParallelPass> {
@@ -719,7 +784,8 @@ struct CanonicalizeParallelPass
         SinkThroughSelectOfConstants<arith::DivUIOp>,
         SinkThroughSelectOfConstants<arith::AddIOp>,
         SinkThroughSelectOfConstants<arith::MulIOp>, SelectOfNullPointer,
-        IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>>(ctx);
+        IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>,
+        FlattenAggregateAlloca>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_aggregate_alloca.mlir
+++ b/test/lit_tests/canonicalize_parallel_aggregate_alloca.mlir
@@ -1,0 +1,51 @@
+// RUN: enzymexlamlir-opt --canonicalize-parallel %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @union_scratch
+  // CHECK: %[[A:.+]] = memref.alloca() {alignment = 8 : i64} : memref<4xf64>
+  // CHECK-NEXT: memref.store %{{.*}}, %[[A]][%{{.*}}] : memref<4xf64>
+  // CHECK-NEXT: memref.load %[[A]][%{{.*}}] : memref<4xf64>
+  // CHECK-NOT: memref2pointer
+  func.func @union_scratch(%i: index, %v: f64) -> f64 {
+    %a = memref.alloca() {alignment = 8 : i64} : memref<!llvm.struct<"union.anon", (array<2 x array<2 x f64>>)>>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<!llvm.struct<"union.anon", (array<2 x array<2 x f64>>)>>) -> !llvm.ptr
+    %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+    memref.store %v, %m[%i] : memref<?xf64>
+    %r = memref.load %m[%i] : memref<?xf64>
+    return %r : f64
+  }
+
+  // CHECK-LABEL: func.func @shared_array
+  // CHECK: %[[A:.+]] = memref.alloca() : memref<24xi32, 3>
+  // CHECK: "enzymexla.memref2pointer"(%[[A]]) : (memref<24xi32, 3>) -> !llvm.ptr<3>
+  func.func @shared_array() -> !llvm.ptr<3> {
+    %a = memref.alloca() : memref<3x!llvm.array<2 x array<4 x i32>>, 3>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<3x!llvm.array<2 x array<4 x i32>>, 3>) -> !llvm.ptr<3>
+    return %p : !llvm.ptr<3>
+  }
+
+  // CHECK-LABEL: func.func @mixed_leaves
+  // CHECK: memref.alloca() : memref<!llvm.struct<(i32, f64)>>
+  func.func @mixed_leaves() -> !llvm.ptr {
+    %a = memref.alloca() : memref<!llvm.struct<(i32, f64)>>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<!llvm.struct<(i32, f64)>>) -> !llvm.ptr
+    return %p : !llvm.ptr
+  }
+
+  // CHECK-LABEL: func.func @padded
+  // CHECK: memref.alloca() : memref<!llvm.struct<(i8, i32)>>
+  func.func @padded() -> !llvm.ptr {
+    %a = memref.alloca() : memref<!llvm.struct<(i8, i32)>>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<!llvm.struct<(i8, i32)>>) -> !llvm.ptr
+    return %p : !llvm.ptr
+  }
+
+  // CHECK-LABEL: func.func @typed_user
+  // CHECK: memref.alloca() : memref<!llvm.struct<(array<2 x f64>)>>
+  func.func @typed_user(%i: index) -> !llvm.struct<(array<2 x f64>)> {
+    %a = memref.alloca() : memref<!llvm.struct<(array<2 x f64>)>>
+    %p = "enzymexla.memref2pointer"(%a) : (memref<!llvm.struct<(array<2 x f64>)>>) -> !llvm.ptr
+    %r = memref.load %a[] : memref<!llvm.struct<(array<2 x f64>)>>
+    return %r : !llvm.struct<(array<2 x f64>)>
+  }
+}


### PR DESCRIPTION
Scratch declared as one struct value — MFEM's TMOP kernels keep a register array inside a `union` — reaches the memref world as

```mlir
%a = memref.alloca() : memref<!llvm.struct<"union.anon", (array<2 x array<2 x f64>>)>>
%p = "enzymexla.memref2pointer"(%a) : (...) -> !llvm.ptr<3>
%m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr<3>) -> memref<?xf64, 3>
```

and raising then stops at `cannot raise dynamic or non-primitive alloca`. The buffer is never touched as a struct: its only consumers cast it straight back to a pointer.

This adds a `canonicalize-parallel` pattern that, when every leaf of the aggregate is the same scalar type and the aggregate carries no padding (data-layout size equals leaves × leaf size), replaces the alloca by a `memref<N x leaf>` with the same alignment and memory space. `Memref2Pointer2MemrefCast` (#3068) then folds the pointer round trip into a view and the accesses land on the flat buffer. Allocas with mixed leaves, padding, or any typed (non-pointer) user are left alone.

This is the general form of the union branch's `flattenStructMemrefAllocas` (part of #3015); it is what `fem/tmop/assemble/grad2_limit.cpp` and `grad3_limit.cpp` need to raise strict in the MFEM CUDA→xla-gpu campaign (#2968).

Test: `test/lit_tests/canonicalize_parallel_aggregate_alloca.mlir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
