### PR TITLE
affine-cfg: raise the sign extension of an affine condition

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2471,13 +2471,16 @@ struct MoveIfToAffine : public OpRewritePattern<scf::IfOp> {
   }
 };
 
-struct MoveExtToAffine : public OpRewritePattern<arith::ExtUIOp> {
-  using OpRewritePattern::OpRewritePattern;
+// An extension of an affine-conditional i1 becomes an affine.if yielding the
+// extended constants: 1/0 for extui, -1/0 for extsi.
+template <typename ExtOp>
+struct MoveExtToAffine : public OpRewritePattern<ExtOp> {
+  using OpRewritePattern<ExtOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(arith::ExtUIOp ifOp,
+  LogicalResult matchAndRewrite(ExtOp ifOp,
                                 PatternRewriter &rewriter) const override {
-    if (!ifOp->getParentOfType<affine::AffineForOp>() &&
-        !ifOp->getParentOfType<affine::AffineParallelOp>())
+    if (!ifOp->template getParentOfType<affine::AffineForOp>() &&
+        !ifOp->template getParentOfType<affine::AffineParallelOp>())
       return failure();
 
     if (!ifOp.getOperand().getType().isInteger(1))
@@ -2564,8 +2567,9 @@ struct MoveExtToAffine : public OpRewritePattern<arith::ExtUIOp> {
           IntegerSet::get(/*dim*/ 0, /*symbol*/ applies.size(), exprs, eqflags);
       fully2ComposeIntegerSetAndOperands(rewriter, &iset, &operands, DI, scope);
       affine::canonicalizeSetAndOperands(&iset, &operands);
+      int64_t trueValue = std::is_same_v<ExtOp, arith::ExtSIOp> ? -1 : 1;
       Value tval[1] = {arith::ConstantIntOp::create(rewriter, ifOp.getLoc(),
-                                                    ifOp.getType(), 1)};
+                                                    ifOp.getType(), trueValue)};
       Value fval[1] = {arith::ConstantIntOp::create(rewriter, ifOp.getLoc(),
                                                     ifOp.getType(), 0)};
       affine::AffineIfOp affineIfOp = affine::AffineIfOp::create(
@@ -6701,14 +6705,15 @@ void mlir::enzyme::populateAffineCFGPatterns(RewritePatternSet &rpl) {
           /* IndexCastMovement,*/ AffineFixup<affine::AffineLoadOp>,
           AffineFixup<affine::AffineStoreOp>, CanonicalizIfBounds,
           MoveStoreToAffine, MoveIfToAffine, MoveEnzymeRMWToAffine,
-          MoveRMWToAffine, MoveLoadToAffine, MoveExtToAffine,
-          MoveSIToFPToAffine, CmpExt, MoveSelectToAffine,
-          AffineIfSimplification, AffineIfSimplificationIsl, CombineAffineIfs,
-          MergeNestedAffineParallelLoops, PrepMergeNestedAffineParallelLoops,
-          MergeNestedAffineParallelIf, MergeParallelInductions, OptimizeRem,
-          CanonicalieForBounds, SinkStoreInIf, SinkStoreInAffineIf,
-          AddAddCstEnd, LiftMemrefRead, CompareVs1, AffineForReductionIter,
-          AffineForReductionSink>(context, 2);
+          MoveRMWToAffine, MoveLoadToAffine, MoveExtToAffine<arith::ExtUIOp>,
+          MoveExtToAffine<arith::ExtSIOp>, MoveSIToFPToAffine, CmpExt,
+          MoveSelectToAffine, AffineIfSimplification, AffineIfSimplificationIsl,
+          CombineAffineIfs, MergeNestedAffineParallelLoops,
+          PrepMergeNestedAffineParallelLoops, MergeNestedAffineParallelIf,
+          MergeParallelInductions, OptimizeRem, CanonicalieForBounds,
+          SinkStoreInIf, SinkStoreInAffineIf, AddAddCstEnd, LiftMemrefRead,
+          CompareVs1, AffineForReductionIter, AffineForReductionSink>(context,
+                                                                      2);
   rpl.add<FoldAffineApplyAdd, FoldAffineApplySub, FoldAffineApplyRem,
           FoldAffineApplyDiv, FoldAffineApplyMul, FoldAppliesIntoLoad>(context,
                                                                        2);

--- a/test/lit_tests/affinecfg_extsi_bool.mlir
+++ b/test/lit_tests/affinecfg_extsi_bool.mlir
@@ -1,0 +1,29 @@
+// RUN: enzymexlamlir-opt --affine-cfg --split-input-file %s | FileCheck %s
+
+// A sign extension of an affine condition is an affine.if yielding -1 or 0,
+// the way a zero extension yields 1 or 0.
+
+func.func @extsi_dim(%d: i32, %out: memref<?xi32>) {
+  %c0_i32 = arith.constant 0 : i32
+  affine.parallel (%t, %c) = (0, 0) to (8, 2) {
+    %ci = arith.index_castui %c : index to i32
+    %ne = arith.cmpi ne, %ci, %c0_i32 : i32
+    %e = arith.extsi %ne : i1 to i32
+    %v = arith.addi %d, %e : i32
+    affine.store %v, %out[%t + 8 * %c] : memref<?xi32>
+  }
+  return
+}
+
+// CHECK:       #[[SET:.+]] = affine_set<(d0) : (d0 - 1 >= 0)>
+// CHECK-LABEL: func.func @extsi_dim
+// CHECK-DAG:     %[[M1:.+]] = arith.constant -1 : i32
+// CHECK-DAG:     %[[Z:.+]] = arith.constant 0 : i32
+// CHECK:         affine.parallel (%[[T:.+]], %[[C:.+]]) = (0, 0) to (8, 2)
+// CHECK-NEXT:      %[[E:.+]] = affine.if #[[SET]](%[[C]]) -> i32 {
+// CHECK-NEXT:        affine.yield %[[M1]] : i32
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        affine.yield %[[Z]] : i32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[V:.+]] = arith.addi %arg0, %[[E]] : i32
+// CHECK-NEXT:      affine.store %[[V]], %arg1[%[[T]] + %[[C]] * 8]


### PR DESCRIPTION
`MoveExtToAffine` turned a zero extension of an affine-conditional `i1` into an `affine.if` yielding 1 or 0; a sign extension of one — how a `d + (c != k)`-style bound arrives from the frontend (LDV's `D1D + (c != 0)` with `c = threadIdx.z`) — stayed arithmetic, so the loop it bounded did not raise. The pattern is now templated over the extension op and yields -1 for `extsi`.

Test: `affinecfg_extsi_bool.mlir`. Full lit suite green locally (1288/1288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
