### PR TITLE
Raising: check the i1 index_cast test line for line

### DIFF
--- a/test/lit_tests/raising/raise_index_cast_i1.mlir
+++ b/test/lit_tests/raising/raise_index_cast_i1.mlir
@@ -30,11 +30,47 @@ func.func @unsigned(%out: memref<4xf64, 1>) {
   return
 }
 
-// CHECK-LABEL: func.func private @unsigned_raised(
-// CHECK-NOT: stablehlo.negate
-// CHECK: return
+// CHECK:    func.func private @unsigned_raised(%arg0: tensor<4xf64>) -> tensor<4xf64> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<4xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c_0 : tensor<4xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<4xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_1 : tensor<4xi64>
+// CHECK-NEXT:    %3 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i64>) -> tensor<4xi64>
+// CHECK-NEXT:    %4 = arith.cmpi eq, %2, %3 : tensor<4xi64>
+// CHECK-NEXT:    %5 = stablehlo.convert %4 : (tensor<4xi1>) -> tensor<4xi64>
+// CHECK-NEXT:    %6 = arith.sitofp %5 : tensor<4xi64> to tensor<4xf64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %6, dims = [0] : (tensor<4xf64>) -> tensor<4xf64>
+// CHECK-NEXT:    %8 = stablehlo.dynamic_update_slice %arg0, %7, %c_7 : (tensor<4xf64>, tensor<4xf64>, tensor<i64>) -> tensor<4xf64>
+// CHECK-NEXT:    return %8 : tensor<4xf64>
+// CHECK-NEXT:  }
 
-// CHECK-LABEL: func.func private @signed_raised(
-// CHECK: %[[CMP:.+]] = arith.cmpi eq
-// CHECK: %[[CV:.+]] = stablehlo.convert %[[CMP]] : (tensor<4xi1>) -> tensor<4xi64>
-// CHECK-NEXT: stablehlo.negate %[[CV]] : tensor<4xi64>
+// CHECK:    func.func private @signed_raised(%arg0: tensor<4xf64>) -> tensor<4xf64> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<4xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c_0 : tensor<4xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<4xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_1 : tensor<4xi64>
+// CHECK-NEXT:    %3 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i64>) -> tensor<4xi64>
+// CHECK-NEXT:    %4 = arith.cmpi eq, %2, %3 : tensor<4xi64>
+// CHECK-NEXT:    %5 = stablehlo.convert %4 : (tensor<4xi1>) -> tensor<4xi64>
+// CHECK-NEXT:    %6 = stablehlo.negate %5 : tensor<4xi64>
+// CHECK-NEXT:    %7 = arith.sitofp %6 : tensor<4xi64> to tensor<4xf64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %7, dims = [0] : (tensor<4xf64>) -> tensor<4xf64>
+// CHECK-NEXT:    %9 = stablehlo.dynamic_update_slice %arg0, %8, %c_7 : (tensor<4xf64>, tensor<4xf64>, tensor<i64>) -> tensor<4xf64>
+// CHECK-NEXT:    return %9 : tensor<4xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Follow-up to #3121: its lit test only looked for the `stablehlo.negate`. This checks both raised functions line for line (the unsigned cast converting without a negate, the signed one with it), so a change in what surrounds the convert shows up.

Test-only; the raised output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
