### PR TITLE
mem2reg: do an access through a branch between allocations in each arm

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -23,7 +23,9 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/Passes.h"
 #include "src/enzyme_ad/jax/Dialect/Ops.h"
@@ -3169,6 +3171,180 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
   return todo;
 }
 
+// The allocation a buffer is, looked at through the casts that only respell
+// it.
+static Value bufferRoot(Value v) {
+  while (Operation *op = v.getDefiningOp()) {
+    if (!isa<memref::CastOp, memref::MemorySpaceCastOp, Memref2PointerOp,
+             Pointer2MemrefOp, LLVM::BitcastOp, LLVM::AddrSpaceCastOp>(op))
+      break;
+    v = op->getOperand(0);
+  }
+  return v;
+}
+
+static bool isAllocation(Value v) {
+  return v.getDefiningOp<memref::AllocaOp>() ||
+         v.getDefiningOp<memref::AllocOp>() ||
+         v.getDefiningOp<LLVM::AllocaOp>() ||
+         v.getDefiningOp<memref::GetGlobalOp>();
+}
+
+// A branch choosing between buffers: an arith.select, or an scf.if or
+// affine.if with an else, yielding a memref or pointer.
+struct BufferBranch {
+  Operation *op;
+  unsigned resultNo;
+
+  Value result() const { return op->getResult(resultNo); }
+  Value armValue(unsigned arm) const {
+    if (auto sel = dyn_cast<arith::SelectOp>(op))
+      return arm == 0 ? sel.getTrueValue() : sel.getFalseValue();
+    return op->getRegion(arm).front().getTerminator()->getOperand(resultNo);
+  }
+  // The ops of an arm the chosen buffer is computed from, in program order,
+  // which a copy of the arm has to carry along.
+  bool armSlice(unsigned arm, SmallVectorImpl<Operation *> &slice) const {
+    if (isa<arith::SelectOp>(op))
+      return true;
+    Block &body = op->getRegion(arm).front();
+    SmallPtrSet<Operation *, 4> needed;
+    SmallVector<Value> work = {armValue(arm)};
+    while (!work.empty()) {
+      Operation *def = work.pop_back_val().getDefiningOp();
+      if (!def || def->getBlock() != &body || !needed.insert(def).second)
+        continue;
+      if (!isMemoryEffectFree(def) || def->getNumRegions())
+        return false;
+      work.append(def->operand_begin(), def->operand_end());
+    }
+    for (Operation &o : body.without_terminator())
+      if (needed.count(&o))
+        slice.push_back(&o);
+    return true;
+  }
+};
+
+static std::optional<BufferBranch> bufferBranch(Value v) {
+  auto res = dyn_cast<OpResult>(v);
+  if (!res || !isa<MemRefType, LLVM::LLVMPointerType>(v.getType()))
+    return std::nullopt;
+  Operation *op = res.getOwner();
+  if (auto sel = dyn_cast<arith::SelectOp>(op)) {
+    if (!sel.getCondition().getType().isInteger(1))
+      return std::nullopt;
+  } else if (auto sif = dyn_cast<scf::IfOp>(op)) {
+    if (sif.getElseRegion().empty())
+      return std::nullopt;
+  } else if (auto aif = dyn_cast<affine::AffineIfOp>(op)) {
+    if (!aif.hasElse())
+      return std::nullopt;
+  } else
+    return std::nullopt;
+  return BufferBranch{op, res.getResultNumber()};
+}
+
+// Whether `user` takes the buffer as the thing it accesses or respells, and
+// which operand that is.
+static std::optional<unsigned> bufferOperand(Operation *user, Value buf) {
+  unsigned idx;
+  if (isa<memref::LoadOp, affine::AffineLoadOp, LLVM::LoadOp>(user))
+    idx = 0;
+  else if (isa<memref::StoreOp, affine::AffineStoreOp, LLVM::StoreOp>(user))
+    idx = 1;
+  else if (isa<memref::CastOp, memref::MemorySpaceCastOp, Memref2PointerOp,
+               Pointer2MemrefOp, LLVM::BitcastOp, LLVM::AddrSpaceCastOp,
+               LLVM::GEPOp>(user))
+    idx = 0;
+  else
+    return std::nullopt;
+  if (user->getOperand(idx) != buf)
+    return std::nullopt;
+  return idx;
+}
+
+// A load or store through a branch between allocations names neither of them,
+// and keeps both from being promoted. Doing the access in each arm instead, on
+// the buffer that arm chose, gives every allocation accesses of its own: the
+// branch is asked again where the access stands, with the arm's own
+// computation of the buffer carried along. A cast or offset of the branch's
+// result is pushed into the arms the same way, so an access reached through
+// one still ends at an allocation. Anything else done with the result stays as
+// it was.
+static bool splitBufferBranchAccesses(Operation *f) {
+  SmallVector<BufferBranch> work;
+  f->walk([&](Operation *op) {
+    for (Value res : op->getResults())
+      if (auto br = bufferBranch(res))
+        if (isAllocation(bufferRoot(br->armValue(0))) ||
+            isAllocation(bufferRoot(br->armValue(1))))
+          work.push_back(*br);
+  });
+
+  bool changed = false;
+  while (!work.empty()) {
+    BufferBranch br = work.pop_back_val();
+    SmallVector<Operation *> slices[2];
+    if (!br.armSlice(0, slices[0]) || !br.armSlice(1, slices[1]))
+      continue;
+
+    for (OpOperand &use : llvm::make_early_inc_range(br.result().getUses())) {
+      Operation *user = use.getOwner();
+      auto operand = bufferOperand(user, br.result());
+      if (!operand)
+        continue;
+
+      OpBuilder b(user);
+      Operation *newBr;
+      if (auto aif = dyn_cast<affine::AffineIfOp>(br.op))
+        newBr = affine::AffineIfOp::create(
+            b, user->getLoc(), user->getResultTypes(), aif.getIntegerSet(),
+            aif.getOperands(), /*withElseRegion=*/true);
+      else
+        // A select and an scf.if both lead with their condition.
+        newBr = scf::IfOp::create(b, user->getLoc(), user->getResultTypes(),
+                                  br.op->getOperand(0),
+                                  /*withElseRegion=*/true);
+      for (unsigned arm = 0; arm < 2; ++arm) {
+        Block *dst = &newBr->getRegion(arm).front();
+        // A branch built without results comes with its yields already.
+        if (!dst->empty() && dst->back().hasTrait<OpTrait::IsTerminator>())
+          dst->back().erase();
+        OpBuilder ab = OpBuilder::atBlockEnd(dst);
+        IRMapping m;
+        for (Operation *o : slices[arm])
+          ab.clone(*o, m);
+        Operation *access = ab.clone(*user, m);
+        access->setOperand(*operand, m.lookupOrDefault(br.armValue(arm)));
+        if (isa<affine::AffineIfOp>(newBr))
+          affine::AffineYieldOp::create(ab, user->getLoc(),
+                                        access->getResults());
+        else
+          scf::YieldOp::create(ab, user->getLoc(), access->getResults());
+      }
+      user->replaceAllUsesWith(newBr->getResults());
+      user->erase();
+      changed = true;
+      // A respelling of the branch's result is a branch between buffers again,
+      // whose own accesses want splitting.
+      if (newBr->getNumResults())
+        if (auto inner = bufferBranch(newBr->getResult(0)))
+          work.push_back(*inner);
+    }
+
+    // A branch nothing is left to ask goes, so long as it did nothing but
+    // choose: the yields of a spent arm would still hold the allocation.
+    bool onlyChose = llvm::all_of(br.op->getRegions(), [](Region &arm) {
+      return llvm::all_of(arm.front().without_terminator(),
+                          [](Operation &o) { return isMemoryEffectFree(&o); });
+    });
+    if (onlyChose && llvm::all_of(br.op->getResults(),
+                                  [](Value r) { return r.use_empty(); }))
+      br.op->erase();
+  }
+  return changed;
+}
+
 // A select between two constants, so that each arm names a place of its own.
 static arith::SelectOp selectOfConstants(Value v) {
   auto sel = v.getDefiningOp<arith::SelectOp>();
@@ -3289,6 +3465,10 @@ void PolygeistMem2Reg::runOnOperation() {
 
     // Load op's whose results were replaced by those forwarded from stores.
     SmallVector<Operation *, 8> loadOpsToErase;
+
+    // An allocation reached only through a branch between buffers is not yet
+    // promotable; splitting the accesses first gives it accesses of its own.
+    changed |= splitBufferBranchAccesses(f);
 
     // Walk all load's and perform store to load forwarding.
     SmallVector<mlir::Value, 4> toPromote;

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -3247,20 +3247,28 @@ static std::optional<BufferBranch> bufferBranch(Value v) {
 // Whether `user` takes the buffer as the thing it accesses or respells, and
 // which operand that is.
 static std::optional<unsigned> bufferOperand(Operation *user, Value buf) {
-  unsigned idx;
-  if (isa<memref::LoadOp, affine::AffineLoadOp, LLVM::LoadOp>(user))
-    idx = 0;
-  else if (isa<memref::StoreOp, affine::AffineStoreOp, LLVM::StoreOp>(user))
-    idx = 1;
-  else if (isa<memref::CastOp, memref::MemorySpaceCastOp, Memref2PointerOp,
-               Pointer2MemrefOp, LLVM::BitcastOp, LLVM::AddrSpaceCastOp,
-               LLVM::GEPOp>(user))
-    idx = 0;
-  else
+  if (auto store = dyn_cast<enzyme::StoreLikeInterface>(user)) {
+    if (store.getStoredPointer() != buf)
+      return std::nullopt;
+    // The pointer written through, which is not the value written even when
+    // the two are spelled the same.
+    bool skippedValue = false;
+    for (OpOperand &operand : user->getOpOperands()) {
+      if (!skippedValue && operand.get() == store.getStoredValue()) {
+        skippedValue = true;
+        continue;
+      }
+      if (operand.get() == buf)
+        return operand.getOperandNumber();
+    }
     return std::nullopt;
-  if (user->getOperand(idx) != buf)
+  }
+  if (!isa<memref::LoadOp, affine::AffineLoadOp, LLVM::LoadOp, memref::CastOp,
+           memref::MemorySpaceCastOp, Memref2PointerOp, Pointer2MemrefOp,
+           LLVM::BitcastOp, LLVM::AddrSpaceCastOp, LLVM::GEPOp>(user) ||
+      user->getOperand(0) != buf)
     return std::nullopt;
-  return idx;
+  return 0;
 }
 
 // A load or store through a branch between allocations names neither of them,

--- a/test/lit_tests/mem2reg_buffer_branch.mlir
+++ b/test/lit_tests/mem2reg_buffer_branch.mlir
@@ -1,0 +1,130 @@
+// RUN: enzymexlamlir-opt %s -polygeist-mem2reg | FileCheck %s
+
+// An access through a branch between two allocations names neither of them,
+// and keeps both from being promoted. The access is done in each arm instead,
+// on the buffer that arm chose, and the forwarding then sees an access of
+// each allocation on its own. This is MFEM's H(div) mass kernel choosing
+// between two shared arrays by the thread's component,
+// `const real_t *B = (c == 0) ? sBo : sBc`, which arrives as an affine.if
+// yielding a cast of one alloca or the other.
+
+#set = affine_set<(d0) : (d0 == 0)>
+
+module {
+  func.func @load_through_if(%a: f64, %b: f64) -> f64 {
+    %s = memref.alloca() : memref<8xf64>
+    %t = memref.alloca() : memref<12xf64>
+    affine.store %a, %s[1] : memref<8xf64>
+    affine.store %b, %t[1] : memref<12xf64>
+    %r = affine.for %i = 0 to 2 iter_args(%acc = %a) -> f64 {
+      %buf = affine.if #set(%i) -> memref<?xf64> {
+        %cs = memref.cast %s : memref<8xf64> to memref<?xf64>
+        affine.yield %cs : memref<?xf64>
+      } else {
+        %ct = memref.cast %t : memref<12xf64> to memref<?xf64>
+        affine.yield %ct : memref<?xf64>
+      }
+      %v = affine.load %buf[1] : memref<?xf64>
+      %n = arith.addf %acc, %v : f64
+      affine.yield %n : f64
+    }
+    return %r : f64
+  }
+
+  func.func @store_through_select(%c: i1, %v: f64, %a: f64) -> (f64, f64) {
+    %s = memref.alloca() : memref<4xf64>
+    %t = memref.alloca() : memref<4xf64>
+    affine.store %a, %s[2] : memref<4xf64>
+    affine.store %a, %t[2] : memref<4xf64>
+    %buf = arith.select %c, %s, %t : memref<4xf64>
+    affine.store %v, %buf[2] : memref<4xf64>
+    %rs = affine.load %s[2] : memref<4xf64>
+    %rt = affine.load %t[2] : memref<4xf64>
+    return %rs, %rt : f64, f64
+  }
+
+  // The access is reached through a cast of the branch's result: the cast
+  // goes into the arms first.
+  func.func @load_through_cast(%c: i1, %a: f64, %b: f64) -> f64 {
+    %s = memref.alloca() : memref<4xf64>
+    %t = memref.alloca() : memref<4xf64>
+    affine.store %a, %s[0] : memref<4xf64>
+    affine.store %b, %t[0] : memref<4xf64>
+    %buf = scf.if %c -> memref<4xf64> {
+      scf.yield %s : memref<4xf64>
+    } else {
+      scf.yield %t : memref<4xf64>
+    }
+    %p = "enzymexla.memref2pointer"(%buf) : (memref<4xf64>) -> !llvm.ptr
+    %r = llvm.load %p : !llvm.ptr -> f64
+    return %r : f64
+  }
+
+  // A branch that does more than choose stays, even once nothing asks it,
+  // and the allocation it still names is not promoted.
+  func.func @arm_with_effect(%c: i1, %a: f64, %out: memref<f64>) -> f64 {
+    %s = memref.alloca() : memref<4xf64>
+    %t = memref.alloca() : memref<4xf64>
+    affine.store %a, %s[0] : memref<4xf64>
+    affine.store %a, %t[0] : memref<4xf64>
+    %buf = scf.if %c -> memref<4xf64> {
+      affine.store %a, %out[] : memref<f64>
+      scf.yield %s : memref<4xf64>
+    } else {
+      scf.yield %t : memref<4xf64>
+    }
+    %r = affine.load %buf[0] : memref<4xf64>
+    return %r : f64
+  }
+
+  // A branch between buffers that are not allocations is left alone.
+  func.func @not_allocations(%c: i1, %s: memref<4xf64>, %t: memref<4xf64>) -> f64 {
+    %buf = arith.select %c, %s, %t : memref<4xf64>
+    %r = affine.load %buf[0] : memref<4xf64>
+    return %r : f64
+  }
+}
+
+// CHECK-LABEL: func.func @load_through_if(
+// CHECK-NOT:     memref.alloca
+// CHECK:         affine.for
+// CHECK-NOT:       memref.cast
+// CHECK:           %[[v:.+]] = affine.if #set(%{{.+}}) -> f64 {
+// CHECK-NEXT:        affine.yield %arg0 : f64
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        affine.yield %arg1 : f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      arith.addf %{{.+}}, %[[v]]
+
+// CHECK-LABEL: func.func @store_through_select(
+// CHECK-NOT:     memref.alloca
+// CHECK:         %[[r:.+]]:2 = scf.if %arg0 -> (f64, f64) {
+// CHECK-NEXT:      scf.yield %arg1, %arg2 : f64, f64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      scf.yield %arg2, %arg1 : f64, f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[r]]#0, %[[r]]#1 : f64, f64
+
+// CHECK-LABEL: func.func @load_through_cast(
+// CHECK-NOT:     memref.alloca
+// CHECK:         %[[r:.+]] = scf.if %arg0 -> (f64) {
+// CHECK-NEXT:      scf.yield %arg1 : f64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      scf.yield %arg2 : f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[r]] : f64
+
+// CHECK-LABEL: func.func @arm_with_effect(
+// CHECK:         %[[s:.+]] = memref.alloca() : memref<4xf64>
+// CHECK:         %[[t:.+]] = memref.alloca() : memref<4xf64>
+// CHECK:         scf.if %arg0 -> (memref<4xf64>) {
+// CHECK-NEXT:      affine.store %arg1, %arg2[]
+// CHECK:         %[[r:.+]] = scf.if %arg0 -> (f64) {
+// CHECK-NEXT:      affine.load %[[s]][0]
+// CHECK:         } else {
+// CHECK-NEXT:      affine.load %[[t]][0]
+// CHECK:         return %[[r]] : f64
+
+// CHECK-LABEL: func.func @not_allocations(
+// CHECK:         %[[buf:.+]] = arith.select %arg0, %arg1, %arg2
+// CHECK-NEXT:    affine.load %[[buf]][0]


### PR DESCRIPTION
Alternative to #3105, which expanded buffer-yielding branches inside the raiser. This does it in `polygeist-mem2reg` instead, as a preprocessing that runs before the promotion (and before the split of accesses at a select between constant indices).

A load or store through an `arith.select`, `scf.if` or `affine.if` that chooses between two allocations names neither of them, and keeps both from being promoted. Each such access is done in each arm instead, on the buffer that arm chose, with the arm's own computation of the buffer (its casts) cloned along. Casts and offsets (`memref.cast`, memory-space casts, `memref2pointer`/`pointer2memref`, `llvm.bitcast`/`addrspacecast`/`getelementptr`) of the branch's result are pushed into the arms the same way, iteratively, so an access reached through them ends at an allocation too. A branch that only chose is dropped once nothing asks it; one whose arms have effects stays. Only branches with at least one arm rooted at an allocation (`memref.alloca`/`alloc`, `llvm.alloca`, `memref.get_global`) are touched.

This is MFEM's `const real_t *B = (c == 0) ? sBo : sBc` between two shared arrays: in the pre-raise dumps of the whole CUDA suite it is the only shape of buffer-yielding branch (47 `affine.if`s in `bilininteg_vectorfemass_pa.cpp` and `qinterp/eval_hdiv.cpp`, all `memref.cast` of an alloca in each arm). Running this mem2reg on those dumps removes all 47, and the raiser then raises both TUs identically to before (same 66 whiles, same 32 racy-store warnings) with no buffer-branch handling of its own.

Not covered, unlike #3105: a branch between buffers that are not allocations (e.g. two function arguments, as in #3105's ping-pong test). None occur in the MFEM suite.

Test: `mem2reg_buffer_branch.mlir` (affine.if of casts in a loop, select, cast chain, effectful arm, non-allocation arms). lit: 1301/1301.
