### PR TITLE
Fix two debug-build assertions in llvm-to-affine-access and a gep fold test

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -1284,11 +1284,6 @@ public:
     return AffineExprBuilder::getMap();
   }
 
-  PtrVal getBase() {
-    assert(base);
-    return base;
-  }
-
   void maybeReplaceBase(Value before, Value after) {
     if (base == before)
       base = cast<PtrVal>(after);
@@ -2055,7 +2050,8 @@ convertLLVMToAffineAccess(Operation *op,
   // index the builders by base once and tell only the bucket that cares.
   DenseMap<Value, SmallVector<AffineAccessBuilder *>> buildersByBase;
   for (auto &aabp : accessBuilders)
-    buildersByBase[aabp->getBase()].push_back(aabp.get());
+    if (aabp->base)
+      buildersByBase[aabp->base].push_back(aabp.get());
   auto replaceBases = [&](Value before, Value after) {
     auto it = buildersByBase.find(before);
     if (it == buildersByBase.end())

--- a/test/lit_tests/gep_fold_pointer_element.mlir
+++ b/test/lit_tests/gep_fold_pointer_element.mlir
@@ -22,11 +22,11 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
     return %v : memref<?xf32>
   }
 
-  llvm.func @func_element(%base: !llvm.ptr, %off: i64) -> !llvm.func<void ()> {
+  func.func @func_element(%base: !llvm.ptr, %off: i64) -> !llvm.func<void ()> {
     %g = llvm.getelementptr inbounds|nuw %base[%off] : (!llvm.ptr, i64) -> !llvm.ptr, i8
     %m = "enzymexla.pointer2memref"(%g) : (!llvm.ptr) -> memref<?x!llvm.func<void ()>>
     %v = affine.load %m[0] : memref<?x!llvm.func<void ()>>
-    llvm.return %v : !llvm.func<void ()>
+    return %v : !llvm.func<void ()>
   }
 }
 
@@ -42,6 +42,6 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr, dense<
 // CHECK: %[[g:.+]] = llvm.getelementptr inbounds|nuw %arg0[%arg1]
 // CHECK: "enzymexla.pointer2memref"(%[[g]])
 
-// CHECK-LABEL: llvm.func @func_element(
+// CHECK-LABEL: func.func @func_element(
 // CHECK: %[[g:.+]] = llvm.getelementptr inbounds|nuw %arg0[%arg1]
 // CHECK: "enzymexla.pointer2memref"(%[[g]])


### PR DESCRIPTION
Follow-up to #3082's CI, whose debug lit run (it runs when the release one fails) showed two assertion failures that a release build never reaches.

`convertLLVMToAffineAccess` keeps every access builder it creates, including the ones whose `build` failed and so have no base; the conversion loop already checks `aab.base` before using one. The by-base index from #2827 asked each builder for its base through `getBase()`, which asserts on a null base, so any function with one unconvertible access aborted a debug build (`raising/llvm_to_affine_negative_divisor.mlir`, `llvm_to_memref_both.mlir`, `llvmtoaffinememref.mlir`, `masked_affine_for.mlir`, `llvm_to_memref_access_not_affine.mlir`). The index now skips builders without a base, and the accessor, which has no other caller, is gone.

`gep_fold_pointer_element.mlir` @func_element was an `llvm.func` returning `!llvm.func<void ()>`, which `LLVMFunctionType` rejects as a result type; the parser asserts on it in a debug build. It is a `func.func` now, which can return the value the test loads.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
