### PR TITLE
Add an llvm-to-omp pass raising OpenMP runtime calls to the OpenMP dialect

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToOmp.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToOmp.cpp
@@ -1,0 +1,5422 @@
+//===- LLVMToOmp.cpp - Convert LLVM dialect OMP runtime → OMP dialect ----===//
+//
+// Converts OpenMP runtime calls (omp_* and __kmpc_*) in the LLVM dialect to
+// structured OpenMP dialect operations.  Aligned with OpenMPOps.td.
+//
+// ── Design ────────────────────────────────────────────────────────────────
+//   Phase 1 — module walk: structural conversions that cross function
+//             boundaries (fork_call→parallel, paired calls, wsloop, tasks,
+//             atomics).
+//   Phase 2 — greedy pattern rewrite: leaf replacements (barrier, flush,
+//             taskwait, taskyield, cancel, …).
+//
+// ── API notes vs OpenMPOps.td ─────────────────────────────────────────────
+//
+//  BUILDER FORMS
+//  Ops that have an explicit OpBuilder<(ins CArg<"const *Operands
+//  &">:$clauses)> use the struct-based form.  Atomic ops do NOT — they use
+//  auto-generated positional builders (arguments from !con(explicit-args,
+//  clausesArgs)):
+//
+//    AtomicReadOp  (loc, x_src, v_dst, element_type_attr, hint, memory_order)
+//    AtomicWriteOp (loc, x_dst, expr, hint, memory_order)
+//    AtomicUpdateOp(loc, x_ptr, atomic_control, hint, memory_order)
+//    AtomicCaptureOp(loc, hint, memory_order)
+//
+//  REGION / BLOCK CREATION
+//    WsloopOp    — [NoTerminator, SingleBlock]: region.front() auto-created;
+//                  never add omp.terminator inside wsloop.
+//    AtomicUpdateOp — SingleBlockImplicitTerminator<"YieldOp"> (implies
+//                  SingleBlock): block auto-created with implicit empty
+//                  YieldOp.
+//    AtomicCaptureOp— SingleBlockImplicitTerminator<"TerminatorOp"> (implies
+//                  SingleBlock): ONE block, implicit TerminatorOp at end;
+//                  contains nested atomic sub-ops (update+read, etc.).
+//    All other ops (ParallelOp, TeamsOp, SingleOp, MasterOp, CriticalOp,
+//    OrderedRegionOp, TaskgroupOp, TaskOp, LoopNestOp …) — create block
+//    explicitly.
+//
+//  ARGUMENT SEMANTICS
+//    AtomicReadOp : x = SOURCE ptr, v = DESTINATION ptr.
+//    AtomicWriteOp: x = DESTINATION ptr, expr = value to write.
+//    YieldOp with value: b.create<omp::YieldOp>(loc, ValueRange{val}).
+//
+//  NOWAIT
+//    Supported on WsloopOp (via WsloopOperands.nowait = UnitAttr) and
+//    SingleOp (via SingleOperands.nowait = UnitAttr).
+//    Detection: if a __kmpc_barrier call immediately follows the
+//    end-of-construct call in the same block, the construct is synchronising
+//    (no nowait).  If absent, set nowait = true.
+//
+// ── Assumptions ────────────────────────────────────────────────────────────
+//   A. Outlined fns follow Clang naming and are called from exactly one fork.
+//   B. Push calls precede the fork in the same block.
+//   C. Paired begin/end calls are in the same block.
+//   D. Static wsloop init/fini in the same block.
+//   E. Dynamic wsloop triple in the same block (run before loop transforms).
+//   F. GPU device modules (nvptx64/amdgcn) rejected upfront.
+//
+// ── Unsupported ────────────────────────────────────────────────────────────
+//   __kmpc_reduce: needs mem2reg + struct layout analysis → emitWarning.
+//   Task depend clauses: needs kmp_depend_info_t layout → dropped + warning.
+//   GPU __kmpc_target_init/deinit → emitError (hard reject).
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir::enzyme {
+#define GEN_PASS_DEF_LLVMTOOMP
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace mlir::enzyme
+
+#define DEBUG_TYPE "llvm-to-omp"
+
+#define SW(s, p) ((s).starts_with(p))
+
+using namespace mlir;
+using namespace mlir::LLVM;
+using namespace mlir::omp;
+
+//===----------------------------------------------------------------------===//
+// §1  Utilities
+//===----------------------------------------------------------------------===//
+namespace {
+
+static StringRef getCalleeName(LLVM::CallOp op) {
+  if (auto c = op.getCallee())
+    return *c;
+  return {};
+}
+static bool isCallTo(LLVM::CallOp op, StringRef n) {
+  return getCalleeName(op) == n;
+}
+static bool calleeStartsWith(LLVM::CallOp op, StringRef p) {
+  return SW(getCalleeName(op), p);
+}
+
+static LLVM::LLVMFuncOp resolveOutlinedFn(ModuleOp mod, LLVM::CallOp call,
+                                          unsigned idx = 2) {
+  if (call.getNumOperands() <= idx)
+    return {};
+  if (auto a = call.getOperand(idx).getDefiningOp<LLVM::AddressOfOp>())
+    return mod.lookupSymbol<LLVM::LLVMFuncOp>(a.getGlobalName());
+  return {};
+}
+
+static std::optional<int64_t> getConstInt(Value v) {
+  if (!v)
+    return {};
+  if (auto c = v.getDefiningOp<LLVM::ConstantOp>())
+    if (auto ia = dyn_cast<IntegerAttr>(c.getValue()))
+      return ia.getInt();
+  if (auto c = v.getDefiningOp<arith::ConstantIntOp>())
+    return c.value();
+  return {};
+}
+
+/// Like getConstInt but also handles `arith.constant N : index`
+/// (arith::ConstantOp whose value attribute carries an index integer).
+static std::optional<int64_t> getConstIndex(Value v) {
+  if (!v)
+    return {};
+  if (auto c = v.getDefiningOp<arith::ConstantOp>())
+    if (auto ia = dyn_cast<IntegerAttr>(c.getValue()))
+      return ia.getInt();
+  return getConstInt(v);
+}
+
+/// Forward-scan block of `after` for the first call to `callee`.
+static LLVM::CallOp findNextCallTo(Operation *after, StringRef callee) {
+  // First try same-block scan (fast path, covers simple cases).
+  bool found = false;
+  for (Operation &op : *after->getBlock()) {
+    if (!found) {
+      found = (&op == after);
+      continue;
+    }
+    if (auto c = dyn_cast<LLVM::CallOp>(&op))
+      if (getCalleeName(c) == callee)
+        return c;
+  }
+
+  // Cross-block BFS: follow successor edges.
+  // Stop at function boundaries or if we visit too many blocks.
+  SmallPtrSet<Block *, 16> visited;
+  SmallVector<Block *, 8> worklist;
+
+  // Seed with successors of after's block.
+  for (Block *succ : after->getBlock()->getSuccessors())
+    worklist.push_back(succ);
+
+  while (!worklist.empty()) {
+    Block *bb = worklist.pop_back_val();
+    if (!visited.insert(bb).second)
+      continue;
+
+    // Scan this block for the target call.
+    for (Operation &op : *bb) {
+      if (auto c = dyn_cast<LLVM::CallOp>(&op))
+        if (getCalleeName(c) == callee)
+          return c;
+    }
+
+    // Continue to successors.
+    for (Block *succ : bb->getSuccessors())
+      worklist.push_back(succ);
+  }
+  return {};
+}
+
+/// Find the matching end call for `start`, correctly handling nesting.
+/// `beginCallee` is the name of the opening call (same as start's callee).
+/// `endCallee` is the name of the closing call.
+/// Searches only within the same block as `start`.
+static LLVM::CallOp findMatchingEnd(LLVM::CallOp start, StringRef beginCallee,
+                                    StringRef endCallee) {
+  int depth = 0;
+  bool past = false;
+  for (Operation &op : *start->getBlock()) {
+    if (!past) {
+      past = (&op == start.getOperation());
+      continue;
+    }
+    auto c = dyn_cast<LLVM::CallOp>(&op);
+    if (!c)
+      continue;
+    StringRef n = getCalleeName(c);
+    if (n == beginCallee) {
+      ++depth;
+      continue;
+    }
+    if (n == endCallee) {
+      if (depth == 0)
+        return c;
+      --depth;
+    }
+  }
+  return {};
+}
+
+/// Like findMatchingEnd but matches the begin by prefix rather than
+/// exact name. Used for wsloop init/fini where the type suffix varies.
+static LLVM::CallOp findMatchingEndByPrefix(LLVM::CallOp start,
+                                            StringRef beginPrefix,
+                                            StringRef endCallee) {
+  int depth = 0;
+  bool past = false;
+  for (Operation &op : *start->getBlock()) {
+    if (!past) {
+      past = (&op == start.getOperation());
+      continue;
+    }
+    auto c = dyn_cast<LLVM::CallOp>(&op);
+    if (!c)
+      continue;
+    StringRef n = getCalleeName(c);
+    if (n.starts_with(beginPrefix)) {
+      ++depth;
+      continue;
+    }
+    if (n == endCallee) {
+      if (depth == 0)
+        return c;
+      --depth;
+    }
+  }
+  return {};
+}
+
+/// All ops strictly between begin and end in the same block.
+static int64_t gepLastConstantIndex(LLVM::GEPOp gep) {
+  int64_t slot = 0;
+  bool hasAny = false;
+  for (auto idxUnion : gep.getIndices()) {
+    hasAny = true;
+    if (idxUnion.template is<IntegerAttr>()) {
+      slot = idxUnion.template get<IntegerAttr>().getInt();
+    } else {
+      Value dynIdx = idxUnion.template get<Value>();
+      if (auto c = getConstInt(dynIdx))
+        slot = *c;
+      else
+        return -1; // genuinely dynamic index — cannot determine slot statically
+    }
+  }
+  return hasAny ? slot : 0;
+}
+
+static SmallVector<Operation *> opsBetween(Operation *begin, Operation *end) {
+  SmallVector<Operation *> r;
+  bool in = false;
+  for (Operation &op : *begin->getBlock()) {
+    if (&op == begin) {
+      in = true;
+      continue;
+    }
+    if (&op == end)
+      break;
+    if (in)
+      r.push_back(&op);
+  }
+  return r;
+}
+
+/// __kmpc_taskloop is handed the kmp_task_t lower/upper-bound fields as
+/// llvm.getelementptr at a byte offset off the kmp_task_t*, while the stores
+/// that fill those fields go through enzymexla.pointer2memref of the same base
+/// at the equivalent element index.  Recover the stored value, so the bounds
+/// become plain SSA values and the whole task-struct initialisation falls
+/// dead.  Loading through the field pointer instead would keep
+/// __kmpc_omp_task_alloc alive and place the load ahead of the getelementptr
+/// that defines its operand.
+static Value traceTaskFieldValue(Value fieldPtr, Operation *before) {
+  Value base = fieldPtr;
+  int64_t byteOff = 0;
+  if (auto gep = fieldPtr.getDefiningOp<LLVM::GEPOp>()) {
+    int64_t slot = gepLastConstantIndex(gep);
+    auto gepElemTy = dyn_cast<IntegerType>(gep.getElemType());
+    if (slot < 0 || !gepElemTy || gepElemTy.getWidth() % 8)
+      return {};
+    byteOff = slot * (gepElemTy.getWidth() / 8);
+    base = gep.getBase();
+  }
+
+  Value result;
+  Operation *latestStore = nullptr;
+  for (Operation *user : base.getUsers()) {
+    if (user->getName().getStringRef() != "enzymexla.pointer2memref")
+      continue;
+    if (user->getNumResults() != 1)
+      continue;
+    auto memTy = dyn_cast<MemRefType>(user->getResult(0).getType());
+    if (!memTy || memTy.getRank() != 1)
+      continue;
+    auto elemTy = dyn_cast<IntegerType>(memTy.getElementType());
+    if (!elemTy || elemTy.getWidth() % 8)
+      continue;
+    int64_t width = elemTy.getWidth() / 8;
+    for (Operation *su : user->getResult(0).getUsers()) {
+      auto st = dyn_cast<memref::StoreOp>(su);
+      if (!st || st.getIndices().size() != 1)
+        continue;
+      std::optional<int64_t> idx = getConstIndex(st.getIndices()[0]);
+      if (!idx || *idx * width != byteOff)
+        continue;
+      if (st->getBlock() != before->getBlock())
+        continue;
+      if (!st->isBeforeInBlock(before))
+        continue;
+      if (!latestStore || latestStore->isBeforeInBlock(st)) {
+        latestStore = st;
+        result = st.getValueToStore();
+      }
+    }
+  }
+  return result;
+}
+
+/// Erase what is left of the kmp_task_t initialisation once a taskloop has
+/// been lifted: the per-field memref stores, the pointer2memref bridges they
+/// go through, and the getelementptrs that addressed the bound fields.  Each
+/// op is skipped unless it is already use-empty, so a chain this pass did not
+/// fully account for is left standing rather than erased from under its uses.
+static void eraseTaskStructInit(LLVM::CallOp alloc) {
+  Value td = alloc.getResult();
+  SmallVector<Operation *> toErase;
+  for (Operation *u : td.getUsers()) {
+    if (u->getName().getStringRef() == "enzymexla.pointer2memref") {
+      for (Operation *su : u->getResult(0).getUsers())
+        if (isa<memref::StoreOp>(su))
+          toErase.push_back(su); // innermost first
+      toErase.push_back(u);
+    } else if (isa<LLVM::GEPOp>(u)) {
+      toErase.push_back(u);
+    }
+  }
+  for (Operation *op : toErase)
+    if (op->use_empty())
+      op->erase();
+}
+
+/// True when the loop body between `init` and `fini` holds an
+/// omp.ordered.region.  convertPaired lifts __kmpc_ordered ahead of the
+/// worksharing-loop conversions, so by the time a wsloop is built its body
+/// already carries the region — and omp.ordered.region only verifies inside a
+/// worksharing loop that declares the `ordered` clause.
+static bool bodyHasOrderedRegion(Operation *init, Operation *fini) {
+  for (Operation *op : opsBetween(init, fini)) {
+    bool found = false;
+    op->walk([&](omp::OrderedRegionOp) { found = true; });
+    if (found)
+      return true;
+  }
+  return false;
+}
+
+/// Move ops before the last op of `tgt` (the terminator).
+static void moveBeforeTerminator(SmallVectorImpl<Operation *> &ops,
+                                 Block *tgt) {
+  Operation *term = &tgt->back();
+  for (Operation *op : ops)
+    op->moveBefore(term);
+}
+
+//===----------------------------------------------------------------------===//
+// §1d  stripCasts
+//
+// Walk backwards through scalar type-conversion ops (arith and LLVM dialect)
+// to reach the underlying value.  Used by analyzeReductionCase1 so that a
+// cast chain between a load and the combining binop does not prevent matching.
+//===----------------------------------------------------------------------===//
+static Value stripCasts(Value v) {
+  while (v) {
+    Operation *def = v.getDefiningOp();
+    if (!def || def->getNumOperands() != 1 || def->getNumResults() != 1)
+      break;
+    if (isa<arith::TruncIOp, arith::ExtSIOp, arith::ExtUIOp, arith::TruncFOp,
+            arith::ExtFOp, arith::FPToSIOp, arith::SIToFPOp, arith::FPToUIOp,
+            arith::UIToFPOp, arith::IndexCastOp, arith::IndexCastUIOp,
+            LLVM::ZExtOp, LLVM::SExtOp, LLVM::TruncOp, LLVM::FPExtOp,
+            LLVM::FPTruncOp, LLVM::BitcastOp>(def))
+      v = def->getOperand(0);
+    else
+      break;
+  }
+  return v;
+}
+
+//===----------------------------------------------------------------------===//
+// §2  Nowait detection
+//
+// Clang emits __kmpc_barrier after constructs without the nowait clause.
+// If the very next call after `endOp` in the same block is a barrier,
+// the construct is synchronising (not nowait).  Otherwise → nowait.
+//===----------------------------------------------------------------------===//
+
+/// Returns true if NO implicit barrier follows `endOp` (nowait semantics).
+/// If eraseBarrier and a barrier is found, erase it (so Phase-2 BarrierPat
+/// won't double-convert it).
+static bool detectNowait(Operation *endOp, bool eraseBarrier = false) {
+  bool found = false;
+  for (Operation &op : *endOp->getBlock()) {
+    if (!found) {
+      found = (&op == endOp);
+      continue;
+    }
+    if (auto c = dyn_cast<LLVM::CallOp>(&op)) {
+      bool isB = (getCalleeName(c) == "__kmpc_barrier" ||
+                  getCalleeName(c) == "__kmpc_cancel_barrier");
+      if (isB && eraseBarrier)
+        c.erase();
+      return !isB;
+    }
+    return true; // non-call op before any barrier → nowait
+  }
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// §1c  buildPreHoistMap  (replaces hoistEscapingDeps)
+//
+// Scans the body of `loopOp` (scf::WhileOp or scf::ForOp) for operands that
+// are defined inside `erasedSet` but OUTSIDE the loop itself — typically values
+// computed in the lb<=ub scf.if preamble between init and fini.  Clones those
+// defining-op chains to just before `insertBefore` and returns a DenseMap that
+// seeds the inliner's IRMapping so the cloned body never holds erased-range
+// refs.
+//
+// Why this is correct where hoistEscapingDeps was not:
+//   hoistEscapingDeps ran AFTER cloning → raw erased-range refs already in wsOp
+//     → had to retroactively patch clones → needed block-arg resurrection maps
+//     → every new app revealed a new edge case.
+//   buildPreHoistMap runs BEFORE cloning → the IRMapping is complete when
+//     inlineWhileBodyIntoNest / inlineForBodyIntoNest execute → clone is clean
+//     → erase loop needs only dropAllUses + erase.
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Transforms/RegionUtils.h"
+
+// static IRMapping buildPreHoistMap(Operation *insertBefore,
+//                                    Operation *loopOp,
+//                                    const SmallPtrSet<Operation *, 32>
+//                                    &erasedSet) {
+//   OpBuilder b(insertBefore);
+//   llvm::DenseMap<Value, Value> lifted;
+
+//   // Canonical MLIR primitive: collects every Value used inside loopOp's
+//   // regions that is defined outside those regions.  Block args of loopOp
+//   // itself are excluded by construction — no isAncestor guard needed.
+//   llvm::SetVector<Value> captured;
+//   mlir::getUsedValuesDefinedAbove(loopOp->getRegions(), captured);
+
+//   std::function<Value(Value)> hoist = [&](Value v) -> Value {
+//     if (auto it = lifted.find(v); it != lifted.end()) return it->second;
+//     Operation *def = v.getDefiningOp();
+//     if (!def) {
+//       // Block arg defined above the loop but inside another erased op.
+//       if (Operation *ownerOp =
+//               cast<BlockArgument>(v).getOwner()->getParentOp())
+//         if (erasedSet.count(ownerOp)) {
+//           Value u = b.create<LLVM::UndefOp>(ownerOp->getLoc(), v.getType());
+//           return lifted[v] = u;
+//         }
+//       return v;
+//     }
+//     if (!erasedSet.count(def)) return v;
+//     IRMapping m;
+//     for (Value operand : def->getOperands())
+//       m.map(operand, hoist(operand));
+//     Operation *cloned = b.clone(*def, m);
+//     for (auto [orig, live] : llvm::zip(def->getResults(),
+//     cloned->getResults()))
+//       lifted[orig] = live;
+//     return lifted[v];
+//   };
+
+//   IRMapping result;
+//   for (Value cap : captured) {
+//     // Only hoist captures that come from the erased range.
+//     Operation *def = cap.getDefiningOp();
+//     bool needsHoist = def ? erasedSet.count(def) : [&] {
+//       Operation *ownerOp =
+//           cast<BlockArgument>(cap).getOwner()->getParentOp();
+//       return ownerOp && erasedSet.count(ownerOp);
+//     }();
+//     if (!needsHoist) continue;
+//     Value live = hoist(cap);
+//     if (live != cap) result.map(cap, live);
+//   }
+//   return result;
+// }
+
+//===----------------------------------------------------------------------===//
+// §1b  hoistEscapingDeps
+//
+// Problem pattern (convertStaticWs / convertDynWs):
+//   1. inlineForBodyIntoNest / inlineWhileBodyIntoNest clones a loop body
+//      into a fresh omp.loop_nest block.  Operands NOT in the IRMapping are
+//      kept as raw Value pointers — e.g. memref.loads for c[0], c[1], extent
+//      that live inside the enclosing scf.if guard (which is between init and
+//      fini and will therefore be erased).
+//   2. The bulk-erase loop then destroys those ops (via scf.if erasure),
+//      leaving dangling references in the cloned body.
+//   3. LLVM fires "operation destroyed but still has uses."
+//
+// Fix: after building wsOp/nestOp, walk wsOp for any operand whose defining
+// op is strictly inside the init..fini range (direct or nested).  For each
+// such value, clone its defining-op chain to just before wsOp (in SSA order
+// via recursive memoisation) and patch every in-wsOp use with the clone.
+//
+// KEY correctness requirement: the erasedSet must contain ONLY ops strictly
+// between init and fini (mirroring opsBetween).  Including ops BEFORE init
+// causes spurious hoisting of the loop bounds and the entire for-body
+// computation chain, which pulls the loop IV (a child-region block argument)
+// into the parent scope → dominance error.
+//===----------------------------------------------------------------------===//
+// static void hoistEscapingDeps(omp::WsloopOp wsOp,
+//                                LLVM::CallOp rangeBegin,
+//                                LLVM::CallOp rangeEnd) {
+//   // ── Step 1: erase set
+//   ──────────────────────────────────────────────────── SmallPtrSet<Operation
+//   *, 32> erasedSet;
+//   {
+//     auto between = opsBetween(rangeBegin, rangeEnd);
+//     for (Operation *op : between) {
+//       erasedSet.insert(op);
+//       op->walk([&](Operation *inner) { erasedSet.insert(inner); });
+//     }
+//   }
+//   if (erasedSet.empty()) return;
+
+//   // ── Step 1b: block-argument resurrection map
+//   ──────────────────────────────
+//   // Block arguments have no defining op; ensureLive would return them as-is,
+//   // leaving live references inside wsOp after the erasedSet ops are
+//   destroyed.
+//   //
+//   // scf.while layout:
+//   //   before-block args  → getInits() (always 1-to-1)
+//   //   after-block args   → scf.condition operands[1+]  (NOT inits!)
+//   //
+//   // The two counts can differ (e.g. HPGMG: 1 init but 2 after-block args).
+//   // Guard every index against getInits().size(); for extra after-block args
+//   // that have no corresponding init, emit an llvm.undef placeholder — those
+//   // args only appear inside the erased scf.while body so correctness is
+//   // unaffected.
+//   llvm::DenseMap<Value, Value> blockArgReplacement;
+//   for (Operation *op : erasedSet) {
+//     if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+//       auto inits = whileOp.getInits();
+
+//       // before-block: always matches inits in a well-formed scf.while,
+//       // but guard for robustness.
+//       Block &beforeBlk = whileOp.getBefore().front();
+//       for (unsigned i = 0;
+//            i < beforeBlk.getNumArguments() && i < (unsigned)inits.size();
+//            ++i)
+//         blockArgReplacement[beforeBlk.getArgument(i)] = inits[i];
+
+//       // after-block: args correspond to scf.condition operands[1+], not
+//       inits.
+//       // Their count may exceed inits.size() (the crash case in HPGMG).
+//       Block &afterBlk = whileOp.getAfter().front();
+//       OpBuilder tmpB(wsOp);
+//       for (unsigned i = 0; i < afterBlk.getNumArguments(); ++i) {
+//         Value repl;
+//         if (i < (unsigned)inits.size()) {
+//           repl = inits[i];
+//         } else {
+//           // No corresponding init — emit undef so ensureLive has something
+//           // safe to return if this arg escaped into wsOp.
+//           repl = tmpB.create<LLVM::UndefOp>(
+//               whileOp.getLoc(), afterBlk.getArgument(i).getType());
+//         }
+//         blockArgReplacement[afterBlk.getArgument(i)] = repl;
+//       }
+//     } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+//       // iter-args → corresponding init values
+//       for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i)
+//         blockArgReplacement[forOp.getRegionIterArg(i)] =
+//         forOp.getInitArgs()[i];
+//       // IV is always remapped by inlineForBodyIntoNest, so no entry needed
+//     }
+//     // scf.if has no block args in its regions — no entry needed.
+//   }
+
+//   // ── Step 2: memoised recursive lift
+//   ────────────────────────────────────── llvm::DenseMap<Value, Value> lifted;
+//   OpBuilder b(wsOp);
+
+//   std::function<Value(Value)> ensureLive = [&](Value v) -> Value {
+//     auto it = lifted.find(v);
+//     if (it != lifted.end()) return it->second;
+
+//     Operation *def = v.getDefiningOp();
+
+//     // ── Block argument ────────────────────────────────────────────────────
+//     if (!def) {
+//       // 1. Explicit replacement map (scf.while inits, scf.for iter-args).
+//       auto bIt = blockArgReplacement.find(v);
+//       if (bIt != blockArgReplacement.end()) {
+//         Value safe = ensureLive(bIt->second);
+//         lifted[v] = safe;
+//         return safe;
+//       }
+//       // 2. Block arg whose parent op is inside the erased set
+//       //    (e.g. IV of a scf.for nested inside the erased scf.if).
+//       //    Returning it as-is would leave a dangling reference after
+//       erasure. if (Block *ownerBlk = cast<BlockArgument>(v).getOwner()) {
+//         if (Operation *ownerOp = ownerBlk->getParentOp()) {
+//           if (erasedSet.count(ownerOp)) {
+//             Value undef = b.create<LLVM::UndefOp>(ownerOp->getLoc(),
+//             v.getType()); lifted[v] = undef; return undef;
+//           }
+//         }
+//       }
+//       // 3. Block arg defined outside the erased set — safe as-is.
+//       return v;
+//     }
+
+//     // ── Op result: outside erased set — safe as-is ────────────────────────
+//     if (!erasedSet.count(def)) return v;
+
+//     // ── Op result: inside erased set — clone transitively ─────────────────
+//     IRMapping m;
+//     for (Value operand : def->getOperands())
+//       m.map(operand, ensureLive(operand));
+
+//     Operation *cloned = b.clone(*def, m);
+
+//     for (auto [origR, newR] :
+//          llvm::zip(def->getResults(), cloned->getResults()))
+//       lifted[origR] = newR;
+
+//     return lifted[v];
+//   };
+
+//   // ── Step 3: patch dangling operands inside wsOp
+//   ────────────────────────── wsOp->walk([&](Operation *op) {
+//     for (unsigned i = 0, e = op->getNumOperands(); i < e; ++i) {
+//       Value v = op->getOperand(i);
+//       Operation *def = v.getDefiningOp();
+//       bool inErasedSet   = def && erasedSet.count(def);
+//       bool isErasedArg   = !def && blockArgReplacement.count(v);
+//       if (inErasedSet || isErasedArg)
+//         op->setOperand(i, ensureLive(v));
+//     }
+//   });
+// }
+
+//===----------------------------------------------------------------------===//
+// §3  Outlined-function inliner
+//
+// Drops args 0,1 (global_tid*, bound_tid*), maps rest to `caps`, clones
+// all blocks, converts llvm.return → omp.terminator.
+//===----------------------------------------------------------------------===//
+
+static LogicalResult inlineOutlinedBody(LLVM::LLVMFuncOp fn, Region &dst,
+                                        OpBuilder &b, ValueRange caps) {
+  if (fn.getBody().empty())
+    return fn.emitError("LLVMToOmp: outlined fn '")
+           << fn.getName() << "' has empty body";
+  IRMapping map;
+  Block &entry = fn.getBody().front();
+
+  // Map arg0 (global_tid*) and arg1 (bound_tid*) to undef so that
+  // cloned ops don't hold live references into the source function's
+  // block arguments after fn.erase().  These are OMP bookkeeping ptrs
+  // unused by the structured dialect; any __kmpc_barrier calls that
+  // consume the loaded gtid are handled by BarrierPat in Phase 2.
+  for (unsigned i = 0; i < 2 && i < entry.getNumArguments(); ++i) {
+    BlockArgument arg = entry.getArgument(i);
+    map.map(arg, b.create<LLVM::UndefOp>(fn.getLoc(), arg.getType()));
+  }
+
+  // Map captured args (index 2 onwards) to caller-supplied values.
+  for (unsigned i = 0, e = caps.size(); i < e; ++i) {
+    unsigned ai = i + 2;
+    if (ai < entry.getNumArguments())
+      map.map(entry.getArgument(ai), caps[i]);
+  }
+  SmallVector<Block *> dblks;
+  bool first = true;
+  for (Block &sb : fn.getBody()) {
+    Block *db;
+    if (first) {
+      db = &dst.front();
+      first = false;
+    } else {
+      db = b.createBlock(&dst);
+      for (BlockArgument a : sb.getArguments())
+        map.map(a, db->addArgument(a.getType(), a.getLoc()));
+    }
+    map.map(&sb, db);
+    dblks.push_back(db);
+  }
+  unsigned idx = 0;
+  for (Block &sb : fn.getBody()) {
+    b.setInsertionPointToEnd(dblks[idx++]);
+    for (Operation &op : sb)
+      isa<LLVM::ReturnOp>(op) ? (void)b.create<omp::TerminatorOp>(op.getLoc())
+                              : (void)b.clone(op, map);
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// §4  Schedule mapping
+//===----------------------------------------------------------------------===//
+
+static omp::ClauseScheduleKind kmpSched(int64_t s) {
+  // Mask off OpenMP 5.0 monotonic/nonmonotonic modifier bits (29, 30)
+  // before matching against base schedule constants.
+  s &= ~((int64_t)0x60000000);
+  switch (s) {
+  case 33:
+  case 34:
+    return omp::ClauseScheduleKind::Static;
+  case 35:
+    return omp::ClauseScheduleKind::Dynamic;
+  case 36:
+    return omp::ClauseScheduleKind::Guided;
+  case 38:
+    return omp::ClauseScheduleKind::Auto;
+  default:
+    return omp::ClauseScheduleKind::Static;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// §5  Atomic name parser
+//===----------------------------------------------------------------------===//
+
+struct AtomicDesc {
+  enum class Op { Unknown, Read, Write, Update, Capture };
+  enum class Bin { Unknown, Add, Sub, Mul, Div, And, Or, Xor, Shl, Shr };
+  Type elemType;
+  Op op = Op::Unknown;
+  Bin bin = Bin::Unknown;
+};
+
+static AtomicDesc parseAtomicName(StringRef name, MLIRContext *ctx) {
+  AtomicDesc d;
+  StringRef r = name.drop_front(strlen("__kmpc_atomic_"));
+  // Longest-match on type prefix (float10/16 before float1).
+  struct TE {
+    const char *p;
+    unsigned n;
+    Type (*mk)(MLIRContext *);
+  };
+  static const TE T[] = {
+      {"fixed1_", 7,
+       [](MLIRContext *c) { return (Type)IntegerType::get(c, 8); }},
+      {"fixed2_", 7,
+       [](MLIRContext *c) { return (Type)IntegerType::get(c, 16); }},
+      {"fixed4_", 7,
+       [](MLIRContext *c) { return (Type)IntegerType::get(c, 32); }},
+      {"fixed8_", 7,
+       [](MLIRContext *c) { return (Type)IntegerType::get(c, 64); }},
+      {"float4_", 7, [](MLIRContext *c) { return (Type)Float32Type::get(c); }},
+      {"float8_", 7, [](MLIRContext *c) { return (Type)Float64Type::get(c); }},
+      {"float10_", 8, [](MLIRContext *c) { return (Type)Float80Type::get(c); }},
+      {"float16_", 8,
+       [](MLIRContext *c) { return (Type)Float128Type::get(c); }},
+  };
+  for (auto &t : T) {
+    if (SW(r, t.p)) {
+      d.elemType = t.mk(ctx);
+      r = r.drop_front(t.n);
+      break;
+    }
+  }
+  if (!d.elemType)
+    return d;
+  if (r == "rd")
+    d.op = AtomicDesc::Op::Read;
+  else if (r == "wr")
+    d.op = AtomicDesc::Op::Write;
+  else if (SW(r, "capture"))
+    d.op = AtomicDesc::Op::Capture;
+  else {
+    d.op = AtomicDesc::Op::Update;
+    if (SW(r, "add"))
+      d.bin = AtomicDesc::Bin::Add;
+    else if (SW(r, "sub"))
+      d.bin = AtomicDesc::Bin::Sub;
+    else if (SW(r, "mul"))
+      d.bin = AtomicDesc::Bin::Mul;
+    else if (SW(r, "div"))
+      d.bin = AtomicDesc::Bin::Div;
+    else if (SW(r, "andb") || SW(r, "andl"))
+      d.bin = AtomicDesc::Bin::And;
+    else if (SW(r, "orb") || SW(r, "orl"))
+      d.bin = AtomicDesc::Bin::Or;
+    else if (SW(r, "xor"))
+      d.bin = AtomicDesc::Bin::Xor;
+    else if (SW(r, "shl"))
+      d.bin = AtomicDesc::Bin::Shl;
+    else if (SW(r, "shr"))
+      d.bin = AtomicDesc::Bin::Shr;
+    else
+      d.op = AtomicDesc::Op::Unknown;
+  }
+  return d;
+}
+
+static Value emitBinop(OpBuilder &b, Location loc, AtomicDesc::Bin bin,
+                       Value lhs, Value rhs) {
+  bool fp = isa<FloatType>(lhs.getType());
+
+  switch (bin) {
+  case AtomicDesc::Bin::Add:
+    return fp ? b.create<LLVM::FAddOp>(loc, lhs, rhs).getResult()
+              : b.create<LLVM::AddOp>(loc, lhs, rhs).getResult();
+
+  case AtomicDesc::Bin::Sub:
+    return fp ? b.create<LLVM::FSubOp>(loc, lhs, rhs).getResult()
+              : b.create<LLVM::SubOp>(loc, lhs, rhs).getResult();
+
+  case AtomicDesc::Bin::Mul:
+    return fp ? b.create<LLVM::FMulOp>(loc, lhs, rhs).getResult()
+              : b.create<LLVM::MulOp>(loc, lhs, rhs).getResult();
+
+  case AtomicDesc::Bin::Div:
+    return fp ? b.create<LLVM::FDivOp>(loc, lhs, rhs).getResult()
+              : b.create<LLVM::SDivOp>(loc, lhs, rhs).getResult();
+
+  case AtomicDesc::Bin::And:
+    return b.create<LLVM::AndOp>(loc, lhs, rhs).getResult();
+
+  case AtomicDesc::Bin::Or:
+    return b.create<LLVM::OrOp>(loc, lhs, rhs).getResult();
+
+  case AtomicDesc::Bin::Xor:
+    return b.create<LLVM::XOrOp>(loc, lhs, rhs).getResult();
+
+  case AtomicDesc::Bin::Shl:
+    return b.create<LLVM::ShlOp>(loc, lhs, rhs).getResult();
+
+  case AtomicDesc::Bin::Shr:
+    return b.create<LLVM::LShrOp>(loc, lhs, rhs).getResult();
+
+  default:
+    return {};
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// §6  Pending-clause accumulator  (__kmpc_push_* before fork)
+//===----------------------------------------------------------------------===//
+
+struct PendingClauses {
+  Value numThreads;
+  bool hasProcBind = false;
+  omp::ClauseProcBindKind procBind = omp::ClauseProcBindKind::Primary;
+  Value numTeams, /*, numTeamsUpper*/ threadLimit;
+};
+
+static PendingClauses collectPendingClauses(LLVM::CallOp anchor) {
+  PendingClauses pc;
+  for (Operation &op : *anchor->getBlock()) {
+    if (&op == anchor.getOperation())
+      break;
+    auto call = dyn_cast<LLVM::CallOp>(&op);
+    if (!call)
+      continue;
+    StringRef n = getCalleeName(call);
+    if (n == "__kmpc_push_num_threads" && call.getNumOperands() >= 3)
+      pc.numThreads = call.getOperand(2);
+    else if (n == "__kmpc_push_proc_bind" && call.getNumOperands() >= 3) {
+      pc.hasProcBind = true;
+      if (auto v = getConstInt(call.getOperand(2))) {
+        switch (*v) {
+        case 1:
+          pc.procBind = omp::ClauseProcBindKind::Primary;
+          break;
+        case 2:
+          pc.procBind = omp::ClauseProcBindKind::Close;
+          break;
+        case 3:
+          pc.procBind = omp::ClauseProcBindKind::Spread;
+          break;
+        }
+      }
+    } else if (n == "__kmpc_push_num_teams" && call.getNumOperands() >= 4) {
+      pc.numTeams = call.getOperand(2);
+      pc.threadLimit = call.getOperand(3);
+    }
+  }
+  return pc; // no erase vector, no erase loop
+}
+
+//===----------------------------------------------------------------------===//
+// §7  AtomicUpdateOp region helper
+//
+// td: traits = [SingleBlockImplicitTerminator<"YieldOp">]
+//       → region auto-created with ONE block + empty YieldOp at end.
+//     arguments include explicit $x and $atomic_control (OptionalAttr).
+//     The block arg = current value of *x (element type) must be added.
+//     The implicit empty YieldOp must be replaced with one yielding the result.
+//
+// YieldOp with a value: b.create<omp::YieldOp>(loc, ValueRange{result})
+//   (the explicit no-arg builder is just a convenience; ODS also generates
+//    the variadic-operand form used here)
+//===----------------------------------------------------------------------===//
+
+static LogicalResult buildAtomicUpdateRegion(OpBuilder &b, Location loc,
+                                             omp::AtomicUpdateOp updOp,
+                                             Type elemTy, AtomicDesc::Bin bin,
+                                             Value rhs) {
+  // SingleBlockImplicitTerminator<"YieldOp"> → block already exists.
+  Block *blk = &updOp.getRegion().front();
+  BlockArgument xCurr = blk->addArgument(elemTy, loc); // current value of *x
+  b.setInsertionPoint(blk->getTerminator()); // before implicit YieldOp
+  Value result = emitBinop(b, loc, bin, xCurr, rhs);
+  if (!result)
+    return failure();
+  blk->getTerminator()->erase(); // remove implicit empty YieldOp
+  b.setInsertionPointToEnd(blk);
+  // YieldOp with value:  assemblyFormat = "('(' $results^ ':' type($results)
+  // ')')?"
+  b.create<omp::YieldOp>(loc, ValueRange{result});
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// §8  Pass definition
+//===----------------------------------------------------------------------===//
+namespace mlir::enzyme {
+namespace {
+
+struct LLVMToOMPPass : ::mlir::enzyme::impl::LLVMToOMPBase<LLVMToOMPPass> {
+  using ::mlir::enzyme::impl::LLVMToOMPBase<LLVMToOMPPass>::LLVMToOMPBase;
+
+  void runOnOperation() override;
+
+private:
+  void convertTeams(ModuleOp);
+  void convertParallel(ModuleOp);
+  void convertPaired(ModuleOp);
+  void convertStaticWs(ModuleOp);
+  void convertDynWs(ModuleOp);
+  void convertTasks(ModuleOp);
+  void convertTaskloop(ModuleOp);
+  void convertAtomics(ModuleOp);
+  void convertReductions(ModuleOp);
+  void applyLeafPatterns(ModuleOp);
+};
+//===----------------------------------------------------------------------===//
+// §9  __kmpc_fork_teams → omp.teams
+//
+// td: TeamsOp — explicit builder OpBuilder<(ins CArg<"const TeamsOperands &">)>
+//     No SingleBlock → create entry block explicitly.
+//===----------------------------------------------------------------------===//
+/// Count how many times each outlined function appears as operand `fnIdx`
+/// of a fork call in `calls`.  Used to defer fn.erase() until the last
+/// fork call that references the function has been converted.
+static llvm::DenseMap<LLVM::LLVMFuncOp, unsigned>
+countOutlinedFnUses(ModuleOp mod, ArrayRef<LLVM::CallOp> calls,
+                    unsigned fnIdx = 2) {
+  llvm::DenseMap<LLVM::LLVMFuncOp, unsigned> counts;
+  for (LLVM::CallOp call : calls)
+    if (auto fn = resolveOutlinedFn(mod, call, fnIdx))
+      counts[fn]++;
+  return counts;
+}
+
+void LLVMToOMPPass::convertTeams(ModuleOp mod) {
+  SmallVector<LLVM::CallOp> calls;
+  mod.walk([&](LLVM::CallOp c) {
+    if (isCallTo(c, "__kmpc_fork_teams"))
+      calls.push_back(c);
+  });
+  if (calls.empty())
+    return;
+  // Outlined functions appear outer-first in the module body (Clang emission
+  // order). Reversing gives innermost-first so that when the outer body is
+  // cloned, the inner fork_call has already been replaced by omp.parallel.
+  std::reverse(calls.begin(), calls.end());
+
+  auto fnCounts = countOutlinedFnUses(mod, calls, /*fnIdx=*/2);
+
+  for (LLVM::CallOp call : calls) {
+    PendingClauses pc = collectPendingClauses(call);
+    LLVM::LLVMFuncOp fn = resolveOutlinedFn(mod, call);
+    if (!fn) {
+      call.emitWarning("LLVMToOmp: cannot resolve outlined fn for "
+                       "__kmpc_fork_teams — left as llvm.call");
+      continue;
+    }
+    SmallVector<Value> caps;
+    for (unsigned i = 3; i < call.getNumOperands(); ++i)
+      caps.push_back(call.getOperand(i));
+    OpBuilder b(call);
+    Location loc = call.getLoc();
+
+    omp::TeamsOperands tOprs;
+    tOprs.ifExpr = Value{};
+    // __kmpc_push_num_teams carries the single count of `num_teams(N)`, which
+    // is the league's upper bound.  omp.teams only accepts a lower bound
+    // alongside an upper one, so leaving numTeamsLower unset is required here.
+    if (pc.numTeams)
+      tOprs.numTeamsUpperVars = ValueRange(pc.numTeams);
+    if (pc.threadLimit)
+      tOprs.threadLimitVars = ValueRange(pc.threadLimit);
+    else
+      tOprs.threadLimitVars = ValueRange{};
+    tOprs.allocateVars = ValueRange{};
+    tOprs.allocatorVars = ValueRange{};
+    tOprs.privateVars = ValueRange{};
+
+    auto teamsOp = b.create<omp::TeamsOp>(loc, tOprs);
+    b.createBlock(&teamsOp.getRegion());
+    b.setInsertionPointToStart(&teamsOp.getRegion().front());
+    if (failed(inlineOutlinedBody(fn, teamsOp.getRegion(), b, caps))) {
+      teamsOp.erase();
+      call.emitError("LLVMToOmp: inlining fork_teams failed");
+      signalPassFailure();
+      return;
+    }
+    call.erase();
+    // Erase fn only after its last fork_teams call has been converted.
+    if (fn && --fnCounts[fn] == 0 && SymbolTable::symbolKnownUseEmpty(fn, mod))
+      fn.erase(); // added symbolKnownUser for call sites that are not
+                  // parallelized, I could imagine not erasing the fn should
+                  // also work
+    LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] fork_teams → omp.teams\n");
+  }
+}
+
+/// Simplify all __kmpc_* calls in `fn` for single-threaded (serialized)
+/// execution.  Called for outlined functions preserved on the serialized
+/// (__kmpc_serialized_parallel) path after their fork_call sites are gone.
+static void serializeOutlinedFn(LLVM::LLVMFuncOp fn) {
+  MLIRContext *ctx = fn.getContext();
+  OpBuilder b(ctx);
+
+  SmallVector<LLVM::CallOp> toProcess;
+  fn.walk([&](LLVM::CallOp c) { toProcess.push_back(c); });
+
+  for (LLVM::CallOp c : toProcess) {
+    if (!c->getBlock())
+      continue;
+    StringRef n = getCalleeName(c);
+    b.setInsertionPoint(c);
+    Location loc = c.getLoc();
+
+    // ── reduce: always takes case-1 (direct update), no lock needed ──────
+    if (n == "__kmpc_reduce_nowait" || n == "__kmpc_reduce") {
+      if (!c.getResults().empty()) {
+        Value one = b.create<LLVM::ConstantOp>(loc, b.getI32Type(),
+                                               b.getI32IntegerAttr(1));
+        c.getResult().replaceAllUsesWith(one);
+      }
+      c.erase();
+      continue;
+    }
+    if (n == "__kmpc_end_reduce_nowait" || n == "__kmpc_end_reduce") {
+      c.erase();
+      continue;
+    }
+
+    // ── static wsloop: lb/ub/stride already stored, init is a no-op ──────
+    if (n.starts_with("__kmpc_for_static_init_") ||
+        n == "__kmpc_for_static_fini") {
+      c.erase();
+      continue;
+    }
+
+    // ── dynamic dispatch init / fini ─────────────────────────────────────
+    if (n.starts_with("__kmpc_dispatch_init_") ||
+        n.starts_with("__kmpc_dispatch_fini_") ||
+        n == "__kmpc_dispatch_deinit") {
+      c.erase();
+      continue;
+    }
+
+    // ── dispatch_next ─────────────────────────────────────────────────────
+    // There are TWO dispatch_next call sites per dispatch loop:
+    //
+    //   (A) INITIAL gate check — immediately after dispatch_init, OUTSIDE
+    //       the scf.while dispatch loop.  The surrounding scf.if checks
+    //       "dispatch_next != 0" to decide whether to enter the loop at all.
+    //       Replace with 1 so the body executes (= there is work to do).
+    //
+    //   (B) CONTINUATION check — inside the scf.while's before-block,
+    //       feeds scf.condition.  Replace with 0 so the loop terminates
+    //       after one pass (single-thread serialised execution of the full
+    //       lb..ub range).  Without this the condition folds to
+    //       scf.condition(true) and the while becomes an infinite loop.
+    if (n.starts_with("__kmpc_dispatch_next_")) {
+      if (!c.getResults().empty()) {
+        bool isInsideWhile = false;
+        for (Operation *p = c->getParentOp(); p; p = p->getParentOp())
+          if (isa<scf::WhileOp>(p)) {
+            isInsideWhile = true;
+            break;
+          }
+        int replacement = isInsideWhile ? 0 : 1;
+        Value repl = b.create<LLVM::ConstantOp>(
+            loc, b.getI32Type(), b.getI32IntegerAttr(replacement));
+        c.getResult().replaceAllUsesWith(repl);
+      }
+      c.erase();
+      continue;
+    }
+
+    // ── barrier: no-op with one thread ───────────────────────────────────
+    if (n == "__kmpc_barrier" || n == "__kmpc_cancel_barrier") {
+      c.erase();
+      continue;
+    }
+
+    // ── single: only thread always executes the single block ─────────────
+    if (n == "__kmpc_single") {
+      if (!c.getResults().empty()) {
+        Value one = b.create<LLVM::ConstantOp>(loc, b.getI32Type(),
+                                               b.getI32IntegerAttr(1));
+        c.getResult().replaceAllUsesWith(one);
+      }
+      c.erase();
+      continue;
+    }
+    if (n == "__kmpc_end_single") {
+      c.erase();
+      continue;
+    }
+
+    // ── gtid: thread 0 in serialized context ─────────────────────────────
+    if (n == "__kmpc_global_thread_num") {
+      if (!c.getResults().empty()) {
+        Value zero = b.create<LLVM::ConstantOp>(loc, b.getI32Type(),
+                                                b.getI32IntegerAttr(0));
+        c.getResult().replaceAllUsesWith(zero);
+      }
+      c.erase();
+      continue;
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// §10  __kmpc_fork_call / __kmpc_parallel_51 → omp.parallel
+//
+// td: ParallelOp — explicit builder OpBuilder<(ins CArg<"const ParallelOperands
+// &">)>
+//     No SingleBlock → create entry block explicitly.
+//===----------------------------------------------------------------------===//
+void LLVMToOMPPass::convertParallel(ModuleOp mod) {
+  SmallVector<LLVM::CallOp> calls;
+  mod.walk([&](LLVM::CallOp c) {
+    if (isCallTo(c, "__kmpc_fork_call") || isCallTo(c, "__kmpc_parallel_51"))
+      calls.push_back(c);
+  });
+  if (calls.empty())
+    return;
+
+  // Outlined functions appear outer-first in the module body (Clang emission
+  // order). Reversing gives innermost-first so that when the outer body is
+  // cloned, the inner fork_call has already been replaced by omp.parallel.
+  std::reverse(calls.begin(), calls.end());
+
+  // Pre-count how many times each outlined function is referenced so we can
+  // defer erasure until the very last fork_call for that function is done.
+  llvm::DenseMap<LLVM::LLVMFuncOp, unsigned> fnCounts;
+  for (LLVM::CallOp call : calls) {
+    bool is51 = isCallTo(call, "__kmpc_parallel_51");
+    unsigned idx = is51 ? 5 : 2;
+    if (auto fn = resolveOutlinedFn(mod, call, idx))
+      fnCounts[fn]++;
+  }
+
+  for (LLVM::CallOp call : calls) {
+    if (!call->getBlock()) {
+      llvm::errs() << "[DEBUG] skipping erased fork_call\n";
+      continue;
+    }
+    PendingClauses pc = collectPendingClauses(call);
+    bool is51 = isCallTo(call, "__kmpc_parallel_51");
+    unsigned fnIdx = is51 ? 5 : 2;
+    if (is51 && call.getNumOperands() > 3)
+      pc.numThreads = call.getOperand(3);
+
+    LLVM::LLVMFuncOp fn = resolveOutlinedFn(mod, call, fnIdx);
+    if (!fn) {
+      call.emitWarning("LLVMToOmp: cannot resolve outlined fn for "
+                       "fork_call — left as llvm.call");
+      // NOTE: no exit(-2) here — just skip and continue.
+      continue;
+    }
+    SmallVector<Value> caps;
+    for (unsigned i = fnIdx + 1; i < call.getNumOperands(); ++i)
+      caps.push_back(call.getOperand(i));
+    OpBuilder b(call);
+    Location loc = call.getLoc();
+    MLIRContext *ctx = mod.getContext();
+
+    omp::ClauseProcBindKindAttr procBindKind;
+    if (pc.hasProcBind)
+      procBindKind = omp::ClauseProcBindKindAttr::get(ctx, pc.procBind);
+
+    omp::ParallelOperands ops;
+    ops.ifExpr = Value{};
+    if (pc.numThreads)
+      ops.numThreadsVars = ValueRange(pc.numThreads);
+    else
+      ops.numThreadsVars = ValueRange{};
+    ops.procBindKind = procBindKind;
+    ops.privateVars = ValueRange{};
+    ops.allocateVars = ValueRange{};
+    ops.allocatorVars = ValueRange{};
+    ops.reductionVars = ValueRange{};
+
+    auto parallelOp = b.create<omp::ParallelOp>(loc, ops);
+    b.createBlock(&parallelOp.getRegion());
+    b.setInsertionPointToStart(&parallelOp.getRegion().front());
+    if (failed(inlineOutlinedBody(fn, parallelOp.getRegion(), b, caps))) {
+      parallelOp.erase();
+      call.emitError("LLVMToOmp: inlining parallel outlined fn failed");
+      signalPassFailure();
+      return;
+    }
+
+    call.erase();
+    // Erase the outlined function only once all its fork_call sites are gone.
+    if (--fnCounts[fn] == 0 &&
+        SymbolTable::symbolKnownUseEmpty(
+            fn, mod)) // added symbolKnownUser for call sites that are not
+                      // parallelized, I could imagine not erasing the fn should
+                      // also work
+      fn.erase();
+    LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] fork_call → omp.parallel\n");
+  }
+
+  // Simplify __kmpc_* calls in outlined functions that survived on the
+  // serialized path (SymbolTable::symbolKnownUseEmpty returned false above).
+  for (auto &[fn, count] : fnCounts) {
+    if (count != 0)
+      continue; // fn was erased — nothing to do
+    if (!fn || fn->getBlock() == nullptr)
+      continue;
+    // fn still exists → it has remaining direct-call uses (serialized path)
+    if (!SymbolTable::symbolKnownUseEmpty(fn, mod))
+      serializeOutlinedFn(fn);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// §11  Paired begin/end structural calls
+//
+//   single    / end_single    → omp.single   (OpenMP_NowaitClause ✓)
+//   master    / end_master    → omp.master   (no clause builder)
+//   critical  / end_critical  → omp.critical (OptionalAttr<FlatSymbolRefAttr>)
+//   ordered   / end_ordered   → omp.ordered.region
+//   (OpenMP_ParallelizationLevelClause) taskgroup / end_taskgroup →
+//   omp.taskgroup (OpenMP_TaskReductionClause) sections                  → warn
+//   + leave
+//
+// None of these have SingleBlock → create blocks explicitly.
+//===----------------------------------------------------------------------===//
+
+void LLVMToOMPPass::convertPaired(ModuleOp mod) {
+
+  // ---- shared helper for scf.if-guarded constructs (single, master) ----
+  //
+  // Both __kmpc_single and __kmpc_master return an i32 that gates the body:
+  //   %r  = llvm.call @__kmpc_BEGIN(...)
+  //   %ne = arith.cmpi ne, %r, 0
+  //   scf.if %ne {
+  //     <body>
+  //     llvm.call @__kmpc_END(...)
+  //   }
+  //   [optional __kmpc_barrier → no nowait]
+  //
+  auto convertIfGuarded = [&](StringRef beginCallee, StringRef endCallee,
+                              auto makeOmpOp) {
+    SmallVector<LLVM::CallOp> starts;
+    mod.walk([&](LLVM::CallOp c) {
+      if (isCallTo(c, beginCallee))
+        starts.push_back(c);
+    });
+    for (LLVM::CallOp start : starts) {
+      OpBuilder b(start);
+      Location loc = start.getLoc();
+
+      // Replace the i32 guard result so cmpi users don't dangle after erase.
+      if (!start.getResults().empty()) {
+        Value one = b.create<LLVM::ConstantOp>(loc, b.getI32Type(),
+                                               b.getI32IntegerAttr(1));
+        start.getResult().replaceAllUsesWith(one);
+      }
+
+      // Find the scf.if in the same block whose then-region holds endCallee.
+      scf::IfOp ifOp;
+      bool pastStart = false;
+      for (Operation &op : *start->getBlock()) {
+        if (&op == start.getOperation()) {
+          pastStart = true;
+          continue;
+        }
+        if (!pastStart)
+          continue;
+        auto sif = dyn_cast<scf::IfOp>(&op);
+        if (!sif)
+          continue;
+        bool hasEnd = false;
+        sif.getThenRegion().walk([&](LLVM::CallOp c) {
+          if (isCallTo(c, endCallee))
+            hasEnd = true;
+        });
+        if (hasEnd) {
+          ifOp = sif;
+          break;
+        }
+      }
+      if (!ifOp) {
+        start.emitError("LLVMToOmp: '")
+            << beginCallee << "' without matching '" << endCallee << "'";
+        signalPassFailure();
+        return;
+      }
+
+      // Create the omp op just before the scf.if.
+      b.setInsertionPoint(ifOp);
+      Operation *ompOp = makeOmpOp(b, loc, ifOp);
+      Block *body = b.createBlock(&ompOp->getRegion(0));
+      b.setInsertionPointToStart(body);
+      b.create<omp::TerminatorOp>(loc);
+
+      // Move body ops (everything before endCallee in the then-block).
+      LLVM::CallOp endCall;
+      ifOp.getThenRegion().walk([&](LLVM::CallOp c) {
+        if (isCallTo(c, endCallee))
+          endCall = c;
+      });
+      SmallVector<Operation *> toMove;
+      for (Operation &op : ifOp.getThenRegion().front()) {
+        if (&op == endCall.getOperation() || isa<scf::YieldOp>(&op))
+          break;
+        toMove.push_back(&op);
+      }
+      moveBeforeTerminator(toMove, body);
+
+      endCall.erase();
+      start.erase();
+      ifOp.erase();
+    }
+  };
+
+  // ---- single ----
+  // td: SingleOp has clauses=[..., OpenMP_NowaitClause, ...]
+  //     Builder: OpBuilder<(ins CArg<"const SingleOperands &">:$clauses)>
+  //     SingleOperands.nowait = UnitAttr (from OpenMP_NowaitClause)
+  convertIfGuarded(
+      "__kmpc_single", "__kmpc_end_single",
+      [&](OpBuilder &b, Location loc, scf::IfOp ifOp) -> Operation * {
+        // Barrier after the scf.if signals no-nowait.
+        bool nw = detectNowait(ifOp, /*eraseBarrier=*/false);
+        omp::SingleOperands sOps;
+        if (nw)
+          sOps.nowait = b.getUnitAttr();
+        LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] single → omp.single"
+                                << (nw ? " nowait" : "") << "\n");
+        return b.create<omp::SingleOp>(loc, sOps).getOperation();
+      });
+
+  // ---- master ----
+  // td: MasterOp — no clause builder, `$region attr-dict`. No explicit args.
+  convertIfGuarded("__kmpc_master", "__kmpc_end_master",
+                   [&](OpBuilder &b, Location loc, scf::IfOp) -> Operation * {
+                     LLVM_DEBUG(llvm::dbgs()
+                                << "[LLVMToOmp] master → omp.master\n");
+                     return b.create<omp::MasterOp>(loc).getOperation();
+                   });
+
+  // ---- masked ----
+  // td: MaskedOp — clauses=[OpenMP_FilterClause]
+  //     Builder: OpBuilder<(ins CArg<"const MaskedOperands &">:$clauses)>
+  //     MaskedOperands.filteredThreadId = Value (optional i32 filter thread ID)
+  //     __kmpc_masked(ident, gtid, filter) → i32 guard, same scf.if pattern as
+  //     master/single.  filter=0 is tid==master; filter>0 targets that specific
+  //     tid.
+  {
+    SmallVector<LLVM::CallOp> starts;
+    mod.walk([&](LLVM::CallOp c) {
+      if (isCallTo(c, "__kmpc_masked"))
+        starts.push_back(c);
+    });
+    for (LLVM::CallOp start : starts) {
+      OpBuilder b(start);
+      Location loc = start.getLoc();
+
+      // filter value = arg 2 of __kmpc_masked(ident, gtid, filter)
+      Value filterVal =
+          start.getNumOperands() > 2 ? start.getOperand(2) : Value{};
+
+      // Replace guard result with constant 1 so cmpi users don't dangle after
+      // erase.
+      if (!start.getResults().empty()) {
+        Value one = b.create<LLVM::ConstantOp>(loc, b.getI32Type(),
+                                               b.getI32IntegerAttr(1));
+        start.getResult().replaceAllUsesWith(one);
+      }
+
+      // Find the scf.if in the same block whose then-region holds
+      // __kmpc_end_masked.
+      scf::IfOp ifOp;
+      bool pastStart = false;
+      for (Operation &op : *start->getBlock()) {
+        if (&op == start.getOperation()) {
+          pastStart = true;
+          continue;
+        }
+        if (!pastStart)
+          continue;
+        auto sif = dyn_cast<scf::IfOp>(&op);
+        if (!sif)
+          continue;
+        bool hasEnd = false;
+        sif.getThenRegion().walk([&](LLVM::CallOp c) {
+          if (isCallTo(c, "__kmpc_end_masked"))
+            hasEnd = true;
+        });
+        if (hasEnd) {
+          ifOp = sif;
+          break;
+        }
+      }
+      if (!ifOp) {
+        start.emitError("LLVMToOmp: '__kmpc_masked' without matching "
+                        "'__kmpc_end_masked'");
+        signalPassFailure();
+        return;
+      }
+
+      // Build omp.masked before the scf.if.
+      b.setInsertionPoint(ifOp);
+      omp::MaskedOperands mOps;
+      if (filterVal)
+        mOps.filteredThreadId = filterVal;
+      auto maskedOp = b.create<omp::MaskedOp>(loc, mOps);
+      Block *body = b.createBlock(&maskedOp.getRegion());
+      b.setInsertionPointToStart(body);
+      b.create<omp::TerminatorOp>(loc);
+
+      // Move body ops (everything before __kmpc_end_masked in the then-block).
+      LLVM::CallOp endCall;
+      ifOp.getThenRegion().walk([&](LLVM::CallOp c) {
+        if (isCallTo(c, "__kmpc_end_masked"))
+          endCall = c;
+      });
+      SmallVector<Operation *> toMove;
+      for (Operation &op : ifOp.getThenRegion().front()) {
+        if (&op == endCall.getOperation() || isa<scf::YieldOp>(&op))
+          break;
+        toMove.push_back(&op);
+      }
+      moveBeforeTerminator(toMove, body);
+
+      endCall.erase();
+      start.erase();
+      ifOp.erase();
+      LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] masked → omp.masked"
+                              << (filterVal ? " (filter)" : "") << "\n");
+    }
+  }
+
+  // ---- critical / critical_with_hint ----
+  // td: CriticalOp — arguments = (ins OptionalAttr<FlatSymbolRefAttr>:$name)
+  //     assemblyFormat = [("(" $name^ ")")? $region attr-dict]
+  {
+    SmallVector<LLVM::CallOp> starts;
+    mod.walk([&](LLVM::CallOp c) {
+      if (isCallTo(c, "__kmpc_critical") ||
+          isCallTo(c, "__kmpc_critical_with_hint"))
+        starts.push_back(c);
+    });
+    for (LLVM::CallOp start : starts) {
+      LLVM::CallOp end =
+          findMatchingEnd(start, "__kmpc_critical", "__kmpc_end_critical");
+      if (!end) {
+        start.emitError("LLVMToOmp: __kmpc_critical without matching end");
+        signalPassFailure();
+        return;
+      }
+      OpBuilder b(start);
+      Location loc = start.getLoc();
+      // name = FlatSymbolRefAttr{} means unnamed (anonymous critical).
+      // Could derive from the kmp_critical_name* global; left unnamed here.
+      auto critOp = b.create<omp::CriticalOp>(loc, FlatSymbolRefAttr{});
+      Block *body = b.createBlock(&critOp.getRegion());
+      b.setInsertionPointToStart(body);
+      b.create<omp::TerminatorOp>(loc);
+      auto ops = opsBetween(start, end);
+      moveBeforeTerminator(ops, body);
+      start.erase();
+      end.erase();
+      LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] critical → omp.critical\n");
+    }
+  }
+
+  // ---- ordered ----
+  // td: OrderedRegionOp — clauses=[OpenMP_ParallelizationLevelClause]
+  //     Builder: OpBuilder<(ins CArg<"const OrderedRegionOperands
+  //     &">:$clauses)> parallelized = UnitAttr when simd.  __kmpc_ordered is
+  //     always non-simd.
+  {
+    SmallVector<LLVM::CallOp> starts;
+    mod.walk([&](LLVM::CallOp c) {
+      if (isCallTo(c, "__kmpc_ordered"))
+        starts.push_back(c);
+    });
+    for (LLVM::CallOp start : starts) {
+      LLVM::CallOp end =
+          findMatchingEnd(start, "__kmpc_ordered", "__kmpc_end_ordered");
+      if (!end) {
+        start.emitError("LLVMToOmp: __kmpc_ordered without matching end");
+        signalPassFailure();
+        return;
+      }
+      OpBuilder b(start);
+      Location loc = start.getLoc();
+      omp::OrderedRegionOperands ordOps; // parallelized not set → non-simd
+      auto ordOp = b.create<omp::OrderedRegionOp>(loc, ordOps);
+      Block *body = b.createBlock(&ordOp.getRegion());
+      b.setInsertionPointToStart(body);
+      b.create<omp::TerminatorOp>(loc);
+      auto ops = opsBetween(start, end);
+      moveBeforeTerminator(ops, body);
+      start.erase();
+      end.erase();
+      LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] ordered → omp.ordered.region\n");
+    }
+  }
+
+  // ---- taskgroup ----
+  // td: TaskgroupOp — clauses=[OpenMP_AllocateClause,
+  // OpenMP_TaskReductionClause]
+  //     Builder: OpBuilder<(ins CArg<"const TaskgroupOperands &">:$clauses)>
+  //     Assembly: custom<TaskReductionRegion>($region, $task_reduction_vars,
+  //               type($task_reduction_vars), $task_reduction_byref,
+  //               $task_reduction_syms)
+  //     NOTE: fields are task_reduction_vars/byref/syms — NOT reduction_vars.
+  {
+    SmallVector<LLVM::CallOp> starts;
+    mod.walk([&](LLVM::CallOp c) {
+      if (isCallTo(c, "__kmpc_taskgroup"))
+        starts.push_back(c);
+    });
+    for (LLVM::CallOp start : starts) {
+      LLVM::CallOp end =
+          findMatchingEnd(start, "__kmpc_taskgroup", "__kmpc_end_taskgroup");
+      if (!end) {
+        start.emitWarning("LLVMToOmp: __kmpc_taskgroup without matching end"
+                          " — left as llvm.call");
+        continue;
+      }
+      OpBuilder b(start);
+      Location loc = start.getLoc();
+      omp::TaskgroupOperands tgOps; // task_reduction_* all empty
+      auto tgOp = b.create<omp::TaskgroupOp>(loc, tgOps);
+      Block *body = b.createBlock(&tgOp.getRegion());
+      b.setInsertionPointToStart(body);
+      b.create<omp::TerminatorOp>(loc);
+      auto ops = opsBetween(start, end);
+      moveBeforeTerminator(ops, body);
+      start.erase();
+      end.erase();
+      LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] taskgroup → omp.taskgroup\n");
+    }
+  }
+
+  // ---- sections ----
+  // Full recovery needs CFG analysis of the switch dispatch pattern.
+  // Warn and leave as-is.
+  mod.walk([&](LLVM::CallOp c) {
+    if (isCallTo(c, "__kmpc_sections_init") ||
+        isCallTo(c, "__kmpc_next_section"))
+      c.emitWarning(
+          "LLVMToOmp: sections not yet converted — left as llvm.call");
+  });
+}
+
+//===----------------------------------------------------------------------===//
+// §12  Static work-sharing loop  (__kmpc_for_static_init_* / _fini)
+//
+// td: WsloopOp traits = [..., NoTerminator, ..., SingleBlock]
+//       → region.front() already exists after build(); NEVER add
+//       omp.terminator.
+//     WsloopOp clauses include OpenMP_NowaitClause and OpenMP_ScheduleClause.
+//     WsloopOperands.nowait = UnitAttr (OpenMP_NowaitClause)
+//     WsloopOperands.schedule = ClauseScheduleKindAttr (OpenMP_ScheduleClause)
+//
+// td: LoopNestOp traits = [RecursiveMemoryEffects, SameVariadicOperandSize]
+//       → no SingleBlock; create block explicitly and add IV block arg.
+//     LoopNestOperands.loopLowerBounds/loopUpperBounds/loopSteps
+//       come from OpenMP_LoopRelatedClause.
+//     IVs = region.getArguments() (entry block args).
+//     Terminated by omp.yield.
+//
+// Nowait detection: is there a __kmpc_barrier immediately after fini?
+//===----------------------------------------------------------------------===//
+
+// //===----------------------------------------------------------------------===//
+// Helper 1: trace pre-init stored value through pointer2memref + memref.store
+//
+// Clang stores lb/ub/stride into the alloca ptrs BEFORE the init call:
+//   pointer2memref(ptr) → memref.store val, [0]
+// We need `val` (the original full-range bound), not a load from ptr.
+//===----------------------------------------------------------------------===//
+
+static Value traceLastStoredValue(Value ptr, Operation *before) {
+  Value result;
+  Operation *latestStore = nullptr;
+  for (Operation *user : ptr.getUsers()) {
+    // Must be the pointer2memref bridge
+    if (user->getName().getStringRef() != "enzymexla.pointer2memref")
+      continue;
+    if (user->getNumResults() != 1)
+      continue;
+    Value p2m = user->getResult(0);
+    for (Operation *su : p2m.getUsers()) {
+      auto st = dyn_cast<memref::StoreOp>(su);
+      if (!st)
+        continue;
+      // Must be in the same block as `before` and precede it
+      if (st->getBlock() != before->getBlock())
+        continue;
+      if (!st->isBeforeInBlock(before))
+        continue;
+      // Keep the most recent store (handles re-stores)
+      if (!latestStore || latestStore->isBeforeInBlock(st)) {
+        latestStore = st;
+        result = st.getValueToStore();
+      }
+    }
+  }
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// Helper 2: locate the scf.while between init and fini
+//
+// Clang nests it inside an "lb <= ub" scf.if guard:
+//   init
+//   [ub-clamp ops]
+//   scf.if (lb <= ub) {
+//     scf.while (%i = lb_val) { body; condition } do { yield }
+//   }
+//   fini
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+// Helper 3: find first scf.for between init and fini (possibly in scf.if)
+// Used for the sections lowering where Clang emits scf.for instead of
+// scf.while.
+//===----------------------------------------------------------------------===//
+
+// Return the first scf::WhileOp or scf::ForOp encountered in a preorder walk
+// of the ops strictly between `init` and `fini` in their shared block.
+// Preorder guarantees we get the OUTERMOST (top-down first) loop, not the
+// deepest one that MLIR's default post-order walk() would return.
+
+template <typename LoopTy>
+static LoopTy findLoopBetween(Operation *init, Operation *fini) {
+  bool inRange = false;
+  for (Operation &top : *init->getBlock()) {
+    if (&top == init) {
+      inRange = true;
+      continue;
+    }
+    if (&top == fini)
+      break;
+    if (!inRange)
+      continue;
+
+    LoopTy found;
+    // Walk this top-level between-op in preorder; stop at the first match.
+    top.walk<WalkOrder::PreOrder>([&](Operation *inner) -> WalkResult {
+      if (found)
+        return WalkResult::interrupt();
+      if (auto lp = dyn_cast<LoopTy>(inner)) {
+        found = lp;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (found)
+      return found;
+  }
+  return {};
+}
+
+static scf::WhileOp findWhileOpBetween(Operation *init, Operation *fini) {
+  return findLoopBetween<scf::WhileOp>(init, fini);
+}
+
+static scf::ForOp findForOpBetween(Operation *init, Operation *fini) {
+  // Only reached when no scf.while exists between init/fini.
+  return findLoopBetween<scf::ForOp>(init, fini);
+}
+//===----------------------------------------------------------------------===//
+// Helper 4: clone only the per-iteration work from the while's before-block
+//           into nestBlk, remapping the while IV → (possibly extended) nestIV.
+//
+// Clang's before-block mixes body work and loop-control in one block:
+//
+//   %28 = muli %iv, %iv           ← BODY
+//   %29 = gep arr_ptr[%iv]        ← BODY
+//   %30 = trunci %28              ← BODY  (feeds memref.store)
+//   memref.store %30, p2m(%29)[0] ← BODY
+//   %32 = addi %iv, 1             ← CONTROL (step)
+//   %33 = trunci %32              ← CONTROL (for comparison)
+//   %34 = cmpi ne, %ub1, %33      ← CONTROL (condition)
+//   scf.condition(%34) %32        ← CONTROL (terminator)
+//
+// Strategy: backward-reachability from scf.condition marks control ops;
+//           everything else is body and gets cloned.
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Helper 4 (revised): clone the scf.while body into nestBlk.
+// seedMap  — pre-hoisted values for erased-range operands captured from outside
+//            the while.  Populated by buildPreHoistMap before the call so the
+//            clone is self-contained and holds no erased-range references.
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// §1c  liftClauseValue
+//
+// Move v's defining op (recursively) out of the erased range to just before
+// `insertBefore`, so the new wsOp/loop_nest can safely consume v.  Uses MOVE
+// (not clone) — that way every existing user, including users still inside the
+// erased range, keeps working until that range is erased.
+//
+// Returns false if v depends transitively on something we cannot move:
+//   - a block argument whose owning op is in erasedSet
+//   - an op with regions (can't safely relocate)
+// On false, the caller must skip the whole conversion.
+//===----------------------------------------------------------------------===//
+static bool liftClauseValue(Value v, Operation *insertBefore,
+                            const SmallPtrSet<Operation *, 32> &erasedSet) {
+  if (!v)
+    return true;
+  Operation *def = v.getDefiningOp();
+  if (!def) {
+    // Block argument.  Safe iff its owning op is outside the erased range.
+    auto ba = cast<BlockArgument>(v);
+    if (Operation *p = ba.getOwner()->getParentOp())
+      if (erasedSet.count(p))
+        return false;
+    return true;
+  }
+  if (!erasedSet.count(def))
+    return true; // already safe
+  if (def->getNumRegions() > 0)
+    return false; // can't move region ops
+  for (Value operand : def->getOperands())
+    if (!liftClauseValue(operand, insertBefore, erasedSet))
+      return false;
+  def->moveBefore(insertBefore);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Helper 5  moveForBodyIntoNest  (replaces inlineForBodyIntoNest)
+//
+// Move (not clone) the body ops of scf.for into nestBlk before the yield, then
+// retarget forIV uses that landed in the nest via region-scoped RAUW.
+//===----------------------------------------------------------------------===//
+static void moveForBodyIntoNest(OpBuilder &b, Location loc, Block *nestBlk,
+                                scf::ForOp forOp, BlockArgument nestIV) {
+  Value forIV = forOp.getInductionVar();
+  Block *bodyBlk = forOp.getBody();
+  Operation *yieldOp = nestBlk->getTerminator();
+
+  // ── Phase 1: IV cast + iter-arg loads at top of nestBlk ───────────────
+  b.setInsertionPointToStart(nestBlk);
+  Value mappedIV = nestIV;
+  if (forIV.getType() != nestIV.getType()) {
+    mappedIV =
+        isa<IndexType>(forIV.getType())
+            ? b.create<arith::IndexCastUIOp>(loc, forIV.getType(), nestIV)
+                  .getResult()
+            : b.create<arith::ExtSIOp>(loc, forIV.getType(), nestIV)
+                  .getResult();
+  }
+
+  // For each iter-arg, find the backing alloca via the init-value's
+  // memref.load → pointer2memref pattern (same as moveWhileBodyIntoNest
+  // accumulator handling).  Emit llvm.load at the top of nestBlk; fall
+  // back to llvm.undef when no alloca is detectable.
+  struct IterArgInfo {
+    BlockArgument arg;
+    Value alloca;    // null → no backing alloca found
+    Value loadedVal; // result of llvm.load or llvm.undef
+  };
+  SmallVector<IterArgInfo> iterArgInfos;
+  for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
+    BlockArgument iterArg = forOp.getRegionIterArg(i);
+    Value initVal = i < (unsigned)forOp.getInitArgs().size()
+                        ? forOp.getInitArgs()[i]
+                        : Value{};
+    Value iterAlloca;
+    if (initVal)
+      if (auto ld = initVal.getDefiningOp<memref::LoadOp>())
+        if (auto *p2m = ld.getMemRef().getDefiningOp())
+          if (p2m->getName().getStringRef() == "enzymexla.pointer2memref" &&
+              p2m->getNumOperands() == 1)
+            iterAlloca = p2m->getOperand(0);
+    Value loaded =
+        iterAlloca
+            ? b.create<LLVM::LoadOp>(loc, iterArg.getType(), iterAlloca)
+                  .getResult()
+            : b.create<LLVM::UndefOp>(loc, iterArg.getType()).getResult();
+    iterArgInfos.push_back({iterArg, iterAlloca, loaded});
+  }
+
+  // ── Phase 2: Move body ops (minus terminator) before the yield ─────────
+  SmallVector<Operation *> toMove;
+  for (Operation &op : bodyBlk->without_terminator())
+    toMove.push_back(&op);
+  for (Operation *op : toMove)
+    op->moveBefore(yieldOp);
+
+  // ── Phase 3: Region-scoped RAUW of forIV and all iter-args ─────────────
+  Region *nestRegion = nestBlk->getParent();
+  auto inNest = [&](OpOperand &u) {
+    return nestRegion->isAncestor(u.getOwner()->getParentRegion());
+  };
+  forIV.replaceUsesWithIf(mappedIV, inNest);
+  for (auto &info : iterArgInfos)
+    info.arg.replaceUsesWithIf(info.loadedVal, inNest);
+
+  // ── Phase 4: Iter-arg writebacks before the omp.yield ──────────────────
+  // The body commonly already stores to the backing alloca (Clang's reduction
+  // pattern), so this store may be redundant but is always harmless.
+  // For the pass-through case (scf.yield(%iter_arg)), substitute loadedVal.
+  auto forYield = cast<scf::YieldOp>(bodyBlk->getTerminator());
+  b.setInsertionPoint(yieldOp);
+  for (unsigned i = 0; i < iterArgInfos.size(); ++i) {
+    auto &info = iterArgInfos[i];
+    if (!info.alloca)
+      continue;
+    Value yieldedVal =
+        i < forYield.getNumOperands() ? forYield.getOperand(i) : Value{};
+    if (!yieldedVal)
+      continue;
+    // Pass-through: scf.yield(%iter_arg) — substitute the loaded value.
+    if (yieldedVal == info.arg)
+      yieldedVal = info.loadedVal;
+    Operation *defOp = yieldedVal.getDefiningOp();
+    bool safe = !defOp || nestRegion->isAncestor(defOp->getParentRegion());
+    if (!safe)
+      continue;
+    b.create<LLVM::StoreOp>(loc, yieldedVal, info.alloca);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Helper 4  moveWhileBodyIntoNest  (replaces inlineWhileBodyIntoNest)
+//
+// Move (not clone) the per-iteration work from scf.while.before into nestBlk,
+// then retarget block-arg uses via region-scoped RAUW.  Accumulator handling:
+//   - locate backing alloca via inits[i] = memref.load(p2m(alloca))[0] pattern
+//   - emit  %loaded = llvm.load %alloca  at the top of nest body
+//   - emit  llvm.store %newAcc, %alloca  before the yield
+//
+// Classification:
+//   reachWriteback = backward-reachable from scf.condition operands [1..N]
+//                    (these MUST be moved so writebacks can reference them)
+//   controlOnly    = backward-reachable from scf.condition operand 0 (bool)
+//                    AND not in reachWriteback (these stay; erased with while)
+//   body           = everything else in beforeBlk (moved)
+//===----------------------------------------------------------------------===//
+static void moveWhileBodyIntoNest(OpBuilder &b, Location loc, Block *nestBlk,
+                                  scf::WhileOp whileOp, BlockArgument nestIV) {
+  Block *beforeBlk = &whileOp.getBefore().front();
+
+  // ── Dispatch-while guard ───────────────────────────────────────────────
+  // Clang's dispatch scf.while carries no SSA block args — loop state
+  // lives in alloca'd lb/ub/stride/lastiter pointers.  All per-iteration
+  // work sits in the BEFORE-BLOCK, guarded by:
+  //
+  //   scf.if (lb <= ub) {            ← lbUbGuard
+  //     scf.for %i = lb to ub+1 { … }   ← simple element-level work
+  //     — OR —
+  //     scf.while (%i=lb, %acc=…) { … } ← reduction accumulator
+  //   }
+  //   %next = dispatch_next(…)       ← loop-continuation check
+  //   scf.condition(%next != 0)
+  //
+  // The after-block is always just scf.yield.
+  if (beforeBlk->getNumArguments() == 0) {
+    // ── Find the lb<=ub guard ──────────────────────────────────────────
+    scf::IfOp lbUbGuard;
+    for (Operation &op : beforeBlk->without_terminator())
+      if (auto sif = dyn_cast<scf::IfOp>(&op)) {
+        lbUbGuard = sif;
+        break;
+      }
+
+    if (lbUbGuard) {
+      // ── Identify the inner loop kind ──────────────────────────────────
+      scf::ForOp innerFor;
+      scf::WhileOp innerWhile;
+      for (Operation &op : lbUbGuard.getThenRegion().front()) {
+        if (!innerFor && !innerWhile) {
+          if (auto f = dyn_cast<scf::ForOp>(&op))
+            innerFor = f;
+          else if (auto w = dyn_cast<scf::WhileOp>(&op))
+            innerWhile = w;
+        }
+      }
+
+      if (innerFor) {
+        // ── Simple element-level scf.for (e.g. process_chunk calls) ──────
+        // forIV is remapped to nestIV; body ops are moved into nestBlk.
+        moveForBodyIntoNest(b, loc, nestBlk, innerFor, nestIV);
+
+      } else if (innerWhile) {
+        // ── Reduction accumulator scf.while ──────────────────────────────
+        // The inner while carries (iv, acc, …) as SSA block args.
+        // Strategy:
+        //   1. Move preamble ops (lb_i64 cast, local_sum load, …) that
+        //      precede innerWhile in the then-block into nestBlk so the
+        //      inner while's inits are in scope.
+        //   2. Recursively call moveWhileBodyIntoNest on the inner while.
+        //      It will classify its body vs. control ops, remap the inner
+        //      IV to (cast) nestIV, and emit accumulator write-backs.
+        SmallVector<Operation *> preamble;
+        for (Operation &op : lbUbGuard.getThenRegion().front()) {
+          if (&op == innerWhile.getOperation())
+            break;
+          if (isa<scf::YieldOp>(&op))
+            break;
+          preamble.push_back(&op);
+        }
+        for (Operation *op : preamble)
+          op->moveBefore(nestBlk->getTerminator());
+
+        // Recursive call: handles SSA block args, IV remapping, writebacks.
+        moveWhileBodyIntoNest(b, loc, nestBlk, innerWhile, nestIV);
+
+      } else {
+        // ── No inner loop — move all then-block ops directly (bulk body) ──
+        SmallVector<Operation *> toMove;
+        for (Operation &op :
+             lbUbGuard.getThenRegion().front().without_terminator())
+          toMove.push_back(&op);
+        for (Operation *op : toMove)
+          op->moveBefore(nestBlk->getTerminator());
+      }
+
+    } else {
+      // ── No lb<=ub guard in before-block — defensive after-block fallback ──
+      Block *afterBlk = &whileOp.getAfter().front();
+      scf::ForOp innerFor;
+      for (Operation &op : *afterBlk)
+        if (auto f = dyn_cast<scf::ForOp>(&op)) {
+          innerFor = f;
+          break;
+        }
+      if (innerFor) {
+        moveForBodyIntoNest(b, loc, nestBlk, innerFor, nestIV);
+      } else {
+        SmallVector<Operation *> toMove;
+        for (Operation &op : afterBlk->without_terminator())
+          toMove.push_back(&op);
+        for (Operation *op : toMove)
+          op->moveBefore(nestBlk->getTerminator());
+      }
+    }
+    return;
+  }
+  // ── End dispatch-while guard ───────────────────────────────────────────
+
+  BlockArgument whileIV = beforeBlk->getArgument(0);
+  Operation *condOp = beforeBlk->getTerminator();
+  auto inits = whileOp.getInits();
+  Operation *yieldOp = nestBlk->getTerminator();
+
+  // ── Classify before-block ops ──────────────────────────────────────────
+  SmallPtrSet<Operation *, 16> reachWriteback;
+  {
+    SmallVector<Value> wl;
+    for (unsigned i = 1; i < condOp->getNumOperands(); ++i)
+      wl.push_back(condOp->getOperand(i));
+    while (!wl.empty()) {
+      Value v = wl.pop_back_val();
+      Operation *def = v.getDefiningOp();
+      if (!def || def->getBlock() != beforeBlk)
+        continue;
+      if (!reachWriteback.insert(def).second)
+        continue;
+      for (Value o : def->getOperands())
+        wl.push_back(o);
+    }
+  }
+  SmallPtrSet<Operation *, 16> controlOnly;
+  if (condOp->getNumOperands() > 0) {
+    SmallVector<Value> wl;
+    wl.push_back(condOp->getOperand(0));
+    while (!wl.empty()) {
+      Value v = wl.pop_back_val();
+      Operation *def = v.getDefiningOp();
+      if (!def || def->getBlock() != beforeBlk)
+        continue;
+      if (reachWriteback.contains(def))
+        continue; // body wins
+      if (!controlOnly.insert(def).second)
+        continue;
+      for (Value o : def->getOperands())
+        wl.push_back(o);
+    }
+  }
+
+  // ── Phase 1: IV cast + accumulator loads at top of nest body ───────────
+  b.setInsertionPointToStart(nestBlk);
+  Value mappedIV = nestIV;
+  if (whileIV.getType() != nestIV.getType())
+    mappedIV = b.create<arith::ExtSIOp>(loc, whileIV.getType(), nestIV);
+
+  struct AccInfo {
+    BlockArgument arg;
+    Value alloca;     // null → no backing alloca, no writeback
+    Value loadedVal;  // load of alloca, or undef if no alloca
+    Value newAccOrig; // condOp operand at index argIndex
+  };
+  SmallVector<AccInfo> accInfos;
+  for (unsigned i = 1; i < beforeBlk->getNumArguments(); ++i) {
+    BlockArgument accArg = beforeBlk->getArgument(i);
+    Value initVal = i < (unsigned)inits.size() ? inits[i] : Value{};
+
+    Value accAlloca;
+    if (initVal)
+      if (auto ld = initVal.getDefiningOp<memref::LoadOp>())
+        if (auto *p2m = ld.getMemRef().getDefiningOp())
+          if (p2m->getName().getStringRef() == "enzymexla.pointer2memref" &&
+              p2m->getNumOperands() == 1)
+            accAlloca = p2m->getOperand(0);
+
+    Value loaded;
+    if (accAlloca)
+      loaded = b.create<LLVM::LoadOp>(loc, accArg.getType(), accAlloca);
+    else
+      loaded = b.create<LLVM::UndefOp>(loc, accArg.getType());
+
+    Value newAcc = (condOp->getNumOperands() > (i + 1))
+                       ? condOp->getOperand(i + 1)
+                       : Value{};
+
+    accInfos.push_back({accArg, accAlloca, loaded, newAcc});
+  }
+
+  // ── Phase 2: move body ops (non-control) before the yield, in order ────
+  SmallVector<Operation *> toMove;
+  for (Operation &op : beforeBlk->without_terminator())
+    if (!controlOnly.contains(&op))
+      toMove.push_back(&op);
+  for (Operation *op : toMove)
+    op->moveBefore(yieldOp);
+
+  // ── Phase 3: region-scoped RAUW of block args ──────────────────────────
+  Region *nestRegion = nestBlk->getParent();
+  auto inNest = [&](OpOperand &u) {
+    return nestRegion->isAncestor(u.getOwner()->getParentRegion());
+  };
+  whileIV.replaceUsesWithIf(mappedIV, inNest);
+  for (auto &acc : accInfos)
+    acc.arg.replaceUsesWithIf(acc.loadedVal, inNest);
+
+  // ── Phase 4: accumulator writebacks before the yield ───────────────────
+  auto translate = [&](Value v) -> Value {
+    if (v == whileIV)
+      return mappedIV;
+    for (auto &a : accInfos)
+      if (v == a.arg)
+        return a.loadedVal;
+    return v;
+  };
+  b.setInsertionPoint(yieldOp);
+  for (auto &acc : accInfos) {
+    if (!acc.alloca || !acc.newAccOrig)
+      continue;
+    Value valToStore = translate(acc.newAccOrig);
+    Operation *defOp = valToStore.getDefiningOp();
+    bool safe = !defOp || nestRegion->isAncestor(defOp->getParentRegion());
+    if (!safe)
+      continue; // writeback would violate dominance; drop it
+    b.create<LLVM::StoreOp>(loc, valToStore, acc.alloca);
+  }
+}
+
+// static void inlineWhileBodyIntoNest(OpBuilder &b, Location loc,
+//                                      Block *nestBlk,
+//                                      scf::WhileOp whileOp,
+//                                      BlockArgument nestIV,
+//                                      IRMapping map) {
+//   Block         *beforeBlk = &whileOp.getBefore().front();
+//   BlockArgument  whileIV   = beforeBlk->getArgument(0);
+//   Operation     *condOp    = beforeBlk->getTerminator();
+
+//   // ── Control ops: backward-reachable from cond bool + next-IV only ─────
+//   SmallPtrSet<Operation *, 8> controlOps;
+//   {
+//     SmallVector<Value> worklist;
+//     for (unsigned i = 0; i <= 1 && i < condOp->getNumOperands(); ++i)
+//       worklist.push_back(condOp->getOperand(i));
+//     while (!worklist.empty()) {
+//       Value v = worklist.pop_back_val();
+//       Operation *def = v.getDefiningOp();
+//       if (!def || def->getBlock() != beforeBlk) continue;
+//       if (!controlOps.insert(def).second) continue;
+//       for (Value op : def->getOperands()) worklist.push_back(op);
+//     }
+//   }
+
+//   b.setInsertionPoint(nestBlk->getTerminator());
+
+//   // ── IV ────────────────────────────────────────────────────────────────
+//   Value mappedIV = nestIV;
+//   if (whileIV.getType() != nestIV.getType())
+//     mappedIV = b.create<arith::ExtSIOp>(loc, whileIV.getType(), nestIV);
+//   map.map(whileIV, mappedIV);
+
+//   // ── Accumulator args ──────────────────────────────────────────────────
+//   auto inits = whileOp.getInits();
+//   struct AccStore { Value alloca; Value newAccOrig; };
+//   SmallVector<AccStore> accStores;
+
+//   for (unsigned i = 1; i < beforeBlk->getNumArguments(); ++i) {
+//     BlockArgument accArg  = beforeBlk->getArgument(i);
+//     Value         initVal = i < (unsigned)inits.size() ? inits[i] : Value{};
+
+//     Value accAlloca;
+//     if (initVal)
+//       if (auto ld = initVal.getDefiningOp<memref::LoadOp>())
+//         if (auto *p2m = ld.getMemRef().getDefiningOp())
+//           if (p2m->getName().getStringRef() == "enzymexla.pointer2memref" &&
+//               p2m->getNumOperands() == 1)
+//             accAlloca = p2m->getOperand(0);
+
+//     if (!accAlloca) {
+//       map.map(accArg, b.create<LLVM::UndefOp>(loc, accArg.getType()));
+//       continue;
+//     }
+//     map.map(accArg,
+//             b.create<LLVM::LoadOp>(loc, accArg.getType(), accAlloca));
+//     if (condOp->getNumOperands() > i + 1)
+//       accStores.push_back({accAlloca, condOp->getOperand(i + 1)});
+//   }
+
+//   // ── ensureCloned: clone a before-block value on demand ───────────────
+//   // Needed in two cases:
+//   //   (A) A body op uses a control-op result directly (e.g. a memref.store
+//   //       writing the new accumulator value — it has no result so the
+//   //       backward trace never marks it as control, but its stored value IS
+//   //       a control op result not in map).
+//   //   (B) The new accumulator value recorded in accStores is a control op
+//   //       (e.g. arith.minsi feeds arith.cmpi → condition bool).
+//   // Without this, b.clone / map.lookupOrDefault silently keeps the original
+//   // erased-range Value, producing a dangling reference after erasure.
+//   std::function<Value(Value)> ensureCloned = [&](Value v) -> Value {
+//     if (map.contains(v)) return map.lookupOrDefault(v);
+//     Operation *def = v.getDefiningOp();
+//     // External to before-block (pre-hoisted or safe outer value).
+//     if (!def || def->getBlock() != beforeBlk)
+//       return map.lookupOrDefault(v);
+//     // Clone the defining op with recursively-ensured operands.
+//     IRMapping m2;
+//     for (Value operand : def->getOperands())
+//       m2.map(operand, ensureCloned(operand));
+//     Operation *cloned = b.clone(*def, m2);
+//     for (auto [orig, newR] :
+//          llvm::zip(def->getResults(), cloned->getResults()))
+//       map.map(orig, newR);
+//     return map.lookupOrDefault(v);
+//   };
+
+//   // ── Clone non-control body ops ────────────────────────────────────────
+//   // Before each clone, resolve any operand that comes from a control op
+//   // (not yet in map) so b.clone finds a valid mapped value.
+//   for (Operation &op : beforeBlk->without_terminator()) {
+//     if (controlOps.contains(&op)) continue;
+//     for (Value operand : op.getOperands())
+//       if (!map.contains(operand))
+//         if (Operation *def = operand.getDefiningOp())
+//           if (def->getBlock() == beforeBlk)
+//             ensureCloned(operand); // adds clone to map for b.clone to pick
+//             up
+//     b.clone(op, map);
+//   }
+
+//   // ── Accumulator write-back ────────────────────────────────────────────
+//   b.setInsertionPoint(nestBlk->getTerminator());
+//   for (auto &[accAlloca, newAccOrig] : accStores)
+//     b.create<LLVM::StoreOp>(loc, ensureCloned(newAccOrig), accAlloca);
+// }
+
+//===----------------------------------------------------------------------===//
+// Helper 5: clone the scf.for body into nestBlk, remapping the for IV to
+// nestIV.  Unlike the while case there are no mixed control ops — the entire
+// body (minus the scf.yield terminator) is the per-iteration work.
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Helper 5 (revised): clone the scf.for body into nestBlk.
+// seedMap  — same role as for inlineWhileBodyIntoNest.
+//===----------------------------------------------------------------------===//
+
+static void inlineForBodyIntoNest(OpBuilder &b, Location loc, Block *nestBlk,
+                                  scf::ForOp forOp, BlockArgument nestIV,
+                                  IRMapping map) { // pre-seeded, used directly
+  Block *bodyBlk = forOp.getBody();
+  Value forIV = forOp.getInductionVar();
+
+  b.setInsertionPoint(nestBlk->getTerminator());
+
+  Value mappedIV = nestIV;
+  if (forIV.getType() != nestIV.getType()) {
+    mappedIV =
+        isa<IndexType>(forIV.getType())
+            ? b.create<arith::IndexCastUIOp>(loc, forIV.getType(), nestIV)
+                  .getResult()
+            : b.create<arith::ExtSIOp>(loc, forIV.getType(), nestIV)
+                  .getResult();
+  }
+  map.map(forIV, mappedIV);
+
+  for (Operation &op : bodyBlk->without_terminator())
+    b.clone(op, map);
+}
+
+//===----------------------------------------------------------------------===//
+// Rewritten convertStaticWs
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// §12  Static work-sharing loop (revised — no hoistEscapingDeps)
+//===----------------------------------------------------------------------===//
+
+//   for (LLVM::CallOp init : inits) {
+//     LLVM::CallOp fini = findMatchingEndByPrefix(
+//         init, "__kmpc_for_static_init_", "__kmpc_for_static_fini");
+//     if (!fini) {
+//       init.emitWarning("LLVMToOmp: for_static_init without fini — skipped");
+//       continue;
+//     }
+//     if (init->getBlock() != fini->getBlock()) {
+//       init.emitWarning(
+//           "LLVMToOmp: init/fini in different blocks (optimized CFG) —
+//           skipped");
+//       continue;
+//     }
+
+//     bool nw = detectNowait(fini, /*eraseBarrier=*/true);
+
+//     StringRef    sfx = getCalleeName(init).drop_front(
+//         strlen("__kmpc_for_static_init_"));
+//     MLIRContext *ctx  = mod.getContext();
+//     Type iterTy = SW(sfx, "8") ? (Type)IntegerType::get(ctx, 64)
+//                                 : (Type)IntegerType::get(ctx, 32);
+
+//     omp::ClauseScheduleKind sched = omp::ClauseScheduleKind::Static;
+//     if (auto sv = getConstInt(init.getNumOperands() > 2
+//                                   ? init.getOperand(2) : Value{}))
+//       sched = kmpSched(*sv);
+//     Value chunk = init.getNumOperands() > 8 ? init.getOperand(8) : Value{};
+
+//     Value lbPtr = init.getNumOperands() > 4 ? init.getOperand(4) : Value{};
+//     Value ubPtr = init.getNumOperands() > 5 ? init.getOperand(5) : Value{};
+//     Value stPtr = init.getNumOperands() > 6 ? init.getOperand(6) : Value{};
+//     if (!lbPtr || !ubPtr || !stPtr) {
+//       init.emitWarning("LLVMToOmp: for_static_init missing ptr args —
+//       skipped"); continue;
+//     }
+
+//     Value lb = traceLastStoredValue(lbPtr, init);
+//     Value ub = traceLastStoredValue(ubPtr, init);
+//     Value st = traceLastStoredValue(stPtr, init);
+//     if (!lb || !ub || !st) {
+//       init.emitWarning(
+//           "LLVMToOmp: cannot trace wsloop bounds via pointer2memref — "
+//           "compile with -O0 or pre-run mem2reg");
+//       continue;
+//     }
+
+//     scf::WhileOp whileOp = findWhileOpBetween(init, fini);
+//     scf::ForOp   forOp;
+//     if (!whileOp) forOp = findForOpBetween(init, fini);
+//     if (!whileOp && !forOp) {
+//       init.emitWarning(
+//           "LLVMToOmp: no loop body (scf.while or scf.for) found between "
+//           "init/fini — skipped");
+//       continue;
+//     }
+
+//     // ── Build erased set & pre-hoist map before touching the IR ─────────
+//     SmallPtrSet<Operation *, 32> erasedSet;
+//     for (Operation *op : opsBetween(init, fini)) {
+//       erasedSet.insert(op);
+//       op->walk([&](Operation *inner) { erasedSet.insert(inner); });
+//     }
+//     Operation *loopOp = whileOp ? whileOp.getOperation()
+//                                  : forOp.getOperation();
+//     IRMapping map = buildPreHoistMap(init, loopOp, erasedSet);
+
+//     OpBuilder b(init);
+//     Location  loc = init.getLoc();
+
+//     // ── omp.wsloop ───────────────────────────────────────────────────────
+//     omp::WsloopOperands wOps;
+//     wOps.scheduleKind = omp::ClauseScheduleKindAttr::get(ctx, sched);
+//     if (chunk) wOps.scheduleChunk = chunk;
+//     if (nw)    wOps.nowait        = b.getUnitAttr();
+
+//     auto   wsOp  = b.create<omp::WsloopOp>(loc, wOps);
+//     Block *wsBlk = b.createBlock(&wsOp.getRegion());
+//     b.setInsertionPointToStart(wsBlk);
+
+//     // ── omp.loop_nest ────────────────────────────────────────────────────
+//     omp::LoopNestOperands lnOps;
+//     lnOps.loopLowerBounds = {lb};
+//     lnOps.loopUpperBounds = {ub};
+//     lnOps.loopSteps       = {st};
+//     lnOps.loopInclusive   = b.getUnitAttr();
+
+//     auto   nestOp  = b.create<omp::LoopNestOp>(loc, lnOps);
+//     Block *nestBlk = b.createBlock(&nestOp.getRegion());
+//     nestBlk->addArgument(iterTy, loc);
+//     b.setInsertionPointToStart(nestBlk);
+//     b.create<omp::YieldOp>(loc);
+
+//     // ── Inline body — map is complete, clone produces no erased-range refs
+//     if (whileOp)
+//       inlineWhileBodyIntoNest(b, loc, nestBlk, whileOp,
+//                               nestBlk->getArgument(0), map);
+//     else
+//       inlineForBodyIntoNest(b, loc, nestBlk, forOp,
+//                             nestBlk->getArgument(0), map);
+
+//     #ifndef NDEBUG
+//     wsOp->walk([&](Operation *op) {
+//       for (Value v : op->getOperands())
+//         if (Operation *d = v.getDefiningOp())
+//           assert(!erasedSet.count(d) &&
+//                 "inlineWhileBodyIntoNest left a dangling ref to erased
+//                 range");
+//     });
+//     #endif
+
+//     LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] static wsloop"
+//                              << (nw ? " nowait" : "") << "\n");
+//   }
+// }
+
+static bool liftClauseValue(Value v, Operation *insertBefore,
+                            const SmallPtrSet<Operation *, 32> &erasedSet,
+                            SmallPtrSet<Operation *, 32> &lifted,
+                            Region *noLiftRegion = nullptr) { // ← add param
+  if (!v)
+    return true;
+  Operation *def = v.getDefiningOp();
+  if (!def) {
+    auto ba = cast<BlockArgument>(v);
+    if (Operation *p = ba.getOwner()->getParentOp())
+      if (erasedSet.count(p))
+        return false;
+    return true;
+  }
+  if (!erasedSet.count(def))
+    return true;
+  if (lifted.count(def))
+    return true;
+  // ↓ NEW: never move an op that lives inside the protected region
+  if (noLiftRegion && noLiftRegion->isAncestor(def->getParentRegion()))
+    return false;
+  if (def->getNumRegions() > 0)
+    return false;
+  for (Value operand : def->getOperands())
+    if (!liftClauseValue(operand, insertBefore, erasedSet, lifted,
+                         noLiftRegion))
+      return false;
+  def->moveBefore(insertBefore);
+  lifted.insert(def);
+  return true;
+}
+//===----------------------------------------------------------------------===//
+// §12  Static work-sharing loop (move-based)
+//===----------------------------------------------------------------------===//
+void LLVMToOMPPass::convertStaticWs(ModuleOp mod) {
+  SmallVector<LLVM::CallOp> inits;
+  mod.walk([&](LLVM::CallOp c) {
+    if (calleeStartsWith(c, "__kmpc_for_static_init_"))
+      inits.push_back(c);
+  });
+
+  for (LLVM::CallOp init : inits) {
+    LLVM::CallOp fini = findMatchingEndByPrefix(init, "__kmpc_for_static_init_",
+                                                "__kmpc_for_static_fini");
+    if (!fini) {
+      init.emitWarning("LLVMToOmp: for_static_init without fini — skipped");
+      continue;
+    }
+    if (init->getBlock() != fini->getBlock()) {
+      init.emitWarning(
+          "LLVMToOmp: init/fini in different blocks (optimized CFG) — skipped");
+      continue;
+    }
+
+    bool nw = detectNowait(fini, /*eraseBarrier=*/true);
+
+    StringRef sfx =
+        getCalleeName(init).drop_front(strlen("__kmpc_for_static_init_"));
+    MLIRContext *ctx = mod.getContext();
+    Type iterTy = SW(sfx, "8") ? (Type)IntegerType::get(ctx, 64)
+                               : (Type)IntegerType::get(ctx, 32);
+
+    omp::ClauseScheduleKind sched = omp::ClauseScheduleKind::Static;
+    if (auto sv = getConstInt(init.getNumOperands() > 2 ? init.getOperand(2)
+                                                        : Value{}))
+      sched = kmpSched(*sv);
+    Value chunk = init.getNumOperands() > 8 ? init.getOperand(8) : Value{};
+
+    Value lbPtr = init.getNumOperands() > 4 ? init.getOperand(4) : Value{};
+    Value ubPtr = init.getNumOperands() > 5 ? init.getOperand(5) : Value{};
+    Value stPtr = init.getNumOperands() > 6 ? init.getOperand(6) : Value{};
+    if (!lbPtr || !ubPtr || !stPtr) {
+      init.emitWarning("LLVMToOmp: for_static_init missing ptr args — skipped");
+      continue;
+    }
+
+    Value lb = traceLastStoredValue(lbPtr, init);
+    Value ub = traceLastStoredValue(ubPtr, init);
+    Value st = traceLastStoredValue(stPtr, init);
+    if (!lb || !ub || !st) {
+      init.emitWarning(
+          "LLVMToOmp: cannot trace wsloop bounds via pointer2memref — "
+          "compile with -O0 or pre-run mem2reg");
+      continue;
+    }
+
+    scf::WhileOp whileOp = findWhileOpBetween(init, fini);
+    scf::ForOp forOp;
+    if (!whileOp)
+      forOp = findForOpBetween(init, fini);
+
+    // ── NEW: bulk-body fallback ───────────────────────────────────────────
+    // Clang sometimes fuses a per-element loop into a single bulk op (e.g.
+    // llvm.intr.memset) inside a guarding scf.if, with no inner scf.for/while.
+    // Treat the then-block as a single-shot loop body; nestIV goes unused.
+    scf::IfOp bodyIf;
+    if (!whileOp && !forOp) {
+      bodyIf = findLoopBetween<scf::IfOp>(init, fini);
+      // Require the then-block to have actual work, not just scf.yield.
+      if (bodyIf) {
+        bool hasWork = false;
+        for (Operation &op : bodyIf.getThenRegion().front())
+          if (!isa<scf::YieldOp>(&op)) {
+            hasWork = true;
+            break;
+          }
+        if (!hasWork)
+          bodyIf = {};
+      }
+    }
+
+    if (!whileOp && !forOp && !bodyIf) {
+      init.emitWarning(
+          "LLVMToOmp: no loop body (scf.while or scf.for) found between "
+          "init/fini — skipped");
+      continue;
+    }
+
+    // Erase set (built BEFORE any IR modification).
+    SmallPtrSet<Operation *, 32> erasedSet;
+    for (Operation *op : opsBetween(init, fini)) {
+      erasedSet.insert(op);
+      op->walk([&](Operation *inner) { erasedSet.insert(inner); });
+    }
+
+    // One shared lifted set across all liftClauseValue calls so that
+    // each op is moved exactly once and is never re-ordered.
+    SmallPtrSet<Operation *, 32> lifted;
+
+    // Lift clause values out of the erased range (insertBefore=init; wsOp
+    // will be inserted before init immediately after, so these land before
+    // wsOp automatically).
+    if (!liftClauseValue(lb, init, erasedSet, lifted) ||
+        !liftClauseValue(ub, init, erasedSet, lifted) ||
+        !liftClauseValue(st, init, erasedSet, lifted) ||
+        (chunk && !liftClauseValue(chunk, init, erasedSet, lifted))) {
+      init.emitWarning("LLVMToOmp: cannot lift wsloop clause values out of "
+                       "erased range — skipped");
+      continue;
+    }
+
+    OpBuilder b(init);
+    Location loc = init.getLoc();
+
+    // omp.wsloop wrapper.
+    omp::WsloopOperands wOps;
+    wOps.scheduleKind = omp::ClauseScheduleKindAttr::get(ctx, sched);
+    if (chunk)
+      wOps.scheduleChunk = chunk;
+    if (nw)
+      wOps.nowait = b.getUnitAttr();
+    if (bodyHasOrderedRegion(init, fini))
+      wOps.ordered = b.getI64IntegerAttr(0); // ordered, no parameter
+    auto wsOp = b.create<omp::WsloopOp>(loc, wOps);
+    Block *wsBlk = b.createBlock(&wsOp.getRegion());
+    b.setInsertionPointToStart(wsBlk);
+
+    // omp.loop_nest with empty body + yield placeholder.
+    omp::LoopNestOperands lnOps;
+    lnOps.loopLowerBounds = {lb};
+    lnOps.loopUpperBounds = {ub};
+    lnOps.loopSteps = {st};
+    lnOps.loopInclusive = b.getUnitAttr();
+    auto nestOp = b.create<omp::LoopNestOp>(loc, lnOps);
+    Block *nestBlk = b.createBlock(&nestOp.getRegion());
+    BlockArgument nestIV = nestBlk->addArgument(iterTy, loc);
+    b.setInsertionPointToStart(nestBlk);
+    b.create<omp::YieldOp>(loc);
+
+    // Move-based body extraction.
+    if (whileOp)
+      moveWhileBodyIntoNest(b, loc, nestBlk, whileOp, nestIV);
+    else if (forOp)
+      moveForBodyIntoNest(b, loc, nestBlk, forOp, nestIV);
+    else {
+      // Bulk-body: move the scf.if's then-block ops (minus scf.yield)
+      // directly into nestBlk.  nestIV is unused — the body addresses memory
+      // using lb/ub loaded from the allocas, which fixForNest will lift.
+      Block &thenBlk = bodyIf.getThenRegion().front();
+      SmallVector<Operation *> toMove;
+      for (Operation &op : thenBlk.without_terminator())
+        toMove.push_back(&op);
+      for (Operation *op : toMove)
+        op->moveBefore(nestBlk->getTerminator());
+      LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] bulk-body wsloop (no inner loop, "
+                                 "nestIV unused)\n");
+    }
+
+    // Lift any erased-range deps still visible from nestBlk.
+    // Guard: only lift ops that are OUTSIDE nestRegion (preamble ops,
+    // controlOnly ops shared with body, etc.).  Ops already moved INTO
+    // nestRegion are also in erasedSet (built pre-move) but must not be touched
+    // — they reference nestIV and lifting them creates dominance violations.
+    // The shared `lifted` set prevents any op from being moved more than once,
+    // which would corrupt SSA ordering between mutually dependent preamble ops.
+    Region *nestRegion = nestBlk->getParent();
+    {
+      llvm::DenseMap<Value, Value> cloneMap;
+
+      // Ensure `v` is accessible from nestBlk:
+      //   1. If liftable (no nestRegion deps in chain) → lift to before wsOp.
+      //   2. If not liftable (chain passes through nestRegion) → clone into
+      //   nestBlk.
+      std::function<Value(Value, Operation *)> fixForNest;
+      fixForNest = [&](Value v, Operation *insertBefore) -> Value {
+        if (auto it = cloneMap.find(v); it != cloneMap.end())
+          return it->second;
+        Operation *def = v.getDefiningOp();
+        // Block arg, not in erasedSet, or already inside nestRegion: use as-is.
+        if (!def || !erasedSet.count(def) ||
+            nestRegion->isAncestor(def->getParentRegion()))
+          return v;
+        // Try to lift to before wsOp (pass noLiftRegion so we never pull
+        // nestRegion ops out to the outer scope).
+        if (liftClauseValue(v, wsOp, erasedSet, lifted, nestRegion))
+          return v; // now in outer scope, dominates nestBlk ✓
+        // Lift failed (operand depends on a nestRegion value) → clone into
+        // nestBlk.
+        if (def->getNumRegions() > 0)
+          return v; // region ops can't be cloned here
+        IRMapping m;
+        for (Value operand : def->getOperands()) {
+          Value fixed = fixForNest(operand, insertBefore);
+          if (fixed != operand)
+            m.map(operand, fixed);
+        }
+        OpBuilder b(insertBefore);
+        Operation *cloned = b.clone(*def, m);
+        for (auto [orig, res] :
+             llvm::zip(def->getResults(), cloned->getResults()))
+          cloneMap[orig] = res;
+        return cloneMap[v];
+      };
+
+      // Collect ops first so clone insertion doesn't invalidate the walk.
+      SmallVector<Operation *> nestOps;
+      nestOp.getRegion().walk([&](Operation *op) { nestOps.push_back(op); });
+
+      for (Operation *op : nestOps) {
+        for (unsigned i = 0, e = op->getNumOperands(); i < e; ++i) {
+          Value v = op->getOperand(i);
+          Operation *def = v.getDefiningOp();
+          if (!def || !erasedSet.count(def) ||
+              nestRegion->isAncestor(def->getParentRegion()))
+            continue;
+          Value fixed = fixForNest(v, op);
+          if (fixed != v)
+            op->setOperand(i, fixed);
+        }
+      }
+    }
+
+// ── Pre-erase sanity check ─────────────────────────────────────────────
+// Verify that no value defined inside the erased range still has a user
+// that lives outside it.  Fires before the erase so we can print context.
+#ifndef NDEBUG
+    {
+      // Collect the full erased set including all nested ops.
+      SmallPtrSet<Operation *, 32> allErased;
+      for (Operation *op : opsBetween(init, fini)) {
+        allErased.insert(op);
+        op->walk([&](Operation *inner) { allErased.insert(inner); });
+      }
+
+      auto isInErased = [&](Operation *op) -> bool {
+        for (Operation *p = op; p; p = p->getParentOp())
+          if (allErased.count(p))
+            return true;
+        return false;
+      };
+
+      bool anyLeak = false;
+      for (Operation *op : allErased) {
+        // Check op results.
+        for (Value res : op->getResults()) {
+          for (OpOperand &use : res.getUses()) {
+            if (!isInErased(use.getOwner())) {
+              llvm::errs()
+                  << "[LLVMToOmp][BUG] op result escapes erased range:\n"
+                  << "  defined by: " << *op << "\n"
+                  << "  used by:    " << *use.getOwner() << "\n";
+              anyLeak = true;
+            }
+          }
+        }
+        // Check block arguments of every block inside this op.
+        op->walk([&](Block *blk) {
+          for (BlockArgument arg : blk->getArguments()) {
+            for (OpOperand &use : arg.getUses()) {
+              if (!isInErased(use.getOwner())) {
+                llvm::errs()
+                    << "[LLVMToOmp][BUG] block arg escapes erased range:\n"
+                    << "  block arg: " << arg << "  (type: " << arg.getType()
+                    << ", argIndex " << arg.getArgNumber() << ")\n"
+                    << "  owner block parent op: "
+                    << blk->getParentOp()->getName() << "\n"
+                    << "  used by: " << *use.getOwner() << "\n"
+                    << "  user parent op: "
+                    << use.getOwner()->getParentOp()->getName() << "\n";
+                anyLeak = true;
+              }
+            }
+          }
+        });
+      }
+      if (anyLeak)
+        llvm::errs() << "[LLVMToOmp][BUG] erased-range leak detected — "
+                        "erase will abort\n";
+    }
+#endif
+    // ── End sanity check ──────────────────────────────────────────────────
+
+    // Snapshot opsBetween into a local vector before erasing — avoids the
+    // dangling-iterator UB from llvm::reverse(temporary).
+    auto between = opsBetween(init, fini);
+    for (Operation *op : llvm::reverse(between))
+      op->erase();
+    init.erase();
+    fini.erase();
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "[LLVMToOmp] static wsloop" << (nw ? " nowait" : "") << "\n");
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// §13  Dynamic work-sharing loop  (__kmpc_dispatch_init/next/fini)
+//
+// Same WsloopOp/LoopNestOp API as §12.
+// Body ops are between dispatch_next and dispatch_fini.
+// clang outputs __kmpc_for_static_init_* __kmpc_for_static_fini per default
+// when using schedule (dynamic|runtime|guided|auto), it outputs get
+// __kmpc_dispatch_init_*
+// + __kmpc_dispatch_next_* +__kmpc_dispatch_next_* + __kmpc_dispatch_deinit,
+// with the third argument of __kmpc_dispatch_init_* being differently
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// §13  Dynamic work-sharing loop (revised — no hoistEscapingDeps)
+//===----------------------------------------------------------------------===//
+
+//   for (LLVM::CallOp init : inits) {
+//     LLVM::CallOp deinit = findMatchingEndByPrefix(
+//         init, "__kmpc_dispatch_init_", "__kmpc_dispatch_deinit");
+//     if (!deinit) {
+//       StringRef sfx = getCalleeName(init).drop_front(
+//           strlen("__kmpc_dispatch_init_"));
+//       deinit = findMatchingEndByPrefix(
+//           init, "__kmpc_dispatch_init_",
+//           ("__kmpc_dispatch_fini_" + sfx).str());
+//     }
+//     if (!deinit) {
+//       init.emitWarning("LLVMToOmp: dispatch_init without deinit — skipped");
+//       continue;
+//     }
+//     if (init->getBlock() != deinit->getBlock()) {
+//       init.emitWarning(
+//           "LLVMToOmp: init/deinit in different blocks (optimized CFG) —
+//           skipped");
+//       continue;
+//     }
+
+//     bool nowait = detectNowait(deinit, /*eraseBarrier=*/false);
+
+//     StringRef    sfx = getCalleeName(init).drop_front(
+//         strlen("__kmpc_dispatch_init_"));
+//     MLIRContext *ctx  = mod.getContext();
+//     Type iterTy = SW(sfx, "8") ? (Type)IntegerType::get(ctx, 64)
+//                                 : (Type)IntegerType::get(ctx, 32);
+
+//     omp::ClauseScheduleKind sched = omp::ClauseScheduleKind::Dynamic;
+//     if (auto sv = getConstInt(init.getNumOperands() > 2
+//                                   ? init.getOperand(2) : Value{})) {
+//       sched = kmpSched(*sv & ~((int64_t)0x60000000));
+//     }
+
+//     // dispatch_init(ident, gtid, sched, lb, ub, step, chunk)
+//     Value lb    = init.getNumOperands() > 3 ? init.getOperand(3) : Value{};
+//     Value ub    = init.getNumOperands() > 4 ? init.getOperand(4) : Value{};
+//     Value step  = init.getNumOperands() > 5 ? init.getOperand(5) : Value{};
+//     Value chunk = init.getNumOperands() > 6 ? init.getOperand(6) : Value{};
+//     if (!lb || !ub || !step) {
+//       init.emitWarning("LLVMToOmp: dispatch_init missing bounds — skipped");
+//       continue;
+//     }
+
+//     scf::WhileOp iterWhile = findWhileOpBetween(init, deinit);
+//     if (!iterWhile) {
+//       init.emitWarning("LLVMToOmp: no dispatch while found — skipped");
+//       continue;
+//     }
+
+//     // ── Build erased set & pre-hoist map before touching the IR ─────────
+//     SmallPtrSet<Operation *, 32> erasedSet;
+//     for (Operation *op : opsBetween(init, deinit)) {
+//       erasedSet.insert(op);
+//       op->walk([&](Operation *inner) { erasedSet.insert(inner); });
+//     }
+//     IRMapping map = buildPreHoistMap(init, iterWhile, erasedSet);
+
+//     OpBuilder b(init);
+//     Location  loc = init.getLoc();
+
+//     // ── omp.wsloop ───────────────────────────────────────────────────────
+//     omp::WsloopOperands wsOps;
+//     wsOps.scheduleKind = omp::ClauseScheduleKindAttr::get(ctx, sched);
+//     if (chunk)  wsOps.scheduleChunk = chunk;
+//     if (nowait) wsOps.nowait        = b.getUnitAttr();
+
+//     auto   wsOp  = b.create<omp::WsloopOp>(loc, wsOps);
+//     Block *wsBlk = b.createBlock(&wsOp.getRegion());
+//     b.setInsertionPointToStart(wsBlk);
+
+//     // ── omp.loop_nest ────────────────────────────────────────────────────
+//     omp::LoopNestOperands lnOps;
+//     lnOps.loopLowerBounds = {lb};
+//     lnOps.loopUpperBounds = {ub};
+//     lnOps.loopSteps       = {step};
+//     lnOps.loopInclusive   = b.getUnitAttr();
+
+//     auto   nestOp  = b.create<omp::LoopNestOp>(loc, lnOps);
+//     Block *nestBlk = b.createBlock(&nestOp.getRegion());
+//     nestBlk->addArgument(iterTy, loc);
+//     b.setInsertionPointToStart(nestBlk);
+//     b.create<omp::YieldOp>(loc);
+
+//     // ── Inline body — map is complete ────────────────────────────────────
+//     inlineWhileBodyIntoNest(b, loc, nestBlk, iterWhile,
+//                             nestBlk->getArgument(0), map);
+
+//     #ifndef NDEBUG
+//     wsOp->walk([&](Operation *op) {
+//       for (Value v : op->getOperands())
+//         if (Operation *d = v.getDefiningOp())
+//           assert(!erasedSet.count(d) &&
+//                 "inlineWhileBodyIntoNest left a dangling ref to erased
+//                 range");
+//     });
+//     #endif
+
+//     // ── Erase — trivially safe ───────────────────────────────────────────
+//     for (Operation *op : llvm::reverse(opsBetween(init, deinit))) {
+//       op->dropAllUses();
+//       op->erase();
+//     }
+//     init.erase();
+//     deinit.erase();
+
+//     LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] dynamic wsloop"
+//                              << (nowait ? " nowait" : "") << "\n");
+//   }
+// }
+
+//===----------------------------------------------------------------------===//
+// §13  Dynamic work-sharing loop (move-based)
+//===----------------------------------------------------------------------===//
+void LLVMToOMPPass::convertDynWs(ModuleOp mod) {
+  SmallVector<LLVM::CallOp> inits;
+  mod.walk([&](LLVM::CallOp c) {
+    if (calleeStartsWith(c, "__kmpc_dispatch_init_"))
+      inits.push_back(c);
+  });
+
+  for (LLVM::CallOp init : inits) {
+    LLVM::CallOp deinit = findMatchingEndByPrefix(init, "__kmpc_dispatch_init_",
+                                                  "__kmpc_dispatch_deinit");
+    if (!deinit) {
+      StringRef sfx =
+          getCalleeName(init).drop_front(strlen("__kmpc_dispatch_init_"));
+      deinit = findMatchingEndByPrefix(init, "__kmpc_dispatch_init_",
+                                       ("__kmpc_dispatch_fini_" + sfx).str());
+    }
+    if (!deinit) {
+      init.emitWarning("LLVMToOmp: dispatch_init without deinit — skipped");
+      continue;
+    }
+    if (init->getBlock() != deinit->getBlock()) {
+      init.emitWarning("LLVMToOmp: init/deinit in different blocks (optimized "
+                       "CFG) — skipped");
+      continue;
+    }
+
+    bool nowait = detectNowait(deinit, /*eraseBarrier=*/false);
+
+    StringRef sfx =
+        getCalleeName(init).drop_front(strlen("__kmpc_dispatch_init_"));
+    MLIRContext *ctx = mod.getContext();
+    Type iterTy = SW(sfx, "8") ? (Type)IntegerType::get(ctx, 64)
+                               : (Type)IntegerType::get(ctx, 32);
+
+    omp::ClauseScheduleKind sched = omp::ClauseScheduleKind::Dynamic;
+    if (auto sv = getConstInt(init.getNumOperands() > 2 ? init.getOperand(2)
+                                                        : Value{}))
+      sched = kmpSched(*sv & ~((int64_t)0x60000000));
+
+    Value lb = init.getNumOperands() > 3 ? init.getOperand(3) : Value{};
+    Value ub = init.getNumOperands() > 4 ? init.getOperand(4) : Value{};
+    Value step = init.getNumOperands() > 5 ? init.getOperand(5) : Value{};
+    Value chunk = init.getNumOperands() > 6 ? init.getOperand(6) : Value{};
+    if (!lb || !ub || !step) {
+      init.emitWarning("LLVMToOmp: dispatch_init missing bounds — skipped");
+      continue;
+    }
+
+    scf::WhileOp iterWhile = findWhileOpBetween(init, deinit);
+    if (!iterWhile) {
+      init.emitWarning("LLVMToOmp: no dispatch while found — skipped");
+      continue;
+    }
+
+    // Erase set (built BEFORE any IR modification).
+    SmallPtrSet<Operation *, 32> erasedSet;
+    for (Operation *op : opsBetween(init, deinit)) {
+      erasedSet.insert(op);
+      op->walk([&](Operation *inner) { erasedSet.insert(inner); });
+    }
+
+    // One shared lifted set across all liftClauseValue calls.
+    SmallPtrSet<Operation *, 32> lifted;
+
+    // For dispatch, bounds come directly from the init call operands —
+    // they are defined before init so liftClauseValue is usually a no-op,
+    // but we still run it for safety in case of unusual patterns.
+    if (!liftClauseValue(lb, init, erasedSet, lifted) ||
+        !liftClauseValue(ub, init, erasedSet, lifted) ||
+        !liftClauseValue(step, init, erasedSet, lifted) ||
+        (chunk && !liftClauseValue(chunk, init, erasedSet, lifted))) {
+      init.emitWarning("LLVMToOmp: cannot lift dispatch clause values out of "
+                       "erased range — skipped");
+      continue;
+    }
+
+    OpBuilder b(init);
+    Location loc = init.getLoc();
+
+    omp::WsloopOperands wsOps;
+    wsOps.scheduleKind = omp::ClauseScheduleKindAttr::get(ctx, sched);
+    if (chunk)
+      wsOps.scheduleChunk = chunk;
+    if (nowait)
+      wsOps.nowait = b.getUnitAttr();
+    if (bodyHasOrderedRegion(init, deinit))
+      wsOps.ordered = b.getI64IntegerAttr(0); // ordered, no parameter
+    auto wsOp = b.create<omp::WsloopOp>(loc, wsOps);
+    Block *wsBlk = b.createBlock(&wsOp.getRegion());
+    b.setInsertionPointToStart(wsBlk);
+
+    omp::LoopNestOperands lnOps;
+    lnOps.loopLowerBounds = {lb};
+    lnOps.loopUpperBounds = {ub};
+    lnOps.loopSteps = {step};
+    lnOps.loopInclusive = b.getUnitAttr();
+    auto nestOp = b.create<omp::LoopNestOp>(loc, lnOps);
+    Block *nestBlk = b.createBlock(&nestOp.getRegion());
+    BlockArgument nestIV = nestBlk->addArgument(iterTy, loc);
+    b.setInsertionPointToStart(nestBlk);
+    b.create<omp::YieldOp>(loc);
+
+    moveWhileBodyIntoNest(b, loc, nestBlk, iterWhile, nestIV);
+
+    // Same three-property lift as convertStaticWs:
+    //   (1) only lift ops outside nestRegion
+    //   (2) shared `lifted` prevents re-ordering via repeated moveBefore
+    //   (3) insertBefore=wsOp so lifted preamble ops land before the loop
+    Region *nestRegion = nestBlk->getParent();
+    {
+      llvm::DenseMap<Value, Value> cloneMap;
+
+      // Ensure `v` is accessible from nestBlk:
+      //   1. If liftable (no nestRegion deps in chain) → lift to before wsOp.
+      //   2. If not liftable (chain passes through nestRegion) → clone into
+      //   nestBlk.
+      std::function<Value(Value, Operation *)> fixForNest;
+      fixForNest = [&](Value v, Operation *insertBefore) -> Value {
+        if (auto it = cloneMap.find(v); it != cloneMap.end())
+          return it->second;
+        Operation *def = v.getDefiningOp();
+        // Block arg, not in erasedSet, or already inside nestRegion: use as-is.
+        if (!def || !erasedSet.count(def) ||
+            nestRegion->isAncestor(def->getParentRegion()))
+          return v;
+        // Try to lift to before wsOp (pass noLiftRegion so we never pull
+        // nestRegion ops out to the outer scope).
+        if (liftClauseValue(v, wsOp, erasedSet, lifted, nestRegion))
+          return v; // now in outer scope, dominates nestBlk ✓
+        // Lift failed (operand depends on a nestRegion value) → clone into
+        // nestBlk.
+        if (def->getNumRegions() > 0)
+          return v; // region ops can't be cloned here
+        IRMapping m;
+        for (Value operand : def->getOperands()) {
+          Value fixed = fixForNest(operand, insertBefore);
+          if (fixed != operand)
+            m.map(operand, fixed);
+        }
+        OpBuilder b(insertBefore);
+        Operation *cloned = b.clone(*def, m);
+        for (auto [orig, res] :
+             llvm::zip(def->getResults(), cloned->getResults()))
+          cloneMap[orig] = res;
+        return cloneMap[v];
+      };
+
+      // Collect ops first so clone insertion doesn't invalidate the walk.
+      SmallVector<Operation *> nestOps;
+      nestOp.getRegion().walk([&](Operation *op) { nestOps.push_back(op); });
+
+      for (Operation *op : nestOps) {
+        for (unsigned i = 0, e = op->getNumOperands(); i < e; ++i) {
+          Value v = op->getOperand(i);
+          Operation *def = v.getDefiningOp();
+          if (!def || !erasedSet.count(def) ||
+              nestRegion->isAncestor(def->getParentRegion()))
+            continue;
+          Value fixed = fixForNest(v, op);
+          if (fixed != v)
+            op->setOperand(i, fixed);
+        }
+      }
+    }
+
+// ── Pre-erase sanity check ─────────────────────────────────────────────
+// Verify that no value defined inside the erased range still has a user
+// that lives outside it.  Fires before the erase so we can print context.
+#ifndef NDEBUG
+    {
+      // Collect the full erased set including all nested ops.
+      SmallPtrSet<Operation *, 32> allErased;
+      for (Operation *op : opsBetween(init, deinit)) {
+        allErased.insert(op);
+        op->walk([&](Operation *inner) { allErased.insert(inner); });
+      }
+
+      auto isInErased = [&](Operation *op) -> bool {
+        for (Operation *p = op; p; p = p->getParentOp())
+          if (allErased.count(p))
+            return true;
+        return false;
+      };
+
+      bool anyLeak = false;
+      for (Operation *op : allErased) {
+        // Check op results.
+        for (Value res : op->getResults()) {
+          for (OpOperand &use : res.getUses()) {
+            if (!isInErased(use.getOwner())) {
+              llvm::errs()
+                  << "[LLVMToOmp][BUG] op result escapes erased range:\n"
+                  << "  defined by: " << *op << "\n"
+                  << "  used by:    " << *use.getOwner() << "\n";
+              anyLeak = true;
+            }
+          }
+        }
+        // Check block arguments of every block inside this op.
+        op->walk([&](Block *blk) {
+          for (BlockArgument arg : blk->getArguments()) {
+            for (OpOperand &use : arg.getUses()) {
+              if (!isInErased(use.getOwner())) {
+                llvm::errs()
+                    << "[LLVMToOmp][BUG] block arg escapes erased range:\n"
+                    << "  block arg: " << arg << "  (type: " << arg.getType()
+                    << ", argIndex " << arg.getArgNumber() << ")\n"
+                    << "  owner block parent op: "
+                    << blk->getParentOp()->getName() << "\n"
+                    << "  used by: " << *use.getOwner() << "\n"
+                    << "  user parent op: "
+                    << use.getOwner()->getParentOp()->getName() << "\n";
+                anyLeak = true;
+              }
+            }
+          }
+        });
+      }
+      if (anyLeak)
+        llvm::errs() << "[LLVMToOmp][BUG] erased-range leak detected — "
+                        "erase will abort\n";
+    }
+#endif
+    // ── End sanity check ──────────────────────────────────────────────────
+
+    // Snapshot before erasing — avoids dangling-iterator UB.
+    auto between = opsBetween(init, deinit);
+    for (Operation *op : llvm::reverse(between))
+      op->erase();
+    init.erase();
+    deinit.erase();
+
+    LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] dynamic wsloop"
+                            << (nowait ? " nowait" : "") << "\n");
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// §14  Tasks  (__kmpc_task_alloc + __kmpc_omp_task → omp.task)
+//
+// ── Calling conventions ──────────────────────────────────────────────────
+//   Parallel/teams outlined fn: (global_tid*, bound_tid*, cap0, cap1, …)
+//     → inlineOutlinedBody drops args 0,1; maps variadic tail as caps.
+//   Task entry fn:              (i32 gtid, ptr kmp_task_t*)
+//     → ONLY TWO args; captures live in kmp_task_t.shareds (ptr at [0]).
+//
+// ── Capture layout (Clang's kmp_task_t initialisation) ───────────────────
+//   Between __kmpc_task_alloc and __kmpc_omp_task Clang emits:
+//     td        = task_alloc(…)                          : !llvm.ptr
+//     p2m_td    = pointer2memref(td)                     : memref<?x!llvm.ptr>
+//     shareds   = memref.load(p2m_td)[0]                 : !llvm.ptr
+//     p2m_sh    = pointer2memref(shareds)                : memref<?x!llvm.ptr>
+//     memref.store cap_i, p2m_sh[i]
+//   harvestTaskCaptures() traces this chain → {index→Value} pairs.
+//
+// ── Inlining ─────────────────────────────────────────────────────────────
+//   inlineTaskBody() maps arg0→undef, arg1→undef, then pre-maps every
+//   cap-load result  memref.load(p2m(shareds_ptr))[i]  to caps[i] in the
+//   IRMapping before cloning begins.  Ops whose results are fully
+//   pre-mapped are skipped during cloning; the dead p2m/load chain that
+//   fed them is left for DCE.
+//
+// ── Erase order ──────────────────────────────────────────────────────────
+//   1. taskCall.erase()           – removes the __kmpc_omp_task consumer of td
+//   2. complete_if0 erased        – removes if0 completion call (also uses td)
+//   3. eraseTaskSharedsInit()     – removes the shareds store chain (uses td)
+//   4. alloc.erase()              – td is now use-empty
+//   5. fn.erase()                 – outlined entry fn no longer needed
+//
+// td: TaskOp — explicit builder OpBuilder<(ins CArg<"const TaskOperands &">)>
+//     No SingleBlock → create block explicitly.
+//     TaskOperands.untied    = UnitAttr (OpenMP_UntiedClause)
+//     TaskOperands.mergeable = UnitAttr (OpenMP_MergeableClause)
+//===----------------------------------------------------------------------===//
+
+/// Trace the kmp_task_t initialisation chain from `alloc`'s result and
+/// collect the captured values as (index, Value) pairs.
+///
+/// Recognises the memref+pointer2memref pattern emitted by EnzymeXLA:
+///   td        = __kmpc_task_alloc(…)
+///   p2m_td    = pointer2memref(td)        : memref<?x!llvm.ptr>
+///   shareds   = memref.load(p2m_td)[0]   : !llvm.ptr
+///   p2m_sh    = pointer2memref(shareds)   : memref<?x!llvm.ptr>
+///   memref.store cap_i, p2m_sh[i]
+///
+/// Also recognises a plain llvm.load for the first-level dereference
+/// (shareds pointer extraction) as a fallback.
+static SmallVector<std::pair<int64_t, Value>>
+harvestTaskCaptures(LLVM::CallOp alloc) {
+  SmallVector<std::pair<int64_t, Value>> result;
+  Value td = alloc.getResult();
+
+  // ─── Step 1: find shareds_ptr ─────────────────────────────────────────
+  Value sharedsPtr;
+  for (Operation *u : td.getUsers()) {
+    // memref path: pointer2memref(td) → memref.load[0]
+    if (u->getName().getStringRef() == "enzymexla.pointer2memref" &&
+        u->getNumResults() == 1) {
+      Value p2m = u->getResult(0);
+      for (Operation *lu : p2m.getUsers()) {
+        auto ld = dyn_cast<memref::LoadOp>(lu);
+        if (!ld || ld.getIndices().size() != 1)
+          continue;
+        auto idx = getConstIndex(ld.getIndices()[0]);
+        if (idx && *idx == 0) {
+          sharedsPtr = ld.getResult();
+          break;
+        }
+      }
+    }
+    // LLVM path: llvm.load td → shareds_ptr  (non-memref lowering)
+    if (!sharedsPtr)
+      if (auto llvmLd = dyn_cast<LLVM::LoadOp>(u))
+        sharedsPtr = llvmLd.getResult();
+    if (sharedsPtr)
+      break;
+  }
+  if (!sharedsPtr)
+    return result;
+
+  // ─── Step 2: collect stores into shareds ──────────────────────────────
+  for (Operation *u : sharedsPtr.getUsers()) {
+    if (u->getName().getStringRef() == "enzymexla.pointer2memref" &&
+        u->getNumResults() == 1) {
+      Value p2m = u->getResult(0);
+      for (Operation *su : p2m.getUsers()) {
+        auto st = dyn_cast<memref::StoreOp>(su);
+        if (!st || st.getIndices().size() != 1)
+          continue;
+        auto idx = getConstIndex(st.getIndices()[0]);
+        if (idx)
+          result.emplace_back(*idx, st.getValueToStore());
+      }
+    }
+  }
+
+  llvm::sort(result,
+             [](const auto &a, const auto &b) { return a.first < b.first; });
+  return result;
+}
+
+/// Erase the shareds-initialisation chain anchored at alloc's result:
+///   td → p2m_td → load[0] → p2m_sh → stores
+/// Call AFTER taskCall.erase() so td's only remaining users are this chain.
+static void eraseTaskSharedsInit(LLVM::CallOp alloc) {
+  Value td = alloc.getResult();
+  // Collect in inner-to-outer order: stores → p2m_sh → load → p2m_td
+  // so each op is use_empty() by the time we erase it.
+  SmallVector<Operation *> toErase;
+
+  for (Operation *u : td.getUsers()) {
+    if (u->getName().getStringRef() != "enzymexla.pointer2memref")
+      continue;
+    Value p2m_td = u->getResult(0);
+    for (Operation *lu : p2m_td.getUsers()) {
+      auto ld = dyn_cast<memref::LoadOp>(lu);
+      if (!ld)
+        continue;
+      Value shareds = ld.getResult();
+      for (Operation *su : shareds.getUsers()) {
+        if (su->getName().getStringRef() != "enzymexla.pointer2memref")
+          continue;
+        Value p2m_sh = su->getResult(0);
+        for (Operation *stu : p2m_sh.getUsers())
+          if (isa<memref::StoreOp>(stu))
+            toErase.push_back(stu); // innermost
+        toErase.push_back(su);      // p2m_sh
+      }
+      toErase.push_back(lu); // load
+    }
+    toErase.push_back(u); // p2m_td
+  }
+
+  for (Operation *op : toErase)
+    if (op->use_empty())
+      op->erase();
+}
+
+/// Walk fn to pre-populate `map` with  capLoad.getResult() → caps[i].value
+/// for the access chain:
+///   pointer2memref(arg1)[0] → shareds_ptr
+///   pointer2memref(shareds_ptr)[i] → cap_i   ← mapped here
+static void buildTaskCaptureMap(LLVM::LLVMFuncOp fn,
+                                ArrayRef<std::pair<int64_t, Value>> caps,
+                                IRMapping &map) {
+  if (fn.getBody().empty() || fn.getBody().front().getNumArguments() < 2)
+    return;
+  BlockArgument arg1 = fn.getBody().front().getArgument(1);
+
+  // Find shareds_ptr inside the function body
+  Value sharedsPtr;
+  fn.walk([&](Operation *op) {
+    if (sharedsPtr)
+      return;
+    if (op->getName().getStringRef() != "enzymexla.pointer2memref")
+      return;
+    if (op->getNumOperands() != 1 || op->getOperand(0) != arg1)
+      return;
+    if (op->getNumResults() != 1)
+      return;
+    Value p2m = op->getResult(0);
+    for (Operation *u : p2m.getUsers()) {
+      auto ld = dyn_cast<memref::LoadOp>(u);
+      if (!ld || ld.getIndices().size() != 1)
+        continue;
+      auto idx = getConstIndex(ld.getIndices()[0]);
+      if (idx && *idx == 0) {
+        sharedsPtr = ld.getResult();
+        break;
+      }
+    }
+  });
+  if (!sharedsPtr)
+    return;
+
+  // Map each cap-load result to the corresponding harvested value
+  fn.walk([&](Operation *op) {
+    if (op->getName().getStringRef() != "enzymexla.pointer2memref")
+      return;
+    if (op->getNumOperands() != 1 || op->getOperand(0) != sharedsPtr)
+      return;
+    if (op->getNumResults() != 1)
+      return;
+    Value p2m = op->getResult(0);
+    for (Operation *u : p2m.getUsers()) {
+      auto ld = dyn_cast<memref::LoadOp>(u);
+      if (!ld || ld.getIndices().size() != 1)
+        continue;
+      auto idx = getConstIndex(ld.getIndices()[0]);
+      if (!idx)
+        continue;
+      for (const auto &[capIdx, capVal] : caps)
+        if (capIdx == *idx) {
+          map.map(ld.getResult(), capVal);
+          break;
+        }
+    }
+  });
+}
+
+/// Inline a task-entry fn (i32 gtid, ptr kmp_task_t*) into `dst`.
+/// arg0 and arg1 both map to undef; captured values are substituted via
+/// buildTaskCaptureMap before cloning so downstream ops get the real values.
+/// Ops whose results are all pre-mapped are skipped (dead intermediates
+/// are left for DCE).
+static LogicalResult inlineTaskBody(LLVM::LLVMFuncOp fn, Region &dst,
+                                    OpBuilder &b,
+                                    ArrayRef<std::pair<int64_t, Value>> caps) {
+  if (fn.getBody().empty())
+    return fn.emitError("LLVMToOmp: task entry fn '")
+           << fn.getName() << "' has empty body";
+
+  IRMapping map;
+  Location loc = fn.getLoc();
+  Block &entry = fn.getBody().front();
+
+  // arg0=gtid (i32), arg1=kmp_task_t* — both are runtime internals.
+  for (BlockArgument arg : entry.getArguments())
+    map.map(arg, b.create<LLVM::UndefOp>(loc, arg.getType()));
+
+  // Pre-map cap-load results AFTER arg mappings (buildTaskCaptureMap
+  // compares operands against the original arg1 BlockArgument).
+  buildTaskCaptureMap(fn, caps, map);
+
+  if (caps.empty() && entry.getNumArguments() > 1 &&
+      !entry.getArgument(1).use_empty())
+    fn.emitWarning("LLVMToOmp: task captures not harvested (unrecognised "
+                   "kmp_task_t access pattern) — shared variables will be "
+                   "undef in the inlined task body");
+
+  // Clone blocks — identical structure to inlineOutlinedBody
+  SmallVector<Block *> dblks;
+  bool first = true;
+  for (Block &sb : fn.getBody()) {
+    Block *db;
+    if (first) {
+      db = &dst.front();
+      first = false;
+    } else {
+      db = b.createBlock(&dst);
+      for (BlockArgument a : sb.getArguments())
+        map.map(a, db->addArgument(a.getType(), a.getLoc()));
+    }
+    map.map(&sb, db);
+    dblks.push_back(db);
+  }
+  unsigned blkIdx = 0;
+  for (Block &sb : fn.getBody()) {
+    b.setInsertionPointToEnd(dblks[blkIdx++]);
+    for (Operation &op : sb) {
+      if (isa<LLVM::ReturnOp>(op)) {
+        b.create<omp::TerminatorOp>(op.getLoc());
+        continue;
+      }
+      // Skip ops whose results are all pre-mapped (the folded cap loads).
+      // Their operand producers are cloned but left dead for DCE.
+      if (!op.getResults().empty() &&
+          llvm::all_of(op.getResults(),
+                       [&](Value r) { return map.contains(r); }))
+        continue;
+      b.clone(op, map);
+    }
+  }
+  return success();
+}
+
+void LLVMToOMPPass::convertTasks(ModuleOp mod) {
+  SmallVector<LLVM::CallOp> allocs;
+  mod.walk([&](LLVM::CallOp c) {
+    if (isCallTo(c, "__kmpc_omp_task_alloc"))
+      allocs.push_back(c);
+  });
+
+  // ── Deferred-erasure reference count ────────────────────────────────────
+  // An outlined task-entry function may be referenced by more than one
+  // __kmpc_omp_task_alloc site (e.g. a task inside a loop that was unrolled
+  // or duplicated before this pass runs).  Count how many alloc sites point
+  // to each function so we erase it only after the last site is processed.
+  llvm::DenseMap<LLVM::LLVMFuncOp, unsigned> fnCounts;
+  for (LLVM::CallOp alloc : allocs) {
+    // Skip allocs that feed __kmpc_taskloop — handled by convertTaskloop.
+    bool feedsTaskloop = false;
+    for (Operation *u : alloc.getResult().getUsers())
+      if (auto uc = dyn_cast<LLVM::CallOp>(u))
+        if (isCallTo(uc, "__kmpc_taskloop")) {
+          feedsTaskloop = true;
+          break;
+        }
+    if (feedsTaskloop)
+      continue;
+
+    if (alloc.getNumOperands() > 5)
+      if (auto a = alloc.getOperand(5).getDefiningOp<LLVM::AddressOfOp>())
+        if (auto fn = mod.lookupSymbol<LLVM::LLVMFuncOp>(a.getGlobalName()))
+          fnCounts[fn]++;
+  }
+
+  for (LLVM::CallOp alloc : allocs) {
+    Value td = alloc.getResult();
+
+    // Skip allocs whose result flows into __kmpc_taskloop.
+    bool feedsTaskloop = false;
+    for (Operation *u : td.getUsers())
+      if (auto uc = dyn_cast<LLVM::CallOp>(u))
+        if (isCallTo(uc, "__kmpc_taskloop")) {
+          feedsTaskloop = true;
+          break;
+        }
+    if (feedsTaskloop)
+      continue;
+
+    // ── Find the scheduling call that consumes `td` ──────────────────────
+    LLVM::CallOp taskCall;
+    for (Operation *u : llvm::make_early_inc_range(td.getUsers())) {
+      if (auto uc = dyn_cast<LLVM::CallOp>(u)) {
+        StringRef n = getCalleeName(uc);
+        if (n == "__kmpc_omp_task" || n == "__kmpc_omp_task_with_deps") {
+          taskCall = uc;
+          break;
+        }
+        if (n == "__kmpc_omp_task_begin_if0") {
+          taskCall = uc;
+          break;
+        }
+        if (n == "__kmpc_taskloop") {
+          taskCall = {};
+          break;
+        }
+      }
+    }
+    if (!taskCall) {
+      alloc.emitWarning("LLVMToOmp: __kmpc_task_alloc without consumer — "
+                        "left as llvm.call");
+      continue;
+    }
+    if (isCallTo(taskCall, "__kmpc_omp_task_with_deps"))
+      taskCall.emitWarning("LLVMToOmp: task depend clauses dropped — "
+                           "kmp_depend_info_t layout analysis needed");
+
+    // Harvest captures BEFORE touching any IR.
+    auto caps = harvestTaskCaptures(alloc);
+
+    // alloc arg 2 = flags: bit0=untied, bit1=final, bit2=mergeable
+    bool isUntied = false, isMergeable = false;
+    if (auto fv = getConstInt(alloc.getNumOperands() > 2 ? alloc.getOperand(2)
+                                                         : Value{})) {
+      // kmp_tasking_flags_t bit 0 is `tiedness`, and it reads 1 for a TIED
+      // task: Clang emits flags=1 for `#pragma omp task` and flags=0 for
+      // `#pragma omp task untied`.
+      isUntied = (*fv & 1) == 0;
+      isMergeable = (*fv >> 2) & 1;
+    }
+
+    // alloc arg 5 = pointer to task-entry outlined function
+    LLVM::LLVMFuncOp fn;
+    if (alloc.getNumOperands() > 5)
+      if (auto a = alloc.getOperand(5).getDefiningOp<LLVM::AddressOfOp>())
+        fn = mod.lookupSymbol<LLVM::LLVMFuncOp>(a.getGlobalName());
+
+    OpBuilder b(alloc);
+    Location loc = alloc.getLoc();
+    omp::TaskOperands tOps;
+    if (isUntied)
+      tOps.untied = b.getUnitAttr();
+    if (isMergeable)
+      tOps.mergeable = b.getUnitAttr();
+
+    auto taskOp = b.create<omp::TaskOp>(loc, tOps);
+    b.createBlock(&taskOp.getRegion());
+    b.setInsertionPointToStart(&taskOp.getRegion().front());
+
+    if (fn) {
+      if (failed(inlineTaskBody(fn, taskOp.getRegion(), b, caps))) {
+        taskOp.erase();
+        alloc.emitWarning("LLVMToOmp: failed to inline task body — skipped");
+        continue;
+      }
+    } else {
+      b.create<omp::TerminatorOp>(loc);
+      alloc.emitWarning("LLVMToOmp: task entry fn unresolvable — "
+                        "emitting empty omp.task");
+    }
+
+    // Erase order matters for SSA validity:
+    // (1) taskCall holds a direct use of td — erase first.
+    taskCall.erase();
+
+    // (2) __kmpc_omp_task_complete_if0, if present, also uses td.
+    {
+      SmallVector<Operation *> completions;
+      for (Operation *u : td.getUsers())
+        if (auto uc = dyn_cast<LLVM::CallOp>(u))
+          if (isCallTo(uc, "__kmpc_omp_task_complete_if0"))
+            completions.push_back(u);
+      for (Operation *op : completions)
+        op->erase();
+    }
+
+    // (3) Erase the shareds init chain (p2m → load → p2m → stores).
+    eraseTaskSharedsInit(alloc);
+
+    // (4) td is now use-empty — safe to erase.
+    alloc.erase();
+
+    // (5) Erase the outlined entry function only after its last alloc site
+    //     has been converted.  If the same function is referenced by multiple
+    //     task_alloc calls, earlier iterations merely decrement the counter.
+    if (fn && --fnCounts[fn] == 0)
+      fn.erase();
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "[LLVMToOmp] task_alloc → omp.task";
+      if (!caps.empty())
+        llvm::dbgs() << " (" << caps.size() << " cap(s))";
+      llvm::dbgs() << "\n";
+    });
+  }
+}
+
+/// Inline the per-iteration body of a taskloop entry function into `destBlk`.
+///
+/// The Clang-emitted task-entry fn always has this shape:
+///   lb_raw  = load arg1[5]           // i64, lower 32 bits = lb
+///   ub      = load arg1[6]           // i64
+///   lb_sext = sign_extend(lb_raw)    // shli 32 + shrsi 32
+///   if ub >= lb_sext:
+///     start = lb_sext + 1
+///     end   = max(ub+1, start) + 1
+///     for iv_for in [start, end, 1):
+///       val = lb_sext + (iv_for - start)   // = iv_for - 1
+///       <per-iteration work using val>
+///
+/// Strategy:
+///   1. Pre-map lb_raw / lb_sext → lb, ub_raw → ub (taskloop call args).
+///   2. Clone preamble ops (start/end computations) into destBlk.
+///   3. Map iv_for → nestIV + 1  so  val = (nestIV+1) - 1 = nestIV.
+///   4. Clone scf.for body ops (the actual per-iteration work).
+static LogicalResult
+inlineTaskloopBody(LLVM::LLVMFuncOp fn, Block *destBlk, OpBuilder &b,
+                   Location loc, ArrayRef<std::pair<int64_t, Value>> caps,
+                   Value lb, Value ub, BlockArgument nestIV) {
+
+  if (fn.getBody().empty())
+    return fn.emitError("LLVMToOmp: taskloop entry fn '")
+           << fn.getName() << "' has empty body";
+
+  Block &entry = fn.getBody().front();
+
+  // Everything cloned below — the argument placeholders included — belongs
+  // ahead of the loop-nest terminator the caller already put in place.
+  b.setInsertionPoint(destBlk->getTerminator());
+
+  // ── (1) Base mapping: fn args → undef + user captures ─────────────────
+  IRMapping map;
+  for (BlockArgument arg : entry.getArguments())
+    map.map(arg, b.create<LLVM::UndefOp>(loc, arg.getType()));
+  buildTaskCaptureMap(fn, caps, map);
+
+  // ── (2) Pre-map lb/ub field accesses from the task struct (arg1) ───────
+  // arg1[5] → raw lb (i64) → sign-extended chain → lb_sext   map all → lb
+  // arg1[6] → ub                                              map → ub
+  if (entry.getNumArguments() > 1) {
+    BlockArgument arg1 = entry.getArgument(1);
+    fn.walk([&](Operation *op) {
+      if (op->getName().getStringRef() != "enzymexla.pointer2memref")
+        return;
+      if (op->getNumOperands() != 1 || op->getOperand(0) != arg1)
+        return;
+      Value p2m = op->getResult(0);
+      for (Operation *u : p2m.getUsers()) {
+        auto ld = dyn_cast<memref::LoadOp>(u);
+        if (!ld || ld.getIndices().size() != 1)
+          continue;
+        auto idx = getConstIndex(ld.getIndices()[0]);
+        if (!idx)
+          continue;
+        if (*idx == 5) {
+          map.map(ld.getResult(), lb);
+          // sign-extension chain: shli 32 → shrsi 32
+          for (Operation *u2 : ld.getResult().getUsers()) {
+            auto shli = dyn_cast<arith::ShLIOp>(u2);
+            if (!shli)
+              continue;
+            map.map(shli.getResult(), lb);
+            for (Operation *u3 : shli.getResult().getUsers()) {
+              auto shrsi = dyn_cast<arith::ShRSIOp>(u3);
+              if (!shrsi)
+                continue;
+              map.map(shrsi.getResult(), lb);
+            }
+          }
+        }
+        if (*idx == 6)
+          map.map(ld.getResult(), ub);
+      }
+    });
+  }
+
+  // ── (3) Locate scf.if (bounds guard) and scf.for (chunk loop) ─────────
+  scf::IfOp outerIf;
+  scf::ForOp bodyFor;
+  fn.walk([&](scf::IfOp f) {
+    if (!outerIf)
+      outerIf = f;
+  });
+  fn.walk([&](scf::ForOp f) {
+    if (!bodyFor)
+      bodyFor = f;
+  });
+
+  if (!bodyFor) {
+    fn.emitWarning("LLVMToOmp: taskloop fn has no scf.for — "
+                   "falling back to full-body inline (suboptimal)");
+    b.setInsertionPoint(destBlk->getTerminator());
+    for (Block &sb : fn.getBody())
+      for (Operation &op : sb) {
+        if (isa<LLVM::ReturnOp>(op))
+          continue;
+        if (!op.getResults().empty() &&
+            llvm::all_of(op.getResults(),
+                         [&](Value r) { return map.contains(r); }))
+          continue;
+        b.clone(op, map);
+      }
+    return success();
+  }
+
+  b.setInsertionPoint(destBlk->getTerminator());
+
+  // Clang hoists the constants the loop body needs into the entry block, above
+  // the bounds guard, so cloning the guard's contents alone leaves operands
+  // pointing back into the outlined function — and the enclosing llvm.func is
+  // IsolatedFromAbove, so those references do not verify.  Pull each missing
+  // dependency in on demand instead.  Only pure ops are safe to re-order this
+  // way; anything else means the outlined function is not shaped the way this
+  // conversion assumes, and the caller skips the taskloop.
+  bool depsOk = true;
+  llvm::DenseSet<Operation *> visited;
+  std::function<void(Operation *)> cloneWithDeps = [&](Operation *op) {
+    if (!visited.insert(op).second)
+      return;
+    for (Value operand : op->getOperands()) {
+      if (map.contains(operand))
+        continue;
+      Operation *def = operand.getDefiningOp();
+      if (!def || def->getParentOfType<LLVM::LLVMFuncOp>() != fn)
+        continue;
+      if (!isPure(def)) {
+        depsOk = false;
+        continue;
+      }
+      cloneWithDeps(def);
+    }
+    // Skip ops whose results are already in the map (pre-mapped lb/ub chain).
+    if (!op->getResults().empty() &&
+        llvm::all_of(op->getResults(),
+                     [&](Value r) { return map.contains(r); }))
+      return;
+    b.clone(*op, map);
+  };
+
+  // ── (4) Clone preamble ops (before the scf.for, inside the scf.if) ────
+  // These compute start = lb+1, end = ub+2, etc., needed by the for body.
+  Block *preamble = outerIf ? &outerIf.getThenRegion().front() : &entry;
+  for (Operation &op : *preamble) {
+    if (&op == bodyFor.getOperation())
+      break;
+    if (isa<scf::YieldOp>(op))
+      break;
+    cloneWithDeps(&op);
+  }
+
+  // ── (5) Map scf.for IV → nestIV + 1 ────────────────────────────────────
+  // The for body computes: val = lb + (iv_for - start) = iv_for - 1
+  // Setting iv_for = nestIV + 1  →  val = nestIV  ✓
+  Value one =
+      b.create<arith::ConstantOp>(loc, b.getIntegerAttr(nestIV.getType(), 1));
+  Value ivForVal = b.create<arith::AddIOp>(loc, nestIV, one);
+  map.map(bodyFor.getInductionVar(), ivForVal);
+
+  // ── (6) Clone scf.for body ops (the actual per-iteration work) ─────────
+  for (Operation &op : bodyFor.getBody()->without_terminator())
+    cloneWithDeps(&op);
+
+  if (!depsOk)
+    return fn.emitWarning("LLVMToOmp: taskloop body depends on a non-pure op "
+                          "outside the loop guard"),
+           failure();
+
+  return success();
+}
+
+void LLVMToOMPPass::convertTaskloop(ModuleOp mod) {
+  SmallVector<LLVM::CallOp> calls;
+  mod.walk([&](LLVM::CallOp c) {
+    if (isCallTo(c, "__kmpc_taskloop"))
+      calls.push_back(c);
+  });
+
+  // ── Deferred-erasure reference count ────────────────────────────────────
+  // Multiple __kmpc_taskloop call sites may share the same outlined function.
+  // Count references up front so we erase the function only after the last
+  // site has been converted.
+  llvm::DenseMap<LLVM::LLVMFuncOp, unsigned> fnCounts;
+  for (LLVM::CallOp tlCall : calls) {
+    if (tlCall.getNumOperands() < 7)
+      continue;
+    Value taskPtr = tlCall.getOperand(2);
+    auto alloc = dyn_cast_or_null<LLVM::CallOp>(taskPtr.getDefiningOp());
+    if (!alloc || !isCallTo(alloc, "__kmpc_omp_task_alloc"))
+      continue;
+    if (alloc.getNumOperands() > 5)
+      if (auto a = alloc.getOperand(5).getDefiningOp<LLVM::AddressOfOp>())
+        if (auto fn = mod.lookupSymbol<LLVM::LLVMFuncOp>(a.getGlobalName()))
+          fnCounts[fn]++;
+  }
+
+  for (LLVM::CallOp tlCall : calls) {
+    // ── (A) Locate the kmp_task_t* from __kmpc_omp_task_alloc ───────────
+    if (tlCall.getNumOperands() < 7) {
+      tlCall.emitWarning(
+          "LLVMToOmp: __kmpc_taskloop has too few args — skipped");
+      continue;
+    }
+    Value taskPtr = tlCall.getOperand(2);
+    auto alloc = dyn_cast_or_null<LLVM::CallOp>(taskPtr.getDefiningOp());
+    if (!alloc || !isCallTo(alloc, "__kmpc_omp_task_alloc")) {
+      tlCall.emitWarning("LLVMToOmp: __kmpc_taskloop task ptr not from "
+                         "__kmpc_omp_task_alloc — skipped");
+      continue;
+    }
+
+    // ── (B) Extract loop bounds from call args ──────────────────────────
+    Value lbPtr = tlCall.getOperand(4);
+    Value ubPtr = tlCall.getOperand(5);
+    Value step = tlCall.getOperand(6);
+
+    // __kmpc_taskloop(loc, gtid, task, if_val, lb, ub, st, nogroup, sched,
+    //                 grainsize, task_dup) — nogroup comes before sched.
+    // nogroup: 1 = no implicit taskgroup
+    bool isNogroup = false;
+    if (auto ng = getConstInt(tlCall.getNumOperands() > 7 ? tlCall.getOperand(7)
+                                                          : Value{}))
+      isNogroup = (*ng != 0);
+
+    // sched: 0=default, 1=grainsize, 2=num_tasks
+    int64_t schedMode = 0;
+    if (auto sv = getConstInt(tlCall.getNumOperands() > 8 ? tlCall.getOperand(8)
+                                                          : Value{}))
+      schedMode = *sv;
+
+    Value grainOrNum =
+        tlCall.getNumOperands() > 9 ? tlCall.getOperand(9) : Value{};
+
+    // ── (C) Resolve task-entry outlined function ────────────────────────
+    LLVM::LLVMFuncOp fn;
+    if (alloc.getNumOperands() > 5)
+      if (auto a = alloc.getOperand(5).getDefiningOp<LLVM::AddressOfOp>())
+        fn = mod.lookupSymbol<LLVM::LLVMFuncOp>(a.getGlobalName());
+    if (!fn) {
+      tlCall.emitWarning("LLVMToOmp: __kmpc_taskloop entry fn unresolvable "
+                         "— skipped");
+      continue;
+    }
+
+    // ── (D) Harvest captures and build bounds values ────────────────────
+    auto caps = harvestTaskCaptures(alloc);
+
+    // alloc arg 2 = flags: bit0=untied, bit2=mergeable
+    bool isUntied = false, isMergeable = false;
+    if (auto fv = getConstInt(alloc.getNumOperands() > 2 ? alloc.getOperand(2)
+                                                         : Value{})) {
+      // Bit 0 is `tiedness`, set for a TIED task — see convertTasks.
+      isUntied = (*fv & 1) == 0;
+      isMergeable = ((*fv >> 2) & 1) != 0;
+    }
+
+    MLIRContext *ctx = mod.getContext();
+    // Taskloop bounds are always i64 in the kmp_task_t struct.
+    Type iterTy = IntegerType::get(ctx, 64);
+
+    // Recover the full-range lb/ub the runtime would partition into tasks from
+    // the stores that fill the kmp_task_t, not by loading through the field
+    // pointers: the loop bounds have to be values that outlive the task struct,
+    // which is erased below.
+    Value lb = traceTaskFieldValue(lbPtr, tlCall);
+    Value ub = traceTaskFieldValue(ubPtr, tlCall);
+    if (!lb || !ub) {
+      tlCall.emitWarning("LLVMToOmp: cannot trace taskloop bounds through the "
+                         "kmp_task_t stores — skipped");
+      continue;
+    }
+    if (lb.getType() != iterTy || ub.getType() != iterTy ||
+        step.getType() != iterTy) {
+      tlCall.emitWarning("LLVMToOmp: taskloop bounds are not all i64 — "
+                         "skipped");
+      continue;
+    }
+
+    OpBuilder b(tlCall);
+    Location loc = tlCall.getLoc();
+
+    // ── (E) Build omp.taskloop.context (task clauses only) ──────────────
+    omp::TaskloopContextOperands tloOps;
+    if (isUntied)
+      tloOps.untied = b.getUnitAttr();
+    if (isMergeable)
+      tloOps.mergeable = b.getUnitAttr();
+    if (isNogroup)
+      tloOps.nogroup = b.getUnitAttr();
+    if (grainOrNum) {
+      if (schedMode == 1)
+        tloOps.grainsize = grainOrNum;
+      else if (schedMode == 2)
+        tloOps.numTasks = grainOrNum;
+    }
+
+    // Upstream splits the taskloop construct in two: omp.taskloop.context
+    // carries the clauses and needs an omp.terminator, and the
+    // omp.taskloop.wrapper nested inside it is the loop wrapper
+    // (SingleBlock+NoTerminator, like WsloopOp) that holds the omp.loop_nest:
+    //   omp.taskloop.context { omp.taskloop.wrapper { omp.loop_nest ... }
+    //                          omp.terminator }
+    auto taskloopCtxOp = b.create<omp::TaskloopContextOp>(loc, tloOps);
+    Block *ctxBlk = b.createBlock(&taskloopCtxOp.getRegion());
+    b.setInsertionPointToStart(ctxBlk);
+    b.create<omp::TerminatorOp>(loc);
+
+    // The wrapper goes before the context region's terminator.
+    b.setInsertionPoint(ctxBlk->getTerminator());
+    auto taskloopOp = b.create<omp::TaskloopWrapperOp>(loc);
+    Block *tloBlk = b.createBlock(&taskloopOp.getRegion());
+    b.setInsertionPointToStart(tloBlk);
+
+    // ── (F) Build nested omp.loop_nest (loop bounds go here, not above) ─
+    omp::LoopNestOperands lnOps;
+    lnOps.loopLowerBounds = {lb};
+    lnOps.loopUpperBounds = {ub};
+    lnOps.loopSteps = {step};
+    auto nestOp = b.create<omp::LoopNestOp>(loc, lnOps);
+    Block *nestBlk = b.createBlock(&nestOp.getRegion());
+    BlockArgument iv = nestBlk->addArgument(iterTy, loc);
+    b.setInsertionPointToStart(nestBlk);
+    b.create<omp::YieldOp>(loc); // placeholder; body inserted before this
+
+    // ── (G) Inline per-iteration body into nestBlk ──────────────────────
+    if (failed(inlineTaskloopBody(fn, nestBlk, b, loc, caps, lb, ub, iv))) {
+      taskloopCtxOp.erase();
+      tlCall.emitWarning("LLVMToOmp: taskloop body inline failed — skipped");
+      continue;
+    }
+
+    // ── (H) Erase in SSA-valid order ────────────────────────────────────
+    // (1) tlCall directly uses alloc's result — erase first.
+    tlCall.erase();
+    // (2) Erase the shareds init chain (p2m → load → p2m → stores).
+    eraseTaskSharedsInit(alloc);
+    // (3) Erase the bound/field stores and the getelementptrs onto them.
+    eraseTaskStructInit(alloc);
+    // (4) Only now is alloc's result unused.  If some part of the struct
+    //     initialisation was shaped differently than expected it still has a
+    //     user, and erasing would leave that user dangling.
+    bool allocErased = alloc.use_empty();
+    if (allocErased)
+      alloc.erase();
+    else
+      alloc.emitWarning("LLVMToOmp: kmp_task_t still has uses after taskloop "
+                        "lifting — left in place");
+    // (5) Erase the outlined entry function only after its last taskloop call
+    //     site has been converted, and only once nothing names it any more —
+    //     a surviving alloc still takes its address.
+    if (--fnCounts[fn] == 0 && allocErased &&
+        SymbolTable::symbolKnownUseEmpty(fn, mod))
+      fn.erase();
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "[LLVMToOmp] __kmpc_taskloop → omp.taskloop";
+      if (schedMode == 1 && grainOrNum)
+        llvm::dbgs() << " grainsize";
+      if (schedMode == 2 && grainOrNum)
+        llvm::dbgs() << " num_tasks";
+      if (isNogroup)
+        llvm::dbgs() << " nogroup";
+      llvm::dbgs() << "\n";
+    });
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// §15  Reductions — warn + leave (needs mem2reg)
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// §15  Reductions
+//
+// Converts the __kmpc_reduce_nowait protocol to omp.declare_reduction +
+// omp.parallel reduction clauses.
+//
+// Clang's outlined-function lowering of  `reduction(+:sum)`:
+//
+//   local_acc = alloca i32              // thread-private accumulator
+//   memref.store 0, p2m(local_acc)[0]  // initialize to identity
+//   [loop body accumulates into local_acc]
+//   reduce_list = alloca [1 x ptr]
+//   memref.store local_acc, p2m(reduce_list)[0]
+//   %r = __kmpc_reduce_nowait(ident, gtid, 1, 8, reduce_list, fn, lck)
+//   scf.if (%r == 1) {                  // lock-free critical section
+//     *global_sum += *local_acc
+//     __kmpc_end_reduce_nowait(...)
+//   } else { scf.if (%r == 2) {         // atomic path
+//     atomicrmw add global_sum, *local_acc
+//   }}
+//
+// Target form:
+//
+//   omp.declare_reduction @omp_red_add_i32 : i32
+//     init    { %0 = arith.constant 0 : i32;  omp.yield(%0 : i32) }
+//     combiner { ^(%a: i32, %b: i32): %c = addi %a,%b; omp.yield(%c : i32) }
+//     atomic  { ^(%lp: !llvm.ptr, %rp: !llvm.ptr):
+//                 %v = load %rp; atomicrmw add %lp, %v; omp.yield }
+//
+//   omp.parallel reduction(byref @omp_red_add_i32 %global_sum -> %priv :
+//   !llvm.ptr) {
+//     [body uses %priv (block-arg) instead of the old local_acc alloca]
+//     omp.terminator
+//   }
+//===----------------------------------------------------------------------===//
+
+/// Find the scf.if dispatching on __kmpc_reduce*'s return value.
+/// It immediately follows the reduce call (separated by index_castui + cmpi).
+static scf::IfOp findReduceDispatchIf(LLVM::CallOp reduceCall) {
+  bool past = false;
+  for (Operation &op : *reduceCall->getBlock()) {
+    if (&op == reduceCall.getOperation()) {
+      past = true;
+      continue;
+    }
+    if (!past)
+      continue;
+    if (auto sif = dyn_cast<scf::IfOp>(&op))
+      return sif;
+  }
+  return {};
+}
+
+/// Return the last constant index of a GEPOp's index list — for a reduce_list
+/// GEP of the form `gep base[0, i]` that is the array slot number.
+/// Returns -1 if any index is a non-constant Value.
+
+/// Collect the thread-local reduction variable pointers stored into
+/// the reduce_list alloca.  Handles three IR patterns:
+///   Path 1 (memref bridge): pointer2memref(alloca) → memref.store ptr, [i]
+///   Path 2 (LLVM GEP):      llvm.getelementptr alloca[…, i] → llvm.store ptr
+///   Path 3 (direct store):  llvm.store ptr, alloca  (single-element list)
+static SmallVector<Value> extractReduceListPtrs(Value reduceListAlloca) {
+  SmallVector<std::pair<int64_t, Value>> indexed;
+
+  for (Operation *u : reduceListAlloca.getUsers()) {
+    // ── Path 1: enzymexla.pointer2memref → memref.store ──────────────────
+    if (u->getName().getStringRef() == "enzymexla.pointer2memref" &&
+        u->getNumResults() == 1) {
+      Value p2m = u->getResult(0);
+      for (Operation *su : p2m.getUsers()) {
+        auto st = dyn_cast<memref::StoreOp>(su);
+        if (!st || st.getIndices().size() != 1)
+          continue;
+        if (auto idx = getConstIndex(st.getIndices()[0]))
+          indexed.emplace_back(*idx, st.getValueToStore());
+      }
+      continue;
+    }
+    // ── Path 2: llvm.getelementptr → llvm.store ──────────────────────────
+    if (auto gep = dyn_cast<LLVM::GEPOp>(u)) {
+      int64_t slot = gepLastConstantIndex(gep);
+      if (slot < 0)
+        continue;
+      for (Operation *su : gep.getResult().getUsers())
+        if (auto st = dyn_cast<LLVM::StoreOp>(su))
+          indexed.emplace_back(slot, st.getValue());
+      continue;
+    }
+    // ── Path 3: direct llvm.store (single-element reduce_list) ───────────
+    if (auto st = dyn_cast<LLVM::StoreOp>(u))
+      indexed.emplace_back(0, st.getValue());
+  }
+
+  llvm::sort(indexed,
+             [](const auto &a, const auto &b) { return a.first < b.first; });
+  SmallVector<Value> ptrs;
+  for (auto &[_, v] : indexed)
+    ptrs.push_back(v);
+  return ptrs;
+}
+
+//===----------------------------------------------------------------------===//
+// §15a  Select-pattern reduction kind helper
+//
+// Determines whether a (cmpf/cmpi + select) combiner is a max or min, and
+// whether it operates on float / signed-int / unsigned-int.
+//===----------------------------------------------------------------------===//
+enum class SelectRedKind { MaxF, MinF, MaxS, MinS, MaxU, MinU, Unknown };
+
+static SelectRedKind getSelectRedKind(arith::SelectOp selOp) {
+  Value cond = selOp.getCondition();
+  Value trueVal = stripCasts(selOp.getTrueValue());
+
+  if (auto cmpf = cond.getDefiningOp<arith::CmpFOp>()) {
+    bool trueIsCmpLhs = (trueVal == stripCasts(cmpf.getLhs()));
+    using P = arith::CmpFPredicate;
+    bool isMax;
+    switch (cmpf.getPredicate()) {
+    case P::OGT:
+    case P::OGE:
+    case P::UGT:
+    case P::UGE:
+      isMax = trueIsCmpLhs;
+      break;
+    case P::OLT:
+    case P::OLE:
+    case P::ULT:
+    case P::ULE:
+      isMax = !trueIsCmpLhs;
+      break;
+    default:
+      return SelectRedKind::Unknown;
+    }
+    return isMax ? SelectRedKind::MaxF : SelectRedKind::MinF;
+  }
+  if (auto cmpi = cond.getDefiningOp<arith::CmpIOp>()) {
+    bool trueIsCmpLhs = (trueVal == stripCasts(cmpi.getLhs()));
+    using P = arith::CmpIPredicate;
+    bool isMax, isSigned;
+    switch (cmpi.getPredicate()) {
+    case P::sgt:
+    case P::sge:
+      isMax = trueIsCmpLhs;
+      isSigned = true;
+      break;
+    case P::slt:
+    case P::sle:
+      isMax = !trueIsCmpLhs;
+      isSigned = true;
+      break;
+    case P::ugt:
+    case P::uge:
+      isMax = trueIsCmpLhs;
+      isSigned = false;
+      break;
+    case P::ult:
+    case P::ule:
+      isMax = !trueIsCmpLhs;
+      isSigned = false;
+      break;
+    default:
+      return SelectRedKind::Unknown;
+    }
+    if (isMax && isSigned)
+      return SelectRedKind::MaxS;
+    if (!isMax && isSigned)
+      return SelectRedKind::MinS;
+    if (isMax && !isSigned)
+      return SelectRedKind::MaxU;
+    return SelectRedKind::MinU;
+  }
+  return SelectRedKind::Unknown;
+}
+
+struct ReductionBodyInfo {
+  Value globalPtr;
+  Operation *combineOp;
+};
+
+/// Scan the case-1 (lock-free) body for a combining binary op between a
+/// load of the thread-local accumulator and a load of the shared variable.
+///
+/// Recognises two load forms (memref bridge and direct llvm.load) and
+/// tolerates scalar cast chains between the loads and the combiner.
+//===----------------------------------------------------------------------===//
+// analyzeReductionCase1  (extended: also handles cmpf/cmpi + select pattern)
+//===----------------------------------------------------------------------===//
+static std::optional<ReductionBodyInfo> analyzeReductionCase1(Block &body,
+                                                              Value localPtr) {
+  // ── Pass 1: map every load result to its source pointer ──────────────
+  llvm::DenseMap<Value, Value> loadSrc;
+  for (Operation &op : body) {
+    Value src, result;
+    if (auto ld = dyn_cast<memref::LoadOp>(&op)) {
+      if (ld.getIndices().size() != 1)
+        continue;
+      auto *p2m = ld.getMemRef().getDefiningOp();
+      if (!p2m || p2m->getName().getStringRef() != "enzymexla.pointer2memref" ||
+          p2m->getNumOperands() != 1)
+        continue;
+      src = p2m->getOperand(0);
+      result = ld.getResult();
+    } else if (auto ld = dyn_cast<LLVM::LoadOp>(&op)) {
+      src = ld.getAddr();
+      result = ld.getResult();
+    }
+    if (src && result)
+      loadSrc[result] = src;
+  }
+
+  // ── Pass 2: find combiner — direct binary arith op OR select+cmp ─────
+  Value globalPtr;
+  Operation *combiner = nullptr;
+
+  for (Operation &op : body) {
+    // ── Case A: direct binary arith combiner ─────────────────────────────
+    if (op.getNumOperands() == 2 && op.getNumResults() == 1) {
+      if (isa<arith::AddIOp, arith::AddFOp, arith::MulIOp, arith::MulFOp,
+              arith::AndIOp, arith::OrIOp, arith::XOrIOp, arith::MinSIOp,
+              arith::MaxSIOp, arith::MinUIOp, arith::MaxUIOp, arith::MinimumFOp,
+              arith::MaximumFOp>(&op)) {
+        Value o0 = stripCasts(op.getOperand(0));
+        Value o1 = stripCasts(op.getOperand(1));
+        Value s0 = o0 ? loadSrc.lookup(o0) : Value{};
+        Value s1 = o1 ? loadSrc.lookup(o1) : Value{};
+        if (!s0 || !s1)
+          continue;
+        if (s0 == localPtr && s1 != localPtr)
+          globalPtr = s1;
+        else if (s1 == localPtr && s0 != localPtr)
+          globalPtr = s0;
+        else
+          continue;
+        combiner = &op;
+        break;
+      }
+    }
+
+    // ── Case B: arith.select(cmpf/cmpi PRED, load_a, load_b) ─────────────
+    if (auto selOp = dyn_cast<arith::SelectOp>(&op)) {
+      Value trueVal = stripCasts(selOp.getTrueValue());
+      Value falseVal = stripCasts(selOp.getFalseValue());
+      Value s0 = trueVal ? loadSrc.lookup(trueVal) : Value{};
+      Value s1 = falseVal ? loadSrc.lookup(falseVal) : Value{};
+      if (!s0 || !s1)
+        continue;
+      Value tentGlobal;
+      if (s0 == localPtr && s1 != localPtr)
+        tentGlobal = s1;
+      else if (s1 == localPtr && s0 != localPtr)
+        tentGlobal = s0;
+      else
+        continue;
+      // Verify condition is a cmpf/cmpi whose operands both come from loads
+      Value cond = selOp.getCondition();
+      Operation *cmpOp = cond.getDefiningOp();
+      if (!cmpOp || !isa<arith::CmpFOp, arith::CmpIOp>(cmpOp))
+        continue;
+      Value cmpL = stripCasts(cmpOp->getOperand(0));
+      Value cmpR = stripCasts(cmpOp->getOperand(1));
+      if (!loadSrc.count(cmpL) || !loadSrc.count(cmpR))
+        continue;
+      // Must be a recognisable max/min kind
+      if (getSelectRedKind(selOp) == SelectRedKind::Unknown)
+        continue;
+      globalPtr = tentGlobal;
+      combiner = &op;
+      break;
+    }
+  }
+
+  if (!globalPtr || !combiner)
+    return std::nullopt;
+  return ReductionBodyInfo{globalPtr, combiner};
+}
+
+/// Return the value of the first store into localPtr — the identity / init
+/// value for the reduction.  Handles memref-bridge stores, direct llvm.store,
+/// and GEP-then-llvm.store.
+static Value findReductionInit(Value localPtr) {
+  auto nestDepth = [](Operation *op) -> int {
+    int d = 0;
+    for (Operation *p = op->getParentOp(); p; p = p->getParentOp())
+      ++d;
+    return d;
+  };
+
+  Operation *earliest = nullptr;
+  Value initVal;
+
+  auto consider = [&](Operation *st, Value val) {
+    if (!earliest) {
+      earliest = st;
+      initVal = val;
+      return;
+    }
+    if (st->getBlock() == earliest->getBlock()) {
+      if (st->isBeforeInBlock(earliest)) {
+        earliest = st;
+        initVal = val;
+      }
+    } else {
+      if (nestDepth(st) < nestDepth(earliest)) {
+        earliest = st;
+        initVal = val;
+      }
+    }
+  };
+
+  for (Operation *u : localPtr.getUsers()) {
+    // Path 1: pointer2memref → memref.store
+    if (u->getName().getStringRef() == "enzymexla.pointer2memref" &&
+        u->getNumResults() == 1) {
+      Value p2m = u->getResult(0);
+      for (Operation *su : p2m.getUsers())
+        if (auto st = dyn_cast<memref::StoreOp>(su))
+          consider(st, st.getValueToStore());
+    }
+    // Path 2: direct llvm.store %val, %localPtr
+    if (auto st = dyn_cast<LLVM::StoreOp>(u))
+      consider(st, st.getValue());
+    // Path 3: llvm.getelementptr %localPtr[…] → llvm.store
+    if (isa<LLVM::GEPOp>(u))
+      for (Operation *su : u->getResult(0).getUsers())
+        if (auto st = dyn_cast<LLVM::StoreOp>(su))
+          consider(st, st.getValue());
+  }
+  return initVal;
+}
+
+/// Build a unique, stable symbol name: "omp_red_add_i32", "omp_red_mul_f64", …
+//===----------------------------------------------------------------------===//
+// makeRedSymName  (extended)
+//===----------------------------------------------------------------------===//
+static std::string makeRedSymName(Operation *combineOp, Type elemTy) {
+  StringRef opStr = "op";
+  if (isa<arith::AddIOp, arith::AddFOp>(combineOp))
+    opStr = "add";
+  else if (isa<arith::MulIOp, arith::MulFOp>(combineOp))
+    opStr = "mul";
+  else if (isa<arith::AndIOp>(combineOp))
+    opStr = "and";
+  else if (isa<arith::OrIOp>(combineOp))
+    opStr = "or";
+  else if (isa<arith::XOrIOp>(combineOp))
+    opStr = "xor";
+  else if (isa<arith::MinSIOp>(combineOp))
+    opStr = "mins";
+  else if (isa<arith::MaxSIOp>(combineOp))
+    opStr = "maxs";
+  else if (isa<arith::MinUIOp>(combineOp))
+    opStr = "minu";
+  else if (isa<arith::MaxUIOp>(combineOp))
+    opStr = "maxu";
+  else if (isa<arith::MinimumFOp>(combineOp))
+    opStr = "minf";
+  else if (isa<arith::MaximumFOp>(combineOp))
+    opStr = "maxf";
+  else if (auto sel = dyn_cast<arith::SelectOp>(combineOp)) {
+    switch (getSelectRedKind(sel)) {
+    case SelectRedKind::MaxF:
+      opStr = "maxf";
+      break;
+    case SelectRedKind::MinF:
+      opStr = "minf";
+      break;
+    case SelectRedKind::MaxS:
+      opStr = "maxs";
+      break;
+    case SelectRedKind::MinS:
+      opStr = "mins";
+      break;
+    case SelectRedKind::MaxU:
+      opStr = "maxu";
+      break;
+    case SelectRedKind::MinU:
+      opStr = "minu";
+      break;
+    default:
+      break;
+    }
+  }
+  std::string ts;
+  llvm::raw_string_ostream os(ts);
+  elemTy.print(os);
+  for (char &c : ts)
+    if (!llvm::isAlnum(c))
+      c = '_';
+  return ("omp_red_" + opStr + "_" + ts).str();
+}
+
+/// Clone the combining operation in the combiner region with fresh block args.
+
+//===----------------------------------------------------------------------===//
+// emitRedCombiner  (extended)
+//===----------------------------------------------------------------------===//
+static Value emitRedCombiner(OpBuilder &b, Location loc, Operation *tmpl,
+                             Value lhs, Value rhs) {
+  if (isa<arith::AddIOp>(tmpl))
+    return b.create<arith::AddIOp>(loc, lhs, rhs);
+  if (isa<arith::AddFOp>(tmpl))
+    return b.create<arith::AddFOp>(loc, lhs, rhs);
+  if (isa<arith::MulIOp>(tmpl))
+    return b.create<arith::MulIOp>(loc, lhs, rhs);
+  if (isa<arith::MulFOp>(tmpl))
+    return b.create<arith::MulFOp>(loc, lhs, rhs);
+  if (isa<arith::AndIOp>(tmpl))
+    return b.create<arith::AndIOp>(loc, lhs, rhs);
+  if (isa<arith::OrIOp>(tmpl))
+    return b.create<arith::OrIOp>(loc, lhs, rhs);
+  if (isa<arith::XOrIOp>(tmpl))
+    return b.create<arith::XOrIOp>(loc, lhs, rhs);
+  if (isa<arith::MinSIOp>(tmpl))
+    return b.create<arith::MinSIOp>(loc, lhs, rhs);
+  if (isa<arith::MaxSIOp>(tmpl))
+    return b.create<arith::MaxSIOp>(loc, lhs, rhs);
+  if (isa<arith::MinUIOp>(tmpl))
+    return b.create<arith::MinUIOp>(loc, lhs, rhs);
+  if (isa<arith::MaxUIOp>(tmpl))
+    return b.create<arith::MaxUIOp>(loc, lhs, rhs);
+  if (isa<arith::MinimumFOp>(tmpl))
+    return b.create<arith::MinimumFOp>(loc, lhs, rhs);
+  if (isa<arith::MaximumFOp>(tmpl))
+    return b.create<arith::MaximumFOp>(loc, lhs, rhs);
+  if (auto sel = dyn_cast<arith::SelectOp>(tmpl)) {
+    switch (getSelectRedKind(sel)) {
+    case SelectRedKind::MaxF:
+      return b.create<arith::MaximumFOp>(loc, lhs, rhs);
+    case SelectRedKind::MinF:
+      return b.create<arith::MinimumFOp>(loc, lhs, rhs);
+    case SelectRedKind::MaxS:
+      return b.create<arith::MaxSIOp>(loc, lhs, rhs);
+    case SelectRedKind::MinS:
+      return b.create<arith::MinSIOp>(loc, lhs, rhs);
+    case SelectRedKind::MaxU:
+      return b.create<arith::MaxUIOp>(loc, lhs, rhs);
+    case SelectRedKind::MinU:
+      return b.create<arith::MinUIOp>(loc, lhs, rhs);
+    default:
+      return {};
+    }
+  }
+  return {};
+}
+
+/// Map an arith combiner op to the LLVM atomic bin_op for the atomic region.
+//===----------------------------------------------------------------------===//
+// combineOpToAtomicBinOp  (extended)
+//===----------------------------------------------------------------------===//
+static LLVM::AtomicBinOp combineOpToAtomicBinOp(Operation *combineOp) {
+  if (isa<arith::AddIOp>(combineOp))
+    return LLVM::AtomicBinOp::add;
+  if (isa<arith::AddFOp>(combineOp))
+    return LLVM::AtomicBinOp::fadd;
+  if (isa<arith::AndIOp>(combineOp))
+    return LLVM::AtomicBinOp::_and;
+  if (isa<arith::OrIOp>(combineOp))
+    return LLVM::AtomicBinOp::_or;
+  if (isa<arith::XOrIOp>(combineOp))
+    return LLVM::AtomicBinOp::_xor;
+  if (isa<arith::MinSIOp>(combineOp))
+    return LLVM::AtomicBinOp::min;
+  if (isa<arith::MaxSIOp>(combineOp))
+    return LLVM::AtomicBinOp::max;
+  if (isa<arith::MinUIOp>(combineOp))
+    return LLVM::AtomicBinOp::umin;
+  if (isa<arith::MaxUIOp>(combineOp))
+    return LLVM::AtomicBinOp::umax;
+  if (auto sel = dyn_cast<arith::SelectOp>(combineOp)) {
+    switch (getSelectRedKind(sel)) {
+    case SelectRedKind::MaxF:
+      return LLVM::AtomicBinOp::fmax;
+    case SelectRedKind::MinF:
+      return LLVM::AtomicBinOp::fmin;
+    case SelectRedKind::MaxS:
+      return LLVM::AtomicBinOp::max;
+    case SelectRedKind::MinS:
+      return LLVM::AtomicBinOp::min;
+    case SelectRedKind::MaxU:
+      return LLVM::AtomicBinOp::umax;
+    case SelectRedKind::MinU:
+      return LLVM::AtomicBinOp::umin;
+    default:
+      break;
+    }
+  }
+  return LLVM::AtomicBinOp::add; // safe default
+}
+
+/// Erase the reduce_list alloca and all the stores that populated it.
+/// Handles all three patterns recognised by extractReduceListPtrs.
+static void eraseReduceListAlloca(Value reduceListAlloca) {
+  for (Operation *u : llvm::make_early_inc_range(reduceListAlloca.getUsers())) {
+    // Path 1: pointer2memref → memref.store
+    if (u->getName().getStringRef() == "enzymexla.pointer2memref" &&
+        u->getNumResults() == 1) {
+      Value p2m = u->getResult(0);
+      for (Operation *su : llvm::make_early_inc_range(p2m.getUsers()))
+        if (isa<memref::StoreOp>(su))
+          su->erase();
+      if (p2m.use_empty())
+        u->erase();
+      continue;
+    }
+    // Path 2: llvm.getelementptr → llvm.store
+    if (isa<LLVM::GEPOp>(u)) {
+      Value gepRes = u->getResult(0);
+      for (Operation *su : llvm::make_early_inc_range(gepRes.getUsers()))
+        if (isa<LLVM::StoreOp>(su))
+          su->erase();
+      if (gepRes.use_empty())
+        u->erase();
+      continue;
+    }
+    // Path 3: direct llvm.store
+    if (isa<LLVM::StoreOp>(u)) {
+      u->erase();
+      continue;
+    }
+  }
+  if (reduceListAlloca.use_empty())
+    if (auto *op = reduceListAlloca.getDefiningOp())
+      op->erase();
+}
+
+void LLVMToOMPPass::convertReductions(ModuleOp mod) {
+  MLIRContext *ctx = mod.getContext();
+
+  SmallVector<LLVM::CallOp> reduceCalls;
+  mod.walk([&](LLVM::CallOp c) {
+    StringRef n = getCalleeName(c);
+    if (n == "__kmpc_reduce" || n == "__kmpc_reduce_nowait")
+      reduceCalls.push_back(c);
+  });
+
+  LLVM_DEBUG(llvm::dbgs() << "[convertReductions] found " << reduceCalls.size()
+                          << " reduce call(s)\n");
+
+  for (LLVM::CallOp reduceCall : reduceCalls) {
+    Location loc = reduceCall.getLoc();
+    StringRef calleeName = getCalleeName(reduceCall);
+
+    // ── step 1: dispatch scf.if ──────────────────────────────────────────
+    scf::IfOp dispatchIf = findReduceDispatchIf(reduceCall);
+    if (!dispatchIf) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  SKIP: no dispatch scf.if found after the reduce call\n");
+      reduceCall.emitWarning("LLVMToOmp: '")
+          << calleeName
+          << "' not converted — run mem2reg first so reduction GEPs can be "
+             "traced.  Left as llvm.call.";
+      continue;
+    }
+
+    // ── step 2: reduce_list local-var pointers ───────────────────────────
+    if (reduceCall.getNumOperands() < 5) {
+      LLVM_DEBUG(llvm::dbgs() << "  SKIP: reduce call has only "
+                              << reduceCall.getNumOperands() << " operands\n");
+      continue;
+    }
+    Value reduceListAlloca = reduceCall.getOperand(4);
+
+    SmallVector<Value> localPtrs = extractReduceListPtrs(reduceListAlloca);
+    if (localPtrs.empty()) {
+      LLVM_DEBUG(llvm::dbgs() << "  SKIP: no stores into reduce_list found\n");
+      reduceCall.emitWarning("LLVMToOmp: '")
+          << calleeName
+          << "' not converted — cannot trace reduce_list.  Left as llvm.call.";
+      continue;
+    }
+    Value localPtr = localPtrs[0];
+
+    // ── step 3: analyse case-1 (lock-free) body ──────────────────────────
+    Block &case1Blk = dispatchIf.getThenRegion().front();
+
+    auto descOpt = analyzeReductionCase1(case1Blk, localPtr);
+    if (!descOpt) {
+      LLVM_DEBUG(
+          llvm::dbgs()
+          << "  SKIP: analyzeReductionCase1 found no globalPtr/combiner\n");
+      reduceCall.emitWarning("LLVMToOmp: '")
+          << calleeName
+          << "' not converted — cannot analyse case-1 reduction body.  "
+             "Left as llvm.call.";
+      continue;
+    }
+    Value globalPtr = descOpt->globalPtr;
+    Operation *combOp = descOpt->combineOp;
+
+    // ── step 4: element type ──────────────────────────────────────────────
+    Type elemTy;
+    if (auto alloca = localPtr.getDefiningOp<LLVM::AllocaOp>())
+      elemTy = alloca.getElemType();
+    if (!elemTy) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  SKIP: localPtr does not come from llvm.alloca\n");
+      reduceCall.emitWarning("LLVMToOmp: '")
+          << calleeName
+          << "' not converted — cannot determine element type.  Left as "
+             "llvm.call.";
+      continue;
+    }
+
+    // ── step 5: init / identity value ─────────────────────────────────────
+    Value initVal = findReductionInit(localPtr);
+
+    // ── step 6: omp.declare_reduction ─────────────────────────────────────
+    std::string symName = makeRedSymName(combOp, elemTy);
+    if (!mod.lookupSymbol(symName)) {
+      OpBuilder mb(mod.getBody(), mod.getBody()->begin());
+      auto declOp = mb.create<omp::DeclareReductionOp>(
+          loc, symName, elemTy, /*byref_element_type=*/TypeAttr{});
+
+      // init region
+      {
+        Block *blk = mb.createBlock(&declOp.getInitializerRegion());
+        blk->addArgument(elemTy, loc);
+        mb.setInsertionPointToStart(blk);
+        Value iv;
+        if (initVal)
+          if (auto *defOp = initVal.getDefiningOp()) {
+            IRMapping m;
+            iv = mb.clone(*defOp, m)->getResult(0);
+          }
+        if (!iv || iv.getType() != elemTy)
+          iv = mb.create<arith::ConstantOp>(loc, mb.getZeroAttr(elemTy));
+        mb.create<omp::YieldOp>(loc, ValueRange{iv});
+      }
+      // combiner region
+      {
+        Block *blk = mb.createBlock(&declOp.getReductionRegion());
+        BlockArgument lhs = blk->addArgument(elemTy, loc);
+        BlockArgument rhs = blk->addArgument(elemTy, loc);
+        mb.setInsertionPointToStart(blk);
+        Value combined = emitRedCombiner(mb, loc, combOp, lhs, rhs);
+        if (!combined) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "  SKIP: emitRedCombiner returned null for "
+                     << combOp->getName().getStringRef() << "\n");
+          declOp.erase();
+          reduceCall.emitWarning("LLVMToOmp: '")
+              << calleeName
+              << "' not converted — unsupported combiner op.  Left as "
+                 "llvm.call.";
+          goto nextReduction;
+        }
+        mb.create<omp::YieldOp>(loc, ValueRange{combined});
+      }
+      // atomic region
+      {
+        auto ptrTy = LLVM::LLVMPointerType::get(ctx);
+        Block *blk = mb.createBlock(&declOp.getAtomicReductionRegion());
+        BlockArgument lhsPtr = blk->addArgument(ptrTy, loc);
+        BlockArgument rhsPtr = blk->addArgument(ptrTy, loc);
+        mb.setInsertionPointToStart(blk);
+        Value rhsVal = mb.create<LLVM::LoadOp>(loc, elemTy, rhsPtr);
+        mb.create<LLVM::AtomicRMWOp>(loc, combineOpToAtomicBinOp(combOp),
+                                     lhsPtr, rhsVal,
+                                     LLVM::AtomicOrdering::monotonic);
+        mb.create<omp::YieldOp>(loc, ValueRange{});
+      }
+    }
+
+    // ── step 7: find enclosing omp.parallel ───────────────────────────────
+    {
+      omp::ParallelOp parallelOp;
+      for (Operation *p = reduceCall->getParentOp(); p; p = p->getParentOp())
+        if ((parallelOp = dyn_cast<omp::ParallelOp>(p)))
+          break;
+      if (!parallelOp) {
+        // Check whether we're inside a standalone .omp_outlined function
+        // preserved for the __kmpc_serialized_parallel path.  The cloned
+        // copy (inside omp.parallel) was already converted above; this
+        // copy runs single-threaded and needs no OMP dialect representation.
+        bool inOutlinedFn = false;
+        for (Operation *p = reduceCall->getParentOp(); p; p = p->getParentOp())
+          if (auto fn = dyn_cast<LLVM::LLVMFuncOp>(p)) {
+            inOutlinedFn = fn.getName().contains(".omp_outlined");
+            break;
+          }
+        if (inOutlinedFn) {
+          LLVM_DEBUG(
+              llvm::dbgs()
+              << "  SKIP: reduce in serialized outlined fn (single-thread)\n");
+          continue; // silent — real conversion already happened in inlined copy
+        }
+        for (Operation *p = reduceCall->getParentOp(); p; p = p->getParentOp())
+          llvm::errs() << p->getName() << " > ";
+        llvm::errs() << "(top)\n";
+        LLVM_DEBUG(llvm::dbgs()
+                   << "  SKIP: reduce call is not inside an omp.parallel\n");
+        reduceCall.emitWarning("LLVMToOmp: '")
+            << calleeName << "' not inside omp.parallel — left as llvm.call.";
+        continue;
+      }
+      Block *oldEntry = &parallelOp.getRegion().front();
+
+      // ── step 8: rebuild omp.parallel with reduction clause ─────────────
+      OpBuilder b(parallelOp);
+
+      omp::ParallelOperands newOps;
+      newOps.ifExpr = parallelOp.getIfExpr();
+      if (!parallelOp.getNumThreadsVars().empty())
+        newOps.numThreadsVars = parallelOp.getNumThreadsVars();
+      newOps.procBindKind = parallelOp.getProcBindKindAttr();
+      newOps.privateVars = ValueRange{};
+      newOps.allocateVars = ValueRange{};
+      newOps.allocatorVars = ValueRange{};
+      newOps.reductionVars = ValueRange{globalPtr};
+      newOps.reductionByref = SmallVector<bool>{true};
+      newOps.reductionSyms =
+          SmallVector<Attribute>{SymbolRefAttr::get(ctx, symName)};
+
+      auto newParallel = b.create<omp::ParallelOp>(parallelOp.getLoc(), newOps);
+      Block *newEntry = b.createBlock(&newParallel.getRegion());
+      auto ptrTy = LLVM::LLVMPointerType::get(ctx);
+      BlockArgument privPtr = newEntry->addArgument(ptrTy, loc);
+
+      newEntry->getOperations().splice(newEntry->end(),
+                                       oldEntry->getOperations());
+      localPtr.replaceAllUsesWith(privPtr);
+
+      if (auto allocaOp = localPtr.getDefiningOp<LLVM::AllocaOp>())
+        if (localPtr.use_empty())
+          allocaOp.erase();
+
+      parallelOp.erase();
+
+      // ── step 9: erase reduce protocol ──────────────────────────────────
+      SmallVector<Operation *> intermediates;
+      {
+        bool past = false;
+        for (Operation &op : *reduceCall->getBlock()) {
+          if (&op == reduceCall.getOperation()) {
+            past = true;
+            continue;
+          }
+          if (&op == dispatchIf.getOperation())
+            break;
+          if (past)
+            intermediates.push_back(&op);
+        }
+      }
+
+      dispatchIf.erase();
+      for (Operation *op : llvm::reverse(intermediates))
+        op->erase();
+      reduceCall.erase();
+      eraseReduceListAlloca(reduceListAlloca);
+
+      LLVM_DEBUG(llvm::dbgs() << "[convertReductions] OK: " << calleeName
+                              << " → omp.declare_reduction @" << symName
+                              << " + omp.parallel reduction\n");
+    }
+    continue;
+  nextReduction:;
+  }
+
+  // Warn on any survivors
+  mod.walk([&](LLVM::CallOp c) {
+    StringRef n = getCalleeName(c);
+    if (n != "__kmpc_reduce" && n != "__kmpc_reduce_nowait")
+      return;
+    // Silently skip serialized-path copies in preserved outlined functions.
+    for (Operation *p = c->getParentOp(); p; p = p->getParentOp())
+      if (auto fn = dyn_cast<LLVM::LLVMFuncOp>(p)) {
+        if (fn.getName().contains(".omp_outlined"))
+          return;
+        break;
+      }
+    c.emitWarning("LLVMToOmp: '")
+        << n << "' could not be converted.  Left as llvm.call.";
+  });
+}
+//===----------------------------------------------------------------------===//
+// §16  Atomics
+//
+// IMPORTANT: AtomicReadOp, AtomicWriteOp, AtomicUpdateOp, AtomicCaptureOp
+// do NOT have explicit *Operands builders in the td (no `let builders`
+// listing).  The auto-generated positional builders are used instead.
+//
+// ── AtomicReadOp ──────────────────────────────────────────────────────────
+//   td: arguments = !con((ins x:src_ptr, v:dst_ptr, element_type:TypeAttr),
+//                        clausesArgs)    clausesArgs = [hint, memory_order]
+//   Positional builder:
+//     create<AtomicReadOp>(loc, x, v, element_type, hint, memory_order)
+//   Semantics: *v = *x   (x = SOURCE, v = DESTINATION)
+//
+// ── AtomicWriteOp ─────────────────────────────────────────────────────────
+//   td: arguments = !con((ins x:dst_ptr, expr:AnyType), clausesArgs)
+//   Positional builder:
+//     create<AtomicWriteOp>(loc, x, expr, hint, memory_order)
+//   Semantics: *x = expr  (x = DESTINATION)
+//
+// ── AtomicUpdateOp ────────────────────────────────────────────────────────
+//   td: arguments = !con((ins x:ptr, atomic_control:OptionalAttr), clausesArgs)
+//       traits = [SingleBlockImplicitTerminator<"YieldOp">]
+//   Positional builder:
+//     create<AtomicUpdateOp>(loc, x, atomic_control, hint, memory_order)
+//   After build(): region has one block (SingleBlock) + implicit empty YieldOp.
+//   We add the block arg (current *x) and replace the YieldOp.
+//
+// ── AtomicCaptureOp ───────────────────────────────────────────────────────
+//   td: traits = [SingleBlockImplicitTerminator<"TerminatorOp">]
+//       clauses = [OpenMP_HintClause, OpenMP_MemoryOrderClause]
+//   Positional builder:
+//     create<AtomicCaptureOp>(loc, hint, memory_order)
+//   After build(): ONE region, ONE block (SingleBlock), implicit TerminatorOp.
+//   Valid contents: (update+read), (read+update), (read+write) + terminator.
+//===----------------------------------------------------------------------===//
+
+void LLVMToOMPPass::convertAtomics(ModuleOp mod) {
+  SmallVector<LLVM::CallOp> calls;
+  mod.walk([&](LLVM::CallOp c) {
+    if (calleeStartsWith(c, "__kmpc_atomic_"))
+      calls.push_back(c);
+  });
+  MLIRContext *ctx = mod.getContext();
+
+  // Helper: build ClauseMemoryOrderKindAttr for seq_cst (conservative).
+  auto seqCstAttr = [&]() {
+    return omp::ClauseMemoryOrderKindAttr::get(
+        ctx, omp::ClauseMemoryOrderKind::Seq_cst);
+  };
+  // hint arg: absent (OptionalAttr<IntegerAttr>).
+  auto noHint = IntegerAttr{};
+
+  auto safeArg = [](LLVM::CallOp op, unsigned i) -> Value {
+    return i < op.getNumOperands() ? op.getOperand(i) : Value{};
+  };
+
+  for (LLVM::CallOp call : calls) {
+    StringRef name = getCalleeName(call);
+    Location loc = call.getLoc();
+    OpBuilder b(call);
+
+    AtomicDesc desc = parseAtomicName(name, ctx);
+    if (!desc.elemType || desc.op == AtomicDesc::Op::Unknown) {
+      call.emitWarning("LLVMToOmp: unrecognized atomic '")
+          << name << "' — left as llvm.call";
+      continue;
+    }
+
+    // ─── READ ────────────────────────────────────────────────────────────
+    // __kmpc_atomic_TYPE_rd(ident, gtid, src_ptr) → elem_type
+    // x = SOURCE ptr, v = DESTINATION ptr  (confirmed from td assembly:
+    //   "$v `=` $x ... : type($v) , type($x)")
+    if (desc.op == AtomicDesc::Op::Read) {
+      Value src = safeArg(call, 2);
+      if (!src) {
+        call.emitWarning("LLVMToOmp: atomic.rd missing src");
+        continue;
+      }
+      // Allocate a slot to serve as the destination (v).
+      Value arraySize = b.create<arith::ConstantIndexOp>(loc, 1);
+      Value slot = b.create<LLVM::AllocaOp>(
+          loc, LLVM::LLVMPointerType::get(ctx), desc.elemType, arraySize,
+          16u // alignment
+      );
+      // Positional: (loc, x=src, v=slot, element_type, hint, memory_order)
+      b.create<omp::AtomicReadOp>(loc, src, slot, TypeAttr::get(desc.elemType),
+                                  noHint, seqCstAttr());
+      if (!call.getResults().empty()) {
+        Value loaded = b.create<LLVM::LoadOp>(loc, desc.elemType, slot);
+        call.getResult().replaceAllUsesWith(loaded);
+      }
+      call.erase();
+
+      // ─── WRITE ───────────────────────────────────────────────────────────
+      // __kmpc_atomic_TYPE_wr(ident, gtid, dst_ptr, val)
+      // x = DESTINATION ptr, expr = value  (td assembly: "$x `=` $expr")
+    } else if (desc.op == AtomicDesc::Op::Write) {
+      Value dst = safeArg(call, 2), val = safeArg(call, 3);
+      if (!dst || !val) {
+        call.emitWarning("LLVMToOmp: atomic.wr missing args");
+        continue;
+      }
+      // Positional: (loc, x=dst, expr=val, hint, memory_order)
+      b.create<omp::AtomicWriteOp>(loc, dst, val, noHint, seqCstAttr());
+      call.erase();
+
+      // ─── UPDATE ──────────────────────────────────────────────────────────
+      // __kmpc_atomic_TYPE_OP(ident, gtid, x_ptr, rhs)
+    } else if (desc.op == AtomicDesc::Op::Update) {
+      Value xPtr = safeArg(call, 2), rhs = safeArg(call, 3);
+      if (!xPtr || !rhs) {
+        call.emitWarning("LLVMToOmp: atomic.update missing args");
+        continue;
+      }
+      // Positional: (loc, x, atomic_control=absent, hint, memory_order)
+      // AtomicControlAttr{} = null optional attr.
+      auto updOp = b.create<omp::AtomicUpdateOp>(
+          loc, xPtr, omp::AtomicControlAttr{}, noHint, seqCstAttr());
+      // §7 helper: add block arg, build binop, fix YieldOp.
+      if (failed(buildAtomicUpdateRegion(b, loc, updOp, desc.elemType, desc.bin,
+                                         rhs))) {
+        call.emitWarning("LLVMToOmp: update binop not emittable for '")
+            << name << "' — left as llvm.call";
+        updOp.erase();
+        continue;
+      }
+      b.setInsertionPointAfter(updOp);
+      call.erase();
+
+      // ─── CAPTURE ─────────────────────────────────────────────────────────
+      // __kmpc_atomic_TYPE_capture_OP(ident, gtid, res_ptr, x_ptr, val)
+      // Emits update-then-read form: { *x op= val; v = *x }
+      // td: ONE region, ONE block, implicit TerminatorOp.
+      //   Valid forms in the block: (update+read), (read+update), (read+write)
+    } else if (desc.op == AtomicDesc::Op::Capture) {
+      Value res = safeArg(call, 2);
+      Value xPtr = safeArg(call, 3);
+      Value val = safeArg(call, 4);
+      if (!res || !xPtr || !val) {
+        call.emitWarning("LLVMToOmp: atomic.capture missing args — "
+                         "left as llvm.call");
+        continue;
+      }
+      // Determine update binop from suffix after "capture_".
+      AtomicDesc::Bin capBin = AtomicDesc::Bin::Add;
+      bool isWriteCapture = false;
+      StringRef suf = name;
+      if (auto pos = suf.find("capture_"); pos != StringRef::npos) {
+        suf = suf.drop_front(pos + strlen("capture_"));
+        if (SW(suf, "add"))
+          capBin = AtomicDesc::Bin::Add;
+        else if (SW(suf, "sub"))
+          capBin = AtomicDesc::Bin::Sub;
+        else if (SW(suf, "mul"))
+          capBin = AtomicDesc::Bin::Mul;
+        else if (SW(suf, "wr"))
+          isWriteCapture = true;
+      }
+
+      // Positional: (loc, hint, memory_order)
+      // SingleBlockImplicitTerminator<"TerminatorOp"> → block auto-created.
+      auto capOp = b.create<omp::AtomicCaptureOp>(loc, noHint, seqCstAttr());
+      Block *capBlk = &capOp.getRegion().front(); // SingleBlock
+
+      b.setInsertionPoint(capBlk->getTerminator());
+
+      if (isWriteCapture) {
+        // read-then-write form: { v = *x; *x = val }
+        // Positional AtomicReadOp: (x=source, v=dest, elem_type, hint, mo)
+        b.create<omp::AtomicReadOp>(
+            loc, xPtr, res, TypeAttr::get(desc.elemType), noHint, seqCstAttr());
+        b.create<omp::AtomicWriteOp>(loc, xPtr, val, noHint, seqCstAttr());
+      } else {
+        // update-then-read form: { *x op= val; v = *x }
+        // (1) atomic.update
+        auto innerUpd = b.create<omp::AtomicUpdateOp>(
+            loc, xPtr, omp::AtomicControlAttr{}, noHint, seqCstAttr());
+        if (failed(buildAtomicUpdateRegion(b, loc, innerUpd, desc.elemType,
+                                           capBin, val))) {
+          call.emitWarning("LLVMToOmp: capture update binop not emittable — "
+                           "left as llvm.call");
+          capOp.erase();
+          continue;
+        }
+        // (2) atomic.read  — insert before terminator
+        b.setInsertionPoint(capBlk->getTerminator());
+        // x=source, v=destination
+        b.create<omp::AtomicReadOp>(
+            loc, xPtr, res, TypeAttr::get(desc.elemType), noHint, seqCstAttr());
+      }
+      b.setInsertionPointAfter(capOp);
+      call.erase();
+      LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] atomic.capture converted\n");
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// §16b  isBenignOmpRuntimeCall
+//
+// Returns true for omp_* / __kmpc_* names that are legitimate runtime
+// query / utility / timing functions with no OMP dialect equivalent.
+// These are silently left as llvm.call by UnhandledPat instead of
+// producing a "no OMP dialect equivalent" warning.
+//
+// Note: omp_get_thread_num / omp_get_num_threads / omp_get_max_threads
+// are handled by a downstream pass; they are listed here so this pass
+// does not warn about them.
+//===----------------------------------------------------------------------===//
+static bool isBenignOmpRuntimeCall(StringRef name) {
+  // Quick prefix gate before the table scan.
+  if (!name.starts_with("omp_") && !name.starts_with("__kmpc_"))
+    return false;
+
+  static const char *const kBenign[] = {
+      // ── Timing ────────────────────────────────────────────────────────
+      "omp_get_wtime", "omp_get_wtick",
+      // ── Thread / team queries (handled by a downstream pass) ──────────
+      "omp_get_thread_num", "omp_get_num_threads", "omp_get_max_threads",
+      "omp_set_num_threads", "omp_get_num_procs",
+      // ── Nesting / level queries ────────────────────────────────────────
+      "omp_in_parallel", "omp_get_level", "omp_get_active_level",
+      "omp_get_ancestor_thread_num", "omp_get_team_size",
+      // ── Dynamic / nested toggles ──────────────────────────────────────
+      "omp_set_dynamic", "omp_get_dynamic", "omp_set_nested", "omp_get_nested",
+      "omp_set_max_active_levels", "omp_get_max_active_levels",
+      // ── Scheduling ────────────────────────────────────────────────────
+      "omp_set_schedule", "omp_get_schedule",
+      // ── Locks ─────────────────────────────────────────────────────────
+      "omp_init_lock", "omp_destroy_lock", "omp_set_lock", "omp_unset_lock",
+      "omp_test_lock", "omp_init_nest_lock", "omp_destroy_nest_lock",
+      "omp_set_nest_lock", "omp_unset_nest_lock", "omp_test_nest_lock",
+      // ── Device / target queries ────────────────────────────────────────
+      "omp_get_num_devices", "omp_get_default_device", "omp_set_default_device",
+      "omp_is_initial_device", "omp_get_initial_device", "omp_get_device_num",
+      // ── Affinity ──────────────────────────────────────────────────────
+      "omp_get_place_num_procs", "omp_get_place_proc_ids",
+      "omp_get_partition_place_nums",
+      // ── End-reduce helpers ────────────────────────────────────────────
+      // Erased by convertReductions on success; silently left if conversion
+      // failed rather than producing a spurious "no dialect equivalent"
+      // warning.
+      // "__kmpc_end_reduce", "__kmpc_end_reduce_nowait",
+      nullptr};
+  for (const char *const *p = kBenign; *p; ++p)
+    if (name == *p)
+      return true;
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// §17  Leaf patterns (Phase 2 — greedy rewrite)
+//===----------------------------------------------------------------------===//
+
+/// Several of the runtime calls lifted below return an i32 that the code
+/// around them branches on — __kmpc_cancel and __kmpc_cancellationpoint
+/// report whether cancellation was activated, __kmpc_cancel_barrier,
+/// __kmpc_omp_taskwait and __kmpc_omp_taskyield report whether the current
+/// task was cancelled while it waited.  Their OpenMP dialect counterparts are
+/// result-less: that transfer of control is part of the op's own semantics,
+/// and the dialect's own lowering re-emits the runtime test.  So the branch
+/// gets a constant zero — "not activated on this path" — and canonicalization
+/// drops the now-dead fallback.  Erasing the call outright would leave every
+/// use of its result dangling.
+/// True when `op` sits inside some OpenMP dialect region.  omp.cancel and
+/// omp.cancellation_point verify only inside the construct they cancel, and
+/// Clang's outlined functions survive the omp.parallel conversion as dead
+/// copies until the downstream symbol-dce — so those copies keep their
+/// runtime calls rather than growing an orphaned construct.
+static bool isInsideOmpRegion(Operation *op) {
+  for (Operation *p = op->getParentOp(); p; p = p->getParentOp())
+    if (isa<omp::OpenMPDialect>(p->getDialect()))
+      return true;
+  return false;
+}
+
+static bool hasIntOrNoResult(LLVM::CallOp op) {
+  return llvm::all_of(op->getResultTypes(),
+                      [](Type t) { return isa<IntegerType>(t); });
+}
+
+static void replaceLiftedRuntimeCall(PatternRewriter &rw, LLVM::CallOp op) {
+  SmallVector<Value> repl;
+  for (Type ty : op->getResultTypes())
+    repl.push_back(
+        rw.create<LLVM::ConstantOp>(op.getLoc(), ty, rw.getIntegerAttr(ty, 0)));
+  rw.replaceOp(op, repl);
+}
+
+/// __kmpc_barrier / __kmpc_cancel_barrier → omp.barrier
+/// td: BarrierOp — assemblyFormat = "attr-dict", no arguments.
+struct BarrierPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!isCallTo(op, "__kmpc_barrier") &&
+        !isCallTo(op, "__kmpc_cancel_barrier"))
+      return failure();
+    if (!hasIntOrNoResult(op))
+      return failure();
+    rw.create<omp::BarrierOp>(op.getLoc());
+    replaceLiftedRuntimeCall(rw, op);
+    return success();
+  }
+};
+
+/// __kmpc_flush → omp.flush
+/// td: FlushOp — arguments = !con((ins Variadic<AnyType>:$varList),
+/// clausesArgs)
+///     clauses = [] (empty, TODO comment in td).
+///     __kmpc_flush(ident_t*) has no user-facing varList → pass empty.
+struct FlushPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!isCallTo(op, "__kmpc_flush"))
+      return failure();
+    rw.create<omp::FlushOp>(op.getLoc(), ValueRange{});
+    rw.eraseOp(op);
+    return success();
+  }
+};
+
+/// __kmpc_omp_taskwait → omp.taskwait
+/// td: TaskwaitOp — clauses=[OpenMP_DependClause, OpenMP_NowaitClause]
+///     Builder: OpBuilder<(ins CArg<"const TaskwaitOperands &">:$clauses)>
+///     __kmpc_omp_taskwait always blocks; nowait not set.
+struct TaskwaitPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!isCallTo(op, "__kmpc_omp_taskwait"))
+      return failure();
+    if (!hasIntOrNoResult(op))
+      return failure();
+    omp::TaskwaitOperands twOps; // nowait not set — call always blocks
+    rw.create<omp::TaskwaitOp>(op.getLoc(), twOps);
+    replaceLiftedRuntimeCall(rw, op);
+    return success();
+  }
+};
+
+/// __kmpc_omp_taskyield → omp.taskyield
+/// td: TaskyieldOp — assemblyFormat = "attr-dict", no args, no explicit
+/// builder.
+struct TaskyieldPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!isCallTo(op, "__kmpc_omp_taskyield"))
+      return failure();
+    if (!hasIntOrNoResult(op))
+      return failure();
+    rw.create<omp::TaskyieldOp>(op.getLoc());
+    replaceLiftedRuntimeCall(rw, op);
+    return success();
+  }
+};
+
+/// __kmpc_cancel → omp.cancel
+/// td: CancelOp — clauses=[OpenMP_CancelDirectiveNameClause, OpenMP_IfClause]
+///     Builder: OpBuilder<(ins CArg<"const CancelOperands &">:$clauses)>
+///     CancelOperands.cancelDirective = ClauseCancellationConstructType
+///     (ident, gtid, cancel_kind): 1=parallel,2=sections,4=loop,8=taskgroup
+struct CancelPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!isCallTo(op, "__kmpc_cancel"))
+      return failure();
+    if (!hasIntOrNoResult(op) || !isInsideOmpRegion(op))
+      return failure();
+    omp::ClauseCancellationConstructType kind =
+        omp::ClauseCancellationConstructType::Parallel;
+    if (auto v =
+            getConstInt(op.getNumOperands() > 2 ? op.getOperand(2) : Value{}))
+      switch (*v) {
+      case 1:
+        kind = omp::ClauseCancellationConstructType::Parallel;
+        break;
+      case 2:
+        kind = omp::ClauseCancellationConstructType::Sections;
+        break;
+      case 4:
+        kind = omp::ClauseCancellationConstructType::Loop;
+        break;
+      case 8:
+        kind = omp::ClauseCancellationConstructType::Taskgroup;
+        break;
+      }
+    omp::CancelOperands cOps;
+    cOps.cancelDirective = omp::ClauseCancellationConstructTypeAttr::get(
+        op.getContext(), kind); // OpenMP_CancelDirectiveNameClause
+    rw.create<omp::CancelOp>(op.getLoc(), cOps);
+    replaceLiftedRuntimeCall(rw, op);
+    return success();
+  }
+};
+
+/// __kmpc_cancellationpoint → omp.cancellation_point
+/// td: CancellationPointOp — clauses=[OpenMP_CancelDirectiveNameClause]
+///     Builder: OpBuilder<(ins CArg<"const CancellationPointOperands &">)>
+struct CancelPointPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!isCallTo(op, "__kmpc_cancellationpoint"))
+      return failure();
+    if (!hasIntOrNoResult(op) || !isInsideOmpRegion(op))
+      return failure();
+    omp::ClauseCancellationConstructType kind =
+        omp::ClauseCancellationConstructType::Parallel;
+    if (auto v =
+            getConstInt(op.getNumOperands() > 2 ? op.getOperand(2) : Value{}))
+      switch (*v) {
+      case 1:
+        kind = omp::ClauseCancellationConstructType::Parallel;
+        break;
+      case 2:
+        kind = omp::ClauseCancellationConstructType::Sections;
+        break;
+      case 4:
+        kind = omp::ClauseCancellationConstructType::Loop;
+        break;
+      case 8:
+        kind = omp::ClauseCancellationConstructType::Taskgroup;
+        break;
+      }
+    omp::CancellationPointOperands cpOps;
+    cpOps.cancelDirective =
+        omp::ClauseCancellationConstructTypeAttr::get(op.getContext(), kind);
+    rw.create<omp::CancellationPointOp>(op.getLoc(), cpOps);
+    replaceLiftedRuntimeCall(rw, op);
+    return success();
+  }
+};
+
+/// __kmpc_global_thread_num → constant 0
+/// The gtid is internal bookkeeping; all outlined fn uses are already dropped.
+/// `ordered` makes Clang close every iteration with __kmpc_dispatch_fini_*
+/// inside the loop body, on top of the one that terminates the construct.
+/// omp.wsloop subsumes the whole dispatch protocol, so the leftovers are
+/// dropped — but only inside a loop this pass actually lifted, so that a
+/// dispatch loop it declined to convert keeps its calls (and its warning).
+struct DispatchFiniPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!calleeStartsWith(op, "__kmpc_dispatch_fini_"))
+      return failure();
+    if (!op->getParentOfType<omp::LoopNestOp>())
+      return failure();
+    if (!hasIntOrNoResult(op))
+      return failure();
+    replaceLiftedRuntimeCall(rw, op);
+    return success();
+  }
+};
+
+struct GlobalTidPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!isCallTo(op, "__kmpc_global_thread_num"))
+      return failure();
+    if (!op.getResults().empty()) {
+      Value z = rw.create<LLVM::ConstantOp>(op.getLoc(), rw.getI32Type(),
+                                            rw.getI32IntegerAttr(0));
+      op.getResult().replaceAllUsesWith(z);
+    }
+    rw.eraseOp(op);
+    return success();
+  }
+};
+
+/// GPU target init/deinit → hard error (out of scope for this CPU pass).
+struct GpuTargetPat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &) const override {
+    StringRef n = getCalleeName(op);
+    if (!SW(n, "__kmpc_target_init") && !SW(n, "__kmpc_target_deinit") &&
+        !SW(n, "__kmpc_kernel_init") && !SW(n, "__kmpc_spmd_kernel_init"))
+      return failure();
+    op.emitError("LLVMToOmp: GPU/SPMD call '")
+        << n
+        << "' is not supported by this CPU pass — "
+           "use the device-side GPU lowering pipeline.";
+    return failure(); // leave in IR so diagnostic is visible
+  }
+};
+
+/// __kmpc_push_num_threads / _proc_bind / _num_teams
+///   Consumed by collectPendingClauses; no OMP dialect equivalent.
+/// __kmpc_serialized_parallel / __kmpc_end_serialized_parallel
+///   Bookkeeping wrappers for an if(0) parallel region.  The actual work
+///   is a direct call to the outlined function between the two markers and
+///   is already in place; the markers themselves carry no semantics that
+///   the structured OMP dialect needs to model.
+/// All are erased silently after Phase 1.
+struct PushClausePat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    StringRef n = getCalleeName(op);
+    if (n != "__kmpc_push_num_threads" && n != "__kmpc_push_proc_bind" &&
+        n != "__kmpc_push_num_teams" && n != "__kmpc_serialized_parallel" &&
+        n != "__kmpc_end_serialized_parallel")
+      return failure();
+    rw.eraseOp(op);
+    return success();
+  }
+};
+
+struct TaskCompleteIf0Pat : OpRewritePattern<LLVM::CallOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &rw) const override {
+    if (!isCallTo(op, "__kmpc_omp_task_begin_if0") &&
+        !isCallTo(op, "__kmpc_omp_task_complete_if0"))
+      return failure();
+    rw.eraseOp(op);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// §17b  sections dispatch pattern
+//
+// Clang lowers #pragma omp sections to a static wsloop with index-based
+// if-chain dispatch. After convertStaticWs inlines the scf.for body into the
+// loop_nest, the canonical form is:
+//
+//   omp.wsloop [nowait] schedule(static=1) {
+//     omp.loop_nest (%iv):i32 = (0) to (N-1) inclusive step (1) {
+//       %idx = index_castui %iv
+//       %eq0 = cmpi eq, %idx, 0
+//       scf.if %eq0 { body0 } else {
+//         %eq1 = cmpi eq, %idx, 1
+//         scf.if %eq1 { body1 } else { … }
+//       }
+//       omp.yield
+//     }
+//   }
+//
+// Produced:
+//   omp.sections [nowait] {
+//     omp.section { body0; omp.terminator }
+//     omp.section { body1; omp.terminator }
+//     omp.terminator
+//   }
+//===----------------------------------------------------------------------===//
+
+/// Walk the index-dispatch if-chain in `nestBody` and collect per-section
+/// op lists (excluding yield terminators).  Returns false if the pattern
+/// does not match.
+static bool extractSectionBodies(Block *nestBody, Value iv,
+                                 SmallVector<SmallVector<Operation *>> &out) {
+
+  SmallVector<Operation *> ops;
+  for (Operation &op : nestBody->without_terminator())
+    ops.push_back(&op);
+  if (ops.size() < 3)
+    return false;
+
+  // [0]: index_castui (or index_cast) of the loop IV
+  Value idxVal;
+  if (auto c = dyn_cast<arith::IndexCastUIOp>(ops[0])) {
+    if (c.getIn() != iv)
+      return false;
+    idxVal = c.getResult();
+  } else if (auto c = dyn_cast<arith::IndexCastOp>(ops[0])) {
+    if (c.getIn() != iv)
+      return false;
+    idxVal = c.getResult();
+  } else
+    return false;
+
+  // [1]: cmpi eq, %idx, 0
+  auto firstCmp = dyn_cast<arith::CmpIOp>(ops[1]);
+  if (!firstCmp || firstCmp.getPredicate() != arith::CmpIPredicate::eq ||
+      firstCmp.getLhs() != idxVal)
+    return false;
+  auto cst = getConstIndex(firstCmp.getRhs());
+  if (!cst || *cst != 0)
+    return false;
+
+  // [2]: scf.if %cmp0 { body0 } else { chain... }
+  auto outerIf = dyn_cast<scf::IfOp>(ops[2]);
+  if (!outerIf || outerIf.getCondition() != firstCmp.getResult())
+    return false;
+
+  // Section 0 — then-block of the outer if
+  SmallVector<Operation *> sec0;
+  for (Operation &op : outerIf.getThenRegion().front().without_terminator())
+    sec0.push_back(&op);
+  out.push_back(sec0);
+
+  // Sections 1..N-1 — nested else-if chain
+  Region *elseReg = &outerIf.getElseRegion();
+  while (!elseReg->empty()) {
+    Block *elseBlk = &elseReg->front();
+    SmallVector<Operation *> elseOps;
+    for (Operation &op : elseBlk->without_terminator())
+      elseOps.push_back(&op);
+    if (elseOps.empty())
+      break;
+    if (elseOps.size() < 2)
+      return false;
+
+    // cmpi eq, %idx, k  (k == current section count)
+    auto nextCmp = dyn_cast<arith::CmpIOp>(elseOps[0]);
+    if (!nextCmp || nextCmp.getPredicate() != arith::CmpIPredicate::eq ||
+        nextCmp.getLhs() != idxVal)
+      return false;
+    auto nextCst = getConstIndex(nextCmp.getRhs());
+    if (!nextCst || *nextCst != (int64_t)out.size())
+      return false;
+
+    auto nextIf = dyn_cast<scf::IfOp>(elseOps[1]);
+    if (!nextIf || nextIf.getCondition() != nextCmp.getResult())
+      return false;
+
+    SmallVector<Operation *> secN;
+    for (Operation &op : nextIf.getThenRegion().front().without_terminator())
+      secN.push_back(&op);
+    out.push_back(secN);
+
+    // Recurse into the next else (empty for the last section)
+    elseReg = &nextIf.getElseRegion();
+  }
+  return out.size() >= 2;
+}
+
+struct SectionsDispatchPat : OpRewritePattern<omp::WsloopOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(omp::WsloopOp wsOp,
+                                PatternRewriter &rw) const override {
+    // ── (1) Body must be exactly one omp.loop_nest ──────────────────────
+    // WsloopOp has NoTerminator so the region body has no terminator op.
+    Block &wsBlk = wsOp.getRegion().front();
+    if (std::next(wsBlk.begin()) != wsBlk.end())
+      return failure();
+    auto nestOp = dyn_cast<omp::LoopNestOp>(&wsBlk.front());
+    if (!nestOp)
+      return failure();
+
+    // ── (2) Single-dimension, lb=0, step=1, inclusive ───────────────────
+    if (nestOp.getLoopLowerBounds().size() != 1 ||
+        nestOp.getLoopUpperBounds().size() != 1 ||
+        nestOp.getLoopSteps().size() != 1)
+      return failure();
+    if (!nestOp.getLoopInclusiveAttr())
+      return failure();
+
+    auto lb = getConstIndex(nestOp.getLoopLowerBounds()[0]);
+    auto ub = getConstIndex(nestOp.getLoopUpperBounds()[0]);
+    auto st = getConstIndex(nestOp.getLoopSteps()[0]);
+    if (!lb || *lb != 0)
+      return failure();
+    if (!st || *st != 1)
+      return failure();
+    if (!ub || *ub < 1)
+      return failure(); // at least 2 sections
+
+    // ── (3) Body must be the sections dispatch if-chain ─────────────────
+    Block *nestBody = &nestOp.getRegion().front();
+    Value iv = nestOp.getIVs()[0];
+    SmallVector<SmallVector<Operation *>> sectionBodies;
+    if (!extractSectionBodies(nestBody, iv, sectionBodies))
+      return failure();
+    // Section count must exactly match the loop iteration count.
+    if ((int64_t)sectionBodies.size() != *ub + 1)
+      return failure();
+
+    Location loc = wsOp.getLoc();
+    rw.setInsertionPoint(wsOp);
+
+    // ── (4) Build omp.sections ───────────────────────────────────────────
+    omp::SectionsOperands sOps;
+    if (wsOp.getNowaitAttr())
+      sOps.nowait = rw.getUnitAttr();
+    auto sectionsOp = rw.create<omp::SectionsOp>(loc, sOps);
+    Block *secBody = rw.createBlock(&sectionsOp.getRegion());
+
+    // ── (5) Build one omp.section per extracted body ─────────────────────
+    for (auto &bodyOps : sectionBodies) {
+      rw.setInsertionPointToEnd(secBody);
+      auto sectionOp = rw.create<omp::SectionOp>(loc);
+      Block *sBlk = rw.createBlock(&sectionOp.getRegion());
+      rw.setInsertionPointToStart(sBlk);
+      // Section bodies only reference values from outer scopes — no IV
+      // remapping needed.
+      IRMapping map;
+      for (Operation *op : bodyOps)
+        rw.clone(*op, map);
+      rw.create<omp::TerminatorOp>(loc);
+    }
+
+    // ── (6) Terminate the sections region ───────────────────────────────
+    rw.setInsertionPointToEnd(secBody);
+    rw.create<omp::TerminatorOp>(loc);
+
+    // ── (7) Erase the wsloop (and all nested ops) ────────────────────────
+    rw.eraseOp(wsOp);
+    LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] sections dispatch → omp.sections ("
+                            << sectionBodies.size() << " sections)\n");
+    return success();
+  }
+};
+
+/// Catch-all: warn on any remaining __kmpc_* / omp_* calls (priority 0).
+/// Calls that are known to be benign runtime-query / utility functions are
+/// silently skipped via isBenignOmpRuntimeCall().
+struct UnhandledPat : OpRewritePattern<LLVM::CallOp> {
+  UnhandledPat(MLIRContext *ctx) : OpRewritePattern(ctx, /*benefit=*/0) {}
+  LogicalResult matchAndRewrite(LLVM::CallOp op,
+                                PatternRewriter &) const override {
+    StringRef n = getCalleeName(op);
+    if (!SW(n, "__kmpc_") && !SW(n, "omp_"))
+      return failure();
+    // Silently leave benign runtime-query / utility calls in place.
+    if (isBenignOmpRuntimeCall(n))
+      return failure();
+    op.emitWarning("LLVMToOmp: '")
+        << n << "' has no OMP dialect equivalent — left as llvm.call";
+    return failure(); // intentionally leave in IR
+  }
+};
+
+void LLVMToOMPPass::applyLeafPatterns(ModuleOp mod) {
+  RewritePatternSet pats(mod.getContext());
+  pats.add<BarrierPat, FlushPat, TaskwaitPat, TaskyieldPat, CancelPat,
+           CancelPointPat, DispatchFiniPat, GlobalTidPat, GpuTargetPat,
+           PushClausePat, TaskCompleteIf0Pat, SectionsDispatchPat,
+           UnhandledPat>(mod.getContext());
+  (void)applyPatternsGreedily(mod, std::move(pats));
+}
+
+//===----------------------------------------------------------------------===//
+// §19  Pass entry point
+//===----------------------------------------------------------------------===//
+
+void LLVMToOMPPass::runOnOperation() {
+  ModuleOp mod = getOperation();
+
+  // Hard-reject GPU device modules (assumption F).
+  if (auto t = mod->getAttrOfType<StringAttr>("llvm.target_triple")) {
+    StringRef tv = t.getValue();
+    if (tv.contains("nvptx") || tv.contains("amdgcn") ||
+        tv.contains("amdgpu")) {
+      mod.emitError("LLVMToOmp: GPU device module (triple='")
+          << tv << "') not supported.";
+      signalPassFailure();
+      return;
+    }
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] pass started\n");
+
+  // Phase 1 — structural (order matters: teams before parallel so any
+  // fork_call inside a teams outlined fn is reachable when convertParallel
+  // runs).
+  convertTeams(mod);
+  convertParallel(mod);
+  convertPaired(mod);   // single / master / critical / ordered / taskgroup
+  convertStaticWs(mod); // for_static_init/fini  → wsloop static
+  convertDynWs(mod);    // dispatch_init/next/fini→ wsloop dynamic
+  convertTasks(mod);    // task_alloc + omp_task  → omp.task
+  convertTaskloop(mod);
+  convertAtomics(mod); // __kmpc_atomic_*        → omp.atomic.*
+  convertReductions(mod);
+  // Phase 2 — leaf rewrites.
+  applyLeafPatterns(mod);
+  LLVM_DEBUG(llvm::dbgs() << "[LLVMToOmp] pass complete\n");
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// §20  Close namespaces
+//===----------------------------------------------------------------------===//
+
+} // namespace mlir::enzyme
+} // namespace

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -948,6 +948,12 @@ def EnzymeLiftControlFlowToSCFPass : Pass<"enzyme-lift-cf-to-scf"> {
   ];
 }
 
+def LLVMToOMP : Pass<"llvm-to-omp", "ModuleOp"> {
+  let summary = "Lift LLVM dialect OMP runtime calls to OpenMP dialect";
+  let dependentDialects = ["mlir::omp::OpenMPDialect",
+                           "mlir::LLVM::LLVMDialect"];
+}
+
 def LLVMToAffineAccessPass : Pass<"llvm-to-affine-access"> {
   let summary = "";
   let dependentDialects = ["LLVM::LLVMDialect", "enzyme::EnzymeDialect",

--- a/test/lit_tests/llvm_to_omp/README.md
+++ b/test/lit_tests/llvm_to_omp/README.md
@@ -1,0 +1,97 @@
+# `llvm-to-omp` regression tests
+
+These tests cover the `--llvm-to-omp` pass, which lifts the LLVM-dialect
+OpenMP *runtime* calls that clang emits (`__kmpc_fork_call`,
+`__kmpc_for_static_init_*`, `__kmpc_dispatch_*`, `__kmpc_reduce_nowait`, …)
+back into structured OpenMP dialect operations.
+
+## Where the inputs come from
+
+Each `.mlir` input is machine-generated, not hand-written, so that it has the
+shape the pass actually sees in production rather than the shape raw clang
+output happens to have. The distinction matters: `llvm-to-omp` runs *late*,
+after the CFG has been lifted to SCF and after the pointer arithmetic has been
+raised to `memref`. Run against raw `mlir-translate --import-llvm` output the
+pass recognises only `__kmpc_fork_call`; the worksharing-loop, `single` and
+reduction patterns all expect SCF structure that is not there yet.
+
+The inputs were produced from small OpenMP C programs, one per construct:
+
+```sh
+# 1. clang -> LLVM IR -> LLVM dialect
+clang -fopenmp -O1 -S -emit-llvm -o t.ll t.c
+mlir-translate --import-llvm t.ll -o t.mlir
+
+# 2. the pipeline prefix that runs before llvm-to-omp in practice
+#    (taken from spmd-verify.sh, minus the symbol-privatize/symbol-dce
+#    bookkeeping that would delete a test function with no `main` caller)
+enzymexlamlir-opt --pass-pipeline='builtin.module(
+    sroa-wrappers{set_private=false attributor=false},
+    libdevice-funcs-raise,canonicalize,
+    llvm-to-memref-access,polygeist-mem2reg,canonicalize,
+    convert-llvm-to-cf,canonicalize,polygeist-mem2reg,canonicalize,
+    enzyme-lift-cf-to-scf,canonicalize,
+    func.func(canonicalize-loops),llvm.func(canonicalize-loops),
+    canonicalize-scf-for,canonicalize,
+    func.func(canonicalize-loops),llvm.func(canonicalize-loops),canonicalize,
+    llvm-to-affine-access,canonicalize,delinearize-indexing,canonicalize,
+    simplify-affine-exprs,llvm-to-affine-access,canonicalize,
+    func.func(affine-loop-invariant-code-motion),canonicalize,sort-memory,
+    lower-affine,parallel-serialization,canonicalize)' t.mlir
+```
+
+Target/ABI noise from step 1 (TBAA and alias-scope metadata, `target_features`,
+`passthrough`, `target_cpu`/`tune_cpu`, `uwtable_kind`, `dlti.dl_spec`,
+parameter ABI attributes and the `no_unwind`/`convergent` call attributes) was
+stripped so the inputs stay readable. `llvm.intr.lifetime.*` was dropped too:
+it carries nothing for OpenMP raising.
+
+The C sources behind these, and larger end-to-end reproducers, live in the
+data-race-detection benchmark suite used by the SPMD verification project
+(`llvmToOmpTests/` and `threadSanity*/`), which is where this pass was
+originally developed and exercised. `masked_filter.mlir` and
+`single_nowait.mlir` cover the two clause spellings that suite exercises and
+the rest of these tests did not.
+
+## Coverage
+
+| test | construct |
+|---|---|
+| `parallel.mlir` | `parallel` |
+| `num_threads.mlir` | `num_threads` |
+| `wsloop_static.mlir` | `for` with the static schedule |
+| `wsloop_dynamic.mlir` | `for` with a dynamic schedule |
+| `wsloop_guided.mlir` | `schedule(guided, N)` |
+| `wsloop_i64.mlir` | `for` over a 64-bit induction variable |
+| `ordered.mlir` | `ordered` |
+| `sections.mlir` | `sections` |
+| `barrier.mlir` | `barrier` |
+| `single_master.mlir` | `single`, `master` |
+| `single_nowait.mlir` | `single nowait` |
+| `masked.mlir` | `masked` |
+| `masked_filter.mlir` | `masked filter(N)` |
+| `critical.mlir` | `critical` |
+| `flush_taskyield.mlir` | `flush`, `taskyield` |
+| `cancel.mlir` | `cancel`, `cancellation point` |
+| `task.mlir` | `task`, `taskwait` |
+| `taskloop.mlir` | `taskloop grainsize(N)`, `taskgroup` |
+| `taskloop_num_tasks.mlir` | `taskloop num_tasks(N)` |
+| `teams.mlir` | `teams num_teams(N)` |
+| `reduction.mlir` | `reduction` |
+
+## What each test asserts
+
+Every test runs `FileCheck` with `--implicit-check-not="llvm.call @__kmpc"`,
+so a test fails if *any* OpenMP runtime call survives anywhere in the module —
+not merely if the expected `omp.*` ops are missing. Forward declarations of the
+runtime functions are expected to remain; `symbol-dce` removes them downstream.
+
+The dead outlined function (`@<name>.omp_outlined`) is likewise still present
+after the pass: its body has been inlined into the `omp.parallel`, and the
+production pipeline runs `symbol-dce` immediately afterwards to drop it.
+
+`cancel.mlir` is the one test that runs `--symbol-dce` itself. `omp.cancel` and
+`omp.cancellation_point` verify only inside the construct they cancel, so the
+pass leaves the runtime calls alone in that dead copy, where there is no
+enclosing construct — running the DCE the pipeline would run anyway removes the
+copy and with it the calls.

--- a/test/lit_tests/llvm_to_omp/barrier.mlir
+++ b/test/lit_tests/llvm_to_omp/barrier.mlir
@@ -1,0 +1,75 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp barrier` becomes omp.barrier.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c34_i32 = arith.constant 34 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c34_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @barrier(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @barrier.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %4[%c0] : memref<1x!llvm.ptr>
+    %5 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %5[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %2, %3) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @barrier.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %1 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %2 = memref.load %1[%c0] : memref<?x!llvm.ptr>
+    %3 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+    %4 = memref.load %3[%c0] : memref<?xi32>
+    llvm.call tail @body(%2, %4) : (!llvm.ptr, i32) -> ()
+    %5 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %6 = memref.load %5[%c0] : memref<?xi32>
+    llvm.call tail @__kmpc_barrier(%0, %6) {convergent, no_unwind} : (!llvm.ptr, i32) -> ()
+    %7 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %8 = memref.load %7[%c0] : memref<?x!llvm.ptr>
+    %9 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+    %10 = memref.load %9[%c0] : memref<?xi32>
+    llvm.call tail @body(%8, %10) : (!llvm.ptr, i32) -> ()
+    llvm.return
+  }
+  llvm.func @body(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_barrier(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @barrier(
+// CHECK: omp.parallel {
+// CHECK:  llvm.call tail @body(%{{.*}}, %{{.*}}) : (!llvm.ptr, i32) -> ()
+// CHECK:  omp.barrier
+// CHECK:  llvm.call tail @body(%{{.*}}, %{{.*}}) : (!llvm.ptr, i32) -> ()
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/cancel.mlir
+++ b/test/lit_tests/llvm_to_omp/cancel.mlir
@@ -1,0 +1,75 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp --symbol-dce %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp cancel parallel` and `#pragma omp cancellation point parallel`.
+// Both runtime calls return an i32 the surrounding code branches on, while
+// omp.cancel and omp.cancellation_point are result-less and carry that
+// transfer of control themselves — so the branch is fed a constant zero.
+// symbol-dce drops the dead outlined copy, where the two constructs would have
+// no enclosing region to cancel.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c66_i32 = arith.constant 66 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c66_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @cancel_region() {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %1 = llvm.mlir.addressof @cancel_region.omp_outlined : !llvm.ptr
+    llvm.call tail @__kmpc_fork_call(%0, %c0_i32, %1) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @cancel_region.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %c1_i32 = arith.constant 1 : i32
+    %1 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %2 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %3 = memref.load %2[%c0] : memref<?xi32>
+    %4 = llvm.call tail @__kmpc_cancellationpoint(%1, %3, %c1_i32) : (!llvm.ptr, i32, i32) -> i32
+    %5 = arith.cmpi eq, %4, %c0_i32 : i32
+    scf.if %5 {
+      %6 = llvm.call tail @__kmpc_cancel(%1, %3, %c1_i32) : (!llvm.ptr, i32, i32) -> i32
+      %7 = arith.cmpi ne, %6, %c0_i32 : i32
+      scf.if %7 {
+        %8 = llvm.call tail @__kmpc_cancel_barrier(%0, %3) : (!llvm.ptr, i32) -> i32
+      }
+    } else {
+      %6 = llvm.call tail @__kmpc_cancel_barrier(%0, %3) : (!llvm.ptr, i32) -> i32
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_cancellationpoint(!llvm.ptr, i32, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_cancel(!llvm.ptr, i32, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_cancel_barrier(!llvm.ptr, i32) -> i32 attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @cancel_region(
+// CHECK: omp.parallel {
+// CHECK:   omp.cancellation_point cancellation_construct_type(parallel)
+// CHECK:   omp.cancel cancellation_construct_type(parallel)
+// CHECK:   omp.terminator

--- a/test/lit_tests/llvm_to_omp/critical.mlir
+++ b/test/lit_tests/llvm_to_omp/critical.mlir
@@ -1,0 +1,62 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp critical`: the __kmpc_critical / __kmpc_end_critical pair
+// becomes an omp.critical region.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global common @".gomp_critical_user_.var"(dense<0> : tensor<8xi32>) {addr_space = 0 : i32, alignment = 8 : i64, sym_visibility = "private"} : !llvm.array<8 x i32>
+  llvm.func @critical(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @critical.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %4[%c0] : memref<1x!llvm.ptr>
+    %5 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %5[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %2, %3) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @critical.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @".gomp_critical_user_.var" : !llvm.ptr
+    %1 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %2 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %3 = memref.load %2[%c0] : memref<?xi32>
+    llvm.call tail @__kmpc_critical(%1, %3, %0) {convergent, no_unwind} : (!llvm.ptr, i32, !llvm.ptr) -> ()
+    %4 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %5 = memref.load %4[%c0] : memref<?x!llvm.ptr>
+    %6 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+    %7 = memref.load %6[%c0] : memref<?xi32>
+    llvm.call tail @body(%5, %7) : (!llvm.ptr, i32) -> ()
+    llvm.call tail @__kmpc_end_critical(%1, %3, %0) {convergent, no_unwind} : (!llvm.ptr, i32, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func @__kmpc_critical(!llvm.ptr, i32, !llvm.ptr) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_critical(!llvm.ptr, i32, !llvm.ptr) attributes {sym_visibility = "private"}
+  llvm.func @body(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @critical(
+// CHECK: omp.parallel {
+// CHECK:  omp.critical {
+// CHECK:    llvm.call tail @body(%{{.*}}, %{{.*}}) : (!llvm.ptr, i32) -> ()
+// CHECK:    omp.terminator
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/flush_taskyield.mlir
+++ b/test/lit_tests/llvm_to_omp/flush_taskyield.mlir
@@ -1,0 +1,51 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp flush` and `#pragma omp taskyield` become omp.flush and
+// omp.taskyield.  __kmpc_omp_taskyield returns an i32, so the leaf rewrite has
+// to replace the call rather than erase it.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @flush_region(%arg0: !llvm.ptr) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %1 = llvm.mlir.addressof @flush_region.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %3[%c0] : memref<1x!llvm.ptr>
+    llvm.call @__kmpc_fork_call(%0, %c1_i32, %1, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @flush_region.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %c0_i32 = arith.constant 0 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    llvm.call tail @__kmpc_flush(%0) : (!llvm.ptr) -> ()
+    %1 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %2 = memref.load %1[%c0] : memref<?xi32>
+    %3 = llvm.call tail @__kmpc_omp_taskyield(%0, %2, %c0_i32) : (!llvm.ptr, i32, i32) -> i32
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_flush(!llvm.ptr) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_omp_taskyield(!llvm.ptr, i32, i32) -> i32 attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @flush_region(
+// CHECK: omp.parallel {
+// CHECK:   omp.flush
+// CHECK:   omp.taskyield
+// CHECK:   omp.terminator

--- a/test/lit_tests/llvm_to_omp/masked.mlir
+++ b/test/lit_tests/llvm_to_omp/masked.mlir
@@ -1,0 +1,51 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp masked`: the __kmpc_masked / __kmpc_end_masked pair becomes an
+// omp.masked with the thread filter it was given.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @masked_region() {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %1 = llvm.mlir.addressof @masked_region.omp_outlined : !llvm.ptr
+    llvm.call tail @__kmpc_fork_call(%0, %c0_i32, %1) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @masked_region.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %1 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %2 = memref.load %1[%c0] : memref<?xi32>
+    %3 = llvm.call tail @__kmpc_masked(%0, %2, %c0_i32) : (!llvm.ptr, i32, i32) -> i32
+    %4 = arith.cmpi ne, %3, %c0_i32 : i32
+    scf.if %4 {
+      llvm.call tail @body(%c0_i32) : (i32) -> ()
+      llvm.call tail @__kmpc_end_masked(%0, %2) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_masked(!llvm.ptr, i32, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @body(i32 {llvm.noundef}) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_masked(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @masked_region(
+// CHECK: omp.parallel {
+// CHECK:   omp.masked filter(%{{.*}} : i32) {
+// CHECK:     llvm.call tail @body(%{{.*}}) : (i32) -> ()
+// CHECK:     omp.terminator

--- a/test/lit_tests/llvm_to_omp/masked_filter.mlir
+++ b/test/lit_tests/llvm_to_omp/masked_filter.mlir
@@ -1,0 +1,52 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp masked filter(1)`: the filter reaching omp.masked is the thread
+// number the construct was given, not a hardwired zero.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @masked_filter_region() {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %1 = llvm.mlir.addressof @masked_filter_region.omp_outlined : !llvm.ptr
+    llvm.call tail @__kmpc_fork_call(%0, %c0_i32, %1) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @masked_filter_region.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %1 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %2 = memref.load %1[%c0] : memref<?xi32>
+    %3 = llvm.call tail @__kmpc_masked(%0, %2, %c1_i32) : (!llvm.ptr, i32, i32) -> i32
+    %4 = arith.cmpi ne, %3, %c0_i32 : i32
+    scf.if %4 {
+      llvm.call tail @body(%c0_i32) : (i32) -> ()
+      llvm.call tail @__kmpc_end_masked(%0, %2) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_masked(!llvm.ptr, i32, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @body(i32 {llvm.noundef}) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_masked(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @masked_filter_region(
+// CHECK: omp.parallel {
+// CHECK:   omp.masked filter(%{{.*}} : i32) {
+// CHECK:     llvm.call tail @body(%{{.*}}) : (i32) -> ()
+// CHECK:     omp.terminator

--- a/test/lit_tests/llvm_to_omp/num_threads.mlir
+++ b/test/lit_tests/llvm_to_omp/num_threads.mlir
@@ -1,0 +1,56 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `num_threads(4)`: the __kmpc_push_num_threads that
+// clang emits immediately before the fork is folded into the omp.parallel.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @parallel_num_threads(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c4_i32 = arith.constant 4 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @parallel_num_threads.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = llvm.call tail @__kmpc_global_thread_num(%0) : (!llvm.ptr) -> i32
+    %5 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %5[%c0] : memref<1x!llvm.ptr>
+    %6 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %6[%c0] : memref<1xi32>
+    llvm.call tail @__kmpc_push_num_threads(%0, %4, %c4_i32) : (!llvm.ptr, i32, i32) -> ()
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %2, %3) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @parallel_num_threads.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %1 = memref.load %0[%c0] : memref<?x!llvm.ptr>
+    %2 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+    %3 = memref.load %2[%c0] : memref<?xi32>
+    llvm.call tail @body(%1, %3) : (!llvm.ptr, i32) -> ()
+    llvm.return
+  }
+  llvm.func @body(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_global_thread_num(!llvm.ptr) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_push_num_threads(!llvm.ptr, i32, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @parallel_num_threads(
+// CHECK: omp.parallel num_threads(%{{.*}} : i32) {
+// CHECK:  llvm.call tail @body(%{{.*}}, %{{.*}}) : (!llvm.ptr, i32) -> ()
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/ordered.mlir
+++ b/test/lit_tests/llvm_to_omp/ordered.mlir
@@ -1,0 +1,111 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp ordered` inside a worksharing loop.  omp.ordered.region only
+// verifies inside a loop that declares the `ordered` clause, so the wsloop
+// wrapping it has to pick that up; the per-iteration __kmpc_dispatch_fini_*
+// bookkeeping the clause makes Clang emit is subsumed by omp.wsloop.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @ordered_loop(%arg0: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %1 = llvm.mlir.addressof @ordered_loop.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg0, %3[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c1_i32, %1, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @ordered_loop.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %c66_i32 = arith.constant 66 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c-1_i32 = arith.constant -1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %5 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?xi32>
+    %6 = memref.load %5[%c0] : memref<?xi32>
+    %7 = arith.cmpi sgt, %6, %c0_i32 : i32
+    scf.if %7 {
+      %8 = arith.addi %6, %c-1_i32 overflow<nsw> : i32
+      %9 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %9[%c0] : memref<1xi32>
+      %10 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %8, %10[%c0] : memref<1xi32>
+      %11 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c1_i32, %11[%c0] : memref<1xi32>
+      %12 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %12[%c0] : memref<1xi32>
+      %13 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+      %14 = memref.load %13[%c0] : memref<?xi32>
+      llvm.call tail @__kmpc_dispatch_init_4(%0, %14, %c66_i32, %c0_i32, %8, %c1_i32, %c1_i32) : (!llvm.ptr, i32, i32, i32, i32, i32, i32) -> ()
+      %15 = llvm.call @__kmpc_dispatch_next_4(%0, %14, %4, %1, %2, %3) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
+      %16 = arith.cmpi ne, %15, %c0_i32 : i32
+      scf.if %16 {
+        scf.while : () -> () {
+          %17 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+          %18 = memref.load %17[%c0] : memref<1xi32>
+          %19 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+          %20 = memref.load %19[%c0] : memref<1xi32>
+          %21 = arith.cmpi sle, %18, %20 : i32
+          scf.if %21 {
+            %24 = arith.addi %20, %c1_i32 : i32
+            %25 = arith.cmpi slt, %18, %24 : i32
+            scf.if %25 {
+              %26 = arith.addi %18, %c1_i32 : i32
+              %27 = arith.addi %20, %c2_i32 : i32
+              scf.for %arg3 = %26 to %27 step %c1_i32  : i32 {
+                %28 = arith.subi %arg3, %26 : i32
+                %29 = arith.addi %18, %28 : i32
+                llvm.call @__kmpc_ordered(%0, %14) : (!llvm.ptr, i32) -> ()
+                llvm.call @body(%29) : (i32) -> ()
+                llvm.call @__kmpc_end_ordered(%0, %14) : (!llvm.ptr, i32) -> ()
+                llvm.call @__kmpc_dispatch_fini_4(%0, %14) : (!llvm.ptr, i32) -> ()
+              }
+            }
+          }
+          %22 = llvm.call @__kmpc_dispatch_next_4(%0, %14, %4, %1, %2, %3) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
+          %23 = arith.cmpi ne, %22, %c0_i32 : i32
+          scf.condition(%23)
+        } do {
+          scf.yield
+        }
+      }
+      llvm.call @__kmpc_dispatch_deinit(%0, %14) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_init_4(!llvm.ptr, i32, i32, i32, i32, i32, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_next_4(!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_ordered(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @body(i32 {llvm.noundef}) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_ordered(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_fini_4(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_deinit(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @ordered_loop(
+// CHECK: omp.parallel {
+// CHECK:   omp.wsloop nowait ordered(0) schedule(static
+// CHECK:     omp.loop_nest
+// CHECK:       omp.ordered.region {

--- a/test/lit_tests/llvm_to_omp/parallel.mlir
+++ b/test/lit_tests/llvm_to_omp/parallel.mlir
@@ -1,0 +1,51 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// A `#pragma omp parallel` region: the __kmpc_fork_call and its
+// outlined function become an omp.parallel whose body is the inlined outline.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @parallel_region(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @parallel_region.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %4[%c0] : memref<1x!llvm.ptr>
+    %5 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %5[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %2, %3) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @parallel_region.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %1 = memref.load %0[%c0] : memref<?x!llvm.ptr>
+    %2 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+    %3 = memref.load %2[%c0] : memref<?xi32>
+    llvm.call tail @body(%1, %3) : (!llvm.ptr, i32) -> ()
+    llvm.return
+  }
+  llvm.func @body(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @parallel_region(
+// CHECK: omp.parallel {
+// CHECK:  llvm.call tail @body(%{{.*}}, %{{.*}}) : (!llvm.ptr, i32) -> ()
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/reduction.mlir
+++ b/test/lit_tests/llvm_to_omp/reduction.mlir
@@ -1,0 +1,191 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `reduction(+ : s)`: the __kmpc_reduce_nowait dispatch and the combiner
+// in its case-1 block are lifted into an omp.declare_reduction symbol, referenced
+// from the reduction clause of the enclosing omp.parallel.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c514_i32 = arith.constant 514 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c514_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global common @".gomp_critical_user_.reduction.var"(dense<0> : tensor<8xi32>) {addr_space = 0 : i32, alignment = 8 : i64, sym_visibility = "private"} : !llvm.array<8 x i32>
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c18_i32 = arith.constant 18 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c18_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_3() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @reduction(%arg0: !llvm.ptr, %arg1: i32) -> i32 {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_3 : !llvm.ptr
+    %c3_i32 = arith.constant 3 : i32
+    %1 = llvm.mlir.addressof @reduction.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %5 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %5[%c0] : memref<1x!llvm.ptr>
+    %6 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %6[%c0] : memref<1xi32>
+    %7 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %c0_i32, %7[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c3_i32, %1, %3, %4, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    %8 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+    %9 = memref.load %8[%c0] : memref<1xi32>
+    llvm.return %9 : i32
+  }
+  llvm.func internal @reduction.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr, %arg4: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @".gomp_critical_user_.reduction.var" : !llvm.ptr
+    %1 = llvm.mlir.addressof @reduction.omp_outlined.omp.reduction.reduction_func : !llvm.ptr
+    %c8_i64 = arith.constant 8 : i64
+    %2 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %c1_i64 = arith.constant 1 : i64
+    %c34_i32 = arith.constant 34 : i32
+    %3 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c-1_i32 = arith.constant -1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %4 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %5 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %6 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %7 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %8 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %9 = llvm.alloca %c1_i32 x !llvm.array<1 x ptr> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %10 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?xi32>
+    %11 = memref.load %10[%c0] : memref<?xi32>
+    %12 = arith.cmpi sgt, %11, %c0_i32 : i32
+    scf.if %12 {
+      %13 = arith.addi %11, %c-1_i32 : i32
+      %14 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %14[%c0] : memref<1xi32>
+      %15 = "enzymexla.pointer2memref"(%5) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %13, %15[%c0] : memref<1xi32>
+      %16 = "enzymexla.pointer2memref"(%6) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c1_i32, %16[%c0] : memref<1xi32>
+      %17 = "enzymexla.pointer2memref"(%7) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %17[%c0] : memref<1xi32>
+      %18 = "enzymexla.pointer2memref"(%8) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %18[%c0] : memref<1xi32>
+      %19 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+      %20 = memref.load %19[%c0] : memref<?xi32>
+      llvm.call @__kmpc_for_static_init_4(%3, %20, %c34_i32, %7, %4, %5, %6, %c1_i32, %c1_i32) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) -> ()
+      %21 = "enzymexla.pointer2memref"(%5) : (!llvm.ptr) -> memref<1xi32>
+      %22 = memref.load %21[%c0] : memref<1xi32>
+      %23 = arith.minsi %22, %13 : i32
+      %24 = "enzymexla.pointer2memref"(%5) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %23, %24[%c0] : memref<1xi32>
+      %25 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+      %26 = memref.load %25[%c0] : memref<1xi32>
+      %27 = arith.cmpi sle, %26, %23 : i32
+      scf.if %27 {
+        %32 = "enzymexla.pointer2memref"(%8) : (!llvm.ptr) -> memref<1xi32>
+        %33 = memref.load %32[%c0] : memref<1xi32>
+        %34 = "enzymexla.pointer2memref"(%arg4) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+        %35 = memref.load %34[%c0] : memref<?x!llvm.ptr>
+        %36 = arith.extsi %26 : i32 to i64
+        %37 = arith.addi %23, %c1_i32 : i32
+        %38:2 = scf.while (%arg5 = %36, %arg6 = %33) : (i64, i32) -> (i64, i32) {
+          %39 = arith.index_cast %arg5 : i64 to index
+          %40 = "enzymexla.pointer2memref"(%35) : (!llvm.ptr) -> memref<?xi32>
+          %41 = memref.load %40[%39] {alignment = 4 : i64, ordering = 0 : i64} : memref<?xi32>
+          %42 = arith.addi %arg6, %41 : i32
+          %43 = "enzymexla.pointer2memref"(%8) : (!llvm.ptr) -> memref<1xi32>
+          memref.store %42, %43[%c0] : memref<1xi32>
+          %44 = arith.addi %arg5, %c1_i64 : i64
+          %45 = arith.trunci %44 : i64 to i32
+          %46 = arith.cmpi ne, %37, %45 : i32
+          scf.condition(%46) %44, %42 : i64, i32
+        } do {
+        ^bb0(%arg5: i64, %arg6: i32):
+          scf.yield %arg5, %arg6 : i64, i32
+        }
+      }
+      llvm.call @__kmpc_for_static_fini(%3, %20) : (!llvm.ptr, i32) -> ()
+      %28 = "enzymexla.pointer2memref"(%9) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+      memref.store %8, %28[%c0] : memref<1x!llvm.ptr>
+      %29 = llvm.call @__kmpc_reduce_nowait(%2, %20, %c1_i32, %c8_i64, %9, %1, %0) {convergent, no_unwind} : (!llvm.ptr, i32, i32, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
+      %30 = arith.index_castui %29 : i32 to index
+      %31 = arith.cmpi eq, %30, %c1 : index
+      scf.if %31 {
+        %32 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+        %33 = memref.load %32[%c0] : memref<?xi32>
+        %34 = "enzymexla.pointer2memref"(%8) : (!llvm.ptr) -> memref<1xi32>
+        %35 = memref.load %34[%c0] : memref<1xi32>
+        %36 = arith.addi %35, %33 : i32
+        %37 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+        memref.store %36, %37[%c0] : memref<?xi32>
+        llvm.call @__kmpc_end_reduce_nowait(%2, %20, %0) {convergent, no_unwind} : (!llvm.ptr, i32, !llvm.ptr) -> ()
+      } else {
+        %32 = arith.cmpi eq, %30, %c2 : index
+        scf.if %32 {
+          %33 = "enzymexla.pointer2memref"(%8) : (!llvm.ptr) -> memref<1xi32>
+          %34 = memref.load %33[%c0] : memref<1xi32>
+          %35 = llvm.atomicrmw add %arg3, %34 monotonic {alignment = 4 : i64} : !llvm.ptr, i32
+        }
+      }
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_for_static_init_4(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_for_static_fini(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func internal @reduction.omp_outlined.omp.reduction.reduction_func(%arg0: !llvm.ptr, %arg1: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %1 = memref.load %0[%c0] : memref<?x!llvm.ptr>
+    %2 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %3 = memref.load %2[%c0] : memref<?x!llvm.ptr>
+    %4 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<?xi32>
+    %5 = memref.load %4[%c0] : memref<?xi32>
+    %6 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?xi32>
+    %7 = memref.load %6[%c0] : memref<?xi32>
+    %8 = arith.addi %7, %5 : i32
+    %9 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<?xi32>
+    memref.store %8, %9[%c0] : memref<?xi32>
+    llvm.return
+  }
+  llvm.func @__kmpc_reduce_nowait(!llvm.ptr, i32, i32, i64, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_reduce_nowait(!llvm.ptr, i32, !llvm.ptr) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @reduction(
+// CHECK: omp.parallel reduction(byref @omp_red_add_i32 %{{.*}} -> %{{.*}} : !llvm.ptr) {
+// CHECK:    omp.wsloop nowait schedule(static = %{{.*}} : i32) {
+// CHECK:      omp.loop_nest (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
+// CHECK:        omp.yield
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/sections.mlir
+++ b/test/lit_tests/llvm_to_omp/sections.mlir
@@ -1,0 +1,109 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp parallel sections`: clang lowers sections onto the static
+// worksharing-loop runtime, so this raises to an omp.wsloop over the section index.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1026_i32 = arith.constant 1026 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c1026_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @sections(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @sections.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %4[%c0] : memref<1x!llvm.ptr>
+    %5 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %5[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %2, %3) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @sections.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %c2_i32 = arith.constant 2 : i32
+    %c34_i32 = arith.constant 34 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %1 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %5 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %c0_i32, %5[%c0] : memref<1xi32>
+    %6 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %c1_i32, %6[%c0] : memref<1xi32>
+    %7 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %c1_i32, %7[%c0] : memref<1xi32>
+    %8 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %c0_i32, %8[%c0] : memref<1xi32>
+    %9 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %10 = memref.load %9[%c0] : memref<?xi32>
+    llvm.call @__kmpc_for_static_init_4(%0, %10, %c34_i32, %4, %1, %2, %3, %c1_i32, %c1_i32) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) -> ()
+    %11 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+    %12 = memref.load %11[%c0] : memref<1xi32>
+    %13 = arith.minsi %12, %c1_i32 : i32
+    %14 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %13, %14[%c0] : memref<1xi32>
+    %15 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+    %16 = memref.load %15[%c0] : memref<1xi32>
+    %17 = arith.cmpi sle, %16, %13 : i32
+    scf.if %17 {
+      %18 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+      %19 = memref.load %18[%c0] : memref<1xi32>
+      %20 = arith.maxsi %19, %16 : i32
+      %21 = arith.addi %20, %c1_i32 : i32
+      scf.for %arg4 = %16 to %21 step %c1_i32  : i32 {
+        %22 = arith.cmpi ult, %arg4, %c2_i32 : i32
+        scf.if %22 {
+          %23 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+          %24 = memref.load %23[%c0] : memref<?x!llvm.ptr>
+          %25 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+          %26 = memref.load %25[%c0] : memref<?xi32>
+          llvm.call @body(%24, %26) : (!llvm.ptr, i32) -> ()
+        }
+      }
+    }
+    llvm.call @__kmpc_for_static_fini(%0, %10) : (!llvm.ptr, i32) -> ()
+    llvm.return
+  }
+  llvm.func @__kmpc_for_static_init_4(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) attributes {sym_visibility = "private"}
+  llvm.func @body(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_for_static_fini(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @sections(
+// CHECK: omp.parallel {
+// CHECK:  omp.wsloop nowait schedule(static = %{{.*}} : i32) {
+// CHECK:    omp.loop_nest (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
+// CHECK:        llvm.call @body(%{{.*}}, %{{.*}}) : (!llvm.ptr, i32) -> ()
+// CHECK:      omp.yield
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/single_master.mlir
+++ b/test/lit_tests/llvm_to_omp/single_master.mlir
@@ -1,0 +1,97 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp single` and `#pragma omp master`. Both are guarded
+// regions in the incoming IR: a runtime call returning a flag, an scf.if on it,
+// and a matching end call. They become omp.single and omp.master.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c322_i32 = arith.constant 322 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c322_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @single_master(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @single_master.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %4[%c0] : memref<1x!llvm.ptr>
+    %5 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %5[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %2, %3) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @single_master.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %1 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %2 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %3 = memref.load %2[%c0] : memref<?xi32>
+    %4 = llvm.call tail @__kmpc_single(%1, %3) {convergent, no_unwind} : (!llvm.ptr, i32) -> i32
+    %5 = arith.cmpi ne, %4, %c0_i32 : i32
+    scf.if %5 {
+      %8 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      %9 = memref.load %8[%c0] : memref<?x!llvm.ptr>
+      %10 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+      %11 = memref.load %10[%c0] : memref<?xi32>
+      llvm.call tail @body(%9, %11) : (!llvm.ptr, i32) -> ()
+      llvm.call tail @__kmpc_end_single(%1, %3) {convergent, no_unwind} : (!llvm.ptr, i32) -> ()
+    }
+    llvm.call tail @__kmpc_barrier(%0, %3) {convergent, no_unwind} : (!llvm.ptr, i32) -> ()
+    %6 = llvm.call tail @__kmpc_master(%1, %3) : (!llvm.ptr, i32) -> i32
+    %7 = arith.cmpi ne, %6, %c0_i32 : i32
+    scf.if %7 {
+      %8 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      %9 = memref.load %8[%c0] : memref<?x!llvm.ptr>
+      %10 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?xi32>
+      %11 = memref.load %10[%c0] : memref<?xi32>
+      llvm.call tail @body(%9, %11) : (!llvm.ptr, i32) -> ()
+      llvm.call tail @__kmpc_end_master(%1, %3) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_single(!llvm.ptr, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_single(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @body(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_barrier(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_master(!llvm.ptr, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_master(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @single_master(
+// CHECK: omp.parallel {
+// CHECK:  omp.single {
+// CHECK:    llvm.call tail @body(%{{.*}}, %{{.*}}) : (!llvm.ptr, i32) -> ()
+// CHECK:    omp.terminator
+// CHECK:  omp.barrier
+// CHECK:  omp.master {
+// CHECK:    llvm.call tail @body(%{{.*}}, %{{.*}}) : (!llvm.ptr, i32) -> ()
+// CHECK:    omp.terminator
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/single_nowait.mlir
+++ b/test/lit_tests/llvm_to_omp/single_nowait.mlir
@@ -1,0 +1,52 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp single nowait`.  A `single` is synchronising unless its
+// __kmpc_end_single is directly followed by a __kmpc_barrier, so it is the
+// absence of that barrier that has to become the nowait clause.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @single_nowait_region() {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %1 = llvm.mlir.addressof @single_nowait_region.omp_outlined : !llvm.ptr
+    llvm.call tail @__kmpc_fork_call(%0, %c0_i32, %1) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @single_nowait_region.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %1 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %2 = memref.load %1[%c0] : memref<?xi32>
+    %3 = llvm.call tail @__kmpc_single(%0, %2) : (!llvm.ptr, i32) -> i32
+    %4 = arith.cmpi ne, %3, %c0_i32 : i32
+    scf.if %4 {
+      llvm.call tail @body(%c0_i32) : (i32) -> ()
+      llvm.call tail @__kmpc_end_single(%0, %2) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_single(!llvm.ptr, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @body(i32 {llvm.noundef}) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_single(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @single_nowait_region(
+// CHECK: omp.parallel {
+// CHECK:   omp.single nowait {
+// CHECK:     llvm.call tail @body(%{{.*}}) : (i32) -> ()
+// CHECK:     omp.terminator

--- a/test/lit_tests/llvm_to_omp/task.mlir
+++ b/test/lit_tests/llvm_to_omp/task.mlir
@@ -1,0 +1,116 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp task` and `#pragma omp taskwait`: __kmpc_omp_task_alloc plus
+// __kmpc_omp_task become an omp.task, and __kmpc_omp_taskwait becomes omp.taskwait.
+#alias_scope_domain = #llvm.alias_scope_domain<id = distinct[0]<>, description = ".omp_outlined.">
+#alias_scope = #llvm.alias_scope<id = distinct[1]<>, domain = #alias_scope_domain, description = ".omp_outlined.: argument 0">
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c322_i32 = arith.constant 322 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c322_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @task(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @task.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %4[%c0] : memref<1x!llvm.ptr>
+    %5 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %5[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %2, %3) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @task.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %1 = llvm.mlir.addressof @".omp_task_entry." : !llvm.ptr
+    %c16_i64 = arith.constant 16 : i64
+    %c40_i64 = arith.constant 40 : i64
+    %c1_i32 = arith.constant 1 : i32
+    %2 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %3 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %4 = memref.load %3[%c0] : memref<?xi32>
+    %5 = llvm.call tail @__kmpc_single(%2, %4) {convergent, no_unwind} : (!llvm.ptr, i32) -> i32
+    %6 = arith.cmpi ne, %5, %c0_i32 : i32
+    scf.if %6 {
+      %7 = llvm.call tail @__kmpc_omp_task_alloc(%2, %4, %c1_i32, %c40_i64, %c16_i64, %1) : (!llvm.ptr, i32, i32, i64, i64, !llvm.ptr) -> !llvm.ptr
+      %8 = "enzymexla.pointer2memref"(%7) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      %9 = memref.load %8[%c0] : memref<?x!llvm.ptr>
+      %10 = "enzymexla.pointer2memref"(%9) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      memref.store %arg2, %10[%c0] : memref<?x!llvm.ptr>
+      %11 = "enzymexla.pointer2memref"(%9) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      memref.store %arg3, %11[%c1] : memref<?x!llvm.ptr>
+      %12 = llvm.call tail @__kmpc_omp_task(%2, %4, %7) : (!llvm.ptr, i32, !llvm.ptr) -> i32
+      %13 = llvm.call tail @__kmpc_omp_taskwait(%2, %4) {convergent, no_unwind} : (!llvm.ptr, i32) -> i32
+      llvm.call tail @__kmpc_end_single(%2, %4) {convergent, no_unwind} : (!llvm.ptr, i32) -> ()
+    }
+    llvm.call tail @__kmpc_barrier(%0, %4) {convergent, no_unwind} : (!llvm.ptr, i32) -> ()
+    llvm.return
+  }
+  llvm.func @__kmpc_single(!llvm.ptr, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_single(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @body(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func internal @".omp_task_entry."(%arg0: i32, %arg1: !llvm.ptr) -> i32 attributes {dso_local, sym_visibility = "private"} {
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c0_i32 = arith.constant 0 : i32
+    %0 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %1 = memref.load %0[%c0] : memref<?x!llvm.ptr>
+    llvm.intr.experimental.noalias.scope.decl #alias_scope
+    %2 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %3 = memref.load %2[%c0] : memref<?x!llvm.ptr>
+    %4 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %5 = memref.load %4[%c0] : memref<?x!llvm.ptr>
+    %6 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %7 = memref.load %6[%c1] : memref<?x!llvm.ptr>
+    %8 = "enzymexla.pointer2memref"(%7) : (!llvm.ptr) -> memref<?xi32>
+    %9 = memref.load %8[%c0] : memref<?xi32>
+    llvm.call tail @body(%5, %9) {no_unwind, noalias_scopes = [#alias_scope]} : (!llvm.ptr, i32) -> ()
+    llvm.return %c0_i32 : i32
+  }
+  llvm.func @__kmpc_omp_task_alloc(!llvm.ptr, i32, i32, i64, i64, !llvm.ptr) -> !llvm.ptr attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_omp_task(!llvm.ptr, i32, !llvm.ptr) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_omp_taskwait(!llvm.ptr, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_barrier(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @task(
+// CHECK: omp.parallel {
+// CHECK:  omp.single {
+// CHECK:    omp.task {
+// CHECK:      llvm.call tail @body(%{{.*}}, %{{.*}}) {no_unwind, noalias_scopes = [#alias_scope]} : (!llvm.ptr, i32) -> ()
+// CHECK:      omp.terminator
+// CHECK:    omp.taskwait
+// CHECK:    omp.terminator
+// CHECK:  omp.barrier
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/taskloop.mlir
+++ b/test/lit_tests/llvm_to_omp/taskloop.mlir
@@ -1,0 +1,157 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp taskloop grainsize(2)` inside a `single`: __kmpc_taskloop and
+// the kmp_task_t it is handed become an omp.taskloop.context / .wrapper pair
+// around an omp.loop_nest, with the loop bounds recovered from the stores that
+// fill the task struct rather than loaded back out of it.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c322_i32 = arith.constant 322 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c322_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @taskloop_region(%arg0: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %1 = llvm.mlir.addressof @taskloop_region.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg0, %3[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c1_i32, %1, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @taskloop_region.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c9 = arith.constant 9 : index
+    %c7 = arith.constant 7 : index
+    %c6 = arith.constant 6 : index
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %1 = llvm.mlir.zero : !llvm.ptr
+    %c2_i64 = arith.constant 2 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %2 = llvm.mlir.addressof @".omp_task_entry." : !llvm.ptr
+    %c8_i64 = arith.constant 8 : i64
+    %c80_i64 = arith.constant 80 : i64
+    %c1_i32 = arith.constant 1 : i32
+    %c-1_i32 = arith.constant -1 : i32
+    %3 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %4 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %5 = memref.load %4[%c0] : memref<?xi32>
+    %6 = llvm.call tail @__kmpc_single(%3, %5) : (!llvm.ptr, i32) -> i32
+    %7 = arith.cmpi ne, %6, %c0_i32 : i32
+    scf.if %7 {
+      llvm.call tail @__kmpc_taskgroup(%3, %5) : (!llvm.ptr, i32) -> ()
+      %8 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?xi32>
+      %9 = memref.load %8[%c0] : memref<?xi32>
+      %10 = arith.addi %9, %c-1_i32 overflow<nsw> : i32
+      %11 = llvm.call tail @__kmpc_omp_task_alloc(%3, %5, %c1_i32, %c80_i64, %c8_i64, %2) : (!llvm.ptr, i32, i32, i64, i64, !llvm.ptr) -> !llvm.ptr
+      %12 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      %13 = memref.load %12[%c0] : memref<?x!llvm.ptr>
+      %14 = "enzymexla.pointer2memref"(%13) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      memref.store %arg2, %14[%c0] : memref<?x!llvm.ptr>
+      %15 = llvm.getelementptr inbounds %11[40] : (!llvm.ptr) -> !llvm.ptr, i8
+      %16 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi64>
+      memref.store %c0_i64, %16[%c5] : memref<?xi64>
+      %17 = llvm.getelementptr inbounds %11[48] : (!llvm.ptr) -> !llvm.ptr, i8
+      %18 = arith.extsi %10 : i32 to i64
+      %19 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi64>
+      memref.store %18, %19[%c6] : memref<?xi64>
+      %20 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi64>
+      memref.store %c1_i64, %20[%c7] : memref<?xi64>
+      %21 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi64>
+      memref.store %c0_i64, %21[%c9] : memref<?xi64>
+      llvm.call tail @__kmpc_taskloop(%3, %5, %11, %c1_i32, %15, %17, %c1_i64, %c1_i32, %c1_i32, %c2_i64, %1) : (!llvm.ptr, i32, !llvm.ptr, i32, !llvm.ptr, !llvm.ptr, i64, i32, i32, i64, !llvm.ptr) -> ()
+      llvm.call tail @__kmpc_end_taskgroup(%3, %5) : (!llvm.ptr, i32) -> ()
+      llvm.call tail @__kmpc_end_single(%3, %5) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.call tail @__kmpc_barrier(%0, %5) : (!llvm.ptr, i32) -> ()
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_single(!llvm.ptr, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_taskgroup(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func internal @".omp_task_entry."(%arg0: i32, %arg1: !llvm.ptr) -> (i32 {llvm.noundef}) attributes {dso_local, sym_visibility = "private"} {
+    %c6 = arith.constant 6 : index
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c-1_i64 = arith.constant -1 : i64
+    %0 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %1 = memref.load %0[%c0] : memref<?x!llvm.ptr>
+    %2 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?xi64>
+    %3 = memref.load %2[%c5] : memref<?xi64>
+    %4 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?xi64>
+    %5 = memref.load %4[%c6] : memref<?xi64>
+    %6 = arith.addi %5, %c1_i64 : i64
+    %7 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %8 = memref.load %7[%c0] : memref<?x!llvm.ptr>
+    %9 = "enzymexla.pointer2memref"(%8) : (!llvm.ptr) -> memref<?xi32>
+    %10 = memref.load %9[%c0] : memref<?xi32>
+    %11 = arith.cmpi sgt, %10, %c0_i32 : i32
+    %12 = arith.shli %3, %c32_i64 : i64
+    %13 = arith.shrsi %12, %c32_i64 exact : i64
+    %14 = arith.addi %13, %c1_i64 overflow<nsw> : i64
+    %15 = arith.maxsi %6, %14 : i64
+    %16 = arith.subi %15, %13 : i64
+    %17 = arith.cmpi uge, %5, %13 : i64
+    %18 = arith.andi %11, %17 : i1
+    %19 = arith.cmpi sgt, %16, %c0_i64 : i64
+    %20 = arith.andi %18, %19 : i1
+    scf.if %20 {
+      %21 = arith.maxsi %16, %c1_i64 : i64
+      %22 = arith.addi %21, %c1_i64 : i64
+      scf.for %arg2 = %c1_i64 to %22 step %c1_i64  : i64 {
+        %23 = arith.addi %arg2, %c-1_i64 : i64
+        %24 = arith.addi %3, %23 : i64
+        %25 = arith.trunci %24 : i64 to i32
+        llvm.call tail @body(%25) : (i32) -> ()
+      }
+    }
+    llvm.return %c0_i32 : i32
+  }
+  llvm.func @__kmpc_omp_task_alloc(!llvm.ptr, i32, i32, i64, i64, !llvm.ptr) -> (!llvm.ptr {llvm.noalias}) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_taskloop(!llvm.ptr, i32, !llvm.ptr, i32, !llvm.ptr, !llvm.ptr, i64, i32, i32, i64, !llvm.ptr) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_taskgroup(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_single(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_barrier(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @body(i32 {llvm.noundef}) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @taskloop_region(
+// CHECK: omp.parallel {
+// CHECK:   omp.single {
+// CHECK:     omp.taskgroup {
+// CHECK:       omp.taskloop.context grainsize(%{{.*}}: i64) nogroup {
+// CHECK:         omp.taskloop.wrapper {
+// CHECK:           omp.loop_nest (%[[IV:.*]]) : i64 = (%{{.*}}) to (%{{.*}}) step (%{{.*}}) {
+// CHECK:             llvm.call tail @body(%{{.*}}) : (i32) -> ()
+// CHECK:             omp.yield

--- a/test/lit_tests/llvm_to_omp/taskloop_num_tasks.mlir
+++ b/test/lit_tests/llvm_to_omp/taskloop_num_tasks.mlir
@@ -1,0 +1,152 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp taskloop num_tasks(4)`.  __kmpc_taskloop passes nogroup ahead
+// of sched, so reading the two the other way round turns num_tasks into
+// grainsize; this test pins the order down.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c322_i32 = arith.constant 322 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c322_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @taskloop_num_tasks(%arg0: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %1 = llvm.mlir.addressof @taskloop_num_tasks.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg0, %3[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c1_i32, %1, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @taskloop_num_tasks.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c9 = arith.constant 9 : index
+    %c7 = arith.constant 7 : index
+    %c6 = arith.constant 6 : index
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %1 = llvm.mlir.zero : !llvm.ptr
+    %c4_i64 = arith.constant 4 : i64
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %2 = llvm.mlir.addressof @".omp_task_entry." : !llvm.ptr
+    %c8_i64 = arith.constant 8 : i64
+    %c80_i64 = arith.constant 80 : i64
+    %c1_i32 = arith.constant 1 : i32
+    %c-1_i32 = arith.constant -1 : i32
+    %3 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c0_i32 = arith.constant 0 : i32
+    %4 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+    %5 = memref.load %4[%c0] : memref<?xi32>
+    %6 = llvm.call tail @__kmpc_single(%3, %5) : (!llvm.ptr, i32) -> i32
+    %7 = arith.cmpi ne, %6, %c0_i32 : i32
+    scf.if %7 {
+      llvm.call tail @__kmpc_taskgroup(%3, %5) : (!llvm.ptr, i32) -> ()
+      %8 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?xi32>
+      %9 = memref.load %8[%c0] : memref<?xi32>
+      %10 = arith.addi %9, %c-1_i32 overflow<nsw> : i32
+      %11 = llvm.call tail @__kmpc_omp_task_alloc(%3, %5, %c1_i32, %c80_i64, %c8_i64, %2) : (!llvm.ptr, i32, i32, i64, i64, !llvm.ptr) -> !llvm.ptr
+      %12 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      %13 = memref.load %12[%c0] : memref<?x!llvm.ptr>
+      %14 = "enzymexla.pointer2memref"(%13) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+      memref.store %arg2, %14[%c0] : memref<?x!llvm.ptr>
+      %15 = llvm.getelementptr inbounds %11[40] : (!llvm.ptr) -> !llvm.ptr, i8
+      %16 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi64>
+      memref.store %c0_i64, %16[%c5] : memref<?xi64>
+      %17 = llvm.getelementptr inbounds %11[48] : (!llvm.ptr) -> !llvm.ptr, i8
+      %18 = arith.extsi %10 : i32 to i64
+      %19 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi64>
+      memref.store %18, %19[%c6] : memref<?xi64>
+      %20 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi64>
+      memref.store %c1_i64, %20[%c7] : memref<?xi64>
+      %21 = "enzymexla.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi64>
+      memref.store %c0_i64, %21[%c9] : memref<?xi64>
+      llvm.call tail @__kmpc_taskloop(%3, %5, %11, %c1_i32, %15, %17, %c1_i64, %c1_i32, %c2_i32, %c4_i64, %1) : (!llvm.ptr, i32, !llvm.ptr, i32, !llvm.ptr, !llvm.ptr, i64, i32, i32, i64, !llvm.ptr) -> ()
+      llvm.call tail @__kmpc_end_taskgroup(%3, %5) : (!llvm.ptr, i32) -> ()
+      llvm.call tail @__kmpc_end_single(%3, %5) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.call tail @__kmpc_barrier(%0, %5) : (!llvm.ptr, i32) -> ()
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_single(!llvm.ptr, i32) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_taskgroup(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func internal @".omp_task_entry."(%arg0: i32, %arg1: !llvm.ptr) -> (i32 {llvm.noundef}) attributes {dso_local, sym_visibility = "private"} {
+    %c6 = arith.constant 6 : index
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c-1_i64 = arith.constant -1 : i64
+    %0 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %1 = memref.load %0[%c0] : memref<?x!llvm.ptr>
+    %2 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?xi64>
+    %3 = memref.load %2[%c5] : memref<?xi64>
+    %4 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?xi64>
+    %5 = memref.load %4[%c6] : memref<?xi64>
+    %6 = arith.addi %5, %c1_i64 : i64
+    %7 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %8 = memref.load %7[%c0] : memref<?x!llvm.ptr>
+    %9 = "enzymexla.pointer2memref"(%8) : (!llvm.ptr) -> memref<?xi32>
+    %10 = memref.load %9[%c0] : memref<?xi32>
+    %11 = arith.cmpi sgt, %10, %c0_i32 : i32
+    %12 = arith.shli %3, %c32_i64 : i64
+    %13 = arith.shrsi %12, %c32_i64 exact : i64
+    %14 = arith.addi %13, %c1_i64 overflow<nsw> : i64
+    %15 = arith.maxsi %6, %14 : i64
+    %16 = arith.subi %15, %13 : i64
+    %17 = arith.cmpi uge, %5, %13 : i64
+    %18 = arith.andi %11, %17 : i1
+    %19 = arith.cmpi sgt, %16, %c0_i64 : i64
+    %20 = arith.andi %18, %19 : i1
+    scf.if %20 {
+      %21 = arith.maxsi %16, %c1_i64 : i64
+      %22 = arith.addi %21, %c1_i64 : i64
+      scf.for %arg2 = %c1_i64 to %22 step %c1_i64  : i64 {
+        %23 = arith.addi %arg2, %c-1_i64 : i64
+        %24 = arith.addi %3, %23 : i64
+        %25 = arith.trunci %24 : i64 to i32
+        llvm.call tail @body(%25) : (i32) -> ()
+      }
+    }
+    llvm.return %c0_i32 : i32
+  }
+  llvm.func @__kmpc_omp_task_alloc(!llvm.ptr, i32, i32, i64, i64, !llvm.ptr) -> (!llvm.ptr {llvm.noalias}) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_taskloop(!llvm.ptr, i32, !llvm.ptr, i32, !llvm.ptr, !llvm.ptr, i64, i32, i32, i64, !llvm.ptr) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_taskgroup(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_end_single(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_barrier(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @body(i32 {llvm.noundef}) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @taskloop_num_tasks(
+// CHECK: omp.taskloop.context nogroup num_tasks(%{{.*}}: i64) {
+// CHECK:   omp.taskloop.wrapper {
+// CHECK:     omp.loop_nest

--- a/test/lit_tests/llvm_to_omp/teams.mlir
+++ b/test/lit_tests/llvm_to_omp/teams.mlir
@@ -1,0 +1,45 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp teams num_teams(4)`: __kmpc_fork_teams becomes an omp.teams.
+// __kmpc_push_num_teams carries the single count of `num_teams(N)`, which is
+// the league's UPPER bound — omp.teams rejects a lower bound given on its own.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @teams_region() {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c4_i32 = arith.constant 4 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %1 = llvm.mlir.addressof @teams_region.omp_outlined : !llvm.ptr
+    %2 = llvm.call tail @__kmpc_global_thread_num(%0) : (!llvm.ptr) -> i32
+    llvm.call tail @__kmpc_push_num_teams(%0, %2, %c4_i32, %c0_i32) : (!llvm.ptr, i32, i32, i32) -> ()
+    llvm.call tail @__kmpc_fork_teams(%0, %c0_i32, %1) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func @__kmpc_global_thread_num(!llvm.ptr) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_push_num_teams(!llvm.ptr, i32, i32, i32) attributes {sym_visibility = "private"}
+  llvm.func internal @teams_region.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0_i32 = arith.constant 0 : i32
+    llvm.call tail @body(%c0_i32) : (i32) -> ()
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_teams(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @body(i32 {llvm.noundef}) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @teams_region(
+// CHECK: omp.teams num_teams( to %{{.*}} : i32)
+// CHECK:   llvm.call tail @body(%{{.*}}) : (i32) -> ()
+// CHECK:   omp.terminator

--- a/test/lit_tests/llvm_to_omp/wsloop_dynamic.mlir
+++ b/test/lit_tests/llvm_to_omp/wsloop_dynamic.mlir
@@ -1,0 +1,114 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `schedule(dynamic)`: the __kmpc_dispatch_init / _next / _fini
+// dispatch loop becomes an omp.wsloop with a dynamic schedule.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @wsloop_dynamic(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @wsloop_dynamic.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %4[%c0] : memref<1x!llvm.ptr>
+    %5 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %5[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %3, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @wsloop_dynamic.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %c1_i64 = arith.constant 1 : i64
+    %c1073741859_i32 = arith.constant 1073741859 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c-1_i32 = arith.constant -1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %1 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %5 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?xi32>
+    %6 = memref.load %5[%c0] : memref<?xi32>
+    %7 = arith.cmpi sgt, %6, %c0_i32 : i32
+    scf.if %7 {
+      %8 = arith.addi %6, %c-1_i32 : i32
+      %9 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %9[%c0] : memref<1xi32>
+      %10 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %8, %10[%c0] : memref<1xi32>
+      %11 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c1_i32, %11[%c0] : memref<1xi32>
+      %12 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %12[%c0] : memref<1xi32>
+      %13 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+      %14 = memref.load %13[%c0] : memref<?xi32>
+      llvm.call tail @__kmpc_dispatch_init_4(%0, %14, %c1073741859_i32, %c0_i32, %8, %c1_i32, %c1_i32) : (!llvm.ptr, i32, i32, i32, i32, i32, i32) -> ()
+      %15 = llvm.call @__kmpc_dispatch_next_4(%0, %14, %4, %1, %2, %3) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
+      %16 = arith.cmpi ne, %15, %c0_i32 : i32
+      scf.if %16 {
+        scf.while : () -> () {
+          %17 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+          %18 = memref.load %17[%c0] : memref<1xi32>
+          %19 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+          %20 = memref.load %19[%c0] : memref<1xi32>
+          %21 = arith.cmpi sle, %18, %20 : i32
+          scf.if %21 {
+            %24 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+            %25 = memref.load %24[%c0] : memref<?x!llvm.ptr>
+            %26 = arith.extsi %18 : i32 to i64
+            %27 = scf.while (%arg4 = %26) : (i64) -> i64 {
+              %28 = arith.trunci %arg4 : i64 to i32
+              %29 = "enzymexla.pointer2memref"(%25) : (!llvm.ptr) -> memref<?xi32>
+              %30 = arith.index_cast %arg4 : i64 to index
+              memref.store %28, %29[%30] : memref<?xi32>
+              %31 = arith.addi %arg4, %c1_i64 : i64
+              %32 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+              %33 = memref.load %32[%c0] : memref<1xi32>
+              %34 = arith.extsi %33 : i32 to i64
+              %35 = arith.cmpi slt, %arg4, %34 : i64
+              scf.condition(%35) %31 : i64
+            } do {
+            ^bb0(%arg4: i64):
+              scf.yield %arg4 : i64
+            }
+          }
+          %22 = llvm.call @__kmpc_dispatch_next_4(%0, %14, %4, %1, %2, %3) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
+          %23 = arith.cmpi ne, %22, %c0_i32 : i32
+          scf.condition(%23)
+        } do {
+          scf.yield
+        }
+      }
+      llvm.call @__kmpc_dispatch_deinit(%0, %14) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_dispatch_init_4(!llvm.ptr, i32, i32, i32, i32, i32, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_next_4(!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_deinit(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @wsloop_dynamic(
+// CHECK: omp.parallel {
+// CHECK:    omp.wsloop nowait schedule(dynamic = %{{.*}} : i32) {
+// CHECK:      omp.loop_nest (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
+// CHECK:        omp.yield
+// CHECK:  omp.terminator

--- a/test/lit_tests/llvm_to_omp/wsloop_guided.mlir
+++ b/test/lit_tests/llvm_to_omp/wsloop_guided.mlir
@@ -1,0 +1,104 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `schedule(guided, 4)`: a non-static schedule kind reaches omp.wsloop
+// together with its chunk size.
+#access_group = #llvm.access_group<id = distinct[0]<>>
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @guided_loop(%arg0: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %1 = llvm.mlir.addressof @guided_loop.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg0, %3[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c1_i32, %1, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @guided_loop.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %c4_i32 = arith.constant 4 : i32
+    %c1073741860_i32 = arith.constant 1073741860 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c-1_i32 = arith.constant -1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %5 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?xi32>
+    %6 = memref.load %5[%c0] : memref<?xi32>
+    %7 = arith.cmpi sgt, %6, %c0_i32 : i32
+    scf.if %7 {
+      %8 = arith.addi %6, %c-1_i32 overflow<nsw> : i32
+      %9 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %9[%c0] : memref<1xi32>
+      %10 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %8, %10[%c0] : memref<1xi32>
+      %11 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c1_i32, %11[%c0] : memref<1xi32>
+      %12 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %12[%c0] : memref<1xi32>
+      %13 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+      %14 = memref.load %13[%c0] : memref<?xi32>
+      llvm.call tail @__kmpc_dispatch_init_4(%0, %14, %c1073741860_i32, %c0_i32, %8, %c1_i32, %c4_i32) : (!llvm.ptr, i32, i32, i32, i32, i32, i32) -> ()
+      %15 = llvm.call @__kmpc_dispatch_next_4(%0, %14, %4, %1, %2, %3) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
+      %16 = arith.cmpi ne, %15, %c0_i32 : i32
+      scf.if %16 {
+        scf.while : () -> () {
+          %17 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+          %18 = memref.load %17[%c0] : memref<1xi32>
+          %19 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+          %20 = memref.load %19[%c0] : memref<1xi32>
+          %21 = arith.cmpi sle, %18, %20 : i32
+          scf.if %21 {
+            %24 = arith.addi %20, %c1_i32 : i32
+            %25 = arith.cmpi slt, %18, %24 : i32
+            scf.if %25 {
+              %26 = arith.addi %18, %c1_i32 : i32
+              %27 = arith.addi %20, %c2_i32 : i32
+              scf.for %arg3 = %26 to %27 step %c1_i32  : i32 {
+                %28 = arith.subi %arg3, %26 : i32
+                %29 = arith.addi %18, %28 : i32
+                llvm.call @body(%29) {access_groups = [#access_group], no_unwind} : (i32) -> ()
+              }
+            }
+          }
+          %22 = llvm.call @__kmpc_dispatch_next_4(%0, %14, %4, %1, %2, %3) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32
+          %23 = arith.cmpi ne, %22, %c0_i32 : i32
+          scf.condition(%23)
+        } do {
+          scf.yield
+        }
+      }
+      llvm.call @__kmpc_dispatch_deinit(%0, %14) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_init_4(!llvm.ptr, i32, i32, i32, i32, i32, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_next_4(!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> i32 attributes {sym_visibility = "private"}
+  llvm.func @body(i32 {llvm.noundef}) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_dispatch_deinit(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @guided_loop(
+// CHECK: omp.parallel {
+// CHECK:   omp.wsloop nowait schedule(guided = %{{.*}} : i32) {
+// CHECK:     omp.loop_nest (%{{.*}}) : i32 =

--- a/test/lit_tests/llvm_to_omp/wsloop_i64.mlir
+++ b/test/lit_tests/llvm_to_omp/wsloop_i64.mlir
@@ -1,0 +1,110 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// A worksharing loop over a 64-bit induction variable: Clang selects the
+// __kmpc_for_static_init_8 variant, and the whole loop nest has to come out
+// typed i64 rather than i32.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c514_i32 = arith.constant 514 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c514_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local} : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @loop_i64(%arg0: i64) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %1 = llvm.mlir.addressof @loop_i64.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i64 {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi64>
+    memref.store %arg0, %3[%c0] : memref<1xi64>
+    llvm.call @__kmpc_fork_call(%0, %c1_i32, %1, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @loop_i64.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %c34_i32 = arith.constant 34 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c1_i64 = arith.constant 1 : i64
+    %c-1_i64 = arith.constant -1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i64 = arith.constant 2 : i64
+    %1 = llvm.alloca %c1_i32 x i64 {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i64 {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i64 {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %4 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %5 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?xi64>
+    %6 = memref.load %5[%c0] : memref<?xi64>
+    %7 = arith.cmpi sgt, %6, %c0_i64 : i64
+    scf.if %7 {
+      %8 = arith.addi %6, %c-1_i64 overflow<nsw> : i64
+      %9 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi64>
+      memref.store %c0_i64, %9[%c0] : memref<1xi64>
+      %10 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi64>
+      memref.store %8, %10[%c0] : memref<1xi64>
+      %11 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi64>
+      memref.store %c1_i64, %11[%c0] : memref<1xi64>
+      %12 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %12[%c0] : memref<1xi32>
+      %13 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+      %14 = memref.load %13[%c0] : memref<?xi32>
+      llvm.call @__kmpc_for_static_init_8(%0, %14, %c34_i32, %4, %1, %2, %3, %c1_i64, %c1_i64) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> ()
+      %15 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi64>
+      %16 = memref.load %15[%c0] : memref<1xi64>
+      %17 = arith.minsi %16, %8 : i64
+      %18 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi64>
+      memref.store %17, %18[%c0] : memref<1xi64>
+      %19 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi64>
+      %20 = memref.load %19[%c0] : memref<1xi64>
+      %21 = arith.cmpi sle, %20, %17 : i64
+      scf.if %21 {
+        %22 = arith.addi %17, %c1_i64 : i64
+        %23 = arith.cmpi slt, %20, %22 : i64
+        scf.if %23 {
+          %24 = arith.addi %20, %c1_i64 : i64
+          %25 = arith.addi %17, %c2_i64 : i64
+          scf.for %arg3 = %24 to %25 step %c1_i64  : i64 {
+            %26 = arith.subi %arg3, %24 : i64
+            %27 = arith.addi %20, %26 : i64
+            llvm.call @body_i64(%27) : (i64) -> ()
+          }
+        }
+      }
+      llvm.call @__kmpc_for_static_fini(%0, %14) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_for_static_init_8(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) attributes {sym_visibility = "private"}
+  llvm.func @body_i64(i64 {llvm.noundef}) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_for_static_fini(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @loop_i64(
+// CHECK: omp.parallel {
+// CHECK:   omp.wsloop nowait schedule(static = %{{.*}} : i64) {
+// CHECK:     omp.loop_nest (%{{.*}}) : i64 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
+// CHECK:       llvm.call @body_i64(%{{.*}}) : (i64) -> ()

--- a/test/lit_tests/llvm_to_omp/wsloop_static.mlir
+++ b/test/lit_tests/llvm_to_omp/wsloop_static.mlir
@@ -1,0 +1,119 @@
+// RUN: enzymexlamlir-opt --llvm-to-omp %s | FileCheck %s --implicit-check-not="llvm.call @__kmpc"
+
+// `#pragma omp parallel for` with the default (static) schedule.
+// The __kmpc_for_static_init_4 / __kmpc_for_static_fini bracket becomes an
+// omp.wsloop with a static schedule wrapping an omp.loop_nest.
+module {
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_0(";unknown;unknown;0;0;;\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local, sym_visibility = "private"}
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_1() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c514_i32 = arith.constant 514 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c514_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.mlir.global private unnamed_addr constant @mlir.llvm.nameless_global_2() {addr_space = 0 : i32, alignment = 8 : i64, dso_local, sym_visibility = "private"} : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> {
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_0 : !llvm.ptr
+    %c22_i32 = arith.constant 22 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.undef : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+    %2 = llvm.insertvalue %c0_i32, %1[0] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %3 = llvm.insertvalue %c2_i32, %2[1] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %4 = llvm.insertvalue %c0_i32, %3[2] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %5 = llvm.insertvalue %c22_i32, %4[3] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    %6 = llvm.insertvalue %0, %5[4] : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)> 
+    llvm.return %6 : !llvm.struct<"struct.ident_t.1", (i32, i32, i32, i32, ptr)>
+  }
+  llvm.func @wsloop_static(%arg0: !llvm.ptr, %arg1: i32) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_2 : !llvm.ptr
+    %c2_i32 = arith.constant 2 : i32
+    %1 = llvm.mlir.addressof @wsloop_static.omp_outlined : !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x !llvm.ptr {alignment = 8 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1x!llvm.ptr>
+    memref.store %arg0, %4[%c0] : memref<1x!llvm.ptr>
+    %5 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+    memref.store %arg1, %5[%c0] : memref<1xi32>
+    llvm.call @__kmpc_fork_call(%0, %c2_i32, %1, %3, %2) vararg(!llvm.func<void (ptr, i32, ptr, ...)>) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+    llvm.return
+  }
+  llvm.func internal @wsloop_static.omp_outlined(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr, %arg3: !llvm.ptr) attributes {dso_local, sym_visibility = "private"} {
+    %c0 = arith.constant 0 : index
+    %c1_i64 = arith.constant 1 : i64
+    %c34_i32 = arith.constant 34 : i32
+    %0 = llvm.mlir.addressof @mlir.llvm.nameless_global_1 : !llvm.ptr
+    %c-1_i32 = arith.constant -1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %1 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %2 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %3 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %4 = llvm.alloca %c1_i32 x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    %5 = "enzymexla.pointer2memref"(%arg2) : (!llvm.ptr) -> memref<?xi32>
+    %6 = memref.load %5[%c0] : memref<?xi32>
+    %7 = arith.cmpi sgt, %6, %c0_i32 : i32
+    scf.if %7 {
+      %8 = arith.addi %6, %c-1_i32 : i32
+      %9 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %9[%c0] : memref<1xi32>
+      %10 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %8, %10[%c0] : memref<1xi32>
+      %11 = "enzymexla.pointer2memref"(%3) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c1_i32, %11[%c0] : memref<1xi32>
+      %12 = "enzymexla.pointer2memref"(%4) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %c0_i32, %12[%c0] : memref<1xi32>
+      %13 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+      %14 = memref.load %13[%c0] : memref<?xi32>
+      llvm.call @__kmpc_for_static_init_4(%0, %14, %c34_i32, %4, %1, %2, %3, %c1_i32, %c1_i32) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) -> ()
+      %15 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+      %16 = memref.load %15[%c0] : memref<1xi32>
+      %17 = arith.minsi %16, %8 : i32
+      %18 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+      memref.store %17, %18[%c0] : memref<1xi32>
+      %19 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<1xi32>
+      %20 = memref.load %19[%c0] : memref<1xi32>
+      %21 = arith.cmpi sle, %20, %17 : i32
+      scf.if %21 {
+        %22 = "enzymexla.pointer2memref"(%arg3) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+        %23 = memref.load %22[%c0] : memref<?x!llvm.ptr>
+        %24 = arith.extsi %20 : i32 to i64
+        %25 = scf.while (%arg4 = %24) : (i64) -> i64 {
+          %26 = arith.trunci %arg4 : i64 to i32
+          %27 = "enzymexla.pointer2memref"(%23) : (!llvm.ptr) -> memref<?xi32>
+          %28 = arith.index_cast %arg4 : i64 to index
+          memref.store %26, %27[%28] : memref<?xi32>
+          %29 = arith.addi %arg4, %c1_i64 : i64
+          %30 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<1xi32>
+          %31 = memref.load %30[%c0] : memref<1xi32>
+          %32 = arith.extsi %31 : i32 to i64
+          %33 = arith.cmpi slt, %arg4, %32 : i64
+          scf.condition(%33) %29 : i64
+        } do {
+        ^bb0(%arg4: i64):
+          scf.yield %arg4 : i64
+        }
+      }
+      llvm.call @__kmpc_for_static_fini(%0, %14) : (!llvm.ptr, i32) -> ()
+    }
+    llvm.return
+  }
+  llvm.func @__kmpc_for_static_init_4(!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_for_static_fini(!llvm.ptr, i32) attributes {sym_visibility = "private"}
+  llvm.func @__kmpc_fork_call(!llvm.ptr, i32, !llvm.ptr, ...) attributes {sym_visibility = "private"}
+}
+
+// CHECK-LABEL: llvm.func @wsloop_static(
+// CHECK: omp.parallel {
+// CHECK:    omp.wsloop nowait schedule(static = %{{.*}} : i32) {
+// CHECK:      omp.loop_nest (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
+// CHECK:        omp.yield
+// CHECK:  omp.terminator


### PR DESCRIPTION
Clang lowers OpenMP directives to opaque `__kmpc_*` runtime calls long before
MLIR sees them, so a module raised from `-fopenmp` output carries no structure
an MLIR analysis can reason about: an `omp parallel for` is a `__kmpc_fork_call`
to an outlined function that happens to contain an `__kmpc_for_static_init_4`
and a loop. This pass lifts those calls back into the OpenMP dialect, so
downstream passes see `omp.parallel` / `omp.wsloop` / `omp.task` regions
instead.

### What it handles

| runtime protocol | result |
|---|---|
| `__kmpc_fork_call` + outlined fn | `omp.parallel` (body inlined) |
| `__kmpc_fork_teams`, `__kmpc_push_num_teams` | `omp.teams` |
| `__kmpc_push_num_threads` / `__kmpc_push_proc_bind` | `omp.parallel` clauses |
| `__kmpc_for_static_init_*` / `_fini` | `omp.wsloop` + `omp.loop_nest` |
| `__kmpc_dispatch_init_*` / `_next_*` / `_fini_*` | `omp.wsloop` with a dynamic schedule |
| `__kmpc_single` / `master` / `masked` / `critical` / `ordered` / `taskgroup` | the matching region op |
| `__kmpc_omp_task_alloc` + `__kmpc_omp_task` | `omp.task` |
| `__kmpc_taskloop` | `omp.taskloop.context` + `omp.taskloop.wrapper` |
| `__kmpc_reduce_nowait` protocol | `omp.declare_reduction` + a reduction clause |
| `__kmpc_atomic_*` | `omp.atomic.read` / `.write` / `.update` / `.capture` |
| `__kmpc_barrier`, `flush`, `taskwait`, `taskyield`, `cancel`, `cancellationpoint` | the leaf op |
| `__kmpc_serialized_parallel` | serialised body, no `omp.parallel` |

Conversion runs in two phases: a module walk for the structural cases that
cross function boundaries, then a greedy rewrite for the leaf replacements.
`omp_get_thread_num` and the rest of the user-facing `omp_*` query API are
recognised as benign and left alone; anything else still spelled `__kmpc_*`
after the pass gets a warning rather than being silently dropped.

### Where it runs

Late — after the CFG has been lifted to SCF and pointer arithmetic raised to
`memref`. Against raw mlir-translate --import-llvm output only __kmpc_fork_call converts: the worksharing-loop and reduction patterns match SCF structure that is not there yet and skip with a warning, and an unpaired single/masked/critical/ordered fails the pass outright. The exact pipeline
prefix is recorded in `test/lit_tests/llvm_to_omp/README.md`.

### Tests

21 lit tests under `test/lit_tests/llvm_to_omp/`, one per construct: parallel,
num_threads, static/dynamic/guided worksharing loops plus a 64-bit one,
ordered, sections, barrier, single (plain and `nowait`), master, masked (plain
and with a filter), critical, flush, taskyield, cancel, task/taskwait, taskloop
with `grainsize` and with `num_tasks`, teams and reduction.

The inputs are generated rather than hand-written — `clang -fopenmp` output run
through the pipeline prefix above — so they have the shape the patterns
actually meet in practice rather than the shape raw clang output happens to
have. Every test runs FileCheck with `--implicit-check-not="llvm.call @__kmpc"`,
so it fails if *any* runtime call survives anywhere in the module, not merely
if the expected `omp.*` ops are missing. The README records the exact
reproduction recipe, so a test can be regenerated when clang's emission
changes.

### Assumptions

These hold for clang's emission and are checked rather than assumed — a module
that breaks one gets a warning and is left unconverted, not mis-converted:

- outlined functions follow clang's naming and are reached from a single fork;
- `__kmpc_push_*` clause calls precede their fork in the same block;
- paired begin/end calls, and the worksharing-loop init/fini calls, sit in the
  same block (so the pass must run before transforms that split them).

### Not covered

- `target` and the `__tgt_*` offload runtime — separate work, and a bigger job
  than the rest of this pass put together.
- `teams distribute` currently raises to `omp.wsloop` rather than
  `omp.distribute`; it verifies and is correct as a worksharing loop, but the
  more specific op would be better.
- `__kmpc_reduce` (the non-`nowait` form) and `depend` clauses on tasks warn
  and are left alone.
- GPU device modules (`nvptx64` / `amdgcn` triples) are rejected up front.
