### PR TITLE
Inline an scf.while whose condition is false

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -4001,9 +4001,39 @@ struct ForLoopApplyEnzymeAttributes
     return success();
   }
 };
+
+// An scf.while whose condition is false never enters its after region: it is
+// one execution of its before region, whose condition args are its results.
+struct InlineNeverLoopingWhile : public OpRewritePattern<WhileOp> {
+  using OpRewritePattern<WhileOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(WhileOp op,
+                                PatternRewriter &rewriter) const override {
+    scf::ConditionOp condOp = op.getConditionOp();
+    if (!matchPattern(condOp.getCondition(), m_Zero()))
+      return failure();
+    Block *before = op.getBeforeBody();
+    SmallVector<Value> results;
+    for (Value arg : condOp.getArgs()) {
+      if (auto blockArg = dyn_cast<BlockArgument>(arg);
+          blockArg && blockArg.getOwner() == before)
+        arg = op.getInits()[blockArg.getArgNumber()];
+      results.push_back(arg);
+    }
+    rewriter.eraseOp(condOp);
+    rewriter.inlineBlockBefore(before, op, op.getInits());
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
 } // namespace
 } // namespace enzyme
 } // namespace mlir
+
+void mlir::enzyme::populateInlineNeverLoopingWhilePattern(
+    RewritePatternSet &patterns) {
+  patterns.add<InlineNeverLoopingWhile>(patterns.getContext());
+}
 
 void CanonicalizeFor::runOnOperation() {
   mlir::RewritePatternSet rpl(getOperation()->getContext());
@@ -4027,7 +4057,8 @@ void CanonicalizeFor::runOnOperation() {
           // [and should fix] MoveWhileDown3,
           MoveWhileInvariantIfResult, WhileLogicalNegation, SubToAdd,
           WhileCmpOffset, RemoveUnusedCondVar, ReturnSq,
-          MoveSideEffectFreeWhile>(getOperation()->getContext());
+          MoveSideEffectFreeWhile, InlineNeverLoopingWhile>(
+      getOperation()->getContext());
   //    WhileLICM,
   GreedyRewriteConfig config;
   config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);

--- a/src/enzyme_ad/jax/Passes/Passes.h
+++ b/src/enzyme_ad/jax/Passes/Passes.h
@@ -31,6 +31,7 @@ class SliceOp;
 namespace enzyme {
 
 void populateAffineCFGPatterns(RewritePatternSet &rpl);
+void populateInlineNeverLoopingWhilePattern(RewritePatternSet &patterns);
 
 #define GEN_PASS_DECL
 #include "src/enzyme_ad/jax/Passes/Passes.h.inc"

--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -1548,4 +1548,5 @@ void mlir::populateAffineExprSimplificationPatterns(
     FoldCmpUsingLoopBounds
   >(*patterns.getContext(), islAnalysis);
   // clang-format on
+  mlir::enzyme::populateInlineNeverLoopingWhilePattern(patterns);
 }

--- a/test/lit_tests/canonicalizefor_while_false_condition.mlir
+++ b/test/lit_tests/canonicalizefor_while_false_condition.mlir
@@ -1,0 +1,50 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-scf-for --split-input-file | FileCheck %s
+// RUN: enzymexlamlir-opt %s --affine-cfg --split-input-file | FileCheck %s
+
+// A while whose condition is false runs its before region once and never its
+// after region: the condition args, as of the inits, are its results.
+func.func @once(%init: i32, %out: memref<?xf64>, %v: f64) -> (i32, i32) {
+  %false = arith.constant false
+  %c2_i32 = arith.constant 2 : i32
+  %r:2 = scf.while (%j = %init) : (i32) -> (i32, i32) {
+    %ji = arith.index_castui %j : i32 to index
+    memref.store %v, %out[%ji] : memref<?xf64>
+    %next = arith.addi %j, %c2_i32 : i32
+    scf.condition(%false) %j, %next : i32, i32
+  } do {
+  ^bb0(%k: i32, %n: i32):
+    scf.yield %n : i32
+  }
+  return %r#0, %r#1 : i32, i32
+}
+
+// CHECK-LABEL: func.func @once(
+// CHECK-SAME:    %[[INIT:.+]]: i32, %[[OUT:.+]]: memref<?xf64>, %[[V:.+]]: f64
+// CHECK-NOT:     scf.while
+// CHECK:         %[[JI:.+]] = arith.index_castui %[[INIT]] : i32 to index
+// CHECK:         {{memref|affine}}.store %[[V]], %[[OUT]][{{.*}}%[[JI]]
+// CHECK:         %[[NEXT:.+]] = arith.addi %[[INIT]], %{{.+}} : i32
+// CHECK:         return %[[INIT]], %[[NEXT]] : i32, i32
+
+// -----
+
+// A condition that is not a constant keeps the loop (canonicalize-scf-for
+// makes it a for).
+func.func @keep(%init: i32, %n: i32, %out: memref<?xf64>, %v: f64) -> i32 {
+  %c2_i32 = arith.constant 2 : i32
+  %r = scf.while (%j = %init) : (i32) -> i32 {
+    %ji = arith.index_castui %j : i32 to index
+    memref.store %v, %out[%ji] : memref<?xf64>
+    %cond = arith.cmpi slt, %j, %n : i32
+    scf.condition(%cond) %j : i32
+  } do {
+  ^bb0(%k: i32):
+    %next = arith.addi %k, %c2_i32 : i32
+    scf.yield %next : i32
+  }
+  return %r : i32
+}
+
+// CHECK-LABEL: func.func @keep(
+// CHECK:         scf.{{while|for}}
+// CHECK:         memref.store


### PR DESCRIPTION
An `scf.while` whose condition is a constant `false` never enters its after region: it is one execution of its before region, whose condition args (read at the inits) are its results. Upstream has no canonicalization for this direction — `WhileConditionTruth` only propagates a *true* condition into the after region.

`InlineNeverLoopingWhile` is defined with the other while patterns in CanonicalizeFor.cpp and applied by canonicalize-scf-for; `populateInlineNeverLoopingWhilePattern` also adds it to `populateAffineExprSimplificationPatterns`, where the fold in #3093 leaves such a while behind after deciding a rotated remainder loop's condition on its first evaluation. Split out of #3093 as discussed.

Test: `canonicalizefor_while_false_condition.mlir` under both `--canonicalize-scf-for` and `--affine-cfg`. Full lit suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
