### PR TITLE
AffineCFG: any pure op of valid symbols is a valid symbol

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -78,28 +78,16 @@ bool isValidSymbolInt(Operation *defOp, bool recur, Region *scope) {
     return true;
 
   if (recur) {
-    if (isa<arith::SelectOp, IndexCastOp, IndexCastUIOp, AddIOp, MulIOp,
-            DivSIOp, DivUIOp, RemSIOp, RemUIOp, SubIOp, CmpIOp, TruncIOp,
-            ExtUIOp, ExtSIOp, MaxSIOp, MinSIOp, MaxUIOp, MinUIOp>(defOp))
-      if (llvm::all_of(defOp->getOperands(), [&](Value v) {
-            bool b = isValidSymbolInt(v, recur, scope);
-            // if (!b)
-            //	LLVM_DEBUG(llvm::dbgs() << "illegal isValidSymbolInt: "
-            //<< value << " due to " << v << "\n");
-            return b;
-          }))
-        return true;
-    if (auto orOp = dyn_cast<OrIOp>(defOp)) {
-      if (isDisjoint(orOp) && isValidSymbolInt(orOp.getLhs(), recur, scope) &&
-          isValidSymbolInt(orOp.getRhs(), recur, scope))
-        return true;
-    }
-    if (auto shiftOp = dyn_cast<ShLIOp>(defOp)) {
-      APInt intValue;
-      if (isValidSymbolInt(shiftOp.getLhs(), recur, scope) &&
-          matchPattern(shiftOp.getRhs(), m_ConstantInt(&intValue)))
-        return true;
-    }
+    // A region-free op without memory effects is a function of its operands
+    // alone, so with valid symbols for operands its result is invariant over
+    // the scope the way a symbol is; whether it has an affine form is
+    // composableSymbol's question, not this one.
+    if (defOp->getNumRegions() == 0 && defOp->getNumOperands() != 0 &&
+        isMemoryEffectFree(defOp) &&
+        llvm::all_of(defOp->getOperands(), [&](Value v) {
+          return isValidSymbolInt(v, recur, scope);
+        }))
+      return true;
     // A conditional whose regions yield valid symbols produces one: the value
     // is select(cond, thenYield, elseYield) regardless of what else the regions
     // do.  Materializing that is AffineApplyNormalizer::fix's job -- see the

--- a/test/lit_tests/raising/affinecfg_pure_symbol_ops.mlir
+++ b/test/lit_tests/raising/affinecfg_pure_symbol_ops.mlir
@@ -1,0 +1,43 @@
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+module {
+  func.func @ctlz_bound(%arg0: memref<?xf64>, %n: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1_i32 = arith.constant 1 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %cst = arith.constant 1.0 : f64
+    affine.parallel (%t) = (0) to (64) {
+      %s = arith.shrui %n, %c1_i32 : i32
+      %z = math.ctlz %s : i32
+      %w = arith.subi %c32_i32, %z : i32
+      %ub = arith.maxui %w, %c1_i32 : i32
+      %ubi = arith.index_castui %ub : i32 to index
+      scf.for %i = %c0 to %ubi step %c1 {
+        %idx = arith.addi %i, %t : index
+        memref.store %cst, %arg0[%idx] : memref<?xf64>
+      }
+    }
+    return
+  }
+}
+
+// The bound chain runs through math.ctlz, which is no arith op but is pure, so
+// it is a valid symbol: the chain hoists out of the parallel and the loop
+// becomes affine and merges into it.
+
+// CHECK-LABEL:   func.func @ctlz_bound(
+// CHECK-SAME:                          %[[A:.+]]: memref<?xf64>, %[[N:.+]]: i32) {
+// CHECK-NEXT:      %[[CST:.+]] = arith.constant 1.000000e+00 : f64
+// CHECK-NEXT:      %[[C32:.+]] = arith.constant 32 : i32
+// CHECK-NEXT:      %[[C1:.+]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[S:.+]] = arith.shrui %[[N]], %[[C1]] : i32
+// CHECK-NEXT:      %[[Z:.+]] = math.ctlz %[[S]] : i32
+// CHECK-NEXT:      %[[W:.+]] = arith.subi %[[C32]], %[[Z]] : i32
+// CHECK-NEXT:      %[[UB:.+]] = arith.maxui %[[W]], %[[C1]] : i32
+// CHECK-NEXT:      %[[UBI:.+]] = arith.index_cast %[[UB]] : i32 to index
+// CHECK-NEXT:      affine.parallel (%[[T:.+]], %[[I:.+]]) = (0, 0) to (64, symbol(%[[UBI]])) {
+// CHECK-NEXT:        affine.store %[[CST]], %[[A]][%[[I]] + %[[T]]] : memref<?xf64>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/test/lit_tests/raising/affinecfg_select_hoist_capture.mlir
+++ b/test/lit_tests/raising/affinecfg_select_hoist_capture.mlir
@@ -49,9 +49,9 @@ module attributes {gpu.container_module} {
   }
 }
 
-// The selects become an affine.if whose yields capture %247, an scf.if defined
-// inside the parallel and keyed off a non-affine ptrtoint.  It must neither be
-// treated as a valid affine symbol nor hoisted above the values it yields.
+// The selects become affine.ifs yielding results of %247, an scf.if keyed off a
+// pure ptrtoint that hoists out of the parallel ahead of them; nothing may be
+// hoisted above the values it yields.
 
 // CHECK:       #set = affine_set<()[s0] : (s0 == 0)>
 // CHECK-LABEL:   func.func @test(
@@ -62,7 +62,16 @@ module attributes {gpu.container_module} {
 // CHECK-NEXT:      %[[C0_I32:.+]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[C0_I64:.+]] = arith.constant 0 : i64
 // CHECK-NEXT:      %[[NIDX:.+]] = arith.index_cast %[[N]] : i64 to index
+// CHECK-NEXT:      %[[PI:.+]] = llvm.ptrtoint %[[PTR]] : !llvm.ptr to i64
+// CHECK-NEXT:      %[[PZ:.+]] = arith.cmpi eq, %[[PI]], %[[C0_I64]] : i64
 // CHECK-NEXT:      %[[NZ:.+]] = arith.cmpi eq, %[[N]], %[[C0_I64]] : i64
+// CHECK-NEXT:      %[[IF:.+]]:4 = scf.if %[[PZ]] -> (i32, i32, i32, i32) {
+// CHECK-NEXT:        scf.yield %[[C0_I32]], %[[C0_I32]], %[[C0_I32]], %[[C0_I32]] : i32, i32, i32, i32
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        scf.yield %[[C0_I32]], %[[C0_I32]], %[[C0_I32]], %[[C0_I32]] : i32, i32, i32, i32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[SEL1:.+]] = arith.select %[[NZ]], %[[IF]]#1, %[[IF]]#3 : i32
+// CHECK-NEXT:      %[[SEL1IDX:.+]] = arith.index_cast %[[SEL1]] : i32 to index
 // CHECK-NEXT:      %[[IF2:.+]]:3 = scf.if %[[NZ]] -> (i32, i32, i32) {
 // CHECK-NEXT:        scf.yield %[[V]], %[[V]], %[[V]] : i32, i32, i32
 // CHECK-NEXT:      } else {
@@ -70,28 +79,20 @@ module attributes {gpu.container_module} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[IF2IDX:.+]] = arith.index_cast %[[IF2]]#2 : i32 to index
 // CHECK-NEXT:      affine.parallel (%[[TID:.+]]) = (0) to (256) {
-// CHECK-NEXT:        %[[PI:.+]] = llvm.ptrtoint %[[PTR]] : !llvm.ptr to i64
-// CHECK-NEXT:        %[[PZ:.+]] = arith.cmpi eq, %[[PI]], %[[C0_I64]] : i64
-// CHECK-NEXT:        %[[IF:.+]]:4 = scf.if %[[PZ]] -> (i32, i32, i32, i32) {
-// CHECK-NEXT:          scf.yield %[[C0_I32]], %[[C0_I32]], %[[C0_I32]], %[[C0_I32]] : i32, i32, i32, i32
+// CHECK-NEXT:        %[[SEL0:.+]] = affine.if #set()[%[[NIDX]]] -> i32 {
+// CHECK-NEXT:          affine.yield %[[IF]]#0 : i32
 // CHECK-NEXT:        } else {
-// CHECK-NEXT:          scf.yield %[[C0_I32]], %[[C0_I32]], %[[C0_I32]], %[[C0_I32]] : i32, i32, i32, i32
-// CHECK-NEXT:        }
-// CHECK-NEXT:        %[[SEL:.+]]:2 = affine.if #set()[%[[NIDX]]] -> (i32, i32) {
-// CHECK-NEXT:          affine.yield %[[IF]]#0, %[[IF]]#1 : i32, i32
-// CHECK-NEXT:        } else {
-// CHECK-NEXT:          affine.yield %[[IF]]#2, %[[IF]]#3 : i32, i32
+// CHECK-NEXT:          affine.yield %[[IF]]#2 : i32
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %{{.+}}:2 = affine.if #set()[%[[IF2IDX]]] -> (i32, i32) {
-// CHECK-NEXT:          %[[ASM:.+]] = llvm.inline_asm has_side_effects tail_call_kind = <tail> asm_dialect = att "shfl.sync.down.b32 $0, $1, $2, $3, $4;", "=r,r,r,r,r" %[[SEL]]#0, %[[C1_I32]], %[[C31_I32]], %[[CM1_I32]] : (i32, i32, i32, i32) -> i32
-// CHECK-NEXT:          %[[ADD:.+]] = arith.addi %[[SEL]]#0, %[[ASM]] : i32
-// CHECK-NEXT:          %[[SELZ:.+]] = arith.cmpi eq, %[[SEL]]#1, %[[C0_I32]] : i32
-// CHECK-NEXT:          %[[INNER:.+]] = scf.if %[[SELZ]] -> (i32) {
+// CHECK-NEXT:          %[[ASM:.+]] = llvm.inline_asm has_side_effects tail_call_kind = <tail> asm_dialect = att "shfl.sync.down.b32 $0, $1, $2, $3, $4;", "=r,r,r,r,r" %[[SEL0]], %[[C1_I32]], %[[C31_I32]], %[[CM1_I32]] : (i32, i32, i32, i32) -> i32
+// CHECK-NEXT:          %[[ADD:.+]] = arith.addi %[[SEL0]], %[[ASM]] : i32
+// CHECK-NEXT:          %[[INNER:.+]] = affine.if #set()[%[[SEL1IDX]]] -> i32 {
 // CHECK-NEXT:            %[[LOAD:.+]] = llvm.load %[[PTR2]] : !llvm.ptr -> i32
 // CHECK-NEXT:            %[[ADD2:.+]] = arith.addi %[[LOAD]], %[[ADD]] : i32
-// CHECK-NEXT:            scf.yield %[[ADD2]] : i32
+// CHECK-NEXT:            affine.yield %[[ADD2]] : i32
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            scf.yield %[[V]] : i32
+// CHECK-NEXT:            affine.yield %[[V]] : i32
 // CHECK-NEXT:          }
 // CHECK-NEXT:          affine.yield %[[INNER]], %[[C0_I32]] : i32, i32
 // CHECK-NEXT:        } else {


### PR DESCRIPTION
`isValidSymbolInt` decided whether an op's result may serve as an affine symbol from a whitelist of arith ops (`select`, `index_cast`, `addi`, `muli`, the divisions, `cmpi`, the casts, the min/max family) plus special cases for disjoint `ori` and `shli` by a constant. Anything outside the list -- `math.ctlz` in a loop bound (MFEM's `1 << log2` block-size computations), `llvm.ptrtoint`, `arith.shrui`, ... -- kept the whole expression, and every loop bounded by it, out of affine form.

The property the check is actually after is invariance over the scope: a region-free op without memory effects is a function of its operands alone, so with valid symbols for operands its result is as invariant as a symbol. Whether the op also has an affine form is `composableSymbol`'s question and is left there. The whitelist (and the `ori`/`shli` cases it subsumes) becomes that one rule; the `scf.if`/`affine.if` yield handling below it is unchanged.

`affinecfg_select_hoist_capture.mlir` moves with it: the `scf.if` keyed off a pure `llvm.ptrtoint` of an argument now hoists out of the parallel ahead of the selects that read it, which is the ordering that test guards. New test: a `scf.for` bounded by `maxui(32 - ctlz(n >> 1), 1)` now raises and merges into the enclosing parallel.

Part of the `scf.for` inventory from #2968 (class C, data-dependent bounds through non-arith ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
