### PR TITLE
refactor `comm.nccl` subdialect

### DIFF
--- a/src/enzyme_ad/jax/Dialect/Comm/Attrs.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/Attrs.td
@@ -140,19 +140,26 @@ def MpiOpAttr : Comm_Attr<"MpiOp", "mpi.op", [TypedAttrInterface]> {
 }
 
 // NCCL
-def NCCL_RedOps : I32EnumAttr<"NCCL_RedOps", "Named predefined NCCL reduction operators", [
-      I32EnumAttrCase<"NCCL_SUM", 0>,
-      I32EnumAttrCase<"NCCL_PROD", 1>,
-      I32EnumAttrCase<"NCCL_MIN", 2>,
-      I32EnumAttrCase<"NCCL_MAX", 3>,
-      I32EnumAttrCase<"NCCL_AVG", 4>,
+def NcclRedOpEnum : I32EnumAttr<"NcclRedOpEnum", "Named predefined NCCL reduction operators", [
+      I32EnumAttrCase<"ncclSum", 0>,
+      I32EnumAttrCase<"ncclProd", 1>,
+      I32EnumAttrCase<"ncclMin", 2>,
+      I32EnumAttrCase<"ncclMax", 3>,
+      I32EnumAttrCase<"ncclAvg", 4>,
     ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::comm";
 }
 
-def NCCL_RedOpAttr : EnumAttr<Comm_Dialect, NCCL_RedOps, "nccl.red_op"> {
+def NcclRedOpAttr : Comm_Attr<"NcclRedOp", "nccl.red_op", [TypedAttrInterface]> {
+  let parameters = (ins EnumParameter<NcclRedOpEnum>:$value);
   let assemblyFormat = "`<` $value `>`";
+
+  let extraClassDeclaration = [{
+    ::mlir::Type getType() const {
+      return NcclCommType::get(getContext());
+    }
+  }];
 }
 
 #endif // ENZYMEXLA_COMM_DIALECT_ATTRS_TD

--- a/src/enzyme_ad/jax/Dialect/Comm/BUILD
+++ b/src/enzyme_ad/jax/Dialect/Comm/BUILD
@@ -9,6 +9,7 @@ td_library(
         "MPIOps.td",
         "NCCLOps.td",
         "Types.td",
+        "Utils.td",
     ],
     deps = [
         "@llvm-project//mlir:BuiltinDialectTdFiles",

--- a/src/enzyme_ad/jax/Dialect/Comm/MPIOps.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/MPIOps.td
@@ -5,24 +5,9 @@ include "Dialect.td"
 
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
+include "Utils.td"
 include "Types.td"
 include "Attrs.td"
-
-def TensorI32
-    : Type<CPred<"::llvm::isa<::mlir::TensorType>($_self) && "
-                 "::llvm::cast<::mlir::TensorType>($_self).getShape().size() "
-                 "== 0 && "
-                 "::llvm::cast<::mlir::TensorType>($_self).getElementType()."
-                 "isSignlessInteger(32)">,
-           "tensor<i32>", "::mlir::TensorType">,
-      BuildableType<"RankedTensorType::get({}, $_builder.getIntegerType(32))">;
-
-def MpiConstantOp : Comm_Op<"mpi.constant", [ConstantLike, Pure, AllTypesMatch<["value", "result"]>]> {
-  let summary = "Creates a value that represents a MPI constant";
-  let arguments = (ins TypedAttrInterface : $value);
-  let results = (outs AnyTypeOf<[MpiComm, MpiOp]> : $result);
-  let assemblyFormat = "attr-dict $value";
-}
 
 def MpiCommRankOp : Comm_Op<"mpi.comm_rank", [Pure]> {
   let summary = "Equivalent to `MPI_Comm_rank`";

--- a/src/enzyme_ad/jax/Dialect/Comm/MPIOps.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/MPIOps.td
@@ -9,6 +9,13 @@ include "Utils.td"
 include "Types.td"
 include "Attrs.td"
 
+def MpiConstantOp : Comm_Op<"mpi.constant", [ConstantLike, Pure, AllTypesMatch<["value", "result"]>]> {
+  let summary = "Creates a value that represents a MPI constant";
+  let arguments = (ins TypedAttrInterface : $value);
+  let results = (outs AnyTypeOf<[MpiComm, MpiOp]> : $result);
+  let assemblyFormat = "attr-dict $value";
+}
+
 def MpiCommRankOp : Comm_Op<"mpi.comm_rank", [Pure]> {
   let summary = "Equivalent to `MPI_Comm_rank`";
   let arguments = (ins MpiComm : $comm);

--- a/src/enzyme_ad/jax/Dialect/Comm/NCCLOps.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/NCCLOps.td
@@ -67,13 +67,12 @@ def NcclAllReduceOp : Comm_Op<"nccl.all_reduce", []> {
   let arguments = (ins
     AnyTensor : $sendbuf,
     NcclRedOpAttr : $reduceOp,
-    NcclComm : $comm,
-    NcclStream : $stream
+    NcclComm : $comm
     // TODO $inplace unit attr for reusing sendbuf as recvbuf
   );
 
   let results = (outs AnyTensor : $recvbuf);
-  let assemblyFormat = "$sendbuf `,` $reduceOp `,` $comm `,` $stream attr-dict `:` functional-type($sendbuf, $recvbuf)";
+  let assemblyFormat = "$sendbuf `,` $reduceOp `,` $comm attr-dict `:` functional-type($sendbuf, $recvbuf)";
 }
 
 def NcclBroadcastOp : Comm_Op<"nccl.broadcast", []> {
@@ -82,8 +81,7 @@ def NcclBroadcastOp : Comm_Op<"nccl.broadcast", []> {
   let arguments = (ins
     AnyTensor : $sendbuff,
     TensorI32 : $root,
-    NcclComm : $comm,
-    NcclStream : $stream
+    NcclComm : $comm
     // TODO $inplace unit attr for reusing sendbuf as recvbuf
   );
 
@@ -97,8 +95,7 @@ def NcclSendOp : Comm_Op<"nccl.send", []> {
   let arguments = (ins
     AnyTensor : $sendbuff,
     TensorI32 : $peer,
-    NcclComm : $comm,
-    NcclStream : $stream
+    NcclComm : $comm
   );
 
   let assemblyFormat = "operands attr-dict `:` type($sendbuff)";
@@ -109,8 +106,7 @@ def NcclRecvOp : Comm_Op<"nccl.recv", []> {
 
   let arguments = (ins
     TensorI32 : $peer,
-    NcclComm : $comm,
-    NcclStream : $stream
+    NcclComm : $comm
   );
   let results = (outs AnyTensor : $recvbuff);
 

--- a/src/enzyme_ad/jax/Dialect/Comm/NCCLOps.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/NCCLOps.td
@@ -8,81 +8,81 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "Types.td"
 include "Attrs.td"
 
-def NCCLCommSplitOp : Comm_Op<"nccl.comm_split", []> {
+def NcclCommSplitOp : Comm_Op<"nccl.comm_split", []> {
   let summary = "Equivalent to `ncclCommSplit`";
 
   let arguments = (ins
-    NCCL_Comm : $comm,
+    NcclComm : $comm,
     I32 : $color,
     I32 : $key
   );
 
-  let results = (outs NCCL_Comm : $new_comm);
+  let results = (outs NcclComm : $new_comm);
   let assemblyFormat = "operands attr-dict `:` functional-type($comm, results)";
 }
 
-def NCCLCommFinalizeOp : Comm_Op<"nccl.comm_finalize", []> {
+def NcclCommFinalizeOp : Comm_Op<"nccl.comm_finalize", []> {
   let summary = "Equivalent to `ncclCommFinalize`";
-  let arguments = (ins NCCL_Comm : $comm);
+  let arguments = (ins NcclComm : $comm);
   let assemblyFormat = "$comm attr-dict";
 }
 
-def NCCLCommDestroyOp : Comm_Op<"nccl.comm_destroy", []> {
+def NcclCommDestroyOp : Comm_Op<"nccl.comm_destroy", []> {
   let summary = "Equivalent to `ncclCommDestroy`";
-  let arguments = (ins NCCL_Comm : $comm);
+  let arguments = (ins NcclComm : $comm);
   let assemblyFormat = "$comm attr-dict";
 }
 
-def NCCLCommAbortOp : Comm_Op<"nccl.comm_abort", []> {
+def NcclCommAbortOp : Comm_Op<"nccl.comm_abort", []> {
   let summary = "Equivalent to `ncclCommAbort`";
-  let arguments = (ins NCCL_Comm : $comm);
+  let arguments = (ins NcclComm : $comm);
   let assemblyFormat = "$comm attr-dict";
 }
 
-def NCCLCommCountOp : Comm_Op<"nccl.comm_count", [Pure]> {
+def NcclCommCountOp : Comm_Op<"nccl.comm_count", [Pure]> {
   let summary = "Equivalent to `ncclCommCount`";
-  let arguments = (ins NCCL_Comm : $comm);
+  let arguments = (ins NcclComm : $comm);
   let results = (outs I32 : $count);
   let assemblyFormat = "$comm attr-dict `:` type(results)";
 }
 
-def NCCLCommCuDeviceOp : Comm_Op<"nccl.comm_cudevice", [Pure]> {
+def NcclCommCuDeviceOp : Comm_Op<"nccl.comm_cudevice", [Pure]> {
   let summary = "Equivalent to `ncclCommCuDevice`";
-  let arguments = (ins NCCL_Comm : $comm);
+  let arguments = (ins NcclComm : $comm);
   let results = (outs I32 : $cu_device);
   let assemblyFormat = "$comm attr-dict `:` type(results)";
 }
 
-def NCCLCommUserRankOp : Comm_Op<"nccl.comm_user_rank", [Pure]> {
+def NcclCommUserRankOp : Comm_Op<"nccl.comm_user_rank", [Pure]> {
   let summary = "Equivalent to `ncclCommUserRank`";
-  let arguments = (ins NCCL_Comm : $comm);
+  let arguments = (ins NcclComm : $comm);
   let results = (outs I32 : $user_rank);
   let assemblyFormat = "$comm attr-dict `:` type(results)";
 }
 
-def NCCLAllReduceOp : Comm_Op<"nccl.all_reduce", []> {
+def NcclAllReduceOp : Comm_Op<"nccl.all_reduce", []> {
   let summary = "Equivalent to `ncclAllReduce`";
 
   let arguments = (ins
     AnyTensor : $sendbuf,
-    NCCL_RedOpAttr : $reduceOpAttr,
-    NCCL_Comm : $comm,
-    NCCL_Stream : $stream
+    NcclRedOpAttr : $reduceOp,
+    NcclComm : $comm,
+    NcclStream : $stream
     // TODO $inplace unit attr for reusing sendbuf as recvbuf
   );
 
   let results = (outs AnyTensor : $recvbuf);
-  let assemblyFormat = "$sendbuf `,` $reduceOpAttr `,` $comm `,` $stream attr-dict `:` functional-type($sendbuf, $recvbuf)";
+  let assemblyFormat = "$sendbuf `,` $reduceOp `,` $comm `,` $stream attr-dict `:` functional-type($sendbuf, $recvbuf)";
 }
 
-def NCCLBroadcastOp : Comm_Op<"nccl.broadcast", []> {
+def NcclBroadcastOp : Comm_Op<"nccl.broadcast", []> {
   let summary = "Equivalent to `ncclBroadcast`";
 
   let arguments = (ins
     AnyTensor : $sendbuff,
     I32 : $root,
-    NCCL_Comm : $comm,
-    NCCL_Stream : $stream
+    NcclComm : $comm,
+    NcclStream : $stream
     // TODO $inplace unit attr for reusing sendbuf as recvbuf
   );
 
@@ -90,26 +90,26 @@ def NCCLBroadcastOp : Comm_Op<"nccl.broadcast", []> {
   let assemblyFormat = "operands attr-dict `:` functional-type($sendbuff, $recvbuff)";
 }
 
-def NCCLSendOp : Comm_Op<"nccl.send", []> {
+def NcclSendOp : Comm_Op<"nccl.send", []> {
   let summary = "Equivalent to `ncclSend`";
 
   let arguments = (ins
     AnyTensor : $sendbuff,
     I32 : $peer,
-    NCCL_Comm : $comm,
-    NCCL_Stream : $stream
+    NcclComm : $comm,
+    NcclStream : $stream
   );
 
   let assemblyFormat = "operands attr-dict `:` type($sendbuff)";
 }
 
-def NCCLRecvOp : Comm_Op<"nccl.recv", []> {
+def NcclRecvOp : Comm_Op<"nccl.recv", []> {
   let summary = "Equivalent to `ncclRecv`";
 
   let arguments = (ins
     I32 : $peer,
-    NCCL_Comm : $comm,
-    NCCL_Stream : $stream
+    NcclComm : $comm,
+    NcclStream : $stream
   );
   let results = (outs AnyTensor : $recvbuff);
 

--- a/src/enzyme_ad/jax/Dialect/Comm/NCCLOps.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/NCCLOps.td
@@ -5,6 +5,7 @@ include "Dialect.td"
 
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
+include "Utils.td"
 include "Types.td"
 include "Attrs.td"
 
@@ -13,8 +14,8 @@ def NcclCommSplitOp : Comm_Op<"nccl.comm_split", []> {
 
   let arguments = (ins
     NcclComm : $comm,
-    I32 : $color,
-    I32 : $key
+    TensorI32 : $color,
+    TensorI32 : $key
   );
 
   let results = (outs NcclComm : $new_comm);
@@ -42,21 +43,21 @@ def NcclCommAbortOp : Comm_Op<"nccl.comm_abort", []> {
 def NcclCommCountOp : Comm_Op<"nccl.comm_count", [Pure]> {
   let summary = "Equivalent to `ncclCommCount`";
   let arguments = (ins NcclComm : $comm);
-  let results = (outs I32 : $count);
+  let results = (outs TensorI32 : $count);
   let assemblyFormat = "$comm attr-dict `:` type(results)";
 }
 
 def NcclCommCuDeviceOp : Comm_Op<"nccl.comm_cudevice", [Pure]> {
   let summary = "Equivalent to `ncclCommCuDevice`";
   let arguments = (ins NcclComm : $comm);
-  let results = (outs I32 : $cu_device);
+  let results = (outs TensorI32 : $cu_device);
   let assemblyFormat = "$comm attr-dict `:` type(results)";
 }
 
 def NcclCommUserRankOp : Comm_Op<"nccl.comm_user_rank", [Pure]> {
   let summary = "Equivalent to `ncclCommUserRank`";
   let arguments = (ins NcclComm : $comm);
-  let results = (outs I32 : $user_rank);
+  let results = (outs TensorI32 : $user_rank);
   let assemblyFormat = "$comm attr-dict `:` type(results)";
 }
 
@@ -80,7 +81,7 @@ def NcclBroadcastOp : Comm_Op<"nccl.broadcast", []> {
 
   let arguments = (ins
     AnyTensor : $sendbuff,
-    I32 : $root,
+    TensorI32 : $root,
     NcclComm : $comm,
     NcclStream : $stream
     // TODO $inplace unit attr for reusing sendbuf as recvbuf
@@ -95,7 +96,7 @@ def NcclSendOp : Comm_Op<"nccl.send", []> {
 
   let arguments = (ins
     AnyTensor : $sendbuff,
-    I32 : $peer,
+    TensorI32 : $peer,
     NcclComm : $comm,
     NcclStream : $stream
   );
@@ -107,7 +108,7 @@ def NcclRecvOp : Comm_Op<"nccl.recv", []> {
   let summary = "Equivalent to `ncclRecv`";
 
   let arguments = (ins
-    I32 : $peer,
+    TensorI32 : $peer,
     NcclComm : $comm,
     NcclStream : $stream
   );

--- a/src/enzyme_ad/jax/Dialect/Comm/Types.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/Types.td
@@ -23,19 +23,11 @@ def MpiOp : Comm_Type<"MpiOp", "mpi.op"> {
 }
 
 // NCCL
-def NCCL_Comm : Comm_Type<"NCCL_Comm", "nccl.comm"> {
+def NcclComm : Comm_Type<"NcclComm", "nccl.comm"> {
   let summary = "NCCL communicator handler";
 }
 
-def NCCL_Result : Comm_Type<"NCCL_Result", "nccl.result"> {
-  let summary = "NCCL result handler";
-}
-
-def NCCL_Stream : Comm_Type<"NCCL_Stream", "nccl.stream"> {
-  let summary = "NCCL CUDA stream handler";
-}
-
-def NCCL_RedOp : Comm_Type<"NCCL_RedOp", "nccl.redop"> {
+def NcclRedOp : Comm_Type<"NcclRedOp", "nccl.redop"> {
   let summary = "NCCL reduction operation handler";
 }
 

--- a/src/enzyme_ad/jax/Dialect/Comm/Utils.td
+++ b/src/enzyme_ad/jax/Dialect/Comm/Utils.td
@@ -1,0 +1,8 @@
+def TensorI32
+    : Type<CPred<"::llvm::isa<::mlir::TensorType>($_self) && "
+                 "::llvm::cast<::mlir::TensorType>($_self).getShape().size() "
+                 "== 0 && "
+                 "::llvm::cast<::mlir::TensorType>($_self).getElementType()."
+                 "isSignlessInteger(32)">,
+           "tensor<i32>", "::mlir::TensorType">,
+      BuildableType<"RankedTensorType::get({}, $_builder.getIntegerType(32))">;

--- a/test/lit_tests/comm/nccl/all_reduce.mlir
+++ b/test/lit_tests/comm/nccl/all_reduce.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[BUF:.*]]: tensor<4xf32>, %[[COMM:.*]]: !comm.nccl.comm, %[[STREAM:.*]]: !comm.nccl.stream)  -> tensor<4xf32> {
-func.func @main(%buf : tensor<4xf32>, %comm : !comm.nccl.comm, %stream : !comm.nccl.stream) -> tensor<4xf32> {
-    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.all_reduce %[[BUF]], <NCCL_SUM>, %[[COMM]], %[[STREAM]] : (tensor<4xf32>) -> tensor<4xf32>
-    %0 = comm.nccl.all_reduce %buf, #comm.nccl.red_op<NCCL_SUM>, %comm, %stream : (tensor<4xf32>) -> tensor<4xf32>
+// CHECK: func.func @main(%[[BUF:.*]]: tensor<4xf32>, %[[COMM:.*]]: !comm.nccl.comm)  -> tensor<4xf32> {
+func.func @main(%buf : tensor<4xf32>, %comm : !comm.nccl.comm) -> tensor<4xf32> {
+    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.all_reduce %[[BUF]], <ncclSum>, %[[COMM]] : (tensor<4xf32>) -> tensor<4xf32>
+    %0 = comm.nccl.all_reduce %buf, #comm.nccl.red_op<ncclSum>, %comm : (tensor<4xf32>) -> tensor<4xf32>
     return %0 : tensor<4xf32>
 }

--- a/test/lit_tests/comm/nccl/broadcast.mlir
+++ b/test/lit_tests/comm/nccl/broadcast.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[BUF:.*]]: tensor<4xf32>, %[[ROOT:.*]]: i32, %[[COMM:.*]]: !comm.nccl.comm, %[[STREAM:.*]]: !comm.nccl.stream)  -> tensor<4xf32> {
-func.func @main(%buf : tensor<4xf32>, %root : i32, %comm : !comm.nccl.comm, %stream : !comm.nccl.stream) -> tensor<4xf32> {
-    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.broadcast %[[BUF]], %[[ROOT]], %[[COMM]], %[[STREAM]] : (tensor<4xf32>) -> tensor<4xf32>
-    %0 = comm.nccl.broadcast %buf, %root, %comm, %stream : (tensor<4xf32>) -> tensor<4xf32>
+// CHECK: func.func @main(%[[BUF:.*]]: tensor<4xf32>, %[[ROOT:.*]]: tensor<i32>, %[[COMM:.*]]: !comm.nccl.comm)  -> tensor<4xf32> {
+func.func @main(%buf : tensor<4xf32>, %root : tensor<i32>, %comm : !comm.nccl.comm) -> tensor<4xf32> {
+    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.broadcast %[[BUF]], %[[ROOT]], %[[COMM]] : (tensor<4xf32>) -> tensor<4xf32>
+    %0 = comm.nccl.broadcast %buf, %root, %comm : (tensor<4xf32>) -> tensor<4xf32>
     return %0 : tensor<4xf32>
 }

--- a/test/lit_tests/comm/nccl/comm_count.mlir
+++ b/test/lit_tests/comm/nccl/comm_count.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[COMM:.*]]: !comm.nccl.comm) -> i32 {
-func.func @main(%comm : !comm.nccl.comm) -> i32 {
-    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.comm_count %[[COMM]] : i32
-    %0 = comm.nccl.comm_count %comm : i32
-    return %0 : i32
+// CHECK: func.func @main(%[[COMM:.*]]: !comm.nccl.comm) -> tensor<i32> {
+func.func @main(%comm : !comm.nccl.comm) -> tensor<i32> {
+    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.comm_count %[[COMM]] : tensor<i32>
+    %0 = comm.nccl.comm_count %comm : tensor<i32>
+    return %0 : tensor<i32>
 }

--- a/test/lit_tests/comm/nccl/comm_split.mlir
+++ b/test/lit_tests/comm/nccl/comm_split.mlir
@@ -1,7 +1,7 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[COMM:.*]]: !comm.nccl.comm, %[[COLOR:.*]]: i32, %[[KEY:.*]]: i32) -> !comm.nccl.comm {
-func.func @main(%comm : !comm.nccl.comm, %color : i32, %key : i32) -> !comm.nccl.comm {
+// CHECK: func.func @main(%[[COMM:.*]]: !comm.nccl.comm, %[[COLOR:.*]]: tensor<i32>, %[[KEY:.*]]: tensor<i32>) -> !comm.nccl.comm {
+func.func @main(%comm : !comm.nccl.comm, %color : tensor<i32>, %key : tensor<i32>) -> !comm.nccl.comm {
     // CHECK-NEXT: [[v0:%.*]] = comm.nccl.comm_split %[[COMM]], %[[COLOR]], %[[KEY]] : (!comm.nccl.comm) -> !comm.nccl.comm
     %0 = comm.nccl.comm_split %comm, %color, %key : (!comm.nccl.comm) -> !comm.nccl.comm
     return %0 : !comm.nccl.comm

--- a/test/lit_tests/comm/nccl/comm_user_rank.mlir
+++ b/test/lit_tests/comm/nccl/comm_user_rank.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[COMM:.*]]: !comm.nccl.comm) -> i32 {
-func.func @main(%comm : !comm.nccl.comm) -> i32 {
-    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.comm_user_rank %[[COMM]] : i32
-    %0 = comm.nccl.comm_user_rank %comm : i32
-    return %0 : i32
+// CHECK: func.func @main(%[[COMM:.*]]: !comm.nccl.comm) -> tensor<i32> {
+func.func @main(%comm : !comm.nccl.comm) -> tensor<i32> {
+    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.comm_user_rank %[[COMM]] : tensor<i32>
+    %0 = comm.nccl.comm_user_rank %comm : tensor<i32>
+    return %0 : tensor<i32>
 }

--- a/test/lit_tests/comm/nccl/recv.mlir
+++ b/test/lit_tests/comm/nccl/recv.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[peer:.*]]: i32, %[[COMM:.*]]: !comm.nccl.comm, %[[STREAM:.*]]: !comm.nccl.stream) -> tensor<4xf32> {
-func.func @main(%peer : i32, %comm : !comm.nccl.comm, %stream : !comm.nccl.stream) -> tensor<4xf32> {
-    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.recv %[[peer]], %[[COMM]], %[[STREAM]] : tensor<4xf32>
-    %0 = comm.nccl.recv %peer, %comm, %stream : tensor<4xf32>
+// CHECK: func.func @main(%[[peer:.*]]: tensor<i32>, %[[COMM:.*]]: !comm.nccl.comm) -> tensor<4xf32> {
+func.func @main(%peer : tensor<i32>, %comm : !comm.nccl.comm) -> tensor<4xf32> {
+    // CHECK-NEXT: %[[v0:.*]] = comm.nccl.recv %[[peer]], %[[COMM]] : tensor<4xf32>
+    %0 = comm.nccl.recv %peer, %comm : tensor<4xf32>
     return %0 : tensor<4xf32>
 }

--- a/test/lit_tests/comm/nccl/send.mlir
+++ b/test/lit_tests/comm/nccl/send.mlir
@@ -1,8 +1,8 @@
 // RUN: enzymexlamlir-opt %s | FileCheck %s
 
-// CHECK: func.func @main(%[[BUF:.*]]: tensor<4xf32>, %[[PEER:.*]]: i32, %[[COMM:.*]]: !comm.nccl.comm, %[[STREAM:.*]]: !comm.nccl.stream) {
-func.func @main(%buf : tensor<4xf32>, %peer : i32, %comm : !comm.nccl.comm, %stream : !comm.nccl.stream) {
-    // CHECK-NEXT: comm.nccl.send %[[BUF]], %[[PEER]], %[[COMM]], %[[STREAM]] : tensor<4xf32>
-    comm.nccl.send %buf, %peer, %comm, %stream : tensor<4xf32>
+// CHECK: func.func @main(%[[BUF:.*]]: tensor<4xf32>, %[[PEER:.*]]: tensor<i32>, %[[COMM:.*]]: !comm.nccl.comm) {
+func.func @main(%buf : tensor<4xf32>, %peer : tensor<i32>, %comm : !comm.nccl.comm) {
+    // CHECK-NEXT: comm.nccl.send %[[BUF]], %[[PEER]], %[[COMM]] : tensor<4xf32>
+    comm.nccl.send %buf, %peer, %comm : tensor<4xf32>
     return
 }


### PR DESCRIPTION
- removes `NcclStream`
- refactors `NcclRedOpAttr`
- renames types, ops and attributes to be consistent with its MPI counterpart