### PR TITLE
Admit dominating symbols into loop bound domains

### DIFF
--- a/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
+++ b/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp
@@ -130,6 +130,24 @@ static LogicalResult addAffineIfOpDomain(AffineIfOp ifOp, bool isElse,
   return success();
 }
 
+// Loop bound operands that are symbols only by virtue of dominating the affine
+// scope (e.g. an index_cast defined in an scf.if above a gpu wrapper) are
+// rejected by FlatAffineValueConstraints::addBound, which only accepts
+// symbols defined at the top level of a scope. Register them as symbols of the
+// domain up front so the bound constraints can still be added.
+static void addDominatingBoundSymbols(AffineMap map, ValueRange mapOperands,
+                                      Region *scope,
+                                      FlatAffineValueConstraints *domain) {
+  SmallVector<Value> operands(mapOperands);
+  fullyComposeAffineMapAndOperands(&map, &operands);
+  map = simplifyAffineMap(map);
+  canonicalizeMapAndOperands(&map, &operands);
+  for (Value operand : operands)
+    if (!domain->containsVar(operand) && !isAffineInductionVar(operand) &&
+        !isValidSymbol(operand) && isValidSymbol(operand, scope))
+      domain->appendSymbolVar(operand);
+}
+
 static LogicalResult getIndexSetEx(ArrayRef<Operation *> ops,
                                    ArrayRef<bool> isElse,
                                    FlatAffineValueConstraints *domain,
@@ -161,14 +179,27 @@ static LogicalResult getIndexSetEx(ArrayRef<Operation *> ops,
   for (auto &&[op, complement] : llvm::zip(ops, isElse)) {
     // Add constraints from forOp's bounds.
     if (AffineForOp forOp = dyn_cast<AffineForOp>(op)) {
+      Region *scope = getAffineScope(forOp);
+      addDominatingBoundSymbols(forOp.getLowerBoundMap(),
+                                forOp.getLowerBoundOperands(), scope, domain);
+      addDominatingBoundSymbols(forOp.getUpperBoundMap(),
+                                forOp.getUpperBoundOperands(), scope, domain);
       if (failed(domain->addAffineForOpDomain(forOp)))
         return failure();
     } else if (auto ifOp = dyn_cast<AffineIfOp>(op)) {
       if (failed(addAffineIfOpDomain(ifOp, complement, domain)) && !allowFail)
         return failure();
-    } else if (auto parallelOp = dyn_cast<AffineParallelOp>(op))
+    } else if (auto parallelOp = dyn_cast<AffineParallelOp>(op)) {
+      Region *scope = getAffineScope(parallelOp);
+      addDominatingBoundSymbols(parallelOp.getLowerBoundsMap(),
+                                parallelOp.getLowerBoundsOperands(), scope,
+                                domain);
+      addDominatingBoundSymbols(parallelOp.getUpperBoundsMap(),
+                                parallelOp.getUpperBoundsOperands(), scope,
+                                domain);
       if (failed(domain->addAffineParallelOpDomain(parallelOp)))
         return failure();
+    }
   }
   return success();
 }

--- a/test/lit_tests/loop_bound_dominating_symbol.mlir
+++ b/test/lit_tests/loop_bound_dominating_symbol.mlir
@@ -1,0 +1,34 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(simplify-affine-exprs)" %s | FileCheck %s
+// RUN: enzymexlamlir-opt --affine-cfg %s | FileCheck %s
+
+// The outer parallel bound %n is a symbol of the gpu wrapper scope only by
+// dominating it, being defined inside an scf.if rather than at the top level
+// of a scope. The domain of the inner loop must still be derivable, so that
+// under t >= 0, max(t + 2, 2) folds to t + 2.
+func.func private @use(i32)
+func.func @dominating(%ni: i32, %cond: i1) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c2_i32 = arith.constant 2 : i32
+  scf.if %cond {
+    %n = arith.index_cast %ni : i32 to index
+    %w = "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c2, %c1, %c1) ({
+      affine.parallel (%b) = (0) to (symbol(%n)) {
+        affine.parallel (%t) = (0) to (2) {
+          %t2 = arith.addi %t, %c2 : index
+          %lb = arith.index_castui %t2 : index to i32
+          %m = arith.maxsi %lb, %c2_i32 : i32
+          func.call @use(%m) : (i32) -> ()
+        }
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @dominating(
+// CHECK-NOT: arith.maxsi
+// CHECK: %[[lb:.+]] = arith.index_castui
+// CHECK-NOT: arith.maxsi
+// CHECK: func.call @use(%[[lb]])


### PR DESCRIPTION
`FlatAffineValueConstraints::addBound` (via `addInductionVarOrTerminalSymbol`) accepts a bound operand as a symbol only when the region-less `affine::isValidSymbol(Value)` holds, i.e. the value is defined at the top level of an affine scope, a constant, or a pure op over such values. A value that is a symbol of the scope only by *dominating* it — MFEM's typical `%n = arith.index_cast %ni : i32 to index` inside an `scf.if` above the `enzymexla.gpu_wrapper` — fails that check, `addAffineParallelOpDomain` fails, `getDomain` returns null, and every fold that consults the loop domain (`FoldMinMaxUsingLoopBounds`, `FoldCmpUsingLoopBounds`, `UnrollDecidedFor`, …) silently declines.

This registers such operands as symbols of the domain (after the same compose/simplify/canonicalize `addBound` applies, and only when `isValidSymbol(v, scope)` holds) before adding the loop bounds, so `addInductionVarOrTerminalSymbol` finds them via `containsVar`.

Effect on the MFEM convection kernel TU (`--affine-cfg` on the pre-raise module): `scf.for` count 242 → 2, `arith.maxsi` 287 → 65 — the grid-stride remainder loops `for j = castui(t+C) to max(castui(t+C), C')+C step C` now fold to a single trip and unroll, as they already did when the bound symbol was a top-level value.

Test: `loop_bound_dominating_symbol.mlir` (the fold declined on `main` for this shape).

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
