### PR TITLE
Rebuild an affine.if condition inside handleAffineIfOp

### DIFF
--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -1040,25 +1040,29 @@ LogicalResult handleAffineAccessOp(IslAnalysis &islAnalysis, T access) {
   return success();
 }
 
+// Simplifies the condition of `ifOp` against its domain and rebuilds its
+// constraints in the pass's canonical form, which applies even where the domain
+// is unavailable.
 LogicalResult handleAffineIfOp(IslAnalysis &islAnalysis, AffineIfOp ifOp) {
   isl_ctx *ctx = islAnalysis.getCtx();
+  IntegerSet set = ifOp.getCondition();
+  IntegerSet newSet = set;
   LLVM_DEBUG(llvm::dbgs() << "Got domain\n");
   auto [domain, cst] = ::getDomain(ctx, ifOp, true);
-  if (!domain)
+  if (domain) {
+    LLVM_DEBUG(isl_set_dump(domain));
+    LLVM_DEBUG(cst.dump());
+    auto csts = set.getConstraints();
+    AffineMap map = AffineMap::get(set.getNumDims(), set.getNumSymbols(), csts,
+                                   ifOp.getContext());
+    AffineValueMap avm(map, ifOp.getOperands(), {});
+    if (auto newMap = handleAffineValueMap(islAnalysis, avm, domain, cst))
+      newSet = IntegerSet::get(set.getNumDims(), set.getNumSymbols(),
+                               newMap->getResults(), set.getEqFlags());
+  }
+  newSet = mlir::enzyme::recreateExpr(newSet);
+  if (newSet == set)
     return failure();
-  LLVM_DEBUG(isl_set_dump(domain));
-  LLVM_DEBUG(cst.dump());
-  IntegerSet set = ifOp.getCondition();
-  auto csts = set.getConstraints();
-  AffineMap map = AffineMap::get(set.getNumDims(), set.getNumSymbols(), csts,
-                                 ifOp.getContext());
-  AffineValueMap avm(map, ifOp.getOperands(), {});
-  auto newMap = handleAffineValueMap(islAnalysis, avm, domain, cst);
-  if (!newMap)
-    return failure();
-
-  IntegerSet newSet = IntegerSet::get(set.getNumDims(), set.getNumSymbols(),
-                                      newMap->getResults(), set.getEqFlags());
   ifOp.setCondition(newSet);
   return success();
 }
@@ -1199,13 +1203,6 @@ struct SimplifyAffineExprsPass
         (void)handleAffineIfOp(ia, cop);
       else if (auto cop = dyn_cast<AffineParallelOp>(op))
         (void)pruneParallelBounds(ia, cop);
-    });
-
-    op->walk([=](AffineIfOp affineOp) {
-      auto map = affineOp.getIntegerSet();
-      auto map2 = mlir::enzyme::recreateExpr(map);
-      if (map != map2)
-        affineOp.setIntegerSet(map2);
     });
   }
 };

--- a/test/lit_tests/affine_if_recreate.mlir
+++ b/test/lit_tests/affine_if_recreate.mlir
@@ -1,0 +1,41 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(simplify-affine-exprs)" --split-input-file | FileCheck %s
+
+// An affine.if condition the domain does not decide (the symbol is unrelated
+// to the loop) is still rebuilt in canonical form: even terms leave a mod 2,
+// multiples of the divisor leave a floordiv, and sums are ordered.
+func.func @under_loop(%n: index, %m: index, %out: memref<?xf64>, %v: f64) {
+  affine.parallel (%i) = (0) to (symbol(%n)) {
+    affine.if affine_set<(d0)[s0] : ((d0 * 2 + s0 * 5 + 3) mod 2 - 1 >= 0)>(%i)[%m] {
+      memref.store %v, %out[%i] : memref<?xf64>
+    }
+    affine.if affine_set<(d0)[s0] : (s0 * 3 + d0 - 1 >= 0)>(%i)[%m] {
+      memref.store %v, %out[%i] : memref<?xf64>
+    }
+    affine.if affine_set<(d0)[s0, s1] : ((d0 + s1 * 8 + 9) floordiv 4 - s0 == 0)>(%i)[%m, %n] {
+      memref.store %v, %out[%i] : memref<?xf64>
+    }
+  }
+  return
+}
+
+// CHECK-DAG: #[[MOD:.+]] = affine_set<(d0)[s0] : ((s0 * 5 + 3) mod 2 - 1 >= 0)>
+// CHECK-DAG: #[[SUM:.+]] = affine_set<(d0)[s0] : (d0 + s0 * 3 - 1 >= 0)>
+// CHECK-DAG: #[[DIV:.+]] = affine_set<(d0)[s0, s1] : ((d0 + 1) floordiv 4 + -s0 + s1 * 2 + 2 == 0)>
+// CHECK-LABEL: func.func @under_loop(
+// CHECK: affine.if #[[MOD]](
+// CHECK: affine.if #[[SUM]](
+// CHECK: affine.if #[[DIV]](
+
+// -----
+
+// The same without any enclosing affine operation, where no domain exists.
+func.func @top(%n: index, %i: index, %out: memref<?xf64>, %v: f64) {
+  affine.if affine_set<(d0)[s0] : ((d0 * 4 + s0 + 8) floordiv 4 - 3 >= 0)>(%i)[%n] {
+    memref.store %v, %out[%i] : memref<?xf64>
+  }
+  return
+}
+
+// CHECK: #[[TOP:.+]] = affine_set<(d0)[s0] : (d0 + s0 floordiv 4 - 1 >= 0)>
+// CHECK-LABEL: func.func @top(
+// CHECK: affine.if #[[TOP]](


### PR DESCRIPTION
`simplify-affine-exprs` rebuilt every `affine.if` condition through `recreateExpr` in a second walk after `handleAffineIfOp` had simplified it against its domain; the pattern form of the handler (`SimplifyIfAffineExprs`, which `affine-cfg` runs) never got that step. This moves the rebuild to the end of `handleAffineIfOp`, applied also where no domain is available, so both callers agree, and drops the trailing walk.

`affine_if_recreate.mlir` checks the canonical forms (mod dropping even terms, floordiv keeping multiples of the divisor, ordered sums) under a loop and at top level where no domain exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
