### PR TITLE
EnzymeHLOOpt: find CSE twins through a hashed index, not a use-list walk

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -13380,57 +13380,178 @@ bool isCommutativeEquivalent(ValueRange lhs, ValueRange rhs) {
   }
 }
 
+// The live-operation index the CSE patterns of one driver run share.
+// Operations are bucketed on name, inherent attributes, result types and
+// operands (order-insensitive for commutative ops), so an equivalent
+// operation is found in one lookup instead of a walk over an operand's use
+// list, which is quadratic when the operand is a broadcast constant, an
+// iota or an argument with thousands of users. The index is filled before
+// the driver runs and kept complete through the driver's listener (inserted
+// and modified operations are re-hashed, erased ones leave), so every entry
+// is a live operation and a twin is found the moment either side is
+// visited; a candidate is still checked for equivalence.
+struct CSEIndex : public RewriterBase::Listener {
+  DenseMap<size_t, SmallVector<Operation *, 2>> buckets;
+  DenseMap<Operation *, size_t> where;
+
+  static bool indexable(Operation *op) {
+    return op->getNumOperands() > 0 && op->getNumRegions() == 0;
+  }
+
+  static size_t hashOf(Operation *op) {
+    bool commutative = op->hasTrait<::mlir::hlo::OpTrait::IsCommutative>() ||
+                       op->hasTrait<::mlir::OpTrait::IsCommutative>();
+    llvm::hash_code hash = OperationEquivalence::computeHash(
+        op,
+        commutative ? OperationEquivalence::ignoreHashValue
+                    : OperationEquivalence::directHashValue,
+        OperationEquivalence::ignoreHashValue,
+        OperationEquivalence::IgnoreLocations |
+            OperationEquivalence::IgnoreDiscardableAttrs);
+    if (commutative) {
+      size_t operands = 0;
+      for (Value v : op->getOperands())
+        operands += (size_t)hash_value(v);
+      hash = llvm::hash_combine(hash, operands);
+    }
+    return (size_t)hash;
+  }
+
+  void remove(Operation *op) {
+    auto it = where.find(op);
+    if (it == where.end())
+      return;
+    auto bucket = buckets.find(it->second);
+    if (bucket != buckets.end()) {
+      auto &ops = bucket->second;
+      auto pos = llvm::find(ops, op);
+      if (pos != ops.end())
+        ops.erase(pos);
+      if (ops.empty())
+        buckets.erase(bucket);
+    }
+    where.erase(it);
+  }
+
+  void add(Operation *op, size_t hash) {
+    auto it = where.find(op);
+    if (it != where.end()) {
+      if (it->second == hash)
+        return;
+      remove(op);
+    }
+    buckets[hash].push_back(op);
+    where[op] = hash;
+  }
+
+  void add(Operation *op) {
+    if (indexable(op))
+      add(op, hashOf(op));
+  }
+
+  void populate(Operation *root) {
+    root->walk([&](Operation *op) { add(op); });
+  }
+
+  void notifyOperationInserted(Operation *op, OpBuilder::InsertPoint) override {
+    add(op);
+  }
+  void notifyOperationModified(Operation *op) override { add(op); }
+  void notifyOperationErased(Operation *op) override { remove(op); }
+};
+
 template <typename T> struct CSE final : CheckedOpRewritePattern<T, CSE<T>> {
-  using CheckedOpRewritePattern<T, CSE<T>>::CheckedOpRewritePattern;
+  CSEIndex *index;
+
+  CSE(CSEIndex *index, MLIRContext *context, PatternBenefit benefit)
+      : CheckedOpRewritePattern<T, CSE<T>>(context, benefit), index(index) {}
+  // Registered on its own (the transform-dialect pattern names), the
+  // pattern has no driver listener to keep an index live: it walks the use
+  // list of the operand with the fewest users instead.
+  CSE(MLIRContext *context, PatternBenefit benefit = 1)
+      : CheckedOpRewritePattern<T, CSE<T>>(context, benefit), index(nullptr) {}
 
   bool supportsDynamicShapes() { return true; }
 
+  static bool equivalent(T op, Operation *nop) {
+    OperationEquivalence::Flags flags =
+        OperationEquivalence::IgnoreLocations |
+        OperationEquivalence::IgnoreDiscardableAttrs;
+
+    // OperationEquivalence only checks for mlir::OpTrait::IsCommutative
+    if constexpr (!std::is_base_of_v<::mlir::OpTrait::IsCommutative<T>, T>) {
+      flags |= OperationEquivalence::IgnoreCommutativity;
+    }
+
+    if (OperationEquivalence::isEquivalentTo(op, nop, flags))
+      return true;
+    // stablehlo defines a special trait for commutative operations.
+    // check for that here.
+    if constexpr (std::is_base_of_v<::mlir::hlo::OpTrait::IsCommutative<T>,
+                                    T>) {
+      return isCommutativeEquivalent(op->getOperands(), nop->getOperands());
+    }
+    return false;
+  }
+
   LogicalResult matchAndRewriteImpl(T op, PatternRewriter &rewriter) const {
-    if (op->getNumOperands() > 0)
-      for (auto nop : op->getOperand(0).getUsers()) {
+    if (op->getNumOperands() == 0)
+      return failure();
+    if (!index) {
+      Value scan;
+      size_t scanLen = std::numeric_limits<size_t>::max();
+      for (Value v : op->getOperands()) {
+        size_t n = 0;
+        for ([[maybe_unused]] auto &use : v.getUses())
+          if (++n >= scanLen)
+            break;
+        if (n < scanLen) {
+          scanLen = n;
+          scan = v;
+        }
+      }
+      for (Operation *nop : scan.getUsers()) {
+        if (nop == op || !isa<T>(nop) || nop->getBlock() != op->getBlock() ||
+            op->getName() != nop->getName() || !equivalent(op, nop))
+          continue;
+        if (nop->isBeforeInBlock(op))
+          rewriter.replaceOp(op, nop);
+        else
+          rewriter.replaceOp(nop, op);
+        return success();
+      }
+      return failure();
+    }
+    size_t hash = CSEIndex::hashOf(op);
+    Operation *twin = nullptr;
+    auto bucket = index->buckets.find(hash);
+    if (bucket != index->buckets.end())
+      for (Operation *nop : bucket->second) {
         if (nop == op)
           continue;
         if (!isa<T>(nop))
           continue;
         if (nop->getBlock() != op->getBlock())
           continue;
-
         if (op->getName() != nop->getName())
           continue;
-
-        OperationEquivalence::Flags flags =
-            OperationEquivalence::IgnoreLocations |
-            OperationEquivalence::IgnoreDiscardableAttrs;
-
-        // OperationEquivalence only checks for mlir::OpTrait::IsCommutative
-        if constexpr (!std::is_base_of_v<::mlir::OpTrait::IsCommutative<T>,
-                                         T>) {
-          flags |= OperationEquivalence::IgnoreCommutativity;
-        }
-
-        if (!OperationEquivalence::isEquivalentTo(op, nop, flags)) {
-          // stablehlo defines a special trait for commutative operations.
-          // check for that here.
-          if constexpr (std::is_base_of_v<
-                            ::mlir::hlo::OpTrait::IsCommutative<T>, T>) {
-            auto opRange = op->getOperands();
-            auto nopRange = nop->getOperands();
-            if (!isCommutativeEquivalent(opRange, nopRange))
-              continue;
-          } else {
-            continue;
-          }
-        }
-
-        if (nop->isBeforeInBlock(op)) {
-          rewriter.replaceOp(op, nop);
-          return success();
-        } else {
-          rewriter.replaceOp(nop, op);
-          return success();
-        }
+        if (!equivalent(op, nop))
+          continue;
+        twin = nop;
+        break;
       }
-    return failure();
+    if (!twin) {
+      index->add(op, hash);
+      return failure();
+    }
+    if (twin->isBeforeInBlock(op)) {
+      rewriter.replaceOp(op, twin);
+    } else {
+      // The survivor stays indexed for the twins still to come.
+      index->add(op, hash);
+      rewriter.replaceOp(twin, op);
+    }
+    return success();
   }
 };
 
@@ -36955,6 +37076,7 @@ struct EnzymeHLOOptPass
   void runOnOperation() override {
     auto context = getOperation()->getContext();
 
+    CSEIndex cseIndex;
     RewritePatternSet patterns(context);
     mlir::enzyme::populateWithGenerated(patterns);
 
@@ -37131,6 +37253,7 @@ struct EnzymeHLOOptPass
       patterns.add<ReshapePad>(context);
 
     if (cse) {
+      patterns.add<CSEIota>(context, PatternBenefit(65000));
       patterns.add<
           CSE<stablehlo::BroadcastInDimOp>, CSE<stablehlo::SliceOp>,
           CSE<stablehlo::TransposeOp>, CSE<stablehlo::ConvertOp>,
@@ -37141,7 +37264,7 @@ struct EnzymeHLOOptPass
           CSE<stablehlo::MinOp>, CSE<stablehlo::ConcatenateOp>,
           CSE<stablehlo::MaxOp>, CSE<stablehlo::NegOp>, CSE<stablehlo::AbsOp>,
           CSE<enzymexla::RotateOp>, CSE<enzymexla::WrapOp>,
-          CSE<enzymexla::ExtendOp>, CSEIota, CSE<stablehlo::CompareOp>,
+          CSE<enzymexla::ExtendOp>, CSE<stablehlo::CompareOp>,
           CSE<stablehlo::GatherOp>, CSE<stablehlo::ScatterOp>,
           CSE<stablehlo::SelectOp>, CSE<stablehlo::RealOp>, CSE<chlo::ConjOp>,
           CSE<stablehlo::ImagOp>, CSE<stablehlo::BatchNormTrainingOp>,
@@ -37158,7 +37281,7 @@ struct EnzymeHLOOptPass
           CSE<stablehlo::OrOp>, CSE<stablehlo::XorOp>,
           CSE<stablehlo::ConvolutionOp>, CSE<stablehlo::FftOp>,
           CSE<stablehlo::DynamicSliceOp>, CSE<stablehlo::DynamicUpdateSliceOp>,
-          CSE<stablehlo::ReverseOp>>(context, PatternBenefit(65000));
+          CSE<stablehlo::ReverseOp>>(&cseIndex, context, PatternBenefit(65000));
     }
 
     if (passses & 256)
@@ -37457,6 +37580,10 @@ struct EnzymeHLOOptPass
     // successor operands for the values the blocks differed in, and e.g.
     // llvm.invoke cannot carry an index-typed successor operand.
     config.setRegionSimplificationLevel(GreedySimplifyRegionLevel::Normal);
+    if (cse) {
+      cseIndex.populate(getOperation());
+      config.setListener(&cseIndex);
+    }
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
                                      config))) {
       signalPassFailure();

--- a/test/lit_tests/cse_fanout.mlir
+++ b/test/lit_tests/cse_fanout.mlir
@@ -1,0 +1,23 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// The two adds share every operand, in either order; the broadcast they share
+// has other users too. CSE merges them (and the commutative twin) through
+// the hashed index rather than a walk over the broadcast's use list.
+func.func @fanout(%x: tensor<4xf64>, %c: tensor<f64>) -> (tensor<4xf64>, tensor<4xf64>, tensor<4xf64>, tensor<4xf64>) {
+  %b = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<f64>) -> tensor<4xf64>
+  %m0 = stablehlo.multiply %b, %b : tensor<4xf64>
+  %m1 = stablehlo.subtract %b, %x : tensor<4xf64>
+  %a0 = stablehlo.add %b, %x : tensor<4xf64>
+  %a1 = stablehlo.add %x, %b : tensor<4xf64>
+  %s = stablehlo.sine %a1 : tensor<4xf64>
+  return %m0, %m1, %a0, %s : tensor<4xf64>, tensor<4xf64>, tensor<4xf64>, tensor<4xf64>
+}
+
+// CHECK:    func.func @fanout(%arg0: tensor<4xf64>, %arg1: tensor<f64>) -> (tensor<4xf64>, tensor<4xf64>, tensor<4xf64>, tensor<4xf64>) {
+// CHECK-NEXT:    %0 = stablehlo.broadcast_in_dim %arg1, dims = [] : (tensor<f64>) -> tensor<4xf64>
+// CHECK-NEXT:    %1 = stablehlo.multiply %0, %0 : tensor<4xf64>
+// CHECK-NEXT:    %2 = stablehlo.subtract %0, %arg0 : tensor<4xf64>
+// CHECK-NEXT:    %3 = stablehlo.add %0, %arg0 : tensor<4xf64>
+// CHECK-NEXT:    %4 = stablehlo.sine %3 : tensor<4xf64>
+// CHECK-NEXT:    return %1, %2, %3, %4 : tensor<4xf64>, tensor<4xf64>, tensor<4xf64>, tensor<4xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Each `CSE<T>` pattern looked for an equivalent operation by walking the whole use list of the op's first operand. In raised kernels that operand is typically a broadcast constant, an iota or a block argument with thousands of users, so every visit of every such op scanned every sibling: quadratic in the fan-out, and the greedy driver visits each op many times.

Measured on the 1891 kernel modules mfem's GPU unit-test binary hands the linked runtime (each one goes through shape refinement and `enzyme-hlo-opt` at first execution): `enzyme-hlo-opt` took 3651 s in total and up to 290 s on one module (114k lines, 47k `broadcast_in_dim`), 95% of it in these patterns; with `cse=false` the same module takes 3.8 s. Stack sampling put the time in `CSE<AddOp>::matchAndRewriteImpl` → `OperationEquivalence::isEquivalentTo`. This is why the linked runtime's per-execution pipeline dominated "H1 Assembly Levels" (issue #2968): 282 executions × the optimizer on each refined module.

The patterns of one driver run now share a `CSEIndex`: operations bucketed on name, inherent attributes, result types and operands (order-insensitive for commutative ops, using `OperationEquivalence::computeHash`). It is filled before the driver runs and kept complete through the driver's listener (`GreedyRewriteConfig::setListener`: inserted and modified operations are re-hashed, erased ones leave), so every entry is a live operation and a twin is found in one lookup the moment either side is visited; candidates are still checked with `OperationEquivalence`, and the earlier op in the block survives as before. Registered on their own through the transform-dialect pattern names, the patterns have no driver listener and fall back to walking the use list of the operand with the fewest users.

| | before | after |
|---|---|---|
| all 1891 modules, `--enzyme-hlo-opt` | 3651 s | 798 s |
| worst module | 290 s | 26 s |
| worst module, `cse=false` | 3.8 s | 3.6 s |

End to end, in the linked runtime that optimizes each refined module at first execution (libReactantExtra rebuilt from the same tree with and without this change, xla-gpu client, mfem's `H1 Assembly Levels` row, 282 executions):

| runtime | H1 Assembly Levels | result |
|---|---|---|
| without | 770 s | 180/180 assertions |
| with this change | 403 s | 180/180 assertions |
| (with `REACTANT_XLA_NO_HLO_OPT=1`, for scale) | 318 s | 180/180 assertions |

Outputs are byte-identical on 1609 of the modules. Of the 282 that differ, 180 have the same op mix (order), 70 have fewer ops and 32 have more (the extra merges let index folds such as scatter → dynamic_update_slice fire); none lost a merge, and the 72 modules on which the optimizer aborts (a known dynamic-shape class) are the same 72 as on `main`. Lit: all tests pass, plus `cse_fanout.mlir` (full golden) for the commutative twin behind a shared broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
