### PR TITLE
Raising: coalesce grid-stride loops into one parallel axis

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -999,6 +999,52 @@ emitIfAsSelect(Operation *ifOp, Value cond, affine::AffineValueMap map,
   return success();
 }
 
+// A mask over an iv that neither the store location nor the stored value
+// depends on picks which lanes write, and they all write the same thing: the
+// store lands wherever any lane is admitted. Reduces `mask` with `or` over the
+// axes whose iv `isStoreIv` rejects, and rebuilds `maskMap` over the kept ivs.
+static Value reduceMaskToStoreIvs(Location loc, Value mask,
+                                  affine::AffineValueMap &maskMap,
+                                  function_ref<bool(Value)> isStoreIv,
+                                  OpBuilder &builder) {
+  SmallVector<int64_t> lanesToReduce;
+  SmallVector<Value> keptIvs;
+  for (auto [j, E] : llvm::enumerate(maskMap.getAffineMap().getResults())) {
+    Value iv = getIVForExpr(maskMap, E);
+    if (isStoreIv(iv))
+      keptIvs.push_back(iv);
+    else
+      lanesToReduce.push_back(j);
+  }
+  if (lanesToReduce.empty())
+    return mask;
+
+  auto maskType = cast<RankedTensorType>(mask.getType());
+  auto boolType = RankedTensorType::get({}, maskType.getElementType());
+  SmallVector<int64_t> anyShape;
+  for (auto [j, sz] : llvm::enumerate(maskType.getShape()))
+    if (!llvm::is_contained(lanesToReduce, j))
+      anyShape.push_back(sz);
+  Value init = stablehlo::ConstantOp::create(
+      builder, loc, DenseElementsAttr::get(boolType, ArrayRef<bool>(false)));
+  auto any = stablehlo::ReduceOp::create(
+      builder, loc, TypeRange{maskType.clone(anyShape)}, ValueRange{mask},
+      ValueRange{init}, builder.getDenseI64ArrayAttr(lanesToReduce));
+  auto block = new Block();
+  any.getBody().push_back(block);
+  auto a = block->addArgument(boolType, loc);
+  auto b = block->addArgument(boolType, loc);
+  {
+    OpBuilder builder(block, block->end());
+    Value either = stablehlo::OrOp::create(builder, loc, a, b);
+    stablehlo::ReturnOp::create(builder, loc, either);
+  }
+  maskMap = affine::AffineValueMap(
+      AffineMap::getMultiDimIdentityMap(keptIvs.size(), loc.getContext()),
+      keptIvs);
+  return any.getResult(0);
+}
+
 // Builds a `[gridShape..., numColumns]` index tensor from per-dimension index
 // columns, deduplicating induction variables: when the same IV indexes more
 // than one column, the columns share a single grid axis instead of forming a
@@ -1202,8 +1248,10 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
         sliceSizes);
 
     // Broadcast the mask from its IV-space to the update's grid shape.
-    Value mask = pc.mask;
-    affine::AffineValueMap maskMap = maps.lookup(mask);
+    affine::AffineValueMap maskMap = maps.lookup(pc.mask);
+    Value mask = reduceMaskToStoreIvs(
+        loc, pc.mask, maskMap,
+        [&](Value iv) { return llvm::is_contained(ivs, iv); }, builder);
     SmallVector<int64_t> maskBroadcastDims;
     for (auto E : maskMap.getAffineMap().getResults()) {
       Value maskIV = getIVForExpr(maskMap, E);
@@ -2941,51 +2989,15 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
           update, reverseDims);
 
     if (pc.mask) {
-      Value mask = pc.mask;
-      affine::AffineValueMap maskMap = maps.lookup(mask);
-
-      // A mask over an iv that neither the store location nor the stored
-      // value depends on picks which lanes write, and they all write the
-      // same thing: the store lands wherever any lane is admitted.
-      SmallVector<int64_t> lanesToReduce;
-      SmallVector<Value> keptIvs;
-      for (auto [j, E] : llvm::enumerate(maskMap.getAffineMap().getResults())) {
-        Value iv = getIVForExpr(maskMap, E);
-        if (llvm::is_contained(storeOp.getIndices(), iv) ||
-            llvm::is_contained(updateValueMap.getOperands(), iv))
-          keptIvs.push_back(iv);
-        else
-          lanesToReduce.push_back(j);
-      }
-      if (!lanesToReduce.empty()) {
-        auto loc =
-            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo);
-        auto maskType = cast<RankedTensorType>(mask.getType());
-        auto boolType = RankedTensorType::get({}, maskType.getElementType());
-        SmallVector<int64_t> anyShape;
-        for (auto [j, sz] : llvm::enumerate(maskType.getShape()))
-          if (!llvm::is_contained(lanesToReduce, j))
-            anyShape.push_back(sz);
-        Value init = stablehlo::ConstantOp::create(
-            builder, loc,
-            DenseElementsAttr::get(boolType, ArrayRef<bool>(false)));
-        auto any = stablehlo::ReduceOp::create(
-            builder, loc, TypeRange{maskType.clone(anyShape)}, ValueRange{mask},
-            ValueRange{init}, builder.getDenseI64ArrayAttr(lanesToReduce));
-        auto block = new Block();
-        any.getBody().push_back(block);
-        auto a = block->addArgument(boolType, loc);
-        auto b = block->addArgument(boolType, loc);
-        {
-          OpBuilder builder(block, block->end());
-          Value either = stablehlo::OrOp::create(builder, loc, a, b);
-          stablehlo::ReturnOp::create(builder, loc, either);
-        }
-        mask = any.getResult(0);
-        maskMap = affine::AffineValueMap(
-            AffineMap::getMultiDimIdentityMap(keptIvs.size(), op->getContext()),
-            keptIvs);
-      }
+      affine::AffineValueMap maskMap = maps.lookup(pc.mask);
+      Value mask = reduceMaskToStoreIvs(
+          rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
+          pc.mask, maskMap,
+          [&](Value iv) {
+            return llvm::is_contained(storeOp.getIndices(), iv) ||
+                   llvm::is_contained(updateValueMap.getOperands(), iv);
+          },
+          builder);
 
       // here this is a bit annoying but alignMemoryAccess expects non constant
       // dims in its value maps. as such, we remove constant dims from the

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -17,6 +17,7 @@
 
 #include "Enzyme/MLIR/Dialect/Ops.h"
 #include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
+#include "mlir/Dialect/Affine/Analysis/AffineStructures.h"
 #include "mlir/Dialect/Affine/Analysis/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
@@ -31,6 +32,7 @@
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
 
 #include "Interfaces/AutoDiffTypeInterface.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -2942,6 +2944,49 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       Value mask = pc.mask;
       affine::AffineValueMap maskMap = maps.lookup(mask);
 
+      // A mask over an iv that neither the store location nor the stored
+      // value depends on picks which lanes write, and they all write the
+      // same thing: the store lands wherever any lane is admitted.
+      SmallVector<int64_t> lanesToReduce;
+      SmallVector<Value> keptIvs;
+      for (auto [j, E] : llvm::enumerate(maskMap.getAffineMap().getResults())) {
+        Value iv = getIVForExpr(maskMap, E);
+        if (llvm::is_contained(storeOp.getIndices(), iv) ||
+            llvm::is_contained(updateValueMap.getOperands(), iv))
+          keptIvs.push_back(iv);
+        else
+          lanesToReduce.push_back(j);
+      }
+      if (!lanesToReduce.empty()) {
+        auto loc =
+            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo);
+        auto maskType = cast<RankedTensorType>(mask.getType());
+        auto boolType = RankedTensorType::get({}, maskType.getElementType());
+        SmallVector<int64_t> anyShape;
+        for (auto [j, sz] : llvm::enumerate(maskType.getShape()))
+          if (!llvm::is_contained(lanesToReduce, j))
+            anyShape.push_back(sz);
+        Value init = stablehlo::ConstantOp::create(
+            builder, loc,
+            DenseElementsAttr::get(boolType, ArrayRef<bool>(false)));
+        auto any = stablehlo::ReduceOp::create(
+            builder, loc, TypeRange{maskType.clone(anyShape)}, ValueRange{mask},
+            ValueRange{init}, builder.getDenseI64ArrayAttr(lanesToReduce));
+        auto block = new Block();
+        any.getBody().push_back(block);
+        auto a = block->addArgument(boolType, loc);
+        auto b = block->addArgument(boolType, loc);
+        {
+          OpBuilder builder(block, block->end());
+          Value either = stablehlo::OrOp::create(builder, loc, a, b);
+          stablehlo::ReturnOp::create(builder, loc, either);
+        }
+        mask = any.getResult(0);
+        maskMap = affine::AffineValueMap(
+            AffineMap::getMultiDimIdentityMap(keptIvs.size(), op->getContext()),
+            keptIvs);
+      }
+
       // here this is a bit annoying but alignMemoryAccess expects non constant
       // dims in its value maps. as such, we remove constant dims from the
       // update and subsequent previous value as to use the storeValueMap.
@@ -4059,6 +4104,347 @@ struct AffineToStableHLORaisingPass
     return std::nullopt;
   }
 
+  // MFEM_FOREACH_THREAD(i, x, N) is CUDA's grid-stride idiom: lane t of a
+  // block of extent s handles i = t, t+s, t+2s, ... below N, so the lanes
+  // and the loop together visit every i in [0, N) exactly once. Raised
+  // execution is whole-tensor, so serializing the loop (its trip count
+  // differs per lane) gains nothing over one parallel axis of extent N run
+  // from lane 0 alone:
+  //
+  //   affine.parallel (t) = (0) to (s) {
+  //     affine.for j = t + a to N + a step s { B(j) }        // constant s
+  //     affine.for k = 0 to (N - t) ceildiv s { B(t + k*s) } // any s
+  //   }
+  //   =>
+  //   affine.parallel (t) = (0) to (s) {
+  //     affine.if t == 0 { affine.parallel (i) = (0) to (N) { B(i) } }
+  //   }
+  //
+  // Sound when the body depends on the lane only through its index, the
+  // iterations over i are independent, and every guard between the axis
+  // and the loop admits each lane below min(s, N).
+  struct GridStrideLoop {
+    affine::AffineParallelOp par;
+    unsigned axis;
+    affine::AffineForOp loop;
+    affine::AffineValueMap extent;
+    // The lane index i against the loop's own variables: j = i + shift for
+    // the constant-stride form, t = i - k * stride otherwise.
+    std::optional<affine::AffineValueMap> shift;
+    Value stride;
+  };
+
+  static std::optional<GridStrideLoop>
+  matchGridStrideLoop(affine::AffineForOp loop) {
+    if (loop.getNumIterOperands() != 0 ||
+        loop.getLowerBoundMap().getNumResults() != 1 ||
+        loop.getUpperBoundMap().getNumResults() != 1)
+      return std::nullopt;
+    MLIRContext *ctx = loop.getContext();
+
+    Value t;
+    SmallVector<Value> boundOperands(loop.getLowerBoundOperands());
+    llvm::append_range(boundOperands, loop.getUpperBoundOperands());
+    for (Value o : boundOperands) {
+      auto owner = affine::getAffineParallelInductionVarOwner(o);
+      if (!owner || !owner->isProperAncestor(loop))
+        continue;
+      if (t && t != o)
+        return std::nullopt;
+      t = o;
+    }
+    if (!t)
+      return std::nullopt;
+    auto par = affine::getAffineParallelInductionVarOwner(t);
+    unsigned axis = cast<BlockArgument>(t).getArgNumber();
+    if (!par.getReductions().empty() || par.getSteps()[axis] != 1)
+      return std::nullopt;
+    auto parLb = getConstant(par.getLowerBoundMap(axis));
+    if (!parLb || *parLb != 0)
+      return std::nullopt;
+    AffineMap extentMap = par.getUpperBoundMap(axis);
+    if (extentMap.getNumResults() != 1)
+      return std::nullopt;
+    std::optional<int64_t> cst;
+    Value stride;
+    if (auto c = dyn_cast<AffineConstantExpr>(extentMap.getResult(0)))
+      cst = c.getValue();
+    else if (auto s = dyn_cast<AffineSymbolExpr>(extentMap.getResult(0)))
+      stride = par.getUpperBoundsOperands()[extentMap.getNumDims() +
+                                            s.getPosition()];
+    else
+      return std::nullopt;
+
+    GridStrideLoop gs{par, axis, loop, {}, {}, stride};
+    affine::AffineValueMap lb(loop.getLowerBoundMap(),
+                              loop.getLowerBoundOperands());
+    affine::AffineValueMap ub(loop.getUpperBoundMap(),
+                              loop.getUpperBoundOperands());
+    auto canonicalize = [](affine::AffineValueMap &vm) {
+      AffineMap m = vm.getAffineMap();
+      SmallVector<Value> ops(vm.getOperands());
+      affine::canonicalizeMapAndOperands(&m, &ops);
+      vm.reset(m, ops);
+    };
+    auto lbConst = getConstant(lb.getAffineMap());
+    if (cst && loop.getStepAsInt() == *cst) {
+      affine::AffineValueMap tv(AffineMap::getMultiDimIdentityMap(1, ctx), t);
+      gs.shift.emplace();
+      affine::AffineValueMap::difference(lb, tv, &*gs.shift);
+      if (gs.shift->isFunctionOf(0, t))
+        return std::nullopt;
+      canonicalize(*gs.shift);
+      affine::AffineValueMap::difference(ub, *gs.shift, &gs.extent);
+    } else if (loop.getStepAsInt() == 1 && lbConst && *lbConst == 0) {
+      AffineMap um = ub.getAffineMap();
+      auto div = dyn_cast<AffineBinaryOpExpr>(um.getResult(0));
+      if (!div || (div.getKind() != AffineExprKind::FloorDiv &&
+                   div.getKind() != AffineExprKind::CeilDiv))
+        return std::nullopt;
+      AffineExpr den = div.getRHS();
+      if (cst) {
+        if (den != getAffineConstantExpr(*cst, ctx))
+          return std::nullopt;
+      } else {
+        auto s = dyn_cast<AffineSymbolExpr>(den);
+        if (!s || ub.getOperand(um.getNumDims() + s.getPosition()) != stride)
+          return std::nullopt;
+      }
+      auto tIt = llvm::find(ub.getOperands(), t);
+      unsigned tPos = tIt - ub.getOperands().begin();
+      if (tPos >= um.getNumDims())
+        return std::nullopt;
+      AffineExpr n = div.getLHS() + getAffineDimExpr(tPos, ctx);
+      if (div.getKind() == AffineExprKind::FloorDiv)
+        n = n - den + 1;
+      gs.extent.reset(AffineMap::get(um.getNumDims(), um.getNumSymbols(),
+                                     simplifyAffineExpr(n, um.getNumDims(),
+                                                        um.getNumSymbols())),
+                      ub.getOperands());
+    } else {
+      return std::nullopt;
+    }
+    if (gs.extent.isFunctionOf(0, t))
+      return std::nullopt;
+    canonicalize(gs.extent);
+    return gs;
+  }
+
+  // Whether `v`, read from inside a loop nested in `par`, can differ between
+  // lanes of axis `t` other than through `t` itself. Values from outside the
+  // parallel, its other axes, the IVs of the loops between it and the use
+  // (whose bounds the caller has checked are lane-invariant), allocations,
+  // and pure functions of those cannot.
+  static bool variesWithLane(Value v, affine::AffineParallelOp par, Value t,
+                             DenseMap<Value, bool> &memo) {
+    if (v == t)
+      return true;
+    if (auto it = memo.find(v); it != memo.end())
+      return it->second;
+    bool res;
+    if (!par.getRegion().isAncestor(v.getParentRegion()) ||
+        isa<BlockArgument>(v)) {
+      res = false;
+    } else {
+      Operation *def = v.getDefiningOp();
+      if (isa<memref::AllocaOp, memref::AllocOp>(def))
+        res = false;
+      else if (def->getNumRegions() != 0 || !isMemoryEffectFree(def))
+        res = true;
+      else
+        res = llvm::any_of(def->getOperands(), [&](Value o) {
+          return variesWithLane(o, par, t, memo);
+        });
+    }
+    memo[v] = res;
+    return res;
+  }
+
+  // Whether the constraints of `guard` that mention the lane `t` hold over
+  // all of `lanes`, the lanes below min(s, N).
+  static bool guardAdmitsLanes(affine::AffineIfOp guard,
+                               const affine::FlatAffineValueConstraints &lanes,
+                               Value t) {
+    IntegerSet set = guard.getIntegerSet();
+    SmallVector<Value> operands(guard.getOperands());
+    affine::canonicalizeSetAndOperands(&set, &operands);
+    auto cond = affine::FlatAffineValueConstraints::create(set, operands);
+    if (failed(cond))
+      return false;
+    affine::FlatAffineValueConstraints dom(lanes);
+    dom.mergeAndAlignVarsWithOther(0, &*cond);
+    unsigned tPos;
+    if (!cond->findVar(t, &tPos))
+      return true;
+    for (int i = cond->getNumInequalities() - 1; i >= 0; --i)
+      if (cond->atIneq(i, tPos) == 0)
+        cond->removeInequality(i);
+    for (int i = cond->getNumEqualities() - 1; i >= 0; --i)
+      if (cond->atEq(i, tPos) == 0)
+        cond->removeEquality(i);
+    return dom.isSubsetOf(*cond);
+  }
+
+  // isLoopMemoryParallel, but admitting nested affine.parallel: the lanes an
+  // inner grid-stride loop already coalesced into.
+  static bool isLaneLoopParallel(affine::AffineForOp forOp) {
+    SmallVector<Operation *> accesses;
+    auto walkResult = forOp.walk([&](Operation *op) -> WalkResult {
+      Value memref;
+      if (auto read = dyn_cast<affine::AffineReadOpInterface>(op))
+        memref = read.getMemRef();
+      else if (auto write = dyn_cast<affine::AffineWriteOpInterface>(op))
+        memref = write.getMemRef();
+      if (memref) {
+        if (!memref.getDefiningOp() ||
+            !forOp->isProperAncestor(memref.getDefiningOp()))
+          accesses.push_back(op);
+        return WalkResult::advance();
+      }
+      if (isa<affine::AffineForOp, affine::AffineParallelOp,
+              affine::AffineYieldOp, affine::AffineIfOp>(op) ||
+          hasSingleEffect<MemoryEffects::Allocate>(op) ||
+          isMemoryEffectFree(op))
+        return WalkResult::advance();
+      return WalkResult::interrupt();
+    });
+    if (walkResult.wasInterrupted())
+      return false;
+    unsigned depth = affine::getNestingDepth(forOp) + 1;
+    for (Operation *src : accesses) {
+      affine::MemRefAccess srcAccess(src);
+      for (Operation *dst : accesses) {
+        affine::MemRefAccess dstAccess(dst);
+        if (affine::checkMemrefAccessDependence(srcAccess, dstAccess, depth)
+                .value != affine::DependenceResult::NoDependence)
+          return false;
+      }
+    }
+    return true;
+  }
+
+  static void coalesceGridStrideLoops(Operation *root) {
+    MLIRContext *ctx = root->getContext();
+    RewritePatternSet owningPatterns(ctx);
+    for (RegisteredOperationName op : ctx->getRegisteredOperations())
+      if (op.getDialectNamespace() ==
+          affine::AffineDialect::getDialectNamespace())
+        op.getCanonicalizationPatterns(owningPatterns, ctx);
+    FrozenRewritePatternSet patterns(std::move(owningPatterns));
+    GreedyRewriteConfig config;
+    config.setStrictness(GreedyRewriteStrictness::ExistingAndNewOps);
+
+    // Post-order, so an inner loop coalesces before the outer one asks
+    // whether its own iterations are independent.
+    SmallVector<affine::AffineForOp> worklist;
+    root->walk([&](affine::AffineForOp loop) { worklist.push_back(loop); });
+    for (auto loop : worklist) {
+      auto gs = matchGridStrideLoop(loop);
+      if (!gs)
+        continue;
+      if (loop->walk(
+                  [](enzymexla::BarrierOp) { return WalkResult::interrupt(); })
+              .wasInterrupted())
+        continue;
+      Value t = gs->par.getIVs()[gs->axis];
+
+      affine::FlatAffineValueConstraints lanes;
+      if (failed(lanes.addInductionVarOrTerminalSymbol(t)))
+        continue;
+      unsigned tPos;
+      lanes.findVar(t, &tPos);
+      lanes.addBound(presburger::BoundType::LB, tPos, 0);
+      if (failed(lanes.addBound(presburger::BoundType::UB, tPos,
+                                gs->par.getUpperBoundMap(gs->axis),
+                                gs->par.getUpperBoundsOperands())) ||
+          failed(lanes.addBound(presburger::BoundType::UB, tPos,
+                                gs->extent.getAffineMap(),
+                                gs->extent.getOperands())))
+        continue;
+
+      DenseMap<Value, bool> memo;
+      auto laneInvariant = [&](ValueRange vals) {
+        return llvm::none_of(vals, [&](Value o) {
+          return o != t && variesWithLane(o, gs->par, t, memo);
+        });
+      };
+      bool ok = laneInvariant(loop->getOperands());
+      Operation *child = loop;
+      for (Operation *anc = loop->getParentOp(); ok && anc != gs->par;
+           child = anc, anc = anc->getParentOp()) {
+        if (auto guard = dyn_cast<affine::AffineIfOp>(anc))
+          ok = child->getParentRegion() == &guard.getThenRegion() &&
+               guardAdmitsLanes(guard, lanes, t);
+        else if (isa<affine::AffineForOp, affine::AffineParallelOp>(anc))
+          ok = laneInvariant(anc->getOperands());
+        else
+          ok = false;
+      }
+      if (!ok)
+        continue;
+      loop.getBody()->walk([&](Operation *op) {
+        for (Value o : op->getOperands())
+          if (!loop.getRegion().isAncestor(o.getParentRegion()) &&
+              !laneInvariant(o))
+            ok = false;
+      });
+      if (!ok)
+        continue;
+
+      // Build the lane loop around a clone of the body, so that giving up
+      // leaves the original untouched.
+      OpBuilder b(loop);
+      Location loc = loop.getLoc();
+      auto guard = affine::AffineIfOp::create(
+          b, loc, TypeRange(),
+          IntegerSet::get(1, 0, {b.getAffineDimExpr(0)}, {true}), ValueRange{t},
+          /*withElseRegion=*/false);
+      b.setInsertionPointToStart(guard.getThenBlock());
+      auto lane = affine::AffineForOp::create(
+          b, loc, ValueRange{}, AffineMap::getConstantMap(0, ctx),
+          gs->extent.getOperands(), gs->extent.getAffineMap(), 1);
+      Value i = lane.getInductionVar();
+      auto clone = cast<affine::AffineForOp>(b.clone(*loop));
+      Value k = clone.getInductionVar();
+      Block *dst = lane.getBody();
+      dst->getTerminator()->erase();
+      dst->getOperations().splice(dst->end(), clone.getBody()->getOperations());
+      b.setInsertionPointToStart(dst);
+      AffineExpr d0 = b.getAffineDimExpr(0), d1 = b.getAffineDimExpr(1);
+      Value tRepl;
+      if (gs->shift) {
+        int64_t c = loop.getStepAsInt();
+        tRepl = affine::AffineApplyOp::create(b, loc,
+                                              AffineMap::get(1, 0, d0 % c), i);
+        Value a = affine::AffineApplyOp::create(
+            b, loc, gs->shift->getAffineMap(), gs->shift->getOperands());
+        Value kRepl = affine::AffineApplyOp::create(
+            b, loc, AffineMap::get(2, 0, d0 + d1), ValueRange{i, a});
+        replaceAllUsesInRegionWith(k, kRepl, lane.getRegion());
+      } else if (gs->stride) {
+        tRepl = affine::AffineApplyOp::create(
+            b, loc, AffineMap::get(2, 1, d0 - d1 * b.getAffineSymbolExpr(0)),
+            ValueRange{i, k, gs->stride});
+      } else {
+        int64_t c = *getConstant(gs->par.getUpperBoundMap(gs->axis));
+        tRepl = affine::AffineApplyOp::create(
+            b, loc, AffineMap::get(2, 0, d0 - d1 * c), ValueRange{i, k});
+      }
+      replaceAllUsesInRegionWith(t, tRepl, lane.getRegion());
+      SmallVector<Operation *> ops;
+      dst->walk([&](Operation *op) { ops.push_back(op); });
+      (void)applyOpPatternsGreedily(ops, patterns, config);
+
+      if (!k.use_empty() || !isLaneLoopParallel(lane)) {
+        guard.erase();
+        continue;
+      }
+      clone.erase();
+      loop.erase();
+      (void)affine::affineParallelize(lane);
+    }
+  }
+
   // A parallel axis whose extent is dynamic but provably bounded (a block
   // size clamped by a min against a constant) batches at the bound instead
   // of peeling to a serial loop: the axis becomes constant-extent and the
@@ -4304,6 +4690,7 @@ struct AffineToStableHLORaisingPass
     // actually raises.
     for (auto func : funcs) {
       stripAccessMemorySpaceCasts(func);
+      coalesceGridStrideLoops(func);
       boundParallelAxes(func);
       peelDynamicParallelDims(func);
     }
@@ -4327,6 +4714,7 @@ struct AffineToStableHLORaisingPass
     op->walk([&](enzymexla::GPUWrapperOp g) { gwrap.push_back(g); });
     for (auto g : gwrap) {
       stripAccessMemorySpaceCasts(g);
+      coalesceGridStrideLoops(g);
       boundParallelAxes(g);
       peelDynamicParallelDims(g);
     }

--- a/test/lit_tests/raising/raise_grid_stride.mlir
+++ b/test/lit_tests/raising/raise_grid_stride.mlir
@@ -7,6 +7,8 @@
 // RUN: FileCheck %s --check-prefix=CARRIED < %t
 // RUN: FileCheck %s --check-prefix=LANE < %t
 // RUN: FileCheck %s --check-prefix=GUARD < %t
+// RUN: FileCheck %s --check-prefix=SCATTER < %t
+// RUN: FileCheck %s --check-prefix=FOREACH2D < %t
 
 // A grid-stride loop (thread t handles t, t + s, t + 2s, ...) inside a
 // parallel of extent s covers exactly one iteration per lane index; it is
@@ -189,3 +191,60 @@ func.func private @lane_guard(%arg0: memref<8xf64, 1>, %arg1: memref<8xf64, 1>) 
 // GUARD: %[[ANY:.+]] = stablehlo.reduce(%[[M]] init: %[[F]]) applies stablehlo.or across dimensions = [0] : (tensor<4xi1>, tensor<i1>) -> tensor<i1>
 // GUARD: %[[MB:.+]] = stablehlo.broadcast_in_dim %[[ANY]], dims = [] : (tensor<i1>) -> tensor<8xi1>
 // GUARD: stablehlo.select %[[MB]], %{{.*}}, %{{.*}} : tensor<8xi1>, tensor<8xf64>
+
+// The same any-lane guard over a store that raises as a scatter (linearized
+// index over two axes).
+func.func private @lane_guard_scatter(%arg0: memref<15xf64, 1>, %arg1: memref<15xf64, 1>) {
+  affine.parallel (%t) = (0) to (4) {
+    affine.if affine_set<(d0) : (d0 == 0)>(%t) {
+      affine.parallel (%i, %j) = (0, 0) to (5, 3) {
+        %0 = affine.load %arg0[%j * 5 + %i] : memref<15xf64, 1>
+        affine.store %0, %arg1[%i * 3 + %j] : memref<15xf64, 1>
+      }
+    }
+  }
+  return
+}
+
+// SCATTER-LABEL: func.func private @lane_guard_scatter_raised(
+// SCATTER: %[[M:.+]] = stablehlo.compare EQ, %{{.*}}, %{{.*}} : (tensor<4xi64>, tensor<4xi64>) -> tensor<4xi1>
+// SCATTER: %[[ANY:.+]] = stablehlo.reduce(%[[M]] init: %{{.*}}) applies stablehlo.or across dimensions = [0] : (tensor<4xi1>, tensor<i1>) -> tensor<i1>
+// SCATTER: %[[MB:.+]] = stablehlo.broadcast_in_dim %[[ANY]], dims = [] : (tensor<i1>) -> tensor<5x3xi1>
+// SCATTER: stablehlo.select %[[MB]], %{{.*}}, %{{.*}} : tensor<5x3xi1>, tensor<5x3xf64>
+// SCATTER: "stablehlo.scatter"
+
+// The MFEM_FOREACH_THREAD(dy,y,D1D-1) MFEM_FOREACH_THREAD(qx,x,Q1D) transpose
+// load of a basis matrix into shared memory: both axes stride, the outer one
+// behind a guard on the z-axis, and the scratch is indexed linearly.
+#set_y = affine_set<(d0, d1) : (d0 == 0, -d1 + 2 >= 0)>
+#set_x = affine_set<(d0) : (-d0 + 4 >= 0)>
+#uby2 = affine_map<(d0) -> ((3 - d0 + 4) floordiv 5)>
+#ubx2 = affine_map<(d0) -> ((5 - d0 + 4) floordiv 5)>
+func.func private @foreach_thread_2d(%B: memref<20xf64, 1>, %out: memref<15xf64, 1>) {
+  affine.parallel (%tx, %ty, %tz) = (0, 0, 0) to (5, 5, 2) {
+    %sB = memref.alloca() : memref<30xf64>
+    affine.if #set_y(%tz, %ty) {
+      affine.for %ky = 0 to #uby2(%ty) {
+        affine.if #set_x(%tx) {
+          affine.for %kx = 0 to #ubx2(%tx) {
+            %b = affine.load %B[(%ty + %ky * 5) * 5 + %tx + %kx * 5] : memref<20xf64, 1>
+            affine.store %b, %sB[(%tx + %kx * 5) * 3 + %ty + %ky * 5] : memref<30xf64>
+          }
+        }
+      }
+    }
+    "enzymexla.barrier"(%tx, %ty, %tz) : (index, index, index) -> ()
+    affine.if #set_y(%tz, %ty) {
+      %v = affine.load %sB[%tx * 3 + %ty] : memref<30xf64>
+      affine.store %v, %out[%tx * 3 + %ty] : memref<15xf64, 1>
+    }
+  }
+  return
+}
+
+// FOREACH2D-LABEL: func.func private @foreach_thread_2d_raised(
+// FOREACH2D-NOT: stablehlo.while
+// FOREACH2D: stablehlo.gather{{.*}} -> tensor<3x5xf64>
+// FOREACH2D-NOT: stablehlo.while
+// FOREACH2D: stablehlo.scatter
+// FOREACH2D-NOT: stablehlo.while

--- a/test/lit_tests/raising/raise_grid_stride.mlir
+++ b/test/lit_tests/raising/raise_grid_stride.mlir
@@ -1,0 +1,191 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo=err_if_not_fully_raised=false > %t
+// RUN: FileCheck %s --check-prefix=CONST < %t
+// RUN: FileCheck %s --check-prefix=SYM < %t
+// RUN: FileCheck %s --check-prefix=STEP < %t
+// RUN: FileCheck %s --check-prefix=FOREACH < %t
+// RUN: FileCheck %s --check-prefix=NESTED < %t
+// RUN: FileCheck %s --check-prefix=CARRIED < %t
+// RUN: FileCheck %s --check-prefix=LANE < %t
+// RUN: FileCheck %s --check-prefix=GUARD < %t
+
+// A grid-stride loop (thread t handles t, t + s, t + 2s, ...) inside a
+// parallel of extent s covers exactly one iteration per lane index; it is
+// coalesced into a single parallel over the lane index behind t == 0, which
+// raises as whole-tensor ops instead of a stablehlo.while over the strides.
+
+#ub = affine_map<(d0) -> ((6 - d0 + 3) floordiv 4)>
+func.func private @const_stride(%arg0: memref<6xf64, 1>, %arg1: memref<6xf64, 1>) {
+  affine.parallel (%t) = (0) to (4) {
+    affine.for %k = 0 to #ub(%t) {
+      %0 = affine.load %arg0[%t + %k * 4] : memref<6xf64, 1>
+      %1 = arith.addf %0, %0 : f64
+      affine.store %1, %arg1[%t + %k * 4] : memref<6xf64, 1>
+    }
+  }
+  return
+}
+
+// CONST-LABEL: func.func private @const_stride_raised(
+// CONST-NOT: stablehlo.while
+// CONST: arith.addf %{{.*}}, %{{.*}} : tensor<6xf64>
+// CONST-NOT: stablehlo.while
+// CONST: stablehlo.dynamic_update_slice
+// CONST-NOT: stablehlo.while
+
+#ubs = affine_map<(d0)[s0] -> ((64 - d0 + s0 - 1) floordiv s0)>
+func.func private @sym_stride(%arg0: memref<64xf64, 1>, %arg1: memref<64xf64, 1>, %sbuf: memref<i32, 1>) {
+  %c8_i32 = arith.constant 8 : i32
+  %n = affine.load %sbuf[] : memref<i32, 1>
+  %b = arith.minsi %n, %c8_i32 : i32
+  %s = arith.index_cast %b : i32 to index
+  affine.parallel (%t) = (0) to (symbol(%s)) {
+    affine.for %k = 0 to #ubs(%t)[%s] {
+      %0 = affine.load %arg0[%t + %k * symbol(%s)] : memref<64xf64, 1>
+      %1 = arith.addf %0, %0 : f64
+      affine.store %1, %arg1[%t + %k * symbol(%s)] : memref<64xf64, 1>
+    }
+  }
+  return
+}
+
+// SYM-LABEL: func.func private @sym_stride_raised(
+// SYM-NOT: stablehlo.while
+// SYM: arith.addf %{{.*}}, %{{.*}} : tensor<64xf64>
+// SYM-NOT: stablehlo.while
+// SYM: stablehlo.dynamic_update_slice
+// SYM-NOT: stablehlo.while
+
+// The unnormalized form `for j = t to N step s` with a shifted start.
+func.func private @step_form(%arg0: memref<8xf64, 1>, %arg1: memref<8xf64, 1>) {
+  affine.parallel (%t) = (0) to (4) {
+    affine.for %j = affine_map<(d0) -> (d0 + 2)>(%t) to 8 step 4 {
+      %0 = affine.load %arg0[%j] : memref<8xf64, 1>
+      %1 = arith.mulf %0, %0 : f64
+      affine.store %1, %arg1[%j - 2] : memref<8xf64, 1>
+    }
+  }
+  return
+}
+
+// STEP-LABEL: func.func private @step_form_raised(
+// STEP-NOT: stablehlo.while
+// STEP: stablehlo.slice %{{.*}} [2:8] : (tensor<8xf64>) -> tensor<6xf64>
+// STEP: arith.mulf %{{.*}}, %{{.*}} : tensor<6xf64>
+// STEP-NOT: stablehlo.while
+// STEP: stablehlo.dynamic_update_slice
+// STEP-NOT: stablehlo.while
+
+// MFEM_FOREACH_THREAD: a 2-D thread block where the y-axis strides over rows
+// into shared scratch, guarded on the other axis being zero, followed by a
+// barrier and a per-thread read of the scratch.
+#set = affine_set<(d0, d1) : (d0 == 0, -d1 + 5 >= 0)>
+#uby = affine_map<(d0) -> ((6 - d0 + 3) floordiv 4)>
+func.func private @foreach_thread(%arg0: memref<6xf64, 1>, %arg1: memref<6xf64, 1>) {
+  %c1 = arith.constant 1 : index
+  affine.parallel (%tz, %ty) = (0, 0) to (2, 4) {
+    %scr = memref.alloca() : memref<6xf64>
+    affine.if #set(%tz, %ty) {
+      affine.for %k = 0 to #uby(%ty) {
+        %0 = affine.load %arg0[%ty + %k * 4] : memref<6xf64, 1>
+        %1 = arith.addf %0, %0 : f64
+        affine.store %1, %scr[%ty + %k * 4] : memref<6xf64>
+      }
+    }
+    "enzymexla.barrier"(%ty, %tz, %c1) : (index, index, index) -> ()
+    affine.if affine_set<(d0) : (d0 == 0)>(%tz) {
+      %2 = affine.load %scr[%ty] : memref<6xf64>
+      %3 = affine.load %scr[%ty + 1] : memref<6xf64>
+      %4 = arith.addf %2, %3 : f64
+      affine.store %4, %arg1[%ty] : memref<6xf64, 1>
+    }
+  }
+  return
+}
+
+// FOREACH-LABEL: func.func private @foreach_thread_raised(
+// FOREACH-NOT: stablehlo.while
+// FOREACH: arith.addf %{{.*}}, %{{.*}} : tensor<6xf64>
+// FOREACH-NOT: stablehlo.while
+// FOREACH: stablehlo.dynamic_update_slice
+// FOREACH-NOT: stablehlo.while
+
+// Both axes stride: the loops coalesce inner-first into one 2-D parallel.
+#ub2 = affine_map<(d0) -> ((6 - d0 + 3) floordiv 4)>
+func.func private @nested(%arg0: memref<6x6xf64, 1>, %arg1: memref<6x6xf64, 1>) {
+  affine.parallel (%tx, %ty) = (0, 0) to (4, 4) {
+    affine.for %ky = 0 to #ub2(%ty) {
+      affine.for %kx = 0 to #ub2(%tx) {
+        %0 = affine.load %arg0[%ty + %ky * 4, %tx + %kx * 4] : memref<6x6xf64, 1>
+        %1 = arith.addf %0, %0 : f64
+        affine.store %1, %arg1[%ty + %ky * 4, %tx + %kx * 4] : memref<6x6xf64, 1>
+      }
+    }
+  }
+  return
+}
+
+// NESTED-LABEL: func.func private @nested_raised(
+// NESTED-NOT: stablehlo.while
+// NESTED: arith.addf %{{.*}}, %{{.*}} : tensor<6x6xf64>
+// NESTED-NOT: stablehlo.while
+// NESTED: stablehlo.dynamic_update_slice
+// NESTED-NOT: stablehlo.while
+
+// A loop-carried dependence (every stride accumulates into the lane's own
+// slot) is not parallel over the lane index and stays a loop.
+func.func private @carried(%arg0: memref<8xf64, 1>, %arg1: memref<4xf64, 1>) {
+  affine.parallel (%t) = (0) to (4) {
+    affine.for %j = affine_map<(d0) -> (d0)>(%t) to 8 step 4 {
+      %0 = affine.load %arg0[%j] : memref<8xf64, 1>
+      %1 = affine.load %arg1[%t] : memref<4xf64, 1>
+      %2 = arith.addf %0, %1 : f64
+      affine.store %2, %arg1[%t] : memref<4xf64, 1>
+    }
+  }
+  return
+}
+
+// CARRIED-LABEL: func.func private @carried(
+// CARRIED: affine.parallel
+// CARRIED-NEXT: affine.for
+
+// A per-lane value loaded outside the loop cannot be expressed in terms of
+// the lane index, so the loop stays.
+func.func private @lane_value(%arg0: memref<8xf64, 1>, %arg1: memref<8xf64, 1>, %arg2: memref<4xf64, 1>) {
+  affine.parallel (%t) = (0) to (4) {
+    %v = affine.load %arg2[%t] : memref<4xf64, 1>
+    affine.for %j = affine_map<(d0) -> (d0)>(%t) to 8 step 4 {
+      %0 = affine.load %arg0[%j] : memref<8xf64, 1>
+      %1 = arith.addf %0, %v : f64
+      affine.store %1, %arg1[%j] : memref<8xf64, 1>
+    }
+  }
+  return
+}
+
+// LANE-LABEL: func.func private @lane_value(
+// LANE: affine.parallel
+// LANE-NEXT: affine.load
+// LANE-NEXT: affine.for
+
+// The coalesced form's store sits behind a guard on an axis it never indexes
+// by; the write lands wherever any lane is admitted.
+func.func private @lane_guard(%arg0: memref<8xf64, 1>, %arg1: memref<8xf64, 1>) {
+  affine.parallel (%t) = (0) to (4) {
+    affine.if affine_set<(d0) : (d0 == 0)>(%t) {
+      affine.parallel (%i) = (0) to (8) {
+        %0 = affine.load %arg0[%i] : memref<8xf64, 1>
+        affine.store %0, %arg1[%i] : memref<8xf64, 1>
+      }
+    }
+  }
+  return
+}
+
+// GUARD-LABEL: func.func private @lane_guard_raised(
+// GUARD: %[[T:.+]] = stablehlo.iota dim = 0 : tensor<4xi64>
+// GUARD: %[[M:.+]] = stablehlo.compare EQ, %{{.*}}, %{{.*}} : (tensor<4xi64>, tensor<4xi64>) -> tensor<4xi1>
+// GUARD: %[[F:.+]] = stablehlo.constant dense<false> : tensor<i1>
+// GUARD: %[[ANY:.+]] = stablehlo.reduce(%[[M]] init: %[[F]]) applies stablehlo.or across dimensions = [0] : (tensor<4xi1>, tensor<i1>) -> tensor<i1>
+// GUARD: %[[MB:.+]] = stablehlo.broadcast_in_dim %[[ANY]], dims = [] : (tensor<i1>) -> tensor<8xi1>
+// GUARD: stablehlo.select %[[MB]], %{{.*}}, %{{.*}} : tensor<8xi1>, tensor<8xf64>


### PR DESCRIPTION
Part of #2968 (MFEM CUDA → xla-gpu raising).

`MFEM_FOREACH_THREAD(i, x, N)` is the CUDA grid-stride idiom: lane `t` of a block of extent `s` visits `i = t, t+s, t+2s, …` below `N`, so the lanes and the loop together cover `[0, N)` exactly once. Once raised the loop is executed whole-tensor anyway, so serializing it into a masked `stablehlo.while` (its trip count differs per lane) gains nothing over a single parallel axis of extent `N`.

Before the parallel axes are bounded/peeled, the raiser now rewrites

```
affine.parallel (t) = (0) to (s) {
  affine.for j = t + a to N + a step s { B(j) }        // constant s
  affine.for k = 0 to (N - t) ceildiv s { B(t + k*s) } // any s, incl. symbolic
}
```
into
```
affine.parallel (t) = (0) to (s) {
  affine.if t == 0 { affine.parallel (i) = (0) to (N) { B(i) } }
}
```

when

- the body depends on the lane only through the index (`t` is substituted by `i mod s` / `i - k*s`, materialized as `affine.apply`s and folded with the affine canonicalizations; the loop IV must cancel entirely),
- the iterations over `i` are independent (dependence analysis over the rewritten body, admitting the nested `affine.parallel` an inner stride loop already became), and
- every `affine.if` between the axis and the loop admits each lane below `min(s, N)` (Presburger subset test of the guard's `t`-constraints against `0 ≤ t < s, t < N`), and no enclosing loop bound in between varies with the lane.

The rewrite is built on a clone under the guard and dropped if any check fails, so nothing is touched otherwise. Inner loops go first, so the 2-D `MFEM_FOREACH_THREAD(y, …) MFEM_FOREACH_THREAD(x, …)` nests become one 2-D parallel.

This is raiser-only preprocessing rather than a general affine canonicalization: the lane-0 form would serialize real GPU codegen, and it is only sound under the raiser's lockstep execution where barriers are no-ops.

To let the lane-0 form raise, a masked `affine.store` whose mask ranges over an axis that neither its location nor its stored value depends on now `or`-reduces the mask over that axis (the store lands wherever any lane is admitted, and all admitted lanes store the same thing) instead of erroring with "masked affine.store is dependent on less dimensions than masked stored value" (slice path) or emitting an ill-formed broadcast (scatter path, which silently dropped the unaligned mask axes).

Test covers the constant-stride, normalized constant and normalized symbolic forms, the `MFEM_FOREACH_THREAD` shape (guard on the other axis, shared scratch, barrier), a 2-D nest, the `MFEM_FOREACH_THREAD(dy,y,D1D-1) MFEM_FOREACH_THREAD(qx,x,Q1D)` transpose load of a basis matrix into linearly indexed shared memory (both loops stride, guard on the z-axis, raises as gather/scatter), the any-lane masked store on its own for both store paths, and two loops that must stay (a loop-carried accumulation; a per-lane value captured from outside the loop).

Follow-up: after coalescing, a parallel axis whose only remaining uses are `== 0` guards could be dropped entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
