### PR TITLE
canonicalize-parallel: sink ops through a select of constants

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -270,6 +270,47 @@ struct SinkThroughIfOfConstants : public OpRewritePattern<OpT> {
   }
 };
 
+/// The select counterpart: an op over a select between constants is the
+/// select between the op over each arm, where it meets a constant and folds.
+/// A select costs nothing to keep, so a second user of it is no reason to
+/// leave the op where it is.
+template <typename OpT>
+struct SinkThroughSelectOfConstants : public OpRewritePattern<OpT> {
+  using OpRewritePattern<OpT>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpT op,
+                                PatternRewriter &rewriter) const override {
+    arith::SelectOp sel;
+    for (Value operand : op->getOperands()) {
+      Attribute cst;
+      if (matchPattern(operand, m_Constant(&cst)))
+        continue;
+      auto def = operand.getDefiningOp<arith::SelectOp>();
+      if (sel || !def)
+        return failure();
+      sel = def;
+    }
+    if (!sel || !sel.getCondition().getType().isInteger(1))
+      return failure();
+    Value arms[2] = {sel.getTrueValue(), sel.getFalseValue()};
+    for (Value arm : arms) {
+      Attribute cst;
+      if (!matchPattern(arm, m_Constant(&cst)))
+        return failure();
+    }
+
+    Value chosen[2];
+    for (unsigned arm = 0; arm < 2; ++arm) {
+      IRMapping map;
+      map.map(sel.getResult(), arms[arm]);
+      chosen[arm] = rewriter.clone(*op.getOperation(), map)->getResult(0);
+    }
+    rewriter.replaceOpWithNewOp<arith::SelectOp>(op, sel.getCondition(),
+                                                 chosen[0], chosen[1]);
+    return success();
+  }
+};
+
 /// The if counterpart of SelectOfSameBaseGEPs: arms that index one base
 /// differently choose the index instead, with a constant index materialized
 /// where the gep kept it in an attribute.
@@ -668,8 +709,17 @@ struct CanonicalizeParallelPass
         SinkThroughIfOfConstants<arith::DivSIOp, affine::AffineIfOp>,
         SinkThroughIfOfConstants<arith::DivUIOp, scf::IfOp>,
         SinkThroughIfOfConstants<arith::DivUIOp, affine::AffineIfOp>,
-        SelectOfNullPointer, IfOfNullPointer<scf::IfOp>,
-        IfOfNullPointer<affine::AffineIfOp>>(ctx);
+        SinkThroughIfOfConstants<arith::AddIOp, scf::IfOp>,
+        SinkThroughIfOfConstants<arith::AddIOp, affine::AffineIfOp>,
+        SinkThroughIfOfConstants<arith::MulIOp, scf::IfOp>,
+        SinkThroughIfOfConstants<arith::MulIOp, affine::AffineIfOp>,
+        SinkThroughSelectOfConstants<arith::IndexCastOp>,
+        SinkThroughSelectOfConstants<arith::IndexCastUIOp>,
+        SinkThroughSelectOfConstants<arith::DivSIOp>,
+        SinkThroughSelectOfConstants<arith::DivUIOp>,
+        SinkThroughSelectOfConstants<arith::AddIOp>,
+        SinkThroughSelectOfConstants<arith::MulIOp>, SelectOfNullPointer,
+        IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_select_constants.mlir
+++ b/test/lit_tests/canonicalize_parallel_select_constants.mlir
@@ -1,0 +1,89 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel{parallel=false})" | FileCheck %s
+
+// An op over a select between constants is the select between the op over
+// each arm, which folds there: a byte offset chosen between two captures,
+// cast and scaled, arrives as a choice between the two element slots.
+
+module {
+  func.func @cast_divide_add(%c: i1) -> index {
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    %c144 = arith.constant 144 : i64
+    %c184 = arith.constant 184 : i64
+    %off = arith.select %c, %c144, %c184 : i64
+    %i = arith.index_cast %off : i64 to index
+    %d = arith.divsi %i, %c8 : index
+    %a = arith.addi %d, %c1 : index
+    return %a : index
+  }
+
+  // the select feeds two chains; both sink and the select goes with them
+  func.func @two_uses(%c: i1) -> (index, index) {
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c144 = arith.constant 144 : i64
+    %c184 = arith.constant 184 : i64
+    %off = arith.select %c, %c144, %c184 : i64
+    %i = arith.index_cast %off : i64 to index
+    %d8 = arith.divui %i, %c8 : index
+    %d4 = arith.divsi %i, %c4 : index
+    return %d8, %d4 : index, index
+  }
+
+  func.func @multiply(%c: i1) -> i64 {
+    %c3 = arith.constant 3 : i64
+    %c5 = arith.constant 5 : i64
+    %c7 = arith.constant 7 : i64
+    %s = arith.select %c, %c3, %c5 : i64
+    %m = arith.muli %s, %c7 : i64
+    return %m : i64
+  }
+
+  // an arm that is not a constant has nothing to fold against
+  func.func @dynamic_arm(%c: i1, %d: i64) -> index {
+    %c144 = arith.constant 144 : i64
+    %off = arith.select %c, %c144, %d : i64
+    %i = arith.index_cast %off : i64 to index
+    return %i : index
+  }
+
+  // the other operand is not a constant either
+  func.func @dynamic_operand(%c: i1, %x: i64) -> i64 {
+    %c144 = arith.constant 144 : i64
+    %c184 = arith.constant 184 : i64
+    %off = arith.select %c, %c144, %c184 : i64
+    %a = arith.addi %off, %x : i64
+    return %a : i64
+  }
+}
+
+// CHECK:  func.func @cast_divide_add(%[[c:.+]]: i1) -> index {
+// CHECK-DAG:  %[[v19:.+]] = arith.constant 19 : index
+// CHECK-DAG:  %[[v24:.+]] = arith.constant 24 : index
+// CHECK:  %[[r:.+]] = arith.select %[[c]], %[[v19]], %[[v24]] : index
+// CHECK-NEXT:  return %[[r]] : index
+
+// CHECK:  func.func @two_uses(%[[c:.+]]: i1) -> (index, index) {
+// CHECK-DAG:  %[[v18:.+]] = arith.constant 18 : index
+// CHECK-DAG:  %[[v23:.+]] = arith.constant 23 : index
+// CHECK-DAG:  %[[v36:.+]] = arith.constant 36 : index
+// CHECK-DAG:  %[[v46:.+]] = arith.constant 46 : index
+// CHECK-DAG:  %[[d8:.+]] = arith.select %[[c]], %[[v18]], %[[v23]] : index
+// CHECK-DAG:  %[[d4:.+]] = arith.select %[[c]], %[[v36]], %[[v46]] : index
+// CHECK:  return %[[d8]], %[[d4]] : index, index
+
+// CHECK:  func.func @multiply(%[[c:.+]]: i1) -> i64 {
+// CHECK-DAG:  %[[v21:.+]] = arith.constant 21 : i64
+// CHECK-DAG:  %[[v35:.+]] = arith.constant 35 : i64
+// CHECK:  %[[r:.+]] = arith.select %[[c]], %[[v21]], %[[v35]] : i64
+// CHECK-NEXT:  return %[[r]] : i64
+
+// CHECK:  func.func @dynamic_arm(%[[c:.+]]: i1, %[[d:.+]]: i64) -> index {
+// CHECK:  %[[s:.+]] = arith.select %[[c]], %{{.*}}, %[[d]] : i64
+// CHECK-NEXT:  %[[i:.+]] = arith.index_cast %[[s]] : i64 to index
+// CHECK-NEXT:  return %[[i]] : index
+
+// CHECK:  func.func @dynamic_operand(%[[c:.+]]: i1, %[[x:.+]]: i64) -> i64 {
+// CHECK:  %[[s:.+]] = arith.select %[[c]], %{{.*}}, %{{.*}} : i64
+// CHECK-NEXT:  %[[a:.+]] = arith.addi %[[s]], %[[x]] : i64
+// CHECK-NEXT:  return %[[a]] : i64

--- a/test/lit_tests/canonicalize_parallel_select_gep.mlir
+++ b/test/lit_tests/canonicalize_parallel_select_gep.mlir
@@ -75,8 +75,9 @@ func.func private @different_elem(%p: !llvm.ptr, %c: i1, %d: i64) -> !llvm.ptr {
 
 // -----
 
-// End to end: the sunk select feeds a pointer2memref view, and the load
-// rebases onto the base buffer through the existing gep-view fold.
+// End to end: the sunk select feeds a pointer2memref view, the load rebases
+// onto the base buffer through the existing gep-view fold, and the byte
+// offset's cast and division sink through the select into element offsets.
 
 func.func private @through_view(%p: !llvm.ptr, %c: i1, %i: index) -> f64 {
   %a = llvm.getelementptr inbounds|nuw %p[288] : (!llvm.ptr) -> !llvm.ptr, i8
@@ -88,14 +89,11 @@ func.func private @through_view(%p: !llvm.ptr, %c: i1, %i: index) -> f64 {
 }
 
 // CHECK:  func.func private @through_view(%[[p:.+]]: !llvm.ptr, %[[c:.+]]: i1, %[[i:.+]]: index) -> f64 {
-// CHECK-NEXT:  %[[c8:.+]] = arith.constant 8 : index
-// CHECK-NEXT:  %[[cA:.+]] = arith.constant 288 : i64
-// CHECK-NEXT:  %[[cB:.+]] = arith.constant 576 : i64
-// CHECK-NEXT:  %[[bsel:.+]] = arith.select %[[c]], %[[cA]], %[[cB]] : i64
+// CHECK-NEXT:  %[[cB:.+]] = arith.constant 72 : index
+// CHECK-NEXT:  %[[cA:.+]] = arith.constant 36 : index
 // CHECK-NEXT:  %[[view:.+]] = "enzymexla.pointer2memref"(%[[p]]) : (!llvm.ptr) -> memref<?xf64>
-// CHECK-NEXT:  %[[cast:.+]] = arith.index_cast %[[bsel]] : i64 to index
-// CHECK-NEXT:  %[[div:.+]] = arith.divsi %[[cast]], %[[c8]] : index
-// CHECK-NEXT:  %[[add:.+]] = arith.addi %[[i]], %[[div]] : index
+// CHECK-NEXT:  %[[sel:.+]] = arith.select %[[c]], %[[cA]], %[[cB]] : index
+// CHECK-NEXT:  %[[add:.+]] = arith.addi %[[i]], %[[sel]] : index
 // CHECK-NEXT:  %[[x:.+]] = memref.load %[[view]][%[[add]]] : memref<?xf64>
 // CHECK-NEXT:  return %[[x]] : f64
 // CHECK-NEXT:  }


### PR DESCRIPTION
In MFEM's DG diffusion face kernel (`bilininteg_dgdiffusion_pa.cpp:254`) the body reads `const auto &J = shared[side] ? J_shared : J_loc;`, two `DeviceTensor` captures at bytes 144 and 184 of the lambda struct. Clang emits a select of the two geps, `SelectOfSameBaseGEPs` hoists it into the offset, and every access to `J` then indexes the capture struct at

```
%397 = arith.select %396, %c144_i64, %c184_i64 : i64
%399 = arith.index_cast %397 : i64 to index
%400 = arith.divsi %399, %c8 : index
%401 = arith.addi %400, %c1 : index
%402 = memref.load %332[%401] : memref<?x!llvm.ptr>
```

(`%396` is a load from the `MFEM_SHARED` `shared[]` array, so nothing folds it). Nothing sank the cast and the arithmetic through the select, so the index stayed a chain of ops over it.

`SinkThroughSelectOfConstants<OpT>` in canonicalize-parallel is the select counterpart of `SinkThroughIfOfConstants`: an op whose one non-constant operand is a select between constants becomes the select between the op over each arm, which folds. It doesn't require the select to have a single use, since a select costs nothing to keep and the cast above feeds two divisions. Registered for `index_cast`, `index_castui`, `divsi`, `divui`, `addi`, `muli`; `addi` and `muli` are also added to the `if` forms, which only had the cast and the divisions. The chain above becomes `select(c, 19, 24)`, a load at a select of constants, which the polygeist-mem2reg side handles in a separate PR.

Test: `canonicalize_parallel_select_constants.mlir` (the cast/divide/add chain, a select feeding two chains, multiply, a dynamic arm and a dynamic other operand left alone).

`canonicalize_parallel_select_gep.mlir` @through_view now ends with the load at `select(c, 36, 72)` added to the dynamic index rather than the cast-and-divide chain over the sunk byte offset, since the cast and the division sink through the select into element offsets; its expectations are updated to that.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
