### PR TITLE
affine-cfg: a min/max of valid symbols is a valid symbol

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -80,7 +80,7 @@ bool isValidSymbolInt(Operation *defOp, bool recur, Region *scope) {
   if (recur) {
     if (isa<arith::SelectOp, IndexCastOp, IndexCastUIOp, AddIOp, MulIOp,
             DivSIOp, DivUIOp, RemSIOp, RemUIOp, SubIOp, CmpIOp, TruncIOp,
-            ExtUIOp, ExtSIOp>(defOp))
+            ExtUIOp, ExtSIOp, MaxSIOp, MinSIOp, MaxUIOp, MinUIOp>(defOp))
       if (llvm::all_of(defOp->getOperands(), [&](Value v) {
             bool b = isValidSymbolInt(v, recur, scope);
             // if (!b)

--- a/test/lit_tests/affinecfg_minmax_symbol.mlir
+++ b/test/lit_tests/affinecfg_minmax_symbol.mlir
@@ -1,0 +1,44 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+// A rotated do-while loop counts to max(n, 1) + 1. The min/max of valid
+// symbols is itself a symbol: it is hoisted out of the affine scope like the
+// rest of the bound arithmetic, so the loop raises with the max as a symbol
+// operand rather than staying scf.for.
+
+func.func @dowhile(%e : i32, %n : i32, %A : memref<?xf64>) {
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  %c256 = arith.constant 256 : index
+  %cst = arith.constant 0.000000e+00 : f64
+  %ei = arith.index_cast %e : i32 to index
+  %0 = "enzymexla.gpu_wrapper"(%ei, %c1, %c1, %c256, %c1, %c1) ({
+    affine.parallel (%b) = (0) to (symbol(%ei)) {
+      %mx = arith.maxsi %n, %c1_i32 : i32
+      %ub = arith.addi %mx, %c1_i32 : i32
+      scf.for %i = %c1_i32 to %ub step %c1_i32 : i32 {
+        %bi = arith.index_cast %b : index to i32
+        %k = arith.muli %bi, %n : i32
+        %k1 = arith.addi %k, %i : i32
+        %idx = arith.index_cast %k1 : i32 to index
+        memref.store %cst, %A[%idx] : memref<?xf64>
+      }
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK-LABEL:   func.func @dowhile(
+// CHECK-SAME:      %[[e:.*]]: i32, %[[n:.*]]: i32, %[[A:.*]]: memref<?xf64>) {
+// CHECK-DAG:       %[[c1_i32:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[cst:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-DAG:       %[[ei:.*]] = arith.index_cast %[[e]] : i32 to index
+// CHECK-DAG:       %[[mx:.*]] = arith.maxsi %[[n]], %[[c1_i32]] : i32
+// CHECK-DAG:       %[[ni:.*]] = arith.index_cast %[[n]] : i32 to index
+// CHECK:           "enzymexla.gpu_wrapper"
+// CHECK:             %[[mxi:.*]] = arith.index_cast %[[mx]] : i32 to index
+// CHECK:             affine.parallel (%[[b:.*]]) = (0) to (symbol(%[[ei]])) {
+// CHECK:               affine.for %[[i:.*]] = 0 to %[[mxi]] {
+// CHECK:                 affine.store %[[cst]], %[[A]][%[[i]] + %[[b]] * symbol(%[[ni]]) + 1] : memref<?xf64>
+// CHECK:               }
+// CHECK:             }


### PR DESCRIPTION
`canonicalize-scf-for` turns a rotated do-while into `scf.for lb to max(ub, lb) + step`, so a bound like the MFEM mass kernels' `for (k = 1; k <= max(n, 1); ++k)` reaches `affine-cfg` as `arith.addi(arith.maxsi %n, %c1), %c1`. `isValidSymbolInt` did not recurse through min/max, so the bound was not a valid index and the loop stayed `scf.for` all the way into the raiser (`bilininteg_mass_pa.cpp` alone: 24 in-kernel `scf.for` before the raise; 7 after this, the rest maxes over an induction variable, which are `simplify-affine-exprs`'s to fold).

A min/max of valid symbols is itself a symbol: the normalizer's `fix` hoists it out of the affine scope like the rest of the bound arithmetic, and the loop raises with the max as a symbol operand:

```mlir
%mx = arith.maxsi %n, %c1_i32 : i32          // hoisted above the gpu_wrapper
...
  affine.for %i = 0 to %mxi {                 // %mxi = index_cast %mx
    affine.store %cst, %A[%i + %b * symbol(%ni) + 1]
```

Lit test `affinecfg_minmax_symbol.mlir` is that shape inside an `enzymexla.gpu_wrapper`; the 75 existing `affine-cfg` tests pass.

Part of the MFEM raising union (#2968).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
