### PR TITLE
BUILD: make EnzymeXLADialect and RegistryUtils publicly visible

### DIFF
--- a/src/enzyme_ad/jax/BUILD
+++ b/src/enzyme_ad/jax/BUILD
@@ -902,6 +902,7 @@ cc_library(
         "Dialect/Ops.h",
         "Utils.h",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":EnzymeXLAAttrsIncGen",
         ":EnzymeXLACanonicalizers",
@@ -1451,6 +1452,7 @@ cc_library(
         "RegistryUtils.h",
     ],
     copts = triton_copts,
+    visibility = ["//visibility:public"],
     deps = [
         ":TransformOps",
         ":XLADerivatives",


### PR DESCRIPTION
`src/enzyme_ad/jax` has `default_visibility = ["//:__subpackages__"]`, so
`EnzymeXLADialect` and `RegistryUtils` cannot be depended on from outside the
repository. Both are part of the surface an out-of-tree MLIR project needs when
it builds on the EnzymeXLA dialect:

- **`EnzymeXLADialect`** — to link the dialect and include
  `src/enzyme_ad/jax/Dialect/{Dialect,Ops}.h`, i.e. to write passes over
  `enzymexla` ops.
- **`RegistryUtils`** — to reuse the shared dialect/pass registration from
  `RegistryUtils.h` in a downstream `*-opt` tool rather than duplicating it.
  It is already reachable indirectly today: the public `//:RaiseLib` depends
  on it.

This marks both `visibility = ["//visibility:public"]`, consistent with the
eight targets in the same file that already are (`xla_ffi`,
`enzyme_jax_internal`, `CInterface`, `triton_dialect_capi_objects`,
`TritonExtDialect`, `Polymer`, `XLADerivatives`, `enzyme_call`).

No build or behaviour change inside this repository — visibility only.

Context: this unblocks an out-of-tree static verifier for SPMD parallel
programs that consumes the EnzymeXLA dialect and Polygeist raising pipeline,
which currently has to build with `--check_visibility=false` as a workaround.

Note on CI: the `Bazel files check` job is already failing on `main` for
reasons predating this PR — `buildifier -mode check -r .` flags `BUILD`,
`WORKSPACE`, `src/external/isl/BUILD` and an unsorted `deps` entry in
`src/enzyme_ad/jax/BUILD` (`LoopLikeInterface` before `LinalgTransforms`,
from #2875). This PR's own two lines are buildifier-clean; I left the
pre-existing violations to the nightly auto-format job.