### PR TITLE
affine-cfg: keep normalizer operand lists current across hoists

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -410,6 +410,13 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
   SmallVector<AffineExpr, 8> symReplacements;
 
   SmallVector<SmallVectorImpl<Value> *> opsTodos;
+  // Legalizing one operand can clone and erase the op defining another that
+  // is not yet reached -- the same value listed twice, or one the hoist
+  // moves on the way -- so the operands wait here where replaceOp finds them.
+  SmallVector<Value> todoOperands(operands.begin(), operands.end());
+  opsTodos.push_back(&todoOperands);
+  opsTodos.push_back(&addedValues);
+  opsTodos.push_back(&reorderedDims);
   auto replaceOp = [&](Operation *oldOp, Operation *newOp) {
     for (auto [oldV, newV] :
          llvm::zip(oldOp->getResults(), newOp->getResults()))
@@ -668,8 +675,8 @@ AffineApplyNormalizer::AffineApplyNormalizer(AffineMap map,
   };
 
   // 2. Compose affine::AffineApplyOps and dispatch dims or symbols.
-  for (unsigned i = 0, e = operands.size(); i < e; ++i) {
-    auto t = operands[i];
+  for (unsigned i = 0, e = todoOperands.size(); i < e; ++i) {
+    auto t = todoOperands[i];
     auto decast = peelCasts(t);
 
     if (!keptAsSymbol(t, scope, throughSymbols)) {

--- a/test/lit_tests/raising/affinecfg_hoisted_operand_reuse.mlir
+++ b/test/lit_tests/raising/affinecfg_hoisted_operand_reuse.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+// The select is hoisted (cloned and erased) while legalizing the first index;
+// the other index must see the clone, not the erased op.
+
+module {
+  func.func @twice(%m: memref<?x?xf64>, %s: index, %t: index, %n: index, %c: i1) {
+    affine.for %i = 0 to %n {
+      %a = arith.select %c, %s, %t : index
+      %v = memref.load %m[%a, %a] : memref<?x?xf64>
+      affine.store %v, %m[%i, 0] : memref<?x?xf64>
+    }
+    return
+  }
+
+  func.func @derived(%m: memref<?x?xf64>, %s: index, %t: index, %n: index, %c: i1) {
+    %c1 = arith.constant 1 : index
+    affine.for %i = 0 to %n {
+      %a = arith.select %c, %s, %t : index
+      %b = arith.addi %a, %c1 : index
+      %v = memref.load %m[%b, %a] : memref<?x?xf64>
+      affine.store %v, %m[%i, 0] : memref<?x?xf64>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @twice(
+// CHECK-SAME:      %[[M:.*]]: memref<?x?xf64>, %[[S:.*]]: index, %[[T:.*]]: index, %[[N:.*]]: index, %[[C:.*]]: i1) {
+// CHECK:           %[[SEL:.*]] = arith.select %[[C]], %[[S]], %[[T]] : index
+// CHECK:           affine.for %[[I:.*]] = 0 to %[[N]] {
+// CHECK:             %[[V:.*]] = affine.load %[[M]][symbol(%[[SEL]]), symbol(%[[SEL]])] : memref<?x?xf64>
+// CHECK:             affine.store %[[V]], %[[M]][%[[I]], 0] : memref<?x?xf64>
+
+// CHECK-LABEL:   func.func @derived(
+// CHECK-SAME:      %[[M:.*]]: memref<?x?xf64>, %[[S:.*]]: index, %[[T:.*]]: index, %[[N:.*]]: index, %[[C:.*]]: i1) {
+// CHECK:           %[[SEL:.*]] = arith.select %[[C]], %[[S]], %[[T]] : index
+// CHECK:           affine.for %[[I:.*]] = 0 to %[[N]] {
+// CHECK:             %[[V:.*]] = affine.load %[[M]][symbol(%[[SEL]]) + 1, symbol(%[[SEL]])] : memref<?x?xf64>
+// CHECK:             affine.store %[[V]], %[[M]][%[[I]], 0] : memref<?x?xf64>


### PR DESCRIPTION
`AffineApplyNormalizer` legalizes each operand in turn; when an operand is not a valid symbol where it stands, `fix` hoists it by cloning the defining op at the front of the scope and erasing the original. The lists that `replaceOp` patches (`opsTodos`) only covered the per-op operand vectors the hoist itself was walking, so a value already recorded elsewhere kept pointing at the erased op:

- the constructor's own `operands` list, when the same value is used by two indices (`load %m[%a, %a]`) or one index derives from another (`load %m[addi(%a, 1), %a]`) — the second index was read after the first hoist erased `%a`;
- `addedValues` / `reorderedDims`, when `renumberOneSymbol` registers an operand of an `arith.addi` before a later `fix` erases and re-creates it.

Both are use-after-free (segfault under `MoveLoadToAffine`, seen on `bilininteg_curlcurl_pa` and reproducible with the test below on main). The fix copies the operands into a vector registered in `opsTodos` alongside `addedValues` and `reorderedDims`, so every place a value is remembered gets patched when its op is replaced.

Test: `test/lit_tests/raising/affinecfg_hoisted_operand_reuse.mlir` (both shapes; crashes on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
