### PR TITLE
affine-cfg: absorb a || (!a && b) so short-circuit guards become affine.if

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -6557,6 +6557,12 @@ bool areOpposite(Value lhs, Value rhs) {
     if (xorOp.getLhs() == lhs && matchPattern(xorOp.getRhs(), m_One()))
       return true;
   }
+  auto lcmp = lhs.getDefiningOp<arith::CmpIOp>();
+  auto rcmp = rhs.getDefiningOp<arith::CmpIOp>();
+  if (lcmp && rcmp && lcmp.getLhs() == rcmp.getLhs() &&
+      lcmp.getRhs() == rcmp.getRhs() &&
+      lcmp.getPredicate() == arith::invertPredicate(rcmp.getPredicate()))
+    return true;
   return false;
 }
 
@@ -6587,6 +6593,33 @@ struct SimplifyAndOr : public OpRewritePattern<arith::AndIOp> {
   }
 };
 
+struct SimplifyOrAnd : public OpRewritePattern<arith::OrIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::OrIOp op,
+                                PatternRewriter &rewriter) const override {
+
+    for (int i = 0; i < 2; i++) {
+      if (auto andOp = op->getOperand(i).getDefiningOp<arith::AndIOp>()) {
+        for (int j = 0; j < 2; j++) {
+          // or(a, and(a, b)) -> a
+          if (andOp->getOperand(j) == op->getOperand(1 - i)) {
+            rewriter.replaceOp(op, andOp->getOperand(j));
+            return success();
+          }
+          // or(!a, and(a, b)) -> or(!a, b)
+          if (areOpposite(andOp->getOperand(j), op->getOperand(1 - i))) {
+            rewriter.modifyOpInPlace(
+                op, [&]() { op->setOperand(i, andOp->getOperand(1 - j)); });
+            return success();
+          }
+        }
+      }
+    }
+    return failure();
+  }
+};
+
 void mlir::enzyme::populateAffineCFGPatterns(RewritePatternSet &rpl) {
   MLIRContext *context = rpl.getContext();
   mlir::enzyme::addSingleIter(rpl, context);
@@ -6607,7 +6640,7 @@ void mlir::enzyme::populateAffineCFGPatterns(RewritePatternSet &rpl) {
   rpl.add<FoldAffineApplyAdd, FoldAffineApplySub, FoldAffineApplyRem,
           FoldAffineApplyDiv, FoldAffineApplyMul, FoldAppliesIntoLoad>(context,
                                                                        2);
-  rpl.add<SimplifyAndOr>(context, 2);
+  rpl.add<SimplifyAndOr, SimplifyOrAnd>(context, 2);
   rpl.add<SplitParallelInductions, MaskedAffineParallel>(context, 1);
 }
 

--- a/test/lit_tests/affinecfg_or_absorb.mlir
+++ b/test/lit_tests/affinecfg_or_absorb.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+// Clang's short-circuit lowering of `n >= 1 && m >= 1` arrives as
+// !(n < 1 || (n >= 1 && m < 1)). The middle test is the negation of the
+// first and absorbs: or(!a, and(a, b)) -> or(!a, b), which the affine.if
+// conversion then reads as a conjunction of the two negated comparisons.
+
+func.func @absorb(%e : i32, %n : i32, %m : i32, %A : memref<?xf64>) {
+  %true = arith.constant true
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  %c256 = arith.constant 256 : index
+  %cst = arith.constant 0.000000e+00 : f64
+  %ei = arith.index_cast %e : i32 to index
+  %0 = "enzymexla.gpu_wrapper"(%ei, %c1, %c1, %c256, %c1, %c1) ({
+    affine.parallel (%b) = (0) to (symbol(%ei)) {
+      %a = arith.cmpi slt, %n, %c1_i32 : i32
+      %na = arith.cmpi sge, %n, %c1_i32 : i32
+      %bl = arith.cmpi slt, %m, %c1_i32 : i32
+      %and = arith.andi %na, %bl : i1
+      %or = arith.ori %a, %and : i1
+      %cond = arith.xori %or, %true : i1
+      scf.if %cond {
+        memref.store %cst, %A[%b] : memref<?xf64>
+      }
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK: #[[set:.+]] = affine_set<()[s0, s1] : (s0 - 1 >= 0, s1 - 1 >= 0)>
+// CHECK-LABEL:   func.func @absorb(
+// CHECK-SAME:      %[[e:.*]]: i32, %[[n:.*]]: i32, %[[m:.*]]: i32, %[[A:.*]]: memref<?xf64>) {
+// CHECK-DAG:       %[[ni:.*]] = arith.index_cast %[[n]] : i32 to index
+// CHECK-DAG:       %[[mi:.*]] = arith.index_cast %[[m]] : i32 to index
+// CHECK:           affine.parallel (%[[b:.*]]) = (0) to (symbol(%{{.*}})) {
+// CHECK-NOT:         scf.if
+// CHECK:             affine.if #[[set]]()[%[[ni]], %[[mi]]] {
+// CHECK:               affine.store %{{.*}}, %[[A]][%[[b]]] : memref<?xf64>


### PR DESCRIPTION
Clang's short-circuit lowering of a conjunction guard `n >= 1 && m >= 1` reaches the raiser as `!(n < 1 || (n >= 1 && m < 1))`: the middle comparison is the negation of the first. `MoveIfToAffine` reads `!(a || b)` as a conjunction of negated comparisons but has no rule for an `and` under an `or`, so every such `scf.if` survived affine-cfg — in MFEM's element kernels this is the shape of the "any work at all" guard around the rotated do-while nests (bilininteg_mass_pa's `PAMassApplyTriangle`, and the same idiom across the integrator TUs).

- `SimplifyOrAnd`: `or(a, and(a, b)) -> a` and `or(!a, and(a, b)) -> or(!a, b)`, the dual of the existing `SimplifyAndOr`.
- `areOpposite` also recognizes two `arith.cmpi` of the same operands under inverted predicates (`slt` vs `sge`), which is how the negation arrives — no `xori` in sight.

With this the guard becomes `affine.if (n - 1 >= 0, m - 1 >= 0)`, which is exactly the constraint #2946 then uses to fold the do-whiles' `max(n, 1)`. Lit: `affinecfg_or_absorb.mlir`; 77/77 affine-cfg tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
