### PR TITLE
affine-cfg: split a loop or guard on an affine.if of constants

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -2981,6 +2981,12 @@ struct SplitOnAffineIfConstants : public OpRewritePattern<OpTy> {
     Region *scope = getLocalAffineScope(op);
     if (!scope)
       return failure();
+    // Only scalar results are yielded through the affine.if as a select;
+    // a pointer or memref result would leave one no raising can select on.
+    if (!llvm::all_of(op->getResultTypes(), [](Type type) {
+          return isa<IntegerType, IndexType, FloatType>(type);
+        }))
+      return failure();
     affine::AffineIfOp ifOp = findConditional(op, scope);
     if (!ifOp)
       return failure();

--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
 #include "src/enzyme_ad/jax/Passes/AffineUtils.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
 #include "llvm/ADT/SmallSet.h"
@@ -2899,6 +2900,131 @@ struct MoveSelectToAffine : public OpRewritePattern<arith::SelectOp> {
     }
 
     return success(changed);
+  }
+};
+
+// Whether the value derives from `ifOp` through pure region-free ops, or is
+// one of its results.
+static bool derivesFrom(Value value, affine::AffineIfOp ifOp) {
+  SmallVector<Value> todo = {value};
+  DenseSet<Value> seen;
+  while (!todo.empty()) {
+    Value cur = todo.pop_back_val();
+    if (!seen.insert(cur).second)
+      continue;
+    Operation *def = cur.getDefiningOp();
+    if (!def)
+      continue;
+    if (def == ifOp)
+      return true;
+    if (def->getNumRegions() || !isPure(def))
+      continue;
+    todo.append(def->getOperands().begin(), def->getOperands().end());
+  }
+  return false;
+}
+
+// The operands the raising of the op needs affine.
+static SmallVector<Value> raisedOperands(scf::ForOp op) {
+  return {op.getLowerBound(), op.getUpperBound(), op.getStep()};
+}
+static SmallVector<Value> raisedOperands(scf::IfOp op) {
+  return {op.getCondition()};
+}
+
+// An affine.if over dims yielding constants is a select no affine expression
+// expresses, so an scf.for or scf.if whose bounds or condition derive from it
+// cannot raise. Splitting the op on the conditional puts a copy under each
+// branch with the constant in place of the result, and each copy can.
+template <typename OpTy>
+struct SplitOnAffineIfConstants : public OpRewritePattern<OpTy> {
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  // The conditional of constants some raised operand of `op` derives from
+  // through pure region-free ops, when its result is not a symbol already.
+  static affine::AffineIfOp findConditional(OpTy op, Region *scope) {
+    SmallVector<Value> todo = raisedOperands(op);
+    DenseSet<Value> seen;
+    while (!todo.empty()) {
+      Value cur = todo.pop_back_val();
+      if (!seen.insert(cur).second)
+        continue;
+      Operation *def = cur.getDefiningOp();
+      if (!def)
+        continue;
+      if (auto ifOp = dyn_cast<affine::AffineIfOp>(def)) {
+        if (ifOp.getNumResults() == 0 || !ifOp.hasElse())
+          continue;
+        if (getLocalAffineScope(ifOp) != scope)
+          continue;
+        if (llvm::all_of(ifOp.getOperands(), [&](Value o) {
+              return isValidSymbolInt(o, /*recur*/ true, scope);
+            }))
+          continue;
+        auto isConstant = [](Value v) { return matchPattern(v, m_Constant()); };
+        if (llvm::all_of(ifOp.getThenBlock()->getTerminator()->getOperands(),
+                         isConstant) &&
+            llvm::all_of(ifOp.getElseBlock()->getTerminator()->getOperands(),
+                         isConstant))
+          return ifOp;
+        continue;
+      }
+      if (def->getNumRegions() || !isPure(def))
+        continue;
+      todo.append(def->getOperands().begin(), def->getOperands().end());
+    }
+    return nullptr;
+  }
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    Region *scope = getLocalAffineScope(op);
+    if (!scope)
+      return failure();
+    affine::AffineIfOp ifOp = findConditional(op, scope);
+    if (!ifOp)
+      return failure();
+
+    // Values from outside the op that the copies read, the derived ones among
+    // them to be recomputed under each branch.
+    SetVector<Value> external(op->operand_begin(), op->operand_end());
+    getUsedValuesDefinedAbove(op->getRegions(), external);
+
+    Location loc = op.getLoc();
+    auto split = affine::AffineIfOp::create(
+        rewriter, loc, op->getResultTypes(), ifOp.getIntegerSet(),
+        ifOp.getOperands(), /*withElseRegion=*/true);
+    for (int i = 0; i < 2; i++) {
+      Block *block = i == 0 ? split.getThenBlock() : split.getElseBlock();
+      Operation *yield =
+          (i == 0 ? ifOp.getThenBlock() : ifOp.getElseBlock())->getTerminator();
+      // The builder terminates result-less branches itself.
+      Operation *terminator = block->empty() ? nullptr : block->getTerminator();
+      if (terminator)
+        rewriter.setInsertionPoint(terminator);
+      else
+        rewriter.setInsertionPointToEnd(block);
+      IRMapping mapping;
+      for (auto [result, constant] :
+           llvm::zip(ifOp.getResults(), yield->getOperands()))
+        mapping.map(result,
+                    rewriter.clone(*constant.getDefiningOp())->getResult(0));
+      std::function<void(Value)> remap = [&](Value value) {
+        if (mapping.contains(value) || !derivesFrom(value, ifOp))
+          return;
+        Operation *def = value.getDefiningOp();
+        for (Value operand : def->getOperands())
+          remap(operand);
+        rewriter.clone(*def, mapping);
+      };
+      for (Value value : external)
+        remap(value);
+      Operation *copy = rewriter.clone(*op, mapping);
+      if (!terminator)
+        affine::AffineYieldOp::create(rewriter, loc, copy->getResults());
+    }
+    rewriter.replaceOp(op, split.getResults());
+    return success();
   }
 };
 
@@ -6695,13 +6821,14 @@ void mlir::enzyme::populateAffineCFGPatterns(RewritePatternSet &rpl) {
           MoveStoreToAffine, MoveIfToAffine, MoveEnzymeRMWToAffine,
           MoveRMWToAffine, MoveLoadToAffine, MoveExtToAffine<arith::ExtUIOp>,
           MoveExtToAffine<arith::ExtSIOp>, MoveSIToFPToAffine, CmpExt,
-          MoveSelectToAffine, AffineIfSimplification, AffineIfSimplificationIsl,
-          CombineAffineIfs, MergeNestedAffineParallelLoops,
-          PrepMergeNestedAffineParallelLoops, MergeNestedAffineParallelIf,
-          MergeParallelInductions, OptimizeRem, CanonicalieForBounds,
-          SinkStoreInIf, SinkStoreInAffineIf, AddAddCstEnd, LiftMemrefRead,
-          CompareVs1, AffineForReductionIter, AffineForReductionSink>(context,
-                                                                      2);
+          MoveSelectToAffine, SplitOnAffineIfConstants<scf::ForOp>,
+          SplitOnAffineIfConstants<scf::IfOp>, AffineIfSimplification,
+          AffineIfSimplificationIsl, CombineAffineIfs,
+          MergeNestedAffineParallelLoops, PrepMergeNestedAffineParallelLoops,
+          MergeNestedAffineParallelIf, MergeParallelInductions, OptimizeRem,
+          CanonicalieForBounds, SinkStoreInIf, SinkStoreInAffineIf,
+          AddAddCstEnd, LiftMemrefRead, CompareVs1, AffineForReductionIter,
+          AffineForReductionSink>(context, 2);
   rpl.add<FoldAffineApplyAdd, FoldAffineApplySub, FoldAffineApplyRem,
           FoldAffineApplyDiv, FoldAffineApplyMul, FoldAppliesIntoLoad>(context,
                                                                        2);

--- a/test/lit_tests/affinecfg_split_if_constants.mlir
+++ b/test/lit_tests/affinecfg_split_if_constants.mlir
@@ -91,3 +91,33 @@ func.func @symbol_keep(%d: i32, %k: index, %out: memref<?xi32>, %v: i32) {
 // CHECK: affine.if #{{.+}}()[%{{.+}}] -> i32 {
 // CHECK: affine.parallel
 // CHECK-NOT: affine.if
+
+// -----
+
+// A guard yielding a pointer stays: only scalar results select through an
+// affine.if.
+func.func @pointer_keep(%d: i32, %p: !llvm.ptr, %q: !llvm.ptr, %slot: !llvm.ptr) {
+  %c0_i32 = arith.constant 0 : i32
+  %cm1_i32 = arith.constant -1 : i32
+  affine.parallel (%t, %c) = (0, 0) to (8, 2) {
+    %e = affine.if affine_set<(d0) : (d0 - 1 >= 0)>(%c) -> i32 {
+      affine.yield %cm1_i32 : i32
+    } else {
+      affine.yield %c0_i32 : i32
+    }
+    %n = arith.addi %d, %e : i32
+    %ti = arith.index_cast %t : index to i32
+    %cmp = arith.cmpi slt, %ti, %n : i32
+    %s = scf.if %cmp -> !llvm.ptr {
+      scf.yield %p : !llvm.ptr
+    } else {
+      scf.yield %q : !llvm.ptr
+    }
+    llvm.store %s, %slot : !llvm.ptr, !llvm.ptr
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @pointer_keep
+// CHECK: scf.if %{{.+}} -> (!llvm.ptr) {
+// CHECK-NOT: affine.if

--- a/test/lit_tests/affinecfg_split_if_constants.mlir
+++ b/test/lit_tests/affinecfg_split_if_constants.mlir
@@ -1,0 +1,93 @@
+// RUN: enzymexlamlir-opt --affine-cfg --split-input-file %s | FileCheck %s
+
+// An affine.if over a dimension yielding constants is a select no affine
+// expression writes: a loop bounded by its result splits on the conditional,
+// and each copy raises with the constant in place.
+func.func @split_for(%d: i32, %out: memref<?xi32>, %v: i32) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %cm1_i32 = arith.constant -1 : i32
+  affine.parallel (%t, %c) = (0, 0) to (8, 2) {
+    %e = affine.if affine_set<(d0) : (d0 - 1 >= 0)>(%c) -> i32 {
+      affine.yield %cm1_i32 : i32
+    } else {
+      affine.yield %c0_i32 : i32
+    }
+    %ub = arith.addi %d, %e : i32
+    scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
+      %ii = arith.index_cast %i : i32 to index
+      memref.store %v, %out[%ii] : memref<?xi32>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @split_for
+// CHECK-SAME: %[[d:.+]]: i32,
+// CHECK-DAG: %[[dm1:.+]] = arith.addi %[[d]], %{{.+}} : i32
+// CHECK-DAG: %[[a:.+]] = arith.index_cast %[[dm1]]
+// CHECK-DAG: %[[b:.+]] = arith.index_cast %[[d]]
+// CHECK-NOT: scf.for
+// CHECK: affine.if #{{.+}}(%{{.+}}) {
+// CHECK-NEXT: affine.parallel (%{{.+}}) = (0) to (symbol(%[[a]]))
+// CHECK: } else {
+// CHECK-NEXT: affine.parallel (%{{.+}}) = (0) to (symbol(%[[b]]))
+
+// -----
+
+// A guard whose condition derives from the conditional splits the same way.
+func.func @split_if(%d: i32, %out: memref<?xi32>, %v: i32) {
+  %c0_i32 = arith.constant 0 : i32
+  %cm1_i32 = arith.constant -1 : i32
+  affine.parallel (%t, %c) = (0, 0) to (8, 2) {
+    %e = affine.if affine_set<(d0) : (d0 - 1 >= 0)>(%c) -> i32 {
+      affine.yield %cm1_i32 : i32
+    } else {
+      affine.yield %c0_i32 : i32
+    }
+    %n = arith.addi %d, %e : i32
+    %ti = arith.index_cast %t : index to i32
+    %q = arith.cmpi slt, %ti, %n : i32
+    scf.if %q {
+      memref.store %v, %out[%t] : memref<?xi32>
+    }
+  }
+  return
+}
+
+// CHECK-DAG: #[[S1:.+]] = affine_set<(d0)[s0] : (-d0 + s0 - 2 >= 0)>
+// CHECK-DAG: #[[S2:.+]] = affine_set<(d0)[s0] : (-d0 + s0 - 1 >= 0)>
+// CHECK-LABEL: func.func @split_if
+// CHECK-NOT: scf.if
+// CHECK-NOT: arith.cmpi
+// CHECK: affine.if #{{.+}}(%{{.+}}) {
+// CHECK-NEXT: affine.if #[[S1]](
+// CHECK: } else {
+// CHECK-NEXT: affine.if #[[S2]](
+
+// -----
+
+// A conditional over symbols is a symbol itself and needs no split.
+func.func @symbol_keep(%d: i32, %k: index, %out: memref<?xi32>, %v: i32) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %cm1_i32 = arith.constant -1 : i32
+  affine.parallel (%t) = (0) to (8) {
+    %e = affine.if affine_set<()[s0] : (s0 - 1 >= 0)>()[%k] -> i32 {
+      affine.yield %cm1_i32 : i32
+    } else {
+      affine.yield %c0_i32 : i32
+    }
+    %ub = arith.addi %d, %e : i32
+    scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
+      %ii = arith.index_cast %i : i32 to index
+      memref.store %v, %out[%ii] : memref<?xi32>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @symbol_keep
+// CHECK: affine.if #{{.+}}()[%{{.+}}] -> i32 {
+// CHECK: affine.parallel
+// CHECK-NOT: affine.if


### PR DESCRIPTION
An `affine.if` over dimensions yielding constants is a select no affine expression writes — the sign-extended `c != 0` of LDV's `D1D + (c != 0)` bound once #3090 raises it — so an `scf.for` bounded by it or an `scf.if` guarded by it never raised. `SplitOnAffineIfConstants<scf::ForOp | scf::IfOp>` puts a copy of the op under each branch of the conditional with the yielded constant in place of the result, recomputing what derives from it through pure region-free ops, and each copy raises. Only the operands the raising needs (bounds and step, or the condition) are traced; a conditional whose set operands are all symbols is a symbol itself and is left alone.

With #3090 on top, the `d + extsi(c != k)` guards from LDV (`c` a parallel IV in `[0, 2)` and `[0, 3)`) raise to nested `affine.if`s with the index folded under each branch:

```mlir
affine.parallel (%t, %c) = (0, 0) to (8, 2) {
  affine.if #set(%c) {                 // c >= 1
    affine.if #set3(%t)[%d] {          // t <= d - 2
      affine.store %cst, %out[%t + 8]
    }
  } else {
    affine.if #set2(%t)[%d] {          // t <= d - 1
      affine.store %cst, %out[%t]
    }
  }
}
```

Test: `affinecfg_split_if_constants.mlir`. Full lit suite 1289/1289 locally. Independent of #3090 (the test starts from the `affine.if`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
