### PR TITLE
EnzymeHLOOpt: merge the duplicates already present before the driver runs

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -13242,8 +13242,40 @@ struct CSEIndex : public RewriterBase::Listener {
   DenseMap<size_t, SmallVector<Operation *, 2>> buckets;
   DenseMap<Operation *, size_t> where;
 
-  static bool indexable(Operation *op) {
-    return op->getNumOperands() > 0 && op->getNumRegions() == 0;
+  // The operation kinds the registered CSE patterns cover.
+  DenseSet<OperationName> names;
+
+  bool indexable(Operation *op) const {
+    return op->getNumOperands() > 0 && names.contains(op->getName());
+  }
+
+  static bool equivalent(Operation *op, Operation *nop) {
+    OperationEquivalence::Flags flags =
+        OperationEquivalence::IgnoreLocations |
+        OperationEquivalence::IgnoreDiscardableAttrs;
+    // OperationEquivalence only checks for mlir::OpTrait::IsCommutative
+    if (!op->hasTrait<::mlir::OpTrait::IsCommutative>())
+      flags |= OperationEquivalence::IgnoreCommutativity;
+    if (OperationEquivalence::isEquivalentTo(op, nop, flags))
+      return true;
+    // stablehlo defines a special trait for commutative operations.
+    if (op->hasTrait<::mlir::hlo::OpTrait::IsCommutative>())
+      return isCommutativeEquivalent(op->getOperands(), nop->getOperands());
+    return false;
+  }
+
+  // The earlier operation of the block equivalent to `op`, if indexed.
+  Operation *twinOf(Operation *op, size_t hash) const {
+    auto bucket = buckets.find(hash);
+    if (bucket == buckets.end())
+      return nullptr;
+    for (Operation *nop : bucket->second) {
+      if (nop == op || nop->getBlock() != op->getBlock() ||
+          op->getName() != nop->getName() || !equivalent(op, nop))
+        continue;
+      return nop;
+    }
+    return nullptr;
   }
 
   static size_t hashOf(Operation *op) {
@@ -13297,8 +13329,27 @@ struct CSEIndex : public RewriterBase::Listener {
       add(op, hashOf(op));
   }
 
-  void populate(Operation *root) {
-    root->walk([&](Operation *op) { add(op); });
+  // Merge what is already duplicated before the driver sees it: a raised
+  // kernel can be 90% repeated index arithmetic, and letting the driver
+  // discover that one merge at a time re-queues every user of every merge.
+  // One pass in program order does it in linear time, exactly the merges
+  // the patterns would make (same block, same kinds); the patterns then
+  // only track the duplicates the rewrites create.
+  void mergeAndPopulate(Operation *root) {
+    SmallVector<Operation *> ops;
+    root->walk<WalkOrder::PreOrder>([&](Operation *op) {
+      if (indexable(op))
+        ops.push_back(op);
+    });
+    for (Operation *op : ops) {
+      size_t hash = hashOf(op);
+      if (Operation *twin = twinOf(op, hash)) {
+        op->replaceAllUsesWith(twin);
+        op->erase();
+        continue;
+      }
+      add(op, hash);
+    }
   }
 
   void notifyOperationInserted(Operation *op, OpBuilder::InsertPoint) override {
@@ -13312,7 +13363,9 @@ template <typename T> struct CSE final : CheckedOpRewritePattern<T, CSE<T>> {
   CSEIndex *index;
 
   CSE(CSEIndex *index, MLIRContext *context, PatternBenefit benefit)
-      : CheckedOpRewritePattern<T, CSE<T>>(context, benefit), index(index) {}
+      : CheckedOpRewritePattern<T, CSE<T>>(context, benefit), index(index) {
+    index->names.insert(OperationName(T::getOperationName(), context));
+  }
   // Registered on its own (the transform-dialect pattern names), the
   // pattern has no driver listener to keep an index live: it walks the use
   // list of the operand with the fewest users instead.
@@ -37417,7 +37470,13 @@ struct EnzymeHLOOptPass
     config.setUseTopDownTraversal(top_down);
     config.enableFolding();
     if (cse) {
-      cseIndex.populate(getOperation());
+      // Merge what is already duplicated before the driver sees it: a
+      // raised kernel can be 90% repeated index arithmetic, and letting the
+      // driver discover that one merge at a time re-queues every user of
+      // every merge. One hashed pass over the region does it in linear
+      // time; the indexed patterns then only track the duplicates the
+      // rewrites create.
+      cseIndex.mergeAndPopulate(getOperation());
       config.setListener(&cseIndex);
     }
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),

--- a/test/lit_tests/diffrules/stablehlo/transpose_elem_batch_autodiff.mlir
+++ b/test/lit_tests/diffrules/stablehlo/transpose_elem_batch_autodiff.mlir
@@ -24,9 +24,8 @@ module @reactant_vector_... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
   }
 }
 
-// CHECK:  func.func private @"fwddiffe4Const{typeof(fn)}(Main.fn)_autodiff"(%arg0: tensor<2x2xf32>, %arg1: tensor<4x2x2xf32>) -> (tensor<4xf32>, tensor<2x2xf32>, tensor<4x2x2xf32>) {
-// CHECK-NEXT:    %0 = stablehlo.broadcast_in_dim %arg0, dims = [2, 1] : (tensor<2x2xf32>) -> tensor<4x2x2xf32>
-// CHECK-NEXT:    %1 = stablehlo.add %0, %0 : tensor<4x2x2xf32>
-// CHECK-NEXT:    %2 = stablehlo.dot_general %arg1, %1, batching_dims = [0] x [0], contracting_dims = [2, 1] x [1, 2] : (tensor<4x2x2xf32>, tensor<4x2x2xf32>) -> tensor<4xf32>
-// CHECK-NEXT:    return %2, %arg0, %arg1 : tensor<4xf32>, tensor<2x2xf32>, tensor<4x2x2xf32>
+// CHECK:    func.func private @"fwddiffe4Const{typeof(fn)}(Main.fn)_autodiff"(%arg0: tensor<2x2xf32>, %arg1: tensor<4x2x2xf32>) -> (tensor<4xf32>, tensor<2x2xf32>, tensor<4x2x2xf32>) {
+// CHECK-NEXT:    %0 = stablehlo.dot_general %arg1, %arg0, contracting_dims = [2, 1] x [1, 0] : (tensor<4x2x2xf32>, tensor<2x2xf32>) -> tensor<4xf32>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %0 : tensor<4xf32>
+// CHECK-NEXT:    return %1, %arg0, %arg1 : tensor<4xf32>, tensor<2x2xf32>, tensor<4x2x2xf32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/affine_to_stablehlo19.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo19.mlir
@@ -14,15 +14,16 @@ module {
   }
 }
 
-// CHECK:  func.func private @broadcast_test_raised(%arg0: tensor<1x20xf32>, %arg1: tensor<10x10xf32>) -> (tensor<1x20xf32>, tensor<10x10xf32>) {
+// CHECK:    func.func private @broadcast_test_raised(%arg0: tensor<1x20xf32>, %arg1: tensor<10x10xf32>) -> (tensor<1x20xf32>, tensor<10x10xf32>) {
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %[[v0:.+]] = stablehlo.iota dim = 0 : tensor<10x10x1xi64>
-// CHECK-NEXT:    %[[v1:.+]] = stablehlo.iota dim = 1 : tensor<10x10x1xi64>
-// CHECK-NEXT:    %[[v2:.+]] = stablehlo.add %[[v0]], %[[v1]] : tensor<10x10x1xi64>
-// CHECK-NEXT:    %[[v3:.+]] = stablehlo.pad %[[v2]], %c, low = [0, 0, 1], high = [0, 0, 0], interior = [0, 0, 0] : (tensor<10x10x1xi64>, tensor<i64>) -> tensor<10x10x2xi64>
-// CHECK-NEXT:    %[[v4:.+]] = "stablehlo.gather"(%arg0, %[[v3]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<1x20xf32>, tensor<10x10x2xi64>) -> tensor<10x10xf32>
-// CHECK-NEXT:    %[[v5:.+]] = stablehlo.pad %[[v2]], %c, low = [0, 0, 0], high = [0, 0, 1], interior = [0, 0, 0] : (tensor<10x10x1xi64>, tensor<i64>) -> tensor<10x10x2xi64>
-// CHECK-NEXT:    %[[v6:.+]] = "stablehlo.gather"(%arg0, %[[v5]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<1x20xf32>, tensor<10x10x2xi64>) -> tensor<10x10xf32>
-// CHECK-NEXT:    %[[v7:.+]] = arith.addf %[[v4]], %[[v6]] : tensor<10x10xf32>
-// CHECK-NEXT:    return %arg0, %[[v7]] : tensor<1x20xf32>, tensor<10x10xf32>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<10x10xi64>
+// CHECK-NEXT:    %1 = stablehlo.iota dim = 1 : tensor<10x10xi64>
+// CHECK-NEXT:    %2 = stablehlo.add %0, %1 : tensor<10x10xi64>
+// CHECK-NEXT:    %3 = stablehlo.reshape %2 : (tensor<10x10xi64>) -> tensor<10x10x1xi64>
+// CHECK-NEXT:    %4 = stablehlo.pad %3, %c, low = [0, 0, 1], high = [0, 0, 0], interior = [0, 0, 0] : (tensor<10x10x1xi64>, tensor<i64>) -> tensor<10x10x2xi64>
+// CHECK-NEXT:    %5 = "stablehlo.gather"(%arg0, %4) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<1x20xf32>, tensor<10x10x2xi64>) -> tensor<10x10xf32>
+// CHECK-NEXT:    %6 = stablehlo.pad %3, %c, low = [0, 0, 0], high = [0, 0, 1], interior = [0, 0, 0] : (tensor<10x10x1xi64>, tensor<i64>) -> tensor<10x10x2xi64>
+// CHECK-NEXT:    %7 = "stablehlo.gather"(%arg0, %6) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<1x20xf32>, tensor<10x10x2xi64>) -> tensor<10x10xf32>
+// CHECK-NEXT:    %8 = arith.addf %5, %7 : tensor<10x10xf32>
+// CHECK-NEXT:    return %arg0, %8 : tensor<1x20xf32>, tensor<10x10xf32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/affine_to_stablehlo6.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo6.mlir
@@ -101,17 +101,17 @@ module {
     }
 }
 
-// CHECK:  func.func private @"##call__Z18gpu_compute__x_Az_16CompilerMetadataI10StaticSizeI6_185__E12DynamicCheckvv7NDRangeILi1ES0_I5_12__ES0_I5_16__EvvEE21LatitudeLongitudeGridI7Float648Periodic7Bounded4Flat28StaticVerticalDiscretizationIvvS9_S9_EvvS9_S9_11OffsetArrayIS9_Li1E12StepRangeLenIS9_14TwicePrecisionIS9_ESI_5Int64EESL_vESF_IS9_Li1E13CuTracedArrayIS9_Li1ELi1E6_186__EESP_SP_SP_SP_SP_SP_SP_#703$par65_raised"(%arg0: tensor<186xf64>, %arg1: tensor<186xf64>, %arg2: tensor<186xf64>, %arg3: tensor<186xf64>, %arg4: tensor<186xf64>, %arg5: tensor<186xf64>, %arg6: tensor<186xf64>, %arg7: tensor<186xf64>) -> (tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>) {
+// CHECK:    func.func private @"##call__Z18gpu_compute__x_Az_16CompilerMetadataI10StaticSizeI6_185__E12DynamicCheckvv7NDRangeILi1ES0_I5_12__ES0_I5_16__EvvEE21LatitudeLongitudeGridI7Float648Periodic7Bounded4Flat28StaticVerticalDiscretizationIvvS9_S9_EvvS9_S9_11OffsetArrayIS9_Li1E12StepRangeLenIS9_14TwicePrecisionIS9_ESI_5Int64EESL_vESF_IS9_Li1E13CuTracedArrayIS9_Li1ELi1E6_186__EESP_SP_SP_SP_SP_SP_SP_#703$par65_raised"(%arg0: tensor<186xf64>, %arg1: tensor<186xf64>, %arg2: tensor<186xf64>, %arg3: tensor<186xf64>, %arg4: tensor<186xf64>, %arg5: tensor<186xf64>, %arg6: tensor<186xf64>, %arg7: tensor<186xf64>) -> (tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>, tensor<186xf64>) {
 // CHECK-NEXT:    %cst = stablehlo.constant dense<111194.92664455874> : tensor<185xf64>
 // CHECK-NEXT:    %cst_0 = stablehlo.constant dense<0.017453292519943295> : tensor<185xf64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<-93> : tensor<185xi64>
 // CHECK-NEXT:    %cst_1 = stablehlo.constant dense<708422877652.48376> : tensor<185xf64>
-// CHECK-NEXT:    %c_2 = stablehlo.constant {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} dense<-91> : tensor<185xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<-91> : tensor<185xi64>
 // CHECK-NEXT:    %cst_3 = stablehlo.constant dense<5.000000e-01> : tensor<185xf64>
-// CHECK-NEXT:    %c_4 = stablehlo.constant {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} dense<-92> : tensor<185xi64>
-// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 {enzymexla.non_negative = [#enzymexla<guaranteed GUARANTEED>]} : tensor<185xi64>
-// CHECK-NEXT:    %1 = stablehlo.add %0, %c_4 {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<185xi64>
-// CHECK-NEXT:    %2 = stablehlo.convert %1 {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>], enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<185xi64>) -> tensor<185xf64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<-92> : tensor<185xi64>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<185xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c_4 : tensor<185xi64>
+// CHECK-NEXT:    %2 = stablehlo.convert %1 {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} : (tensor<185xi64>) -> tensor<185xf64>
 // CHECK-NEXT:    %3 = stablehlo.add %cst_3, %2 {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>]} : tensor<185xf64>
 // CHECK-NEXT:    %4 = stablehlo.multiply %3, %cst_0 : tensor<185xf64>
 // CHECK-NEXT:    %5 = stablehlo.cosine %4 : tensor<185xf64>
@@ -127,7 +127,7 @@ module {
 // CHECK-NEXT:    %15 = stablehlo.concatenate %14, %11, dim = 0 : (tensor<1xf64>, tensor<185xf64>) -> tensor<186xf64>
 // CHECK-NEXT:    %16 = stablehlo.slice %arg3 [0:1] : (tensor<186xf64>) -> tensor<1xf64>
 // CHECK-NEXT:    %17 = stablehlo.concatenate %16, %6, dim = 0 : (tensor<1xf64>, tensor<185xf64>) -> tensor<186xf64>
-// CHECK-NEXT:    %18 = stablehlo.add %0, %c_2 {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<185xi64>
+// CHECK-NEXT:    %18 = stablehlo.add %0, %c_2 : tensor<185xi64>
 // CHECK-NEXT:    %19 = stablehlo.convert %18 {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} : (tensor<185xi64>) -> tensor<185xf64>
 // CHECK-NEXT:    %20 = stablehlo.multiply %19, %cst_0 : tensor<185xf64>
 // CHECK-NEXT:    %21 = stablehlo.sine %20 : tensor<185xf64>
@@ -138,7 +138,7 @@ module {
 // CHECK-NEXT:    %26 = stablehlo.concatenate %25, %24, dim = 0 : (tensor<1xf64>, tensor<185xf64>) -> tensor<186xf64>
 // CHECK-NEXT:    %27 = stablehlo.sine %4 : tensor<185xf64>
 // CHECK-NEXT:    %28 = stablehlo.add %0, %c : tensor<185xi64>
-// CHECK-NEXT:    %29 = stablehlo.convert %28 {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>], enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<185xi64>) -> tensor<185xf64>
+// CHECK-NEXT:    %29 = stablehlo.convert %28 {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>], enzymexla.no_nan = [#enzymexla<guaranteed GUARANTEED>]} : (tensor<185xi64>) -> tensor<185xf64>
 // CHECK-NEXT:    %30 = stablehlo.add %cst_3, %29 {enzymexla.finite = [#enzymexla<guaranteed GUARANTEED>]} : tensor<185xf64>
 // CHECK-NEXT:    %31 = stablehlo.multiply %30, %cst_0 : tensor<185xf64>
 // CHECK-NEXT:    %32 = stablehlo.sine %31 : tensor<185xf64>

--- a/test/lit_tests/transpose_if2.mlir
+++ b/test/lit_tests/transpose_if2.mlir
@@ -37,21 +37,20 @@ module @reactant_conditi... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
   }
 }
 
-// CHECK: func.func @main(%arg0: tensor<10x2xf64> {tf.aliasing_output = 3 : i32}) -> (tensor<10x2xf64>, tensor<10x2xf64>, tensor<10x2xf64>, tensor<10x2xf64>) {
-// CHECK-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x2xf64>
-// CHECK-NEXT:     %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<1.000000e+00> : tensor<10x2xf64>
-// CHECK-NEXT:     %0 = stablehlo.add %arg0, %cst_1 : tensor<10x2xf64>
-// CHECK-NEXT:     %1 = stablehlo.negate %0 : tensor<10x2xf64>
-// CHECK-NEXT:     %2 = stablehlo.reduce(%0 init: %cst_0) applies stablehlo.add across dimensions = [1, 0] {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<10x2xf64>, tensor<f64>) -> tensor<f64>
-// CHECK-NEXT:     %3 = stablehlo.compare  GT, %2, %cst_0 : (tensor<f64>, tensor<f64>) -> tensor<i1>
-// CHECK-NEXT:     %4 = stablehlo.select %3, %arg0, %0 : tensor<i1>, tensor<10x2xf64>
-// CHECK-NEXT:     %5 = stablehlo.select %3, %0, %1 : tensor<i1>, tensor<10x2xf64>
-// CHECK-NEXT:     %6 = "stablehlo.if"(%3) ({
-// CHECK-NEXT:       stablehlo.return %0 : tensor<10x2xf64>
-// CHECK-NEXT:     }, {
-// CHECK-NEXT:       %7 = stablehlo.add %arg0, %cst : tensor<10x2xf64>
-// CHECK-NEXT:       stablehlo.return %7 : tensor<10x2xf64>
-// CHECK-NEXT:     }) : (tensor<i1>) -> tensor<10x2xf64>
-// CHECK-NEXT:     return %5, %4, %6, %arg0 : tensor<10x2xf64>, tensor<10x2xf64>, tensor<10x2xf64>, tensor<10x2xf64>
-// CHECK-NEXT:   }
+// CHECK:    func.func @main(%arg0: tensor<10x2xf64> {tf.aliasing_output = 3 : i32}) -> (tensor<10x2xf64>, tensor<10x2xf64>, tensor<10x2xf64>, tensor<10x2xf64>) {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<10x2xf64>
+// CHECK-NEXT:    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %cst_1 = stablehlo.constant dense<1.000000e+00> : tensor<10x2xf64>
+// CHECK-NEXT:    %0 = stablehlo.add %arg0, %cst_1 : tensor<10x2xf64>
+// CHECK-NEXT:    %1 = stablehlo.reduce(%0 init: %cst_0) applies stablehlo.add across dimensions = [1, 0] {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<10x2xf64>, tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:    %2 = stablehlo.compare GT, %1, %cst_0 : (tensor<f64>, tensor<f64>) -> tensor<i1>
+// CHECK-NEXT:    %3 = stablehlo.select %2, %arg0, %0 : tensor<i1>, tensor<10x2xf64>
+// CHECK-NEXT:    %4:2 = "stablehlo.if"(%2) ({
+// CHECK-NEXT:      stablehlo.return %0, %0 : tensor<10x2xf64>, tensor<10x2xf64>
+// CHECK-NEXT:    }, {
+// CHECK-NEXT:      %5 = stablehlo.add %arg0, %cst : tensor<10x2xf64>
+// CHECK-NEXT:      %6 = stablehlo.negate %0 : tensor<10x2xf64>
+// CHECK-NEXT:      stablehlo.return %6, %5 : tensor<10x2xf64>, tensor<10x2xf64>
+// CHECK-NEXT:    }) : (tensor<i1>) -> (tensor<10x2xf64>, tensor<10x2xf64>)
+// CHECK-NEXT:    return %4#0, %3, %4#1, %arg0 : tensor<10x2xf64>, tensor<10x2xf64>, tensor<10x2xf64>, tensor<10x2xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Stacked on #3125 (first commit is that PR).

With the CSE patterns fed from a hashed index, what remains of their cost is the driver's: every merge modifies every user of the merged op, each of those goes back on the worklist, and every pattern is tried on it again. A raised kernel can be 90% repeated index arithmetic (the worst mfem module has 114k ops, 10k after CSE), so the driver spends its time re-queueing the consequences of merges it could have started from.

`CSEIndex` now merges before the driver runs: one pass in program order over the kinds the CSE patterns cover, replacing each op by the earlier equivalent in its block, exactly the merges the patterns would make; the patterns then only track the duplicates the rewrites create.

| module | main | #3125 | this |
|---|---|---|---|
| worst (114k ops) | 290 s | 26 s | 1.4 s |
| largest (283k lines) | 220 s | 119 s | 2.2 s |
| same, `cse=false` | 8.6 s | 8.6 s | 8.6 s |

Four goldens change, and this is the part to weigh. Starting the driver from the merged graph changes which use-count-sensitive rewrites fire and how often ops are revisited: `affine_to_stablehlo19` keeps one `reshape` a broadcast used to absorb (one op more), `affine_to_stablehlo6` carries fewer `enzymexla.non_negative` annotations on the same ops (fewer revisits of the annotating pattern), `transpose_if2` and `transpose_elem_batch_autodiff` come out one op shorter. An MLIR `eliminateCommonSubExpressions` pre-pass was tried first: it merges across regions and changed nine goldens, several for the worse, so this keeps to the patterns' own scope (same block, same kinds, commutative-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
