### PR TITLE
Count memory intrinsics as dereferences in the null-pointer fold

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -560,6 +560,9 @@ static bool onlyDereferenced(Value root) {
       } else if (auto rmw = dyn_cast<enzyme::AffineAtomicRMWOp>(user)) {
         if (use.get() != rmw.getMemref())
           return false;
+      } else if (isa<LLVM::MemsetOp, LLVM::MemsetInlineOp, LLVM::MemcpyOp,
+                     LLVM::MemcpyInlineOp, LLVM::MemmoveOp>(user)) {
+        // Fills or copies the pointed-to memory, through either end.
       } else {
         return false;
       }

--- a/test/lit_tests/canonicalize_parallel_null_select_memintrinsics.mlir
+++ b/test/lit_tests/canonicalize_parallel_null_select_memintrinsics.mlir
@@ -1,0 +1,66 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel="parallel=false" | FileCheck %s
+
+module {
+  llvm.func @memset_dst(%p: !llvm.ptr, %n: i32, %i: i64) {
+    %null = llvm.mlir.zero : !llvm.ptr
+    %c0 = arith.constant 0 : i32
+    %c0_i8 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %ok = arith.cmpi sgt, %n, %c0 : i32
+    %s = arith.select %ok, %p, %null : !llvm.ptr
+    %g = llvm.getelementptr %s[%i] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
+    %h = llvm.getelementptr %g[24] : (!llvm.ptr) -> !llvm.ptr, i8
+    "llvm.intr.memset"(%h, %c0_i8, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    llvm.return
+  }
+
+  llvm.func @memcpy_src(%p: !llvm.ptr, %dst: !llvm.ptr, %n: i32) {
+    %null = llvm.mlir.zero : !llvm.ptr
+    %c0 = arith.constant 0 : i32
+    %c16 = arith.constant 16 : i64
+    %ok = arith.cmpi sgt, %n, %c0 : i32
+    %s = arith.select %ok, %null, %p : !llvm.ptr
+    "llvm.intr.memcpy"(%dst, %s, %c16) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    llvm.return
+  }
+
+  llvm.func @memmove_dst(%p: !llvm.ptr, %src: !llvm.ptr, %n: i32) {
+    %null = llvm.mlir.zero : !llvm.ptr
+    %c0 = arith.constant 0 : i32
+    %c16 = arith.constant 16 : i64
+    %ok = arith.cmpi sgt, %n, %c0 : i32
+    %s = arith.select %ok, %p, %null : !llvm.ptr
+    "llvm.intr.memmove"(%s, %src, %c16) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+    llvm.return
+  }
+
+  llvm.func @memset_then_compared(%p: !llvm.ptr, %n: i32) -> i1 {
+    %null = llvm.mlir.zero : !llvm.ptr
+    %c0 = arith.constant 0 : i32
+    %c0_i8 = arith.constant 0 : i8
+    %c24 = arith.constant 24 : i64
+    %ok = arith.cmpi sgt, %n, %c0 : i32
+    %s = arith.select %ok, %p, %null : !llvm.ptr
+    "llvm.intr.memset"(%s, %c0_i8, %c24) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
+    %isnull = llvm.icmp "eq" %s, %null : !llvm.ptr
+    llvm.return %isnull : i1
+  }
+}
+
+// CHECK-LABEL: llvm.func @memset_dst(
+// CHECK-NOT: arith.select
+// CHECK: %[[g:.+]] = llvm.getelementptr %arg0[%arg2]
+// CHECK: %[[h:.+]] = llvm.getelementptr %[[g]][24]
+// CHECK: "llvm.intr.memset"(%[[h]],
+
+// CHECK-LABEL: llvm.func @memcpy_src(
+// CHECK-NOT: arith.select
+// CHECK: "llvm.intr.memcpy"(%arg1, %arg0,
+
+// CHECK-LABEL: llvm.func @memmove_dst(
+// CHECK-NOT: arith.select
+// CHECK: "llvm.intr.memmove"(%arg0, %arg1,
+
+// CHECK-LABEL: llvm.func @memset_then_compared(
+// CHECK: arith.select
+// CHECK: llvm.icmp


### PR DESCRIPTION
`SelectOfNullPointer` / `IfOfNullPointer` fold `select(c, p, null)` to `p` when the result is only ever dereferenced, since the null arm can only fault. `onlyDereferenced` accepted loads, stores and atomics, but not the memory intrinsics, so a select whose only user is a `llvm.intr.memset` (or memcpy/memmove) kept its null arm.

MFEM's `DeviceTensor` constructor does `data = (capacity > 0) ? data_ : nullptr;`, and in `PADGDiffusionSetup3D` (`fem/integ/bilininteg_dgdiffusion_pa.cpp`) the zeroing of three consecutive entries

```cpp
pa(3, p1, p2, f) = 0.0;
pa(4, p1, p2, f) = 0.0;
pa(5, p1, p2, f) = 0.0;
```

is a 24-byte memset of that select:

```mlir
%646 = llvm.getelementptr %283[%645] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>
%647 = llvm.getelementptr %2[%645] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.array<8 x i8>   // %2 = llvm.mlir.zero
%648 = llvm.getelementptr %646[24] : (!llvm.ptr) -> !llvm.ptr, i8
%649 = llvm.getelementptr %647[24] : (!llvm.ptr) -> !llvm.ptr, i8
%650 = arith.select %343, %648, %649 : !llvm.ptr
"llvm.intr.memset"(%650, %c0_i8, %c24_i64) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
```

`SelectOfDifferentBaseGEPs` hoists the select to the bases, but the null fold then declines because the memset is not counted as a dereference, and the select of a null reaches `llvm-to-affine-access` where nothing can type it.

This counts `llvm.intr.memset`/`memset.inline`/`memcpy`/`memcpy.inline`/`memmove` operands as dereferences: they touch the pointed-to memory through either end and never observe the address. Test covers a memset destination behind geps, a memcpy source, a memmove destination, and a memset whose pointer is also compared (kept).

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
