### PR TITLE
Fold a bitwise-or compared against a power of two using loop bounds

### DIFF
--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -1469,16 +1469,16 @@ struct FoldMinMaxUsingLoopBounds : public OpRewritePattern<MinMaxOp> {
   }
 };
 
-// The value `cmp` has on every point of `domain`, its operands read through
-// `substitution`; fails when the domain does not decide it. Values are
+// The value `lhs pred rhs` has on every point of `domain`, the operands read
+// through `substitution`; fails when the domain does not decide it. Values are
 // mathematical integers (no wraparound); an unsigned predicate is only decided
 // when both sides are provably non-negative on the domain.
 FailureOr<bool>
-decideOnDomain(LoopDomain &domain, arith::CmpIOp cmp,
+decideOnDomain(LoopDomain &domain, arith::CmpIPredicate pred, Value lhs,
+               Value rhs,
                const DenseMap<Value, Value> *substitution = nullptr) {
-  arith::CmpIPredicate pred = cmp.getPredicate();
   FailureOr<SmallVector<isl_aff *>> affs =
-      domain.getAffs({cmp.getLhs(), cmp.getRhs()}, substitution);
+      domain.getAffs({lhs, rhs}, substitution);
   if (failed(affs))
     return failure();
   isl_aff *lhsAff = (*affs)[0], *rhsAff = (*affs)[1];
@@ -1526,7 +1526,8 @@ struct FoldCmpUsingLoopBounds : public OpRewritePattern<arith::CmpIOp> {
     LoopDomain domain(islAnalysis.getCtx(), cmp);
     if (!domain)
       return failure();
-    FailureOr<bool> decided = decideOnDomain(domain, cmp);
+    FailureOr<bool> decided =
+        decideOnDomain(domain, cmp.getPredicate(), cmp.getLhs(), cmp.getRhs());
     if (failed(decided))
       return failure();
     rewriter.replaceOpWithNewOp<arith::ConstantOp>(
@@ -1561,7 +1562,8 @@ struct FoldNeverLoopingSCFWhileCondition
     for (auto [arg, init] :
          llvm::zip(whileOp.getBeforeArguments(), whileOp.getInits()))
       initOfArg[arg] = init;
-    FailureOr<bool> decided = decideOnDomain(domain, cmp, &initOfArg);
+    FailureOr<bool> decided = decideOnDomain(
+        domain, cmp.getPredicate(), cmp.getLhs(), cmp.getRhs(), &initOfArg);
     // Holding on the first evaluation says nothing about the next.
     if (failed(decided) || *decided)
       return failure();
@@ -1570,6 +1572,74 @@ struct FoldNeverLoopingSCFWhileCondition
                                                  rewriter.getBoolAttr(false));
     rewriter.modifyOpInPlace(
         condOp, [&] { condOp.getConditionMutable().assign(falseValue); });
+    return success();
+  }
+};
+
+// (a | b) `ult` 2^k holds exactly when every operand is under 2^k, and
+// (a | b) `uge` 2^k when any operand is: bitwise-or sets a bit at or above
+// position k exactly when some operand does, whatever the bit patterns. The or
+// itself is not affine, but the loop bounds may decide an operand's own
+// comparison: an operand decided under 2^k drops out of an `ult` and one
+// decided at least 2^k drops out of a `uge`, while the opposite decision
+// settles the whole comparison.
+struct FoldOrCmpUsingLoopBounds : public OpRewritePattern<arith::CmpIOp> {
+  IslAnalysis &islAnalysis;
+  FoldOrCmpUsingLoopBounds(MLIRContext &context, IslAnalysis &islAnalysis)
+      : OpRewritePattern<arith::CmpIOp>(&context), islAnalysis(islAnalysis) {}
+
+  LogicalResult matchAndRewrite(arith::CmpIOp cmp,
+                                PatternRewriter &rewriter) const override {
+    using Pred = arith::CmpIPredicate;
+    Pred pred = cmp.getPredicate();
+    if (pred != Pred::ult && pred != Pred::uge)
+      return failure();
+    APInt rhsCst;
+    if (!matchPattern(cmp.getRhs(), m_ConstantInt(&rhsCst)) ||
+        !rhsCst.isPowerOf2() || !cmp.getLhs().getDefiningOp<arith::OrIOp>())
+      return failure();
+    LoopDomain domain(islAnalysis.getCtx(), cmp);
+    if (!domain)
+      return failure();
+    SmallVector<Value> leaves;
+    SmallVector<Value> worklist{cmp.getLhs()};
+    while (!worklist.empty()) {
+      Value value = worklist.pop_back_val();
+      if (auto orOp = value.getDefiningOp<arith::OrIOp>()) {
+        worklist.push_back(orOp.getRhs());
+        worklist.push_back(orOp.getLhs());
+      } else {
+        leaves.push_back(value);
+      }
+    }
+    // Under `ult` an operand decided true contributes nothing; under `uge` an
+    // operand decided false does.
+    bool dropsWhen = pred == Pred::ult;
+    SmallVector<Value> kept;
+    for (Value leaf : leaves) {
+      FailureOr<bool> decided =
+          decideOnDomain(domain, pred, leaf, cmp.getRhs());
+      if (failed(decided)) {
+        kept.push_back(leaf);
+        continue;
+      }
+      if (*decided != dropsWhen) {
+        rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+            cmp, rewriter.getBoolAttr(*decided));
+        return success();
+      }
+    }
+    if (kept.size() == leaves.size())
+      return failure();
+    if (kept.empty()) {
+      rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+          cmp, rewriter.getBoolAttr(dropsWhen));
+      return success();
+    }
+    Value lhs = kept.front();
+    for (Value leaf : llvm::drop_begin(kept))
+      lhs = arith::OrIOp::create(rewriter, cmp.getLoc(), lhs, leaf);
+    rewriter.replaceOpWithNewOp<arith::CmpIOp>(cmp, pred, lhs, cmp.getRhs());
     return success();
   }
 };
@@ -1640,6 +1710,7 @@ void mlir::populateAffineExprSimplificationPatterns(
     SimplifyIfAffineExprs,
     PruneParallelBounds,
     FoldCmpUsingLoopBounds,
+    FoldOrCmpUsingLoopBounds,
     FoldMinMaxUsingLoopBounds<arith::MaxSIOp>,
     FoldMinMaxUsingLoopBounds<arith::MinSIOp>,
     FoldMinMaxUsingLoopBounds<arith::MaxUIOp>,

--- a/test/lit_tests/or_cmp_pow2.mlir
+++ b/test/lit_tests/or_cmp_pow2.mlir
@@ -1,0 +1,120 @@
+// RUN: enzymexlamlir-opt --affine-cfg --split-input-file %s | FileCheck %s
+
+// A bitwise-or is under a power of two exactly when every operand is; the
+// thread id the axis bounds put under 4 drops out, leaving the other operand's
+// own comparison.
+func.func @drop(%b: i32, %out: memref<?xi1>) {
+  affine.parallel (%t) = (0) to (4) {
+    %a = arith.index_castui %t : index to i32
+    %c4 = arith.constant 4 : i32
+    %ab = arith.ori %a, %b : i32
+    %r = arith.cmpi ult, %ab, %c4 : i32
+    affine.store %r, %out[%t] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @drop(
+// CHECK-SAME:    %[[B:.+]]: i32
+// CHECK-NOT:     arith.ori
+// CHECK:         %[[R:.+]] = arith.cmpi ult, %[[B]], %{{.+}} : i32
+// CHECK-NEXT:    affine.store %[[R]],
+
+// -----
+
+// An operand the bounds put at or above the power of two settles `ult` false.
+func.func @never_under(%b: i32, %out: memref<?xi1>) {
+  affine.parallel (%t) = (4) to (8) {
+    %a = arith.index_castui %t : index to i32
+    %c4 = arith.constant 4 : i32
+    %ab = arith.ori %a, %b : i32
+    %r = arith.cmpi ult, %ab, %c4 : i32
+    affine.store %r, %out[%t] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @never_under(
+// CHECK-NOT:     arith.cmpi
+// CHECK:         %[[F:.+]] = arith.constant false
+// CHECK:         affine.store %[[F]],
+
+// -----
+
+// And reaches a power of two exactly when some operand does: an operand at or
+// above it settles `uge` true, one under it drops out.
+func.func @atleast(%b: i32, %out: memref<?xi1>, %out2: memref<?xi1>) {
+  affine.parallel (%t) = (4) to (8) {
+    %a = arith.index_castui %t : index to i32
+    %c4 = arith.constant 4 : i32
+    %ab = arith.ori %a, %b : i32
+    %r = arith.cmpi uge, %ab, %c4 : i32
+    affine.store %r, %out[%t] : memref<?xi1>
+  }
+  affine.parallel (%t) = (0) to (4) {
+    %a = arith.index_castui %t : index to i32
+    %c4 = arith.constant 4 : i32
+    %ab = arith.ori %a, %b : i32
+    %r = arith.cmpi uge, %ab, %c4 : i32
+    affine.store %r, %out2[%t] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @atleast(
+// CHECK-SAME:    %[[B:.+]]: i32
+// CHECK-NOT:     arith.ori
+// CHECK:         %[[T:.+]] = arith.constant true
+// CHECK:         affine.store %[[T]],
+// CHECK:         %[[R:.+]] = arith.cmpi uge, %[[B]], %{{.+}} : i32
+// CHECK-NEXT:    affine.store %[[R]],
+
+// -----
+
+// Every operand of an or chain decided drops it entirely.
+func.func @all(%out: memref<?xi1>) {
+  affine.parallel (%t1, %t2, %t3) = (0, 0, 0) to (4, 2, 1) {
+    %a = arith.index_castui %t1 : index to i32
+    %b = arith.index_castui %t2 : index to i32
+    %c = arith.index_castui %t3 : index to i32
+    %c4 = arith.constant 4 : i32
+    %ab = arith.ori %a, %b : i32
+    %abc = arith.ori %ab, %c : i32
+    %r = arith.cmpi ult, %abc, %c4 : i32
+    affine.store %r, %out[%t1 * 2 + %t2 + %t3] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @all(
+// CHECK-NOT:     arith.cmpi
+// CHECK:         %[[T:.+]] = arith.constant true
+// CHECK:         affine.store %[[T]],
+
+// -----
+
+// Nothing folds when no operand is decided, when the bound is not a power of
+// two, or when the comparison is signed.
+func.func @keep(%a: i32, %b: i32, %out: memref<?xi1>) {
+  affine.parallel (%t) = (0) to (4) {
+    %ti = arith.index_castui %t : index to i32
+    %c3 = arith.constant 3 : i32
+    %c4 = arith.constant 4 : i32
+    %ab = arith.ori %a, %b : i32
+    %r = arith.cmpi ult, %ab, %c4 : i32
+    %tb = arith.ori %ti, %b : i32
+    %s = arith.cmpi ult, %tb, %c3 : i32
+    %u = arith.cmpi slt, %tb, %c4 : i32
+    affine.store %r, %out[%t] : memref<?xi1>
+    affine.store %s, %out[%t] : memref<?xi1>
+    affine.store %u, %out[%t] : memref<?xi1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @keep(
+// CHECK:         %[[AB:.+]] = arith.ori %arg0, %arg1 : i32
+// CHECK:         arith.cmpi ult, %[[AB]], %{{.+}} : i32
+// CHECK:         %[[TB:.+]] = arith.ori %{{.+}}, %arg1 : i32
+// CHECK:         arith.cmpi ult, %[[TB]], %{{.+}} : i32
+// CHECK:         arith.cmpi slt, %[[TB]], %{{.+}} : i32


### PR DESCRIPTION
`(a | b) ult 2^k` holds exactly when every operand is under `2^k`, and `(a | b) uge 2^k` when any operand is: bitwise-or sets a bit at or above position `k` exactly when some operand does. The or itself is not affine, so `FoldCmpUsingLoopBounds` cannot see through it; `FoldOrCmpUsingLoopBounds` instead asks the block's `LoopDomain` about each operand's own comparison against `2^k` (`decideOnDomain` of #3093, now taking the predicate and operands so a comparison that exists only as an operand and a bound can be asked):

- under `ult`, an operand decided under `2^k` drops out of the or; one decided at or above it settles the comparison `false`;
- under `uge`, an operand decided at or above `2^k` settles it `true`; one decided under drops out.

Nothing is rewritten when no operand is decided. The remaining operands are re-or'ed and compared as before (`(tid | b) ult 4` under `tid < 4` becomes `b ult 4`, which is affine and may itself fold).

Test: `or_cmp_pow2.mlir` under `--affine-cfg`. Full lit suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
