### PR TITLE
Add module-owned persistent XLA temporaries

### DIFF
--- a/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
+++ b/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td
@@ -250,6 +250,49 @@ let skipDefaultBuilders = 1;
 let builders = [OpBuilder<(ins "ValueRange" : $blockSizes)>, OpBuilder<(ins)>];
 }
 
+def TempAllocOp : EnzymeXLA_Op<"temp_alloc", [Symbol, HasParent<"ModuleOp">]> {
+  let summary = "declare a module-owned persistent XLA allocation";
+  let description = [{
+    Declares uninitialized, statically shaped device storage allocated when
+    the module is initialized and freed when it is finalized. The declaration
+    must be private. Uses retrieve the allocation with `get_global_temp`;
+    accessing it does not allocate new storage.
+
+    The allocation belongs to the module's XLA runtime. Its contents are
+    mutable and shared by all uses, so callers must synchronize overlapping
+    accesses. The first write and subsequent updates remain explicit copies.
+    This operation does not move copies or computations across calls or loops.
+    Lowering currently requires an XLA backend and C-style memrefs.
+
+    Example:
+    ```mlir
+    enzymexla.temp_alloc "private" @bound : memref<i32, 1>
+    ```
+  }];
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       OptionalAttr<StrAttr>:$sym_visibility,
+                       TypeAttrOf<AnyMemRef>:$type);
+  let assemblyFormat = "($sym_visibility^)? $sym_name `:` $type attr-dict";
+  let hasVerifier = 1;
+}
+
+def GetGlobalTempOp : EnzymeXLA_Op<"get_global_temp", [
+    Pure, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "retrieve a persistent XLA allocation";
+  let description = [{
+    Returns the storage owned by a `temp_alloc` declaration. Repeated accesses
+    to the same symbol alias the same allocation; this operation is not an
+    allocation. The returned reference is borrowed and must not be freed or
+    used beyond the lifetime of the owning module's XLA runtime.
+
+    The allocation handle is stable even when the XLA runtime replaces the
+    underlying PJRT buffer after execution. Its contents are not constant.
+  }];
+  let arguments = (ins FlatSymbolRefAttr:$name);
+  let results = (outs AnyStaticShapeMemRef:$result);
+  let assemblyFormat = "$name `:` type($result) attr-dict";
+}
+
 def XLAWrapperOp : EnzymeXLA_Op<"xla_wrapper", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   DeclareOpInterfaceMethods<CallOpInterface>,

--- a/src/enzyme_ad/jax/Dialect/Ops.cpp
+++ b/src/enzyme_ad/jax/Dialect/Ops.cpp
@@ -2110,6 +2110,33 @@ void GPUErrorOp::build(OpBuilder &builder, OperationState &result) {
   GPUErrorOp::ensureTerminator(*bodyRegion, builder, result.location);
 }
 
+LogicalResult TempAllocOp::verify() {
+  if (!isPrivate())
+    return emitOpError("requires private visibility");
+  auto type = getType();
+  if (!type.hasStaticShape())
+    return emitOpError("requires a static shape");
+  if (!type.getLayout().isIdentity())
+    return emitOpError("requires an identity layout");
+  auto space = dyn_cast_or_null<IntegerAttr>(type.getMemorySpace());
+  if (!space || space.getInt() != 1)
+    return emitOpError("requires device memory space 1");
+  return success();
+}
+
+LogicalResult
+GetGlobalTempOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto allocation =
+      symbolTable.lookupNearestSymbolFrom<TempAllocOp>(*this, getNameAttr());
+  if (!allocation)
+    return emitOpError("'")
+           << getName() << "' does not reference a temp_alloc declaration";
+  if (allocation.getType() != getResult().getType())
+    return emitOpError("result type does not match the temp_alloc type ")
+           << allocation.getType();
+  return success();
+}
+
 LogicalResult
 XLAWrapperOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // TODO: Verify that the result type is same as the type of the referenced

--- a/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
+++ b/src/enzyme_ad/jax/Passes/ConvertPolygeistToLLVM.cpp
@@ -132,6 +132,11 @@ static Block *getAllocaBlock(Operation *op) {
   return nullptr;
 }
 
+// Runtime initialization must precede persistent temporary initialization;
+// destructor priorities run in the reverse order.
+static constexpr int32_t xlaRuntimePriority = 65534;
+static constexpr int32_t xlaTempsPriority = 65535;
+
 static Value insertXLAInitDeinit(mlir::ModuleOp moduleOp, StringRef backend,
                                  RewriterBase &rewriter) {
   auto loc = moduleOp.getLoc();
@@ -174,13 +179,13 @@ static Value insertXLAInitDeinit(mlir::ModuleOp moduleOp, StringRef backend,
     auto ctorSymbol = FlatSymbolRefAttr::get(ctor);
     LLVM::GlobalCtorsOp::create(
         rewriter, loc, rewriter.getArrayAttr({std::move(ctorSymbol)}),
-        rewriter.getI32ArrayAttr({65535}),
+        rewriter.getI32ArrayAttr({xlaRuntimePriority}),
         rewriter.getArrayAttr({LLVM::ZeroAttr::get(rewriter.getContext())}));
 
     auto dtorSymbol = FlatSymbolRefAttr::get(dtor);
     LLVM::GlobalDtorsOp::create(
         rewriter, loc, rewriter.getArrayAttr({std::move(dtorSymbol)}),
-        rewriter.getI32ArrayAttr({65535}),
+        rewriter.getI32ArrayAttr({xlaRuntimePriority}),
         rewriter.getArrayAttr({LLVM::ZeroAttr::get(rewriter.getContext())}));
 
     if (!data || data.getLinkage() == LLVM::Linkage::External) {
@@ -246,6 +251,116 @@ static Value insertXLAInitDeinit(mlir::ModuleOp moduleOp, StringRef backend,
   }
 
   return LLVM::AddressOfOp::create(rewriter, loc, ptrty, data.getSymNameAttr());
+}
+
+// Materialize module-owned allocations before dialect conversion so the
+// ordinary gpu.alloc/dealloc patterns select the XLA runtime ABI. This is
+// independent of the pass or frontend that created the declarations.
+static LogicalResult lowerGlobalTemps(ModuleOp module, StringRef backend,
+                                      bool useCStyleMemRef) {
+  SmallVector<TempAllocOp> allocations(module.getOps<TempAllocOp>());
+  if (allocations.empty())
+    return success();
+  if (!backend.starts_with("xla"))
+    return module.emitError("persistent temporaries require an XLA backend");
+  if (!useCStyleMemRef)
+    return module.emitError(
+        "persistent temporaries require C-style memref lowering");
+  for (TempAllocOp allocation : allocations) {
+    auto elementType = allocation.getType().getElementType();
+    // Diagnose unsupported element types before the ordinary allocation
+    // lowering tries to form an XLA shape for them.
+    if (xla::ConvertMlirTypeToPrimitiveType(elementType) ==
+        xla::PrimitiveType::PRIMITIVE_TYPE_INVALID)
+      return allocation.emitError("unsupported XLA element type ")
+             << elementType;
+  }
+
+  IRRewriter rewriter(module.getContext());
+  SymbolTable symbols(module);
+  auto loc = module.getLoc();
+  auto devicePtrType = LLVM::LLVMPointerType::get(module.getContext(), 1);
+  auto functionType = LLVM::LLVMFunctionType::get(
+      LLVM::LLVMVoidType::get(module.getContext()), {});
+  rewriter.setInsertionPointToEnd(module.getBody());
+  // These functions and slots must not be linkonce: different translation
+  // units own different temporaries even when their local names coincide.
+  auto ctor = LLVM::LLVMFuncOp::create(rewriter, loc, "__reactant_temps_init",
+                                       functionType, LLVM::Linkage::Internal);
+  symbols.insert(ctor);
+  auto dtor = LLVM::LLVMFuncOp::create(rewriter, loc, "__reactant_temps_deinit",
+                                       functionType, LLVM::Linkage::Internal);
+  symbols.insert(dtor);
+  auto *ctorBlock = ctor.addEntryBlock(rewriter);
+  auto *dtorBlock = dtor.addEntryBlock(rewriter);
+
+  DenseMap<Operation *, LLVM::GlobalOp> slots;
+  for (TempAllocOp allocation : allocations) {
+    rewriter.setInsertionPoint(allocation);
+    auto slot = LLVM::GlobalOp::create(
+        rewriter, allocation.getLoc(), devicePtrType, /*constant=*/false,
+        LLVM::Linkage::Internal,
+        ("__reactant_temp_" + allocation.getSymName()).str(), Attribute());
+    symbols.insert(slot);
+    slots[allocation] = slot;
+    auto *initializer = new Block();
+    slot.getInitializerRegion().push_back(initializer);
+    rewriter.setInsertionPointToEnd(initializer);
+    auto null = LLVM::ZeroOp::create(rewriter, loc, devicePtrType);
+    LLVM::ReturnOp::create(rewriter, loc, ValueRange{null});
+
+    rewriter.setInsertionPointToEnd(ctorBlock);
+    auto storage = gpu::AllocOp::create(
+        rewriter, loc, allocation.getType(), /*asyncToken=*/Type(),
+        /*asyncDependencies=*/ValueRange(), /*dynamicSizes=*/ValueRange(),
+        /*symbolOperands=*/ValueRange());
+    auto handle = Memref2PointerOp::create(rewriter, loc, devicePtrType,
+                                           storage.getMemref());
+    auto address = LLVM::AddressOfOp::create(rewriter, loc, slot);
+    LLVM::StoreOp::create(rewriter, loc, handle, address);
+
+    rewriter.setInsertionPointToStart(dtorBlock);
+    address = LLVM::AddressOfOp::create(rewriter, loc, slot);
+    auto loaded = LLVM::LoadOp::create(rewriter, loc, devicePtrType, address);
+    auto memref =
+        Pointer2MemrefOp::create(rewriter, loc, allocation.getType(), loaded);
+    gpu::DeallocOp::create(rewriter, loc, /*asyncToken=*/Type(),
+                           /*asyncDependencies=*/ValueRange(), memref);
+    null = LLVM::ZeroOp::create(rewriter, loc, devicePtrType);
+    LLVM::StoreOp::create(rewriter, loc, null, address);
+  }
+
+  rewriter.setInsertionPointToEnd(ctorBlock);
+  LLVM::ReturnOp::create(rewriter, loc, ValueRange());
+  rewriter.setInsertionPointToEnd(dtorBlock);
+  LLVM::ReturnOp::create(rewriter, loc, ValueRange());
+  rewriter.setInsertionPointToEnd(module.getBody());
+  LLVM::GlobalCtorsOp::create(
+      rewriter, loc, rewriter.getArrayAttr({FlatSymbolRefAttr::get(ctor)}),
+      rewriter.getI32ArrayAttr({xlaTempsPriority}),
+      rewriter.getArrayAttr({LLVM::ZeroAttr::get(module.getContext())}));
+  LLVM::GlobalDtorsOp::create(
+      rewriter, loc, rewriter.getArrayAttr({FlatSymbolRefAttr::get(dtor)}),
+      rewriter.getI32ArrayAttr({xlaTempsPriority}),
+      rewriter.getArrayAttr({LLVM::ZeroAttr::get(module.getContext())}));
+
+  SmallVector<GetGlobalTempOp> accesses;
+  module.walk([&](GetGlobalTempOp access) {
+    if (access->getParentOfType<ModuleOp>() == module)
+      accesses.push_back(access);
+  });
+  for (GetGlobalTempOp access : accesses) {
+    auto allocation = symbols.lookup<TempAllocOp>(access.getName());
+    auto slot = slots.lookup(allocation);
+    rewriter.setInsertionPoint(access);
+    auto address = LLVM::AddressOfOp::create(rewriter, loc, slot);
+    auto handle = LLVM::LoadOp::create(rewriter, loc, devicePtrType, address);
+    rewriter.replaceOpWithNewOp<Pointer2MemrefOp>(
+        access, access.getResult().getType(), handle);
+  }
+  for (TempAllocOp allocation : allocations)
+    rewriter.eraseOp(allocation);
+  return success();
 }
 
 struct Stream2TokenOpLowering : public ConvertOpToLLVMPattern<StreamToTokenOp> {
@@ -4737,6 +4852,10 @@ struct ConvertPolygeistToLLVMPass
     if (useCStyleMemRef && useBarePtrCallConv) {
       emitError(m.getLoc()) << "C-style memref lowering is not compatible with "
                                "bare-pointer calling convention";
+      signalPassFailure();
+      return;
+    }
+    if (failed(lowerGlobalTemps(m, backend, useCStyleMemRef))) {
       signalPassFailure();
       return;
     }

--- a/test/lit_tests/lowering/xla-global-temps-invalid.mlir
+++ b/test/lit_tests/lowering/xla-global-temps-invalid.mlir
@@ -1,0 +1,55 @@
+// RUN: enzymexlamlir-opt %s --split-input-file --verify-diagnostics
+
+module {
+  // expected-error @+1 {{requires private visibility}}
+  enzymexla.temp_alloc @bound : memref<i32, 1>
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{requires a static shape}}
+  enzymexla.temp_alloc "private" @bound : memref<?xi32, 1>
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{requires an identity layout}}
+  enzymexla.temp_alloc "private" @bound : memref<4xi32, strided<[2]>, 1>
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{requires device memory space 1}}
+  enzymexla.temp_alloc "private" @bound : memref<i32>
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{requires device memory space 1}}
+  enzymexla.temp_alloc "private" @bound : memref<i32, "device">
+}
+
+// -----
+
+module {
+  func.func @missing() -> memref<i32, 1> {
+    // expected-error @+1 {{'bound' does not reference a temp_alloc declaration}}
+    %device = enzymexla.get_global_temp @bound : memref<i32, 1>
+    return %device : memref<i32, 1>
+  }
+}
+
+// -----
+
+module {
+  enzymexla.temp_alloc "private" @bound : memref<i32, 1>
+  func.func @mismatch() -> memref<i64, 1> {
+    // expected-error @+1 {{result type does not match the temp_alloc type}}
+    %device = enzymexla.get_global_temp @bound : memref<i64, 1>
+    return %device : memref<i64, 1>
+  }
+}

--- a/test/lit_tests/lowering/xla-global-temps-symbols.mlir
+++ b/test/lit_tests/lowering/xla-global-temps-symbols.mlir
@@ -1,0 +1,29 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(symbol-dce,convert-polygeist-to-llvm{backend=xla-gpu})" | FileCheck %s
+
+module {
+  // Generated LLVM symbols must not collide with existing symbols. Symbol DCE
+  // must retain the declaration referenced by get_global_temp.
+  llvm.func @__reactant_temps_init()
+  llvm.func @__reactant_temps_deinit()
+  llvm.mlir.global external @__reactant_temp_bound() : i32
+  enzymexla.temp_alloc "private" @bound : memref<i32, 1>
+
+  func.func @get_bound() -> memref<i32, 1> {
+    %bound = enzymexla.get_global_temp @bound : memref<i32, 1>
+    return %bound : memref<i32, 1>
+  }
+}
+
+// CHECK: llvm.mlir.global external @__reactant_temp_bound()
+// CHECK: llvm.mlir.global internal @[[SLOT:__reactant_temp_bound_[0-9]+]]()
+// CHECK-LABEL: llvm.func @get_bound()
+// CHECK: llvm.mlir.addressof @[[SLOT]]
+// CHECK: llvm.load
+// CHECK: llvm.func internal @[[CTOR:__reactant_temps_init_[0-9]+]]()
+// CHECK: llvm.mlir.addressof @[[SLOT]]
+// CHECK: llvm.call @reactantXLAMalloc
+// CHECK: llvm.func internal @[[DTOR:__reactant_temps_deinit_[0-9]+]]()
+// CHECK: llvm.mlir.addressof @[[SLOT]]
+// CHECK: llvm.call @reactantXLAFree
+// CHECK: llvm.mlir.global_ctors ctors = [@[[CTOR]]]
+// CHECK: llvm.mlir.global_dtors dtors = [@[[DTOR]]]

--- a/test/lit_tests/lowering/xla-global-temps-types.mlir
+++ b/test/lit_tests/lowering/xla-global-temps-types.mlir
@@ -1,0 +1,20 @@
+// RUN: enzymexlamlir-opt %s --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=xla-gpu})"
+
+module {
+  // expected-error @+1 {{unsupported XLA element type 'index'}}
+  enzymexla.temp_alloc "private" @bound : memref<index, 1>
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{unsupported XLA element type 'i128'}}
+  enzymexla.temp_alloc "private" @bound : memref<i128, 1>
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{unsupported XLA element type 'complex<f16>'}}
+  enzymexla.temp_alloc "private" @bound : memref<complex<f16>, 1>
+}

--- a/test/lit_tests/lowering/xla-global-temps.mlir
+++ b/test/lit_tests/lowering/xla-global-temps.mlir
@@ -1,0 +1,77 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=xla-gpu})" | FileCheck %s
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=xla-cpu})" | FileCheck %s
+// RUN: enzymexlamlir-opt %s --cse | FileCheck %s --check-prefix=CSE
+// RUN: not enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=cuda})" 2>&1 | FileCheck %s --check-prefix=BACKEND
+// RUN: not enzymexlamlir-opt %s --pass-pipeline="builtin.module(convert-polygeist-to-llvm{backend=xla-gpu use-c-style-memref=false})" 2>&1 | FileCheck %s --check-prefix=DESCRIPTOR
+
+// No megakernelize pass is involved. Two accesses to a symbol share storage;
+// separate declarations own separate allocations. The copy remains in update.
+module {
+  enzymexla.temp_alloc "private" @bound : memref<i32, 1>
+  enzymexla.temp_alloc "private" @other : memref<1xi64, 1>
+
+  func.func @update(%value: i32) {
+    %zero = arith.constant 0 : index
+    %four = arith.constant 4 : index
+    %host = memref.alloca() : memref<1xi32>
+    memref.store %value, %host[%zero] : memref<1xi32>
+    %device = enzymexla.get_global_temp @bound : memref<i32, 1>
+    enzymexla.memcpy %device, %host, %four : memref<i32, 1>, memref<1xi32>
+    return
+  }
+
+  func.func @get_bound() -> memref<i32, 1> {
+    %first = enzymexla.get_global_temp @bound : memref<i32, 1>
+    %second = enzymexla.get_global_temp @bound : memref<i32, 1>
+    func.call @consume(%first, %second) : (memref<i32, 1>, memref<i32, 1>) -> ()
+    return %second : memref<i32, 1>
+  }
+  func.func private @consume(memref<i32, 1>, memref<i32, 1>)
+}
+
+// CHECK-DAG: llvm.mlir.global internal @[[BOUND:__reactant_temp_bound]]
+// CHECK-DAG: llvm.mlir.global internal @[[OTHER:__reactant_temp_other]]
+// CHECK-LABEL: llvm.func @update(
+// CHECK-NOT: llvm.call @reactantXLAMalloc
+// CHECK: llvm.mlir.addressof @[[BOUND]]
+// CHECK: llvm.load
+// CHECK: llvm.call @reactantXLAMemcpy
+// CHECK-NOT: llvm.call @reactantXLAFree
+// CHECK: llvm.return
+// CHECK-LABEL: llvm.func @get_bound(
+// CHECK-NOT: llvm.call @reactantXLAMalloc
+// CHECK: llvm.mlir.addressof @[[BOUND]]
+// CHECK: llvm.load
+// CHECK-NOT: llvm.call @reactantXLAFree
+// CHECK: llvm.return
+// CHECK-LABEL: llvm.func internal @__reactant_temps_init()
+// CHECK-DAG: %[[INIT_BOUND:.*]] = llvm.mlir.addressof @[[BOUND]]
+// CHECK-DAG: %[[INIT_OTHER:.*]] = llvm.mlir.addressof @[[OTHER]]
+// CHECK: llvm.call @reactantXLAMalloc
+// CHECK: llvm.store %{{.*}}, %[[INIT_BOUND]] : !llvm.ptr<1>, !llvm.ptr
+// CHECK: llvm.call @reactantXLAMalloc
+// CHECK: llvm.store %{{.*}}, %[[INIT_OTHER]] : !llvm.ptr<1>, !llvm.ptr
+// CHECK: llvm.return
+// CHECK-LABEL: llvm.func internal @__reactant_temps_deinit()
+// CHECK-DAG: %[[FINI_BOUND:.*]] = llvm.mlir.addressof @[[BOUND]]
+// CHECK-DAG: %[[FINI_OTHER:.*]] = llvm.mlir.addressof @[[OTHER]]
+// CHECK-DAG: %[[NULL:.*]] = llvm.mlir.zero : !llvm.ptr<1>
+// CHECK: llvm.load %[[FINI_OTHER]]
+// CHECK: llvm.call @reactantXLAFree
+// CHECK: llvm.store %[[NULL]], %[[FINI_OTHER]]
+// CHECK: llvm.load %[[FINI_BOUND]]
+// CHECK: llvm.call @reactantXLAFree
+// CHECK: llvm.store %[[NULL]], %[[FINI_BOUND]]
+// CHECK: llvm.return
+// CHECK-DAG: llvm.mlir.global_ctors ctors = [@__reactant_temps_init], priorities = [65535 : i32]
+// CHECK-DAG: llvm.mlir.global_dtors dtors = [@__reactant_temps_deinit], priorities = [65535 : i32]
+// CHECK-DAG: llvm.mlir.global_ctors ctors = [@__reactant_xla_init], priorities = [65534 : i32]
+// CHECK-DAG: llvm.mlir.global_dtors dtors = [@__reactant_xla_deinit], priorities = [65534 : i32]
+
+// CSE-LABEL: func.func @get_bound
+// CSE: %[[HANDLE:.*]] = enzymexla.get_global_temp @bound
+// CSE-NOT: enzymexla.get_global_temp
+// CSE: call @consume(%[[HANDLE]], %[[HANDLE]])
+
+// BACKEND: persistent temporaries require an XLA backend
+// DESCRIPTOR: persistent temporaries require C-style memref lowering

--- a/test/lit_tests/lowering/xla.mlir
+++ b/test/lit_tests/lowering/xla.mlir
@@ -134,6 +134,6 @@ module {
 // CHECK-NEXT:    llvm.call @reactantXLADeInit(%0) : (!llvm.ptr) -> ()
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
-// CHECK:  llvm.mlir.global_ctors ctors = [@__reactant_xla_init], priorities = [65535 : i32], data = [#llvm.zero]
-// CHECK:  llvm.mlir.global_dtors dtors = [@__reactant_xla_deinit], priorities = [65535 : i32], data = [#llvm.zero]
+// CHECK:  llvm.mlir.global_ctors ctors = [@__reactant_xla_init], priorities = [65534 : i32], data = [#llvm.zero]
+// CHECK:  llvm.mlir.global_dtors dtors = [@__reactant_xla_deinit], priorities = [65534 : i32], data = [#llvm.zero]
 // CHECK:  llvm.mlir.global linkonce @__reactant_xla_data() {addr_space = 0 : i32, alignment = 8 : i64} : !llvm.ptr


### PR DESCRIPTION
Host code needs XLA temporary buffers that survive repeated calls without allocating and freeing storage on every invocation. Add `enzymexla.temp_alloc` to declare module-owned storage and `enzymexla.get_global_temp` to retrieve its stable, borrowed handle.

`convert-polygeist-to-llvm` lowers declarations to internal handle slots and LLVM constructors/destructors using the existing XLA allocation ABI. Runtime initialization has priority 65534 and temporary initialization has priority 65535, so the shared runtime outlives every module's temporaries. Internal linkage keeps identically named temporaries in separate translation units distinct.

The operations can be emitted independently of `XLAMegakernelizePass`. Copies remain explicit at their original sites; switching LBM's producer to these operations and copy hoisting are separate follow-ups. The initial implementation supports static, identity-layout device memrefs with C-style lowering and documents synchronization requirements for overlapping uses.

Validation:

- Added four LIT tests covering XLA CPU/GPU lowering, constructor/destructor priorities, repeated access/CSE, symbol retention and name collisions, and invalid declarations/types/backend options. Updated the existing XLA lowering test for the runtime priority.
- All 14 selected LIT regression targets passed locally.
- Built `enzymexlamlir-opt` and `mlir-translate`. Linked two separately lowered translation units and exercised them against both a counting mock and the locally built ReactantExtra on an RTX 5090: one shared runtime, two distinct persistent allocations, 200 updates, 400 copies, stable handles, and exactly two frees before runtime teardown.
