### PR TITLE
affine-cfg: an enclosing loop's induction variable is a symbol, not a dim

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -307,6 +307,8 @@ static bool legalCondition(Value en, bool dim, Region *scope,
     }
   }
 
+  bool kept = keptAsSymbol(en, scope, throughSymbols);
+
   while (auto ic = en.getDefiningOp<IndexCastOp>())
     en = ic.getIn();
 
@@ -329,7 +331,7 @@ static bool legalCondition(Value en, bool dim, Region *scope,
   // if (auto IC = dyn_cast_or_null<IndexCastOp>(en.getDefiningOp())) {
   //	if (!outer || legalCondition(IC.getOperand(), false)) return true;
   //}
-  if (!dim)
+  if (!dim && !kept)
     if (auto BA = dyn_cast<BlockArgument>(en)) {
       if (isa<affine::AffineForOp, affine::AffineParallelOp>(
               BA.getOwner()->getParentOp()))

--- a/test/lit_tests/raising/affinecfg_outer_iv_symbol.mlir
+++ b/test/lit_tests/raising/affinecfg_outer_iv_symbol.mlir
@@ -1,0 +1,33 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+// The if inside the wrapper tests a cast of the enclosing loop's induction
+// variable, a symbol from the wrapper's scope.
+
+module {
+  func.func @f(%n : i64, %m : memref<?xi64>) {
+    %c1 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
+    %s = arith.index_cast %n : i64 to index
+    affine.for %i = 1 to %s {
+      %ic = arith.index_cast %i : index to i64
+      %j = arith.index_cast %ic : i64 to index
+      %w = "enzymexla.gpu_wrapper"(%c1, %c1, %c256, %c1, %c1, %c1) ({
+        affine.parallel (%t) = (0) to (256) {
+          affine.if affine_set<()[s0] : (s0 - 3 >= 0)>()[%j] {
+            affine.store %ic, %m[%t] : memref<?xi64>
+          }
+        }
+        "enzymexla.polygeist_yield"() : () -> ()
+      }) : (index, index, index, index, index, index) -> index
+    }
+    return
+  }
+}
+
+// CHECK: #[[SET:.+]] = affine_set<(d0) : (d0 - 3 >= 0)>
+// CHECK-LABEL: func.func @f
+// CHECK:         affine.for %[[I:.+]] = 1 to %{{.*}} {
+// CHECK-NEXT:      %[[IC:.+]] = arith.index_cast %[[I]] : index to i64
+// CHECK:           affine.parallel (%[[T:.+]]) = (0) to (256) {
+// CHECK-NEXT:        affine.if #[[SET]](%[[I]]) {
+// CHECK-NEXT:          affine.store %[[IC]], %{{.*}}[%[[T]]] : memref<?xi64>


### PR DESCRIPTION
`legalCondition` asks for composition of any operand whose casts peel to an `affine.for`/`affine.parallel` argument, but the normalizer reads through those casts only on an operand it does not keep as a symbol. The induction variable of a loop *enclosing* the affine scope (a `gpu_wrapper` inside a host `affine.for`) is defined outside that scope, so a cast of it is a valid symbol the normalizer keeps — `need` never clears and `fully2ComposeIntegerSetAndOperands` spins forever. On MFEM this showed up as `fem/bilinearform_ext.cpp` compiling at 100% CPU with flat memory until killed (an hour and more); it became reachable once #3074 let a host loop bounded by `max(n, 1) + 1` turn into `affine.for`, but the disagreement is older and the test here has no min/max in it.

`legalCondition` now applies the induction-variable rule only when the operand is not kept as a symbol, matching the normalizer. The test's `affine.if` then goes through `canonicalizeSetAndOperands`, which promotes the outer variable to a dim and drops the cast chain.

Found with the 127-object `xla-gpu` sweep over `libmfem`; with this, the affine-cfg run on that TU takes 0.1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
