### PR TITLE
Raising: never emit a rank-0 dynamic_slice

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -2993,10 +2993,22 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
         startIndices.push_back(startIndex);
       }
 
-      newVal = stablehlo::DynamicSliceOp::create(
-          builder,
-          rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo), T,
-          inputTen, startIndices, outputShape);
+      // A rank-0 buffer has nothing to slice (and a rank-0 dynamic_slice
+      // prints in a form no parser reads back); the tensor is the value.
+      if (startIndices.empty())
+        newVal = inputTen.getType() == T
+                     ? inputTen
+                     : stablehlo::ReshapeOp::create(
+                           builder,
+                           rewriteLocation(op->getLoc(),
+                                           pc.options.strip_llvm_debuginfo),
+                           T, inputTen)
+                           .getResult();
+      else
+        newVal = stablehlo::DynamicSliceOp::create(
+            builder,
+            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo), T,
+            inputTen, startIndices, outputShape);
     } else {
       bool needSlice = false;
       bool needPad = false;
@@ -3673,10 +3685,16 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
 
       SmallVector<int64_t> updateShape(updateType.getShape().begin(),
                                        updateType.getShape().end());
-      Value prev = stablehlo::DynamicSliceOp::create(
-          builder,
-          rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-          operand, startIndicesValues, updateShape);
+      // The previous value of a rank-0 buffer is the buffer itself: a
+      // rank-0 dynamic_slice prints in a form no parser reads back.
+      Value prev = updateShape.empty()
+                       ? operand
+                       : stablehlo::DynamicSliceOp::create(
+                             builder,
+                             rewriteLocation(op->getLoc(),
+                                             pc.options.strip_llvm_debuginfo),
+                             operand, startIndicesValues, updateShape)
+                             .getResult();
 
       Value updateWithoutConstantDims = stablehlo::ReshapeOp::create(
           builder,

--- a/test/lit_tests/raising/raise_masked_scalar_store.mlir
+++ b/test/lit_tests/raising/raise_masked_scalar_store.mlir
@@ -1,0 +1,38 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// A masked store into a rank-0 buffer reads the previous value back as the
+// buffer itself. A rank-0 stablehlo.dynamic_slice would print as
+// `%x, , sizes = []`, which no parser reads back (the runtime re-parses the
+// raised module), so none may be emitted.
+func.func @scalar_masked(%out: memref<f64, 1>, %in: memref<4xf64, 1>, %flag: memref<1xi64, 1>) {
+  %c1_i64 = arith.constant 1 : i64
+  affine.parallel (%i) = (0) to (4) {
+    %v = affine.load %in[0] : memref<4xf64, 1>
+    %f = affine.load %flag[0] : memref<1xi64, 1>
+    %c = arith.cmpi eq, %f, %c1_i64 : i64
+    scf.if %c {
+      affine.store %v, %out[] : memref<f64, 1>
+    }
+  }
+  return
+}
+
+// CHECK:    func.func private @scalar_masked_raised(%arg0: tensor<f64>, %arg1: tensor<4xf64>, %arg2: tensor<1xi64>) -> (tensor<f64>, tensor<4xf64>, tensor<1xi64>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<4xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c_0 : tensor<4xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<4xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_1 : tensor<4xi64>
+// CHECK-NEXT:    %3 = stablehlo.slice %arg1 [0:1] : (tensor<4xf64>) -> tensor<1xf64>
+// CHECK-NEXT:    %4 = stablehlo.reshape %3 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %5 = stablehlo.reshape %arg2 : (tensor<1xi64>) -> tensor<i64>
+// CHECK-NEXT:    %6 = arith.cmpi eq, %5, %c : tensor<i64>
+// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:    %8 = stablehlo.reshape %7 : (tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:    %9 = stablehlo.reshape %arg0 : (tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:    %10 = stablehlo.select %6, %8, %9 : tensor<i1>, tensor<f64>
+// CHECK-NEXT:    %11 = stablehlo.broadcast_in_dim %10, dims = [] : (tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:    %12 = stablehlo.dynamic_update_slice %arg0, %11 : (tensor<f64>, tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:    return %12, %arg1, %arg2 : tensor<f64>, tensor<4xf64>, tensor<1xi64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
A masked store's read-back of the previous value (and the dynamic-index load path) sliced the buffer with `stablehlo.dynamic_slice` even when the buffer is rank 0, where the start-index list is empty. That op prints as `stablehlo.dynamic_slice %x, , sizes = []`, which no parser accepts, and the linked runtime re-parses the raised module at first execution. In MFEM's GPU suite `BatchInverseElementTransformation` (426 such slices in `fem/batchitrans.cpp`) and `PA DG Diffusion` die with `custom op 'stablehlo.dynamic_slice' expected 'sizes'`; the objects raised on Aug 30 did not contain the form because the scalar masked stores were not raised this way yet.

For a rank-0 buffer the previous value is the buffer itself.

Test: `raise_masked_scalar_store.mlir` stores a uniform value into a `memref<f64>` under a runtime flag from every lane of a parallel. On main the raised function carries `stablehlo.dynamic_slice %arg0, , sizes = []` and does not re-parse (`custom op 'stablehlo.dynamic_slice' expected 'sizes'`); with the fix the previous value is the buffer itself, and the raised function is checked line for line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD

