### PR TITLE
Raising: a signed index_cast of an i1 sign-extends

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -4127,15 +4127,20 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
         cast<RankedTensorType>(mappedResult.getType()).getElementType();
 
     if (currentType != targetType) {
+      Location loc =
+          rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo);
+      auto shape = cast<ShapedType>(mappedResult.getType()).getShape();
       Value newMappedResult =
-          stablehlo::ConvertOp::create(
-              builder,
-              rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-              RankedTensorType::get(
-                  cast<ShapedType>(mappedResult.getType()).getShape(),
-                  targetType),
-              mappedResult)
+          stablehlo::ConvertOp::create(builder, loc,
+                                       RankedTensorType::get(shape, targetType),
+                                       mappedResult)
               .getResult();
+      // stablehlo.convert reads i1 as boolean (true -> 1), but the signed
+      // index_cast of an i1 sign-extends: true -> -1. Negate the boolean's
+      // conversion, as the arith raising does for extsi.
+      if (isa<arith::IndexCastOp>(op) && currentType.isInteger(1))
+        newMappedResult =
+            stablehlo::NegOp::create(builder, loc, newMappedResult).getResult();
       maps[newMappedResult] = maps.lookup(mappedResult);
       mappedResult = newMappedResult;
     }

--- a/test/lit_tests/raising/raise_index_cast_i1.mlir
+++ b/test/lit_tests/raising/raise_index_cast_i1.mlir
@@ -1,0 +1,40 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo | FileCheck %s
+
+// arith.index_cast of an i1 sign-extends (true -> -1), unlike index_castui
+// (true -> 1). stablehlo.convert reads a boolean as 0/1, so the signed cast
+// negates the conversion, as the arith raising already does for extsi.
+// (mfem's H(curl)/H(div) mass kernels offset an index by `- flag` this way;
+// raising it as +1 broke "Hcurl/Hdiv PA Coefficient" once the cast was no
+// longer hoisted out of the kernel.)
+func.func @signed(%out: memref<4xf64, 1>) {
+  %c2 = arith.constant 2 : index
+  affine.parallel (%i) = (0) to (4) {
+    %b = arith.cmpi eq, %i, %c2 : index
+    %s = arith.index_cast %b : i1 to index
+    %si = arith.index_cast %s : index to i64
+    %f = arith.sitofp %si : i64 to f64
+    affine.store %f, %out[%i] : memref<4xf64, 1>
+  }
+  return
+}
+
+func.func @unsigned(%out: memref<4xf64, 1>) {
+  %c2 = arith.constant 2 : index
+  affine.parallel (%i) = (0) to (4) {
+    %b = arith.cmpi eq, %i, %c2 : index
+    %u = arith.index_castui %b : i1 to index
+    %ui = arith.index_cast %u : index to i64
+    %f = arith.sitofp %ui : i64 to f64
+    affine.store %f, %out[%i] : memref<4xf64, 1>
+  }
+  return
+}
+
+// CHECK-LABEL: func.func private @unsigned_raised(
+// CHECK-NOT: stablehlo.negate
+// CHECK: return
+
+// CHECK-LABEL: func.func private @signed_raised(
+// CHECK: %[[CMP:.+]] = arith.cmpi eq
+// CHECK: %[[CV:.+]] = stablehlo.convert %[[CMP]] : (tensor<4xi1>) -> tensor<4xi64>
+// CHECK-NEXT: stablehlo.negate %[[CV]] : tensor<4xi64>


### PR DESCRIPTION
`arith.index_cast` of an `i1` sign-extends (true → -1) while `index_castui` zero-extends (true → 1). The raising lowered both to `stablehlo.convert`, which reads a boolean as 0/1, so an index offset computed as `- flag` came out as +1 inside the kernel.

MFEM's H(curl)/H(div) mass kernels (`fem/integ/bilininteg_hcurlhdiv_kernels.cpp`) offset their coefficient index that way. The GPU suite's "Hcurl/Hdiv PA Coefficient" failed 10 of 100 assertions (all 2D cases) once the union's broad invariant-scalar hoist, which had computed the cast on the host, was no longer there to mask it; the object-swap bisect named the TU and the union's `DISABLE_HOIST_INVARIANT_SCALARS=1` reproduced it. Negate the boolean's conversion for the signed cast, as the arith raising already does for `extsi`. Lit test `raising/raise_index_cast_i1.mlir` covers both casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
