### PR TITLE
Raising: refine racy stores instead of rejecting them

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -1241,6 +1241,9 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
       }
     }
     if (refine) {
+      emitWarning(loc) << "racy store: the stored value varies along a "
+                          "parallel axis the destination does not index; "
+                          "raising lane 0's write";
       SmallVector<int64_t> starts(UTy.getRank(), 0);
       SmallVector<int64_t> limits(UTy.getShape().begin(), UTy.getShape().end());
       SmallVector<int64_t> ones(UTy.getRank(), 1);
@@ -3224,6 +3227,9 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
         }
       }
       if (refine) {
+        op->emitWarning() << "racy store: the stored value varies along a "
+                             "parallel axis the destination does not index; "
+                             "raising lane 0's write";
         auto UT = cast<RankedTensorType>(update.getType());
         SmallVector<int64_t> starts(UT.getRank(), 0);
         SmallVector<int64_t> limits(UT.getShape().begin(), UT.getShape().end());

--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -1219,8 +1219,59 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
     }
   }
 
-  // The stored value must not vary along a dimension that is absent from the
-  // store indices.
+  // A value varying along an axis the store indices do not cover is a racy
+  // write: every lane along that axis stores to the same location, and the
+  // original program does not define which lane wins. Lane 0 is a sound
+  // refinement, unless a mask varies along the axis: which lanes write at
+  // all is then data-dependent, and the store stays unraisable below.
+  {
+    SmallVector<int64_t> raceDims;
+    for (auto [updateIdx, dim] : llvm::enumerate(broadcastDims))
+      if (dim == -1)
+        raceDims.push_back((int64_t)updateIdx);
+    bool refine = !raceDims.empty();
+    if (refine && pc.mask) {
+      affine::AffineValueMap mm = maps.lookup(pc.mask);
+      for (int64_t ri : raceDims) {
+        Value riv = getIVForExpr(updateValueMap,
+                                 updateValueMap.getAffineMap().getResult(ri));
+        for (auto E : mm.getAffineMap().getResults())
+          if (getIVForExpr(mm, E) == riv)
+            refine = false;
+      }
+    }
+    if (refine) {
+      SmallVector<int64_t> starts(UTy.getRank(), 0);
+      SmallVector<int64_t> limits(UTy.getShape().begin(), UTy.getShape().end());
+      SmallVector<int64_t> ones(UTy.getRank(), 1);
+      for (int64_t ri : raceDims)
+        limits[ri] = 1;
+      Value lane0 = stablehlo::SliceOp::create(builder, loc, update, starts,
+                                               limits, ones);
+      SmallVector<int64_t> keptShape;
+      SmallVector<AffineExpr> keptExprs;
+      SmallVector<int64_t> keptBroadcastDims;
+      for (auto [updateIdx, dim] : llvm::enumerate(broadcastDims)) {
+        if (llvm::is_contained(raceDims, (int64_t)updateIdx))
+          continue;
+        keptShape.push_back(UTy.getShape()[updateIdx]);
+        keptExprs.push_back(updateValueMap.getAffineMap().getResult(updateIdx));
+        keptBroadcastDims.push_back(dim);
+      }
+      update = stablehlo::ReshapeOp::create(
+          builder, loc, RankedTensorType::get(keptShape, UTy.getElementType()),
+          lane0);
+      updateValueMap = affine::AffineValueMap(
+          AffineMap::get(updateValueMap.getAffineMap().getNumDims(),
+                         updateValueMap.getAffineMap().getNumSymbols(),
+                         keptExprs, loc.getContext()),
+          updateValueMap.getOperands());
+      updateValueMap.composeSimplifyAndCanonicalize();
+      maps[update] = updateValueMap;
+      UTy = cast<RankedTensorType>(update.getType());
+      broadcastDims.assign(keptBroadcastDims.begin(), keptBroadcastDims.end());
+    }
+  }
   if (llvm::any_of(broadcastDims, [](int64_t dim) { return dim == -1; })) {
     return nullptr;
   }
@@ -3148,6 +3199,65 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
           broadcastDims[updateIdx] = (updateShape.size() - 1);
           break;
         }
+      }
+    }
+
+    // A value varying along an axis the destination does not index is a racy
+    // write: every lane along that axis stores to the same location, and the
+    // original program does not define which lane wins. Lane 0 is a sound
+    // refinement, unless a mask varies along the axis: which lanes write at
+    // all is then data-dependent, and the store stays unraisable below.
+    {
+      SmallVector<int64_t> raceDims;
+      for (auto [updateIdx, dim] : llvm::enumerate(broadcastDims))
+        if (dim == -1)
+          raceDims.push_back((int64_t)updateIdx);
+      bool refine = !raceDims.empty();
+      if (refine && pc.mask) {
+        affine::AffineValueMap mm = maps.lookup(pc.mask);
+        for (int64_t ri : raceDims) {
+          Value riv = getIVForExpr(updateValueMap,
+                                   updateValueMap.getAffineMap().getResult(ri));
+          for (auto E : mm.getAffineMap().getResults())
+            if (getIVForExpr(mm, E) == riv)
+              refine = false;
+        }
+      }
+      if (refine) {
+        auto UT = cast<RankedTensorType>(update.getType());
+        SmallVector<int64_t> starts(UT.getRank(), 0);
+        SmallVector<int64_t> limits(UT.getShape().begin(), UT.getShape().end());
+        SmallVector<int64_t> ones(UT.getRank(), 1);
+        for (int64_t ri : raceDims)
+          limits[ri] = 1;
+        update = stablehlo::SliceOp::create(
+            builder,
+            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
+            update, starts, limits, ones);
+        SmallVector<int64_t> keptShape;
+        SmallVector<AffineExpr> keptExprs;
+        SmallVector<int64_t> keptBroadcastDims;
+        for (auto [updateIdx, dim] : llvm::enumerate(broadcastDims)) {
+          if (llvm::is_contained(raceDims, (int64_t)updateIdx))
+            continue;
+          keptShape.push_back(UT.getShape()[updateIdx]);
+          keptExprs.push_back(
+              updateValueMap.getAffineMap().getResult(updateIdx));
+          keptBroadcastDims.push_back(dim);
+        }
+        update = stablehlo::ReshapeOp::create(
+            builder,
+            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
+            RankedTensorType::get(keptShape, UT.getElementType()), update);
+        updateValueMap = affine::AffineValueMap(
+            AffineMap::get(updateValueMap.getAffineMap().getNumDims(),
+                           updateValueMap.getAffineMap().getNumSymbols(),
+                           keptExprs, op->getContext()),
+            updateValueMap.getOperands());
+        updateValueMap.composeSimplifyAndCanonicalize();
+        maps[update] = updateValueMap;
+        broadcastDims.assign(keptBroadcastDims.begin(),
+                             keptBroadcastDims.end());
       }
     }
 

--- a/test/lit_tests/raising/raise_racy_store.mlir
+++ b/test/lit_tests/raising/raise_racy_store.mlir
@@ -5,6 +5,7 @@
 func.func @racy(%out: memref<8xf64, 1>, %in: memref<?xf64, 1>) {
   affine.parallel (%e, %t) = (0, 0) to (8, 32) {
     %v = affine.load %in[%e * 32 + %t] : memref<?xf64, 1>
+    // expected-warning @below {{racy store: the stored value varies along a parallel axis the destination does not index; raising lane 0's write}}
     affine.store %v, %out[%e] : memref<8xf64, 1>
   }
   return
@@ -22,6 +23,7 @@ func.func @racy(%out: memref<8xf64, 1>, %in: memref<?xf64, 1>) {
 func.func @racy_scatter(%out: memref<16xf64, 1>, %in: memref<?xf64, 1>) {
   affine.parallel (%e, %t) = (0, 0) to (8, 32) {
     %v = affine.load %in[%e * 32 + %t] : memref<?xf64, 1>
+    // expected-warning @below {{racy store: the stored value varies along a parallel axis the destination does not index; raising lane 0's write}}
     affine.store %v, %out[%e * 2] : memref<16xf64, 1>
   }
   return

--- a/test/lit_tests/raising/raise_racy_store.mlir
+++ b/test/lit_tests/raising/raise_racy_store.mlir
@@ -1,0 +1,52 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file --verify-diagnostics | FileCheck %s
+
+// Every lane along %t stores its own value to out[%e]: the program leaves
+// the winner undefined, so lane 0's value is a sound refinement.
+func.func @racy(%out: memref<8xf64, 1>, %in: memref<?xf64, 1>) {
+  affine.parallel (%e, %t) = (0, 0) to (8, 32) {
+    %v = affine.load %in[%e * 32 + %t] : memref<?xf64, 1>
+    affine.store %v, %out[%e] : memref<8xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @racy_raised(
+// CHECK: %[[G:.+]] = "stablehlo.gather"
+// CHECK: %[[S:.+]] = stablehlo.slice %[[G]] [0:8, 0:1] : (tensor<8x32xf64>) -> tensor<8x1xf64>
+// CHECK: %[[R:.+]] = stablehlo.reshape %[[S]] : (tensor<8x1xf64>) -> tensor<8xf64>
+// CHECK: stablehlo.dynamic_update_slice %arg0, %{{.+}}, %{{.+}} : (tensor<8xf64>, tensor<8xf64>, tensor<i64>) -> tensor<8xf64>
+
+// -----
+
+// The same race through the scatter path (a strided destination).
+func.func @racy_scatter(%out: memref<16xf64, 1>, %in: memref<?xf64, 1>) {
+  affine.parallel (%e, %t) = (0, 0) to (8, 32) {
+    %v = affine.load %in[%e * 32 + %t] : memref<?xf64, 1>
+    affine.store %v, %out[%e * 2] : memref<16xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @racy_scatter_raised(
+// CHECK: %[[G:.+]] = "stablehlo.gather"
+// CHECK: %[[S:.+]] = stablehlo.slice %[[G]] [0:8, 0:1] : (tensor<8x32xf64>) -> tensor<8x1xf64>
+// CHECK: %[[R:.+]] = stablehlo.reshape %[[S]] : (tensor<8x1xf64>) -> tensor<8xf64>
+// CHECK: "stablehlo.scatter"
+
+// -----
+
+// Under a guard varying along the racing axis, which lanes write is data
+// dependent: no refinement, the store stays unraisable.
+func.func @racy_guarded(%out: memref<8xf64, 1>, %in: memref<?xf64, 1>, %qb: memref<i64, 1>) {
+  %qi = affine.load %qb[] : memref<i64, 1>
+  %q = arith.index_cast %qi : i64 to index
+  affine.parallel (%e, %t) = (0, 0) to (8, 32) {
+    affine.if affine_set<(d0)[s0] : (d0 - s0 == 0)>(%t)[%q] {
+      %v = affine.load %in[%e * 32 + %t] : memref<?xf64, 1>
+      // expected-error @below {{affine.store is dependent on less dims than stored value}}
+      affine.store %v, %out[%e] : memref<8xf64, 1>
+    }
+  }
+  return
+}
+


### PR DESCRIPTION
Carved out of #2949. Independent of the other splits (based on main).

A stored value varying along a parallel axis the destination does not index is a racy write: every lane along that axis stores to the same location and the source program does not define which lane wins. With no mask varying along that axis, lane 0 is a sound refinement: slice the axis to one and rebuild the update map from the kept axes. Both the `affine.store` dynamic_update_slice path and the scatter path apply the refinement, and each emits a warning at the refined store so the race is visible in the source. When a mask does vary along the racing axis (a one-hot guard picking the writing lane) which lanes write is data-dependent, and the store stays unraisable with the existing diagnostic.

Test: `raise_racy_store.mlir` (slice path and scatter path each expecting the warning, and the guarded case kept unraisable, via `--verify-diagnostics`). lit: 1299/1299.