### PR TITLE
Fold a monotone live flag into an induction-variable predicate

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeFor.cpp
@@ -1736,6 +1736,265 @@ struct WhileToForHelper {
   }
 };
 
+// A while MoveWhileToFor converted often carries an i1 "live" flag: true on
+// entry, re-computed each iteration as `live ? (f(counter) < N) : false`,
+// where the counter advances by one per live iteration. Every earlier test
+// held whenever the flag is still true, so with f nondecreasing in the
+// counter the conjunction is just the previous iteration's test: the flag
+// equals `iv == lb || f(cnt0 + (iv - lb) - 1) < N`, a pure function of the
+// induction variable. Rewriting it lets the flag and the counter fold away,
+// leaving a guard later analyses can reason about affinely.
+struct ForLiveFlagToIVPredicate : public OpRewritePattern<ForOp> {
+  using OpRewritePattern<ForOp>::OpRewritePattern;
+
+  static bool isKnownNonNegative(Value v, unsigned depth = 0) {
+    if (depth > 6)
+      return false;
+    APInt cst;
+    if (matchPattern(v, m_ConstantInt(&cst)))
+      return cst.isNonNegative();
+    if (auto op = v.getDefiningOp<arith::IndexCastUIOp>())
+      return true;
+    if (auto op = v.getDefiningOp<ExtUIOp>())
+      return true;
+    if (auto op = v.getDefiningOp<AddIOp>())
+      return isKnownNonNegative(op.getLhs(), depth + 1) &&
+             isKnownNonNegative(op.getRhs(), depth + 1);
+    if (auto op = v.getDefiningOp<MulIOp>())
+      return isKnownNonNegative(op.getLhs(), depth + 1) &&
+             isKnownNonNegative(op.getRhs(), depth + 1);
+    return false;
+  }
+
+  // Whether `v` is `arg` plus/times values defined outside the loop, with
+  // every multiplicative factor along the path to `arg` known non-negative
+  // (so v is nondecreasing in arg and clonable at the loop's entry block).
+  static bool isMonotoneInArg(Value v, BlockArgument arg, ForOp loop,
+                              unsigned depth = 0) {
+    if (depth > 8)
+      return false;
+    if (v == arg)
+      return true;
+    Operation *def = v.getDefiningOp();
+    if (!def)
+      return false;
+    if (auto add = dyn_cast<AddIOp>(def)) {
+      for (int i = 0; i < 2; ++i) {
+        Value side = add->getOperand(i), other = add->getOperand(1 - i);
+        if (usesArg(side, arg, depth) && !usesArg(other, arg, depth))
+          return loop.isDefinedOutsideOfLoop(other) &&
+                 isMonotoneInArg(side, arg, loop, depth + 1);
+      }
+      return false;
+    }
+    if (auto mul = dyn_cast<MulIOp>(def)) {
+      for (int i = 0; i < 2; ++i) {
+        Value side = mul->getOperand(i), other = mul->getOperand(1 - i);
+        if (usesArg(side, arg, depth) && !usesArg(other, arg, depth))
+          return loop.isDefinedOutsideOfLoop(other) &&
+                 isKnownNonNegative(other) &&
+                 isMonotoneInArg(side, arg, loop, depth + 1);
+      }
+      return false;
+    }
+    return false;
+  }
+
+  static bool usesArg(Value v, BlockArgument arg, unsigned depth = 0) {
+    if (depth > 8)
+      return false;
+    if (v == arg)
+      return true;
+    Operation *def = v.getDefiningOp();
+    if (!def || !isa<AddIOp, MulIOp>(def))
+      return false;
+    return usesArg(def->getOperand(0), arg, depth + 1) ||
+           usesArg(def->getOperand(1), arg, depth + 1);
+  }
+
+  LogicalResult matchAndRewrite(ForOp loop,
+                                PatternRewriter &rewriter) const override {
+    // Step must be the constant one the conversion emits.
+    APInt stepCst;
+    if (!matchPattern(loop.getStep(), m_ConstantInt(&stepCst)) ||
+        !stepCst.isOne())
+      return failure();
+    // The trip bound must be maxsi(X, 1) + 1 with the last iteration's
+    // continuation test `iv < X`: only the final iteration can fail it, so a
+    // frozen counter is never read by a live iteration.
+    auto ubAdd = loop.getUpperBound().getDefiningOp<AddIOp>();
+    if (!ubAdd)
+      return failure();
+    Value maxVal = nullptr, boundX = nullptr;
+    for (int i = 0; i < 2; ++i) {
+      APInt one;
+      if (matchPattern(ubAdd->getOperand(1 - i), m_ConstantInt(&one)) &&
+          one.isOne())
+        maxVal = ubAdd->getOperand(i);
+    }
+    if (!maxVal)
+      return failure();
+    if (auto maxOp = maxVal.getDefiningOp<MaxSIOp>()) {
+      for (int i = 0; i < 2; ++i) {
+        APInt one;
+        if (matchPattern(maxOp->getOperand(1 - i), m_ConstantInt(&one)) &&
+            one.isOne())
+          boundX = maxOp->getOperand(i);
+      }
+    }
+    if (!boundX)
+      return failure();
+
+    auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+
+    for (auto [argIdx, flagArg] : llvm::enumerate(loop.getRegionIterArgs())) {
+      if (!flagArg.getType().isInteger(1))
+        continue;
+      APInt initTrue;
+      if (!matchPattern(loop.getInitArgs()[argIdx], m_ConstantInt(&initTrue)) ||
+          !initTrue.isOne())
+        continue;
+      // The flag's only use is as the condition of the body if.
+      if (!flagArg.hasOneUse())
+        continue;
+      auto ifOp = dyn_cast<scf::IfOp>(flagArg.getUses().begin()->getOwner());
+      if (!ifOp || ifOp.getCondition() != flagArg ||
+          ifOp->getParentOp() != loop)
+        continue;
+      // The flag is re-yielded from the if: then a comparison, else false.
+      auto flagYielded = dyn_cast<OpResult>(yield.getOperand(argIdx));
+      if (!flagYielded || flagYielded.getOwner() != ifOp)
+        continue;
+      unsigned fr = flagYielded.getResultNumber();
+      auto cmp = ifOp.thenYield().getOperand(fr).getDefiningOp<CmpIOp>();
+      APInt elseFalse;
+      if (!cmp ||
+          !matchPattern(ifOp.elseYield().getOperand(fr),
+                        m_ConstantInt(&elseFalse)) ||
+          !elseFalse.isZero())
+        continue;
+      if (cmp->getParentOp() != ifOp)
+        continue;
+      auto pred = cmp.getPredicate();
+      if (pred != CmpIPredicate::slt && pred != CmpIPredicate::ult &&
+          pred != CmpIPredicate::sle && pred != CmpIPredicate::ule)
+        continue;
+      if (!loop.isDefinedOutsideOfLoop(cmp.getRhs()))
+        continue;
+
+      // Find the counter: an iter_arg whose then-branch update is cnt + 1,
+      // forwarded (possibly through a second guard if) to the yield.
+      BlockArgument counter = nullptr;
+      unsigned counterIdx = 0;
+      for (auto [ci, cArg] : llvm::enumerate(loop.getRegionIterArgs())) {
+        if (ci == argIdx || cArg.getType() != cmp.getLhs().getType())
+          continue;
+        // Locate `cnt + 1` in the then region.
+        AddIOp inc = nullptr;
+        for (auto &use : cArg.getUses()) {
+          if (auto add = dyn_cast<AddIOp>(use.getOwner())) {
+            APInt one;
+            if (add->getParentOp() == ifOp &&
+                ifOp.getThenRegion().isAncestor(add->getParentRegion()) &&
+                matchPattern(add->getOperand(1 - use.getOperandNumber()),
+                             m_ConstantInt(&one)) &&
+                one.isOne()) {
+              inc = add;
+              break;
+            }
+          }
+        }
+        if (!inc)
+          continue;
+        // The yield for this slot must trace back to the increment: either
+        // directly the if result whose then-yield is the increment, or that
+        // value routed through one more if whose then-yield forwards it.
+        Value slot = yield.getOperand(ci);
+        SmallVector<Value, 4> worklist{slot};
+        bool reaches = false;
+        for (unsigned steps = 0; !worklist.empty() && steps < 4; ++steps) {
+          Value v = worklist.pop_back_val();
+          if (v == inc.getResult()) {
+            reaches = true;
+            break;
+          }
+          if (auto res = dyn_cast<OpResult>(v))
+            if (auto innerIf = dyn_cast<scf::IfOp>(res.getOwner()))
+              worklist.push_back(
+                  innerIf.thenYield().getOperand(res.getResultNumber()));
+        }
+        if (!reaches)
+          continue;
+        if (!loop.isDefinedOutsideOfLoop(loop.getInitArgs()[ci]))
+          continue;
+        counter = cArg;
+        counterIdx = ci;
+        break;
+      }
+      if (!counter)
+        continue;
+      // The comparison's varying side is nondecreasing in the counter, so the
+      // conjunction of every earlier test is the previous test.
+      if (!isMonotoneInArg(cmp.getLhs(), counter, loop))
+        continue;
+      // The rewrite changes what the dead iterations yield for the counter,
+      // so its loop result must be unused.
+      if (!loop.getResult(counterIdx).use_empty())
+        continue;
+
+      // counter == cnt0 + (iv - lb) on every live iteration.
+      rewriter.setInsertionPointToStart(loop.getBody());
+      Location loc = loop.getLoc();
+      Value iv = loop.getInductionVar();
+      Value ivOff = SubIOp::create(rewriter, loc, iv, loop.getLowerBound());
+      Value cnt0 = loop.getInitArgs()[counterIdx];
+      Value curCnt = AddIOp::create(rewriter, loc, ivOff, cnt0);
+      Value one = ConstantIntOp::create(rewriter, loc, counter.getType(), 1);
+      Value prevCnt = SubIOp::create(rewriter, loc, curCnt, one);
+
+      // Clone the compared expression at the previous counter value; strip
+      // overflow flags since the first iteration evaluates it out of range
+      // (the or with iv == lb ignores the value, but must not see poison).
+      IRMapping map;
+      map.map(Value(counter), prevCnt);
+      SmallVector<Operation *> chain;
+      std::function<Value(Value)> cloneExpr = [&](Value v) -> Value {
+        if (v == counter)
+          return prevCnt;
+        Operation *def = v.getDefiningOp();
+        if (def && isa<AddIOp, MulIOp>(def) && usesArg(v, counter)) {
+          Value l = cloneExpr(def->getOperand(0));
+          Value r = cloneExpr(def->getOperand(1));
+          Operation *cl = rewriter.clone(*def, map);
+          cl->setOperands({l, r});
+          if (auto add = dyn_cast<AddIOp>(cl))
+            add.setOverflowFlags(arith::IntegerOverflowFlags::none);
+          else if (auto mul = dyn_cast<MulIOp>(cl))
+            mul.setOverflowFlags(arith::IntegerOverflowFlags::none);
+          return cl->getResult(0);
+        }
+        return v;
+      };
+      Value prevLhs = cloneExpr(cmp.getLhs());
+      Value prevTest =
+          CmpIOp::create(rewriter, loc, pred, prevLhs, cmp.getRhs());
+      Value first = CmpIOp::create(rewriter, loc, CmpIPredicate::eq, iv,
+                                   loop.getLowerBound());
+      Value live = OrIOp::create(rewriter, loc, first, prevTest);
+
+      rewriter.modifyOpInPlace(
+          ifOp, [&] { ifOp.getConditionMutable().assign(live); });
+      // Replace counter uses inside the loop with its induction-variable
+      // form; the argument then dies together with the flag.
+      rewriter.replaceUsesWithIf(counter, curCnt, [&](OpOperand &use) {
+        return use.getOwner() != curCnt.getDefiningOp();
+      });
+      return success();
+    }
+    return failure();
+  }
+};
+
 struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
   using OpRewritePattern<WhileOp>::OpRewritePattern;
 
@@ -4040,10 +4299,10 @@ void CanonicalizeFor::runOnOperation() {
   populateSelectExtractPatterns(rpl);
   rpl.add<IfYieldMovementPattern, truncProp, ForOpInductionReplacement,
           RemoveUnusedForResults, RemoveUnusedArgs, MoveWhileToFor,
-          RemoveWhileSelect, SelectTruncToTruncSelect, MaxSimplify,
-          ForBoundUnSwitch, SelectI1Simplify, RemoveInductionVarRelated,
-          ForOpFinalValueOfDeadIterArg, RotateWhileAnd, MoveWhileDown,
-          MoveWhileDown2,
+          ForLiveFlagToIVPredicate, RemoveWhileSelect, SelectTruncToTruncSelect,
+          MaxSimplify, ForBoundUnSwitch, SelectI1Simplify,
+          RemoveInductionVarRelated, ForOpFinalValueOfDeadIterArg,
+          RotateWhileAnd, MoveWhileDown, MoveWhileDown2,
 
           ReplaceRedundantArgs,
 

--- a/test/lit_tests/canonicalizefor_live_flag.mlir
+++ b/test/lit_tests/canonicalizefor_live_flag.mlir
@@ -83,3 +83,42 @@ func.func @gridstride(%N: i32, %ipt: i32, %bsi: index, %tid: i32, %woff: i32, %b
 // CHECK-NEXT: }
 // CHECK-NEXT: return %[[V9]]#1 : f64
 // CHECK-NEXT: }
+
+// -----
+
+// Near-miss: the counter advances by two per iteration, not the `cnt + 1` the
+// fold recognizes. The flag is not a pure function of the induction variable,
+// so the pattern must not fire and the i1 "live" flag stays a carried value.
+func.func @counter_step_two(%N: i32, %ipt: i32, %bsi: index, %tid: i32, %woff: i32, %buf: memref<?xf64>) -> f64 {
+  %bs = arith.index_castui %bsi : index to i32
+  %cst = arith.constant 0.0 : f64
+  %c0_i32 = arith.constant 0 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %r:2 = scf.while (%acc = %cst, %idx = %c0_i32) : (f64, i32) -> (f64, i32) {
+    %t0 = arith.addi %idx, %woff overflow<nsw> : i32
+    %t1 = arith.muli %t0, %bs : i32
+    %i = arith.addi %t1, %tid : i32
+    %inb = arith.cmpi slt, %i, %N : i32
+    %next = arith.addi %idx, %c2_i32 overflow<nsw, nuw> : i32
+    %ne = arith.cmpi ne, %next, %ipt : i32
+    %acc2 = scf.if %inb -> (f64) {
+      %ii = arith.index_cast %i : i32 to index
+      %v = memref.load %buf[%ii] : memref<?xf64>
+      %s = arith.addf %acc, %v : f64
+      scf.yield %s : f64
+    } else {
+      scf.yield %acc : f64
+    }
+    %cond = arith.andi %inb, %ne : i1
+    scf.condition(%cond) %acc2, %next : f64, i32
+  } do {
+  ^bb0(%a: f64, %i2: i32):
+    scf.yield %a, %i2 : f64, i32
+  }
+  return %r#0 : f64
+}
+// The flag stays a loop-carried i1 and the induction-variable predicate fold
+// (an arith.ori of `iv == lb` with the test) never appears.
+// CHECK-LABEL: func.func @counter_step_two(
+// CHECK: scf.for {{.*}} -> (f64, i32, f64, i32, i1)
+// CHECK-NOT: arith.ori

--- a/test/lit_tests/canonicalizefor_live_flag.mlir
+++ b/test/lit_tests/canonicalizefor_live_flag.mlir
@@ -1,0 +1,85 @@
+// RUN: enzymexlamlir-opt %s --cse --canonicalize-scf-for | FileCheck %s
+
+// The while-converted grid-stride loop carries an i1 "live" flag: true on
+// entry, re-computed as `live ? f(counter) < N : false` with the counter
+// advancing once per live iteration. Every earlier test held while the flag
+// is true and f is nondecreasing in the counter, so the flag is just the
+// previous iteration's test: `iv == lb || f(cnt0 + iv - lb - 1) < N`, a pure
+// function of the induction variable, and the flag and counter fold away.
+func.func @gridstride(%N: i32, %ipt: i32, %bsi: index, %tid: i32, %woff: i32, %buf: memref<?xf64>) -> f64 {
+  %bs = arith.index_castui %bsi : index to i32
+  %cst = arith.constant 0.0 : f64
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %r:2 = scf.while (%acc = %cst, %idx = %c0_i32) : (f64, i32) -> (f64, i32) {
+    %t0 = arith.addi %idx, %woff overflow<nsw> : i32
+    %t1 = arith.muli %t0, %bs : i32
+    %i = arith.addi %t1, %tid : i32
+    %inb = arith.cmpi slt, %i, %N : i32
+    %next = arith.addi %idx, %c1_i32 overflow<nsw, nuw> : i32
+    %ne = arith.cmpi ne, %next, %ipt : i32
+    %acc2 = scf.if %inb -> (f64) {
+      %ii = arith.index_cast %i : i32 to index
+      %v = memref.load %buf[%ii] : memref<?xf64>
+      %s = arith.addf %acc, %v : f64
+      scf.yield %s : f64
+    } else {
+      scf.yield %acc : f64
+    }
+    %cond = arith.andi %inb, %ne : i1
+    scf.condition(%cond) %acc2, %next : f64, i32
+  } do {
+  ^bb0(%a: f64, %i2: i32):
+    scf.yield %a, %i2 : f64, i32
+  }
+  return %r#0 : f64
+}
+// CHECK-LABEL: func.func @gridstride(
+// CHECK-SAME: %[[N:.+]]: i32, %[[IPT:.+]]: i32, %[[BSI:.+]]: index, %[[TID:.+]]: i32, %[[WOFF:.+]]: i32, %[[BUF:.+]]: memref<?xf64>
+// CHECK-NEXT: %[[V0:.+]] = arith.constant false
+// CHECK-NEXT: %[[V1:.+]] = arith.constant -1 : i32
+// CHECK-NEXT: %[[V2:.+]] = ub.poison : i32
+// CHECK-NEXT: %[[V3:.+]] = ub.poison : f64
+// CHECK-NEXT: %[[V4:.+]] = arith.constant 1 : i32
+// CHECK-NEXT: %[[V5:.+]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT: %[[V6:.+]] = arith.index_castui %[[BSI]] : index to i32
+// CHECK-NEXT: %[[V7:.+]] = arith.maxsi %[[IPT]], %[[V4]] : i32
+// CHECK-NEXT: %[[V8:.+]] = arith.addi %[[V7]], %[[V4]] : i32
+// CHECK-NEXT: %[[V9:.+]]:3 = scf.for %[[V10:.+]] = %[[V4]] to %[[V8]] step %[[V4]] iter_args(%[[V11:.+]] = %[[V5]], %[[V12:.+]] = %[[V3]], %[[V13:.+]] = %[[V2]]) -> (f64, f64, i32)  : i32 {
+// CHECK-NEXT: %[[V14:.+]] = arith.addi %[[V10]], %[[V1]] : i32
+// CHECK-NEXT: %[[V15:.+]] = arith.addi %[[V14]], %[[V1]] : i32
+// CHECK-NEXT: %[[V16:.+]] = arith.addi %[[V15]], %[[WOFF]] : i32
+// CHECK-NEXT: %[[V17:.+]] = arith.muli %[[V16]], %[[V6]] : i32
+// CHECK-NEXT: %[[V18:.+]] = arith.addi %[[V17]], %[[TID]] : i32
+// CHECK-NEXT: %[[V19:.+]] = arith.cmpi slt, %[[V18]], %[[N]] : i32
+// CHECK-NEXT: %[[V20:.+]] = arith.cmpi eq, %[[V10]], %[[V4]] : i32
+// CHECK-NEXT: %[[V21:.+]] = arith.ori %[[V20]], %[[V19]] : i1
+// CHECK-NEXT: %[[V22:.+]]:3 = scf.if %[[V21]] -> (f64, i32, i1) {
+// CHECK-NEXT: %[[V23:.+]] = arith.addi %[[V14]], %[[WOFF]] overflow<nsw> : i32
+// CHECK-NEXT: %[[V24:.+]] = arith.muli %[[V23]], %[[V6]] : i32
+// CHECK-NEXT: %[[V25:.+]] = arith.addi %[[V24]], %[[TID]] : i32
+// CHECK-NEXT: %[[V26:.+]] = arith.cmpi slt, %[[V25]], %[[N]] : i32
+// CHECK-NEXT: %[[V27:.+]] = arith.addi %[[V14]], %[[V4]] overflow<nsw, nuw> : i32
+// CHECK-NEXT: %[[V28:.+]] = scf.if %[[V26]] -> (f64) {
+// CHECK-NEXT: %[[V29:.+]] = arith.index_cast %[[V25]] : i32 to index
+// CHECK-NEXT: %[[V30:.+]] = memref.load %[[BUF]][%[[V29]]] : memref<?xf64>
+// CHECK-NEXT: %[[V31:.+]] = arith.addf %[[V11]], %[[V30]] : f64
+// CHECK-NEXT: scf.yield %[[V31]] : f64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: scf.yield %[[V11]] : f64
+// CHECK-NEXT: }
+// CHECK-NEXT: scf.yield %[[V28]], %[[V27]], %[[V26]] : f64, i32, i1
+// CHECK-NEXT: } else {
+// CHECK-NEXT: scf.yield %[[V12]], %[[V13]], %[[V0]] : f64, i32, i1
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[V32:.+]] = arith.cmpi slt, %[[V10]], %[[IPT]] : i32
+// CHECK-NEXT: %[[V33:.+]] = arith.andi %[[V32]], %[[V22]]#2 : i1
+// CHECK-NEXT: %[[V34:.+]] = scf.if %[[V33]] -> (f64) {
+// CHECK-NEXT: scf.yield %[[V22]]#0 : f64
+// CHECK-NEXT: } else {
+// CHECK-NEXT: scf.yield %[[V3]] : f64
+// CHECK-NEXT: }
+// CHECK-NEXT: scf.yield %[[V34]], %[[V22]]#0, %[[V22]]#1 : f64, f64, i32
+// CHECK-NEXT: }
+// CHECK-NEXT: return %[[V9]]#1 : f64
+// CHECK-NEXT: }


### PR DESCRIPTION
Adds `ForLiveFlagToIVPredicate` to `CanonicalizeFor.cpp`. A while-loop converted by `MoveWhileToFor` often carries an i1 "live" flag (true on entry, recomputed as `live ? f(counter) < N : false`). When the flag is monotone in a counter that advances once per live iteration, it is just a pure function of the induction variable (`iv == lb || f(cnt0 + iv - lb - 1) < N`), so the flag and counter fold away.

Needed to raise MFEM grid-stride loops.