### PR TITLE
polygeist-mem2reg: split accesses indexed by a select of constants

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -3169,6 +3169,105 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
   return todo;
 }
 
+// A select between two constants, so that each arm names a place of its own.
+static arith::SelectOp selectOfConstants(Value v) {
+  auto sel = v.getDefiningOp<arith::SelectOp>();
+  Attribute cst;
+  if (!sel || !sel.getCondition().getType().isInteger(1) ||
+      !matchPattern(sel.getTrueValue(), m_Constant(&cst)) ||
+      !matchPattern(sel.getFalseValue(), m_Constant(&cst)))
+    return nullptr;
+  return sel;
+}
+
+// An access indexed by a select between constants lands in one of two slots
+// the forwarding could match, yet names neither. When every user of the
+// allocation is an access at a constant index or at such a select, each
+// select-indexed access becomes a branch on the select's condition around an
+// access at each constant, and the forwarding then sees only constant
+// indices. Nested selects are split one index at a time, on successive
+// rounds.
+static bool splitSelectIndexedAccesses(Value AI) {
+  auto constantIndices = [](ValueRange indices) {
+    return llvm::all_of(indices, [](Value idx) {
+      Attribute cst;
+      return matchPattern(idx, m_Constant(&cst));
+    });
+  };
+
+  SmallVector<Operation *> toSplit;
+  std::deque<Value> list = {AI};
+  while (!list.empty()) {
+    Value val = list.front();
+    list.pop_front();
+    for (Operation *U : val.getUsers()) {
+      ValueRange indices;
+      if (auto LO = dyn_cast<memref::LoadOp>(U))
+        indices = LO.getIndices();
+      else if (auto SO = dyn_cast<memref::StoreOp>(U))
+        indices = SO.getIndices();
+      else if (auto LO = dyn_cast<affine::AffineLoadOp>(U)) {
+        if (!LO.getAffineMap().isConstant())
+          return false;
+        continue;
+      } else if (auto SO = dyn_cast<affine::AffineStoreOp>(U)) {
+        if (!SO.getAffineMap().isConstant())
+          return false;
+        continue;
+      } else if (auto GO = dyn_cast<LLVM::GEPOp>(U)) {
+        if (!constantIndices(GO.getDynamicIndices()))
+          return false;
+        list.push_back(GO);
+        continue;
+      } else if (isa<memref::CastOp, Memref2PointerOp, Pointer2MemrefOp,
+                     LLVM::BitcastOp, LLVM::AddrSpaceCastOp>(U)) {
+        list.push_back(U->getResult(0));
+        continue;
+      } else
+        return false;
+
+      bool split = false;
+      for (Value idx : indices) {
+        Attribute cst;
+        if (matchPattern(idx, m_Constant(&cst)))
+          continue;
+        if (!selectOfConstants(idx))
+          return false;
+        split = true;
+      }
+      if (split)
+        toSplit.push_back(U);
+    }
+  }
+
+  for (Operation *op : toSplit) {
+    OpOperand *chosen = nullptr;
+    for (OpOperand &operand : op->getOpOperands())
+      if (selectOfConstants(operand.get())) {
+        chosen = &operand;
+        break;
+      }
+    auto sel = cast<arith::SelectOp>(chosen->get().getDefiningOp());
+    OpBuilder b(op);
+    auto ifOp = scf::IfOp::create(b, op->getLoc(), op->getResultTypes(),
+                                  sel.getCondition(), /*withElseRegion=*/true);
+    Value arms[2] = {sel.getTrueValue(), sel.getFalseValue()};
+    for (unsigned arm = 0; arm < 2; ++arm) {
+      Block *block = &ifOp->getRegion(arm).front();
+      b.setInsertionPointToStart(block);
+      Operation *cloned = b.clone(*op);
+      cloned->setOperand(chosen->getOperandNumber(), arms[arm]);
+      if (op->getNumResults()) {
+        b.setInsertionPointToEnd(block);
+        scf::YieldOp::create(b, op->getLoc(), cloned->getResults());
+      }
+    }
+    op->replaceAllUsesWith(ifOp.getResults());
+    op->erase();
+  }
+  return !toSplit.empty();
+}
+
 void PolygeistMem2Reg::runOnOperation() {
   auto *f = getOperation();
 
@@ -3216,6 +3315,7 @@ void PolygeistMem2Reg::runOnOperation() {
     DenseMap<Operation *, SmallVector<Operation *>> capturedAliasing;
     for (auto AI : toPromote) {
       LLVM_DEBUG(llvm::dbgs() << " attempting to promote " << AI << "\n");
+      changed |= splitSelectIndexedAccesses(AI);
       // A nested region may carry a layout of its own, so the sizes an offset
       // is counted in are the ones in force where the allocation is.
       auto lastStored =

--- a/test/lit_tests/mem2reg_select_index.mlir
+++ b/test/lit_tests/mem2reg_select_index.mlir
@@ -1,0 +1,94 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg | FileCheck %s
+
+// An access at a select between two constant indices names one of two slots
+// without saying which; once every other user of the allocation is an access
+// at a constant, it becomes a branch on the condition around an access at
+// each, and the forwarding resolves both. This is a lambda capture read through
+// `const auto &J = shared ? J_shared : J_loc` in MFEM's DG diffusion
+// kernel, where the select between the two captures' byte offsets ends up as
+// the index of the loads.
+
+module {
+  func.func @load_at_select(%c: i1, %a: f64, %b: f64) -> f64 {
+    %c1 = arith.constant 1 : index
+    %c5 = arith.constant 5 : index
+    %cap = memref.alloca() : memref<8xf64>
+    affine.store %a, %cap[1] : memref<8xf64>
+    affine.store %b, %cap[5] : memref<8xf64>
+    %i = arith.select %c, %c1, %c5 : index
+    %r = memref.load %cap[%i] : memref<8xf64>
+    return %r : f64
+  }
+
+  func.func @store_at_select(%c: i1, %a: f64, %v: f64) -> (f64, f64) {
+    %c1 = arith.constant 1 : index
+    %c5 = arith.constant 5 : index
+    %cap = memref.alloca() : memref<8xf64>
+    affine.store %a, %cap[1] : memref<8xf64>
+    affine.store %a, %cap[5] : memref<8xf64>
+    %i = arith.select %c, %c1, %c5 : index
+    memref.store %v, %cap[%i] : memref<8xf64>
+    %r1 = affine.load %cap[1] : memref<8xf64>
+    %r5 = affine.load %cap[5] : memref<8xf64>
+    return %r1, %r5 : f64, f64
+  }
+
+  // one more access at an index that is neither a constant nor a choice
+  // between constants: nothing is split
+  func.func @dynamic_access(%c: i1, %a: f64, %b: f64, %j: index) -> (f64, f64) {
+    %c1 = arith.constant 1 : index
+    %c5 = arith.constant 5 : index
+    %cap = memref.alloca() : memref<8xf64>
+    affine.store %a, %cap[1] : memref<8xf64>
+    affine.store %b, %cap[5] : memref<8xf64>
+    %i = arith.select %c, %c1, %c5 : index
+    %r = memref.load %cap[%i] : memref<8xf64>
+    %s = memref.load %cap[%j] : memref<8xf64>
+    return %r, %s : f64, f64
+  }
+
+  // a user that is not an access at all, even one the promotion can see
+  // past: nothing is split either
+  func.func @other_user(%c: i1, %a: f64, %b: f64) -> f64 {
+    %c1 = arith.constant 1 : index
+    %c5 = arith.constant 5 : index
+    %cap = memref.alloca() : memref<8xf64>
+    affine.store %a, %cap[1] : memref<8xf64>
+    affine.store %b, %cap[5] : memref<8xf64>
+    %i = arith.select %c, %c1, %c5 : index
+    %r = memref.load %cap[%i] : memref<8xf64>
+    func.call @use(%cap) : (memref<8xf64>) -> ()
+    return %r : f64
+  }
+  func.func private @use(memref<8xf64> {llvm.nocapture})
+}
+
+// CHECK-LABEL: func.func @load_at_select(
+// CHECK-NOT:     memref.alloca
+// CHECK:         %[[r:.+]] = scf.if %arg0 -> (f64) {
+// CHECK-NEXT:      scf.yield %arg1 : f64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      scf.yield %arg2 : f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[r]] : f64
+
+// CHECK-LABEL: func.func @store_at_select(
+// CHECK-NOT:     memref.alloca
+// CHECK:         %[[r:.+]]:2 = scf.if %arg0 -> (f64, f64) {
+// CHECK-NEXT:      scf.yield %arg2, %arg1 : f64, f64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      scf.yield %arg1, %arg2 : f64, f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[r]]#0, %[[r]]#1 : f64, f64
+
+// CHECK-LABEL: func.func @dynamic_access(
+// CHECK:         memref.alloca
+// CHECK-NOT:     scf.if
+// CHECK:         memref.load
+// CHECK:         memref.load
+
+// CHECK-LABEL: func.func @other_user(
+// CHECK:         memref.alloca
+// CHECK-NOT:     scf.if
+// CHECK:         memref.load
+// CHECK:         call @use


### PR DESCRIPTION
Companion to #3082. In MFEM's DG diffusion face kernel (`bilininteg_dgdiffusion_pa.cpp:254`) the body reads `const auto &J = shared[side] ? J_shared : J_loc;`, two `DeviceTensor` captures at bytes 144 and 184 of the lambda struct. After #3082 every access to `J` indexes the capture struct at `select(c, 19, 24)`, where `c` is a load from the `MFEM_SHARED` `shared[]` array that nothing folds. polygeist-mem2reg forwards only constant-index accesses, so the whole capture struct stayed in memory and the wrapper stayed a `gpu.launch_func`.

`splitSelectIndexedAccesses` runs per promotable allocation ahead of the forwarding. When every user of the allocation is an access at constant indices (memref, affine and gep alike), a cast or view of it with the same property, or an access at a select between constants, each select-indexed `memref.load`/`memref.store` becomes `scf.if cond { access[k1] } else { access[k2] }`, and the forwarding then resolves both arms. Nested selects split one index per round of the pass's outer loop. Any other user, an access at a dynamic index or a call taking the allocation, leaves it alone, since splitting would only add branches without promoting anything.

Test: `mem2reg_select_index.mlir` (a load at a select, a store at a select observed by two loads, a dynamic access and a call on the allocation each blocking the split).

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
