### PR TITLE
affine-cfg: keep a pure pointer-choosing affine.if apart from an if with effects

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -3600,6 +3600,29 @@ struct CombineAffineIfs : public OpRewritePattern<affine::AffineIfOp> {
     if (!nextThen && !nextElse)
       return failure();
 
+    // An if with pure arms that yields a pointer or memref is a select
+    // between views; the access raising can only follow it while it stays
+    // one. Merging it into an if with side effects would bury the choice in
+    // arms that do work.
+    auto hasEffects = [](affine::AffineIfOp ifOp) {
+      if (llvm::any_of(ifOp.getThenBlock()->without_terminator(),
+                       [](Operation &op) { return !isPure(&op); }))
+        return true;
+      return ifOp.hasElse() &&
+             llvm::any_of(ifOp.getElseBlock()->without_terminator(),
+                          [](Operation &op) { return !isPure(&op); });
+    };
+    auto isViewSelect = [&](affine::AffineIfOp ifOp) {
+      return llvm::any_of(ifOp.getResultTypes(),
+                          [](Type type) {
+                            return isa<LLVM::LLVMPointerType, MemRefType>(type);
+                          }) &&
+             !hasEffects(ifOp);
+    };
+    if ((isViewSelect(prevIf) && hasEffects(nextIf)) ||
+        (isViewSelect(nextIf) && hasEffects(prevIf)))
+      return failure();
+
     SmallVector<Value> prevElseYielded;
     if (!prevIf.getElseRegion().empty())
       prevElseYielded =

--- a/test/lit_tests/affinecfg_combine_if_view_select.mlir
+++ b/test/lit_tests/affinecfg_combine_if_view_select.mlir
@@ -1,0 +1,72 @@
+// RUN: enzymexlamlir-opt --affine-cfg --split-input-file %s | FileCheck %s
+
+#set = affine_set<()[s0] : (s0 - 1 >= 0)>
+
+// A pure if choosing between pointers is a select between views; it is not
+// merged into the preceding if whose arms store.
+func.func @keep_view_select(%n: index, %a: !llvm.ptr, %b: !llvm.ptr, %out: memref<f64>) {
+  %cst = arith.constant 1.0 : f64
+  affine.if #set()[%n] {
+    affine.store %cst, %out[] : memref<f64>
+  }
+  %p = affine.if #set()[%n] -> !llvm.ptr {
+    affine.yield %a : !llvm.ptr
+  } else {
+    affine.yield %b : !llvm.ptr
+  }
+  llvm.store %cst, %p : f64, !llvm.ptr
+  return
+}
+
+// CHECK-LABEL: func.func @keep_view_select(
+// CHECK: affine.if #{{.+}}()[%{{.+}}] {
+// CHECK-NEXT: affine.store
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[p:.+]] = affine.if #{{.+}}()[%{{.+}}] -> !llvm.ptr {
+// CHECK: llvm.store %{{.+}}, %[[p]]
+
+// -----
+
+#set = affine_set<()[s0] : (s0 - 1 >= 0)>
+
+// A scalar choice merges into the if with effects as before.
+func.func @merge_scalar_select(%n: index, %a: f64, %b: f64, %out: memref<f64>, %out2: memref<f64>) {
+  %cst = arith.constant 1.0 : f64
+  affine.if #set()[%n] {
+    affine.store %cst, %out[] : memref<f64>
+  }
+  %v = affine.if #set()[%n] -> f64 {
+    affine.yield %a : f64
+  } else {
+    affine.yield %b : f64
+  }
+  affine.store %v, %out2[] : memref<f64>
+  return
+}
+
+// CHECK-LABEL: func.func @merge_scalar_select(
+// CHECK: affine.if
+// CHECK-NOT: affine.if
+
+// -----
+
+#set = affine_set<()[s0] : (s0 - 1 >= 0)>
+
+// Two pure pointer choices on the same condition still merge.
+func.func @merge_pure_views(%n: index, %a: !llvm.ptr, %b: !llvm.ptr, %c: !llvm.ptr, %d: !llvm.ptr) -> (!llvm.ptr, !llvm.ptr) {
+  %p = affine.if #set()[%n] -> !llvm.ptr {
+    affine.yield %a : !llvm.ptr
+  } else {
+    affine.yield %b : !llvm.ptr
+  }
+  %q = affine.if #set()[%n] -> !llvm.ptr {
+    affine.yield %c : !llvm.ptr
+  } else {
+    affine.yield %d : !llvm.ptr
+  }
+  return %p, %q : !llvm.ptr, !llvm.ptr
+}
+
+// CHECK-LABEL: func.func @merge_pure_views(
+// CHECK: affine.if
+// CHECK-NOT: affine.if


### PR DESCRIPTION
`CombineAffineIfs` merges adjacent `affine.if`s on the same set and operands, substituting the first if's results by its yields inside the second. When one of them is a pure if that only yields a pointer or memref, it is a select between views, and the access raising in `llvm-to-affine-access` (`LoadIf`, `LoadIfYield`, `StoreIfYield`) can only follow it while it stays one: those patterns require pure arms or yields defined above the if. Merged into a neighbour whose arms store or loop, the choice is yielded out of arms that do work and nothing downstream can select on it.

On MFEM this surfaced with #3094: splitting the guarded `scf.for` next to such a multiplex produced an `affine.if` on the same set,

```
affine.if #set3(%arg5) { scf.for ... }
%132:2 = affine.if #set3(%arg5) -> (!llvm.ptr, i32) { yield %83, %84 } else { yield %89, %40 }
```

`CombineAffineIfs` merged the two, `Pointer2MemrefIf` pushed the casts into the arms, and raising failed with `non pointermemref user of pointer arg in kernel: affine.yield ... : !llvm.ptr, i32` in `bilininteg_mixedvecgrad_pa`, `bilininteg_hcurl_kernels` and `bilininteg_hdiv_kernels`. With this guard all three raise again.

The pattern now declines when one side is a pure if yielding a pointer or memref and the other has effects. Scalar choices and pure pairs still merge; the lit test covers all three cases. Full `//test/lit_tests/...` passes (1297/1297).

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
