### PR TITLE
raise: cse and enzyme-hlo-opt each raised kernel once at compile time

### DIFF
--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -203,6 +203,12 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
                        ",llvm-to-affine-access," + canonicalize + ",";
       pass_pipeline += "func.func(kernelcast),raise-affine-to-stablehlo{prefer_while_raising=false "
       "dump_failed_lockstep=true}," + canonicalize + ",arith-raise{stablehlo=true},"
+      // Optimize each raised kernel once here, before the linked runtime
+      // specializes it to its buffer sizes at first execution: a raised
+      // kernel is largely repeated index arithmetic (cse alone takes the
+      // modules mfem embeds from 844 MB to 252 MB of text), and what
+      // enzyme-hlo-opt folds here it does not fold again per execution.
+      "cse,enzyme-hlo-opt," + canonicalize + ","
       "symbol-dce";
       if (outfile.size() && getenv("EXPORT_REACTANT")) {
         pass_pipeline += ",print{filename="+outfile+".mlir}";

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -203,11 +203,6 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
                        ",llvm-to-affine-access," + canonicalize + ",";
       pass_pipeline += "func.func(kernelcast),raise-affine-to-stablehlo{prefer_while_raising=false "
       "dump_failed_lockstep=true}," + canonicalize + ",arith-raise{stablehlo=true},"
-      // Optimize each raised kernel once here, before the linked runtime
-      // specializes it to its buffer sizes at first execution: a raised
-      // kernel is largely repeated index arithmetic (cse alone takes the
-      // modules mfem embeds from 844 MB to 252 MB of text), and what
-      // enzyme-hlo-opt folds here it does not fold again per execution.
       "cse,enzyme-hlo-opt," + canonicalize + ","
       "symbol-dce";
       if (outfile.size() && getenv("EXPORT_REACTANT")) {


### PR DESCRIPTION
Stacked on #3128 (the dynamic-extent slice fix; without it the optimizer aborts on 72 of the modules below, and a compile-time abort is a build failure).

The xla pipeline handed the raised kernels to the linked runtime as raised, and the runtime ran `enzyme-hlo-opt` on every refined copy at first execution. A raised kernel is largely repeated index arithmetic. Measured over the 1891 kernel modules mfem's GPU unit-test binary embeds (`enzymexlamlir-opt` on the extracted module strings):

| | text | ops | runtime-side `enzyme-hlo-opt` on the result, all modules |
|---|---|---|---|
| as raised (today) | 844 MB | 9.85M | 798 s with #3125 (3651 s without) |
| after `cse` | 252 MB | 2.56M | 227 s |
| after `cse,enzyme-hlo-opt,canonicalize` | 210 MB | 1.84M | 42 s |

So the pipeline now runs `cse,enzyme-hlo-opt,canonicalize` right after `arith-raise`, once per kernel at compile time. The runtime still refines and optimizes per execution; it just starts from the optimized kernel. On the union tree (#3117 plus #3128 and this), all 145 mfem objects compile strict as before (lit green) and the size effect is direct:

| | before | with this |
|---|---|---|
| 145 raised mfem objects | 2164 MB | 639 MB |
| `gpu_unit_tests` binary (linked runtime) | 1041 MB | 379 MB |

Compile time, all 145 mfem objects, CPU-seconds summed over the objects (48-way parallel sweep):

| plugin | compile | slowest object |
|---|---|---|
| without (today) | 5563 s | 354 s |
| this, optimizer as on `main` | 10475 s | 745 s |
| this + #3125 (CSE index) | 9298 s | 613 s |
| this + #3125 + #3131 (provenance walk bound) | 6465 s | 363 s |

The extra cost was eight `fem/tmop/metrics/3xx.cpp` translation units whose raised kernels are the largest in the tree; per the pass timing the optimizer spent 464 s of a 533 s compile in `DUSDUSSubsuming`'s provenance walk, which #3131 bounds. With both, the objects compile 16% slower than today and the slowest one is unchanged.

End to end on mfem's `H1 Assembly Levels` row (282 executions, xla-gpu client, the linked runtime built from the same tree in every row):

| | H1 Assembly Levels | result |
|---|---|---|
| today (kernels as raised, runtime optimizes each refined copy) | 770 s | 180/180 |
| runtime with #3125 only | 403 s | 180/180 |
| this (kernels optimized at compile time; runtime as today) | 278 s | 180/180 |
| `REACTANT_XLA_NO_HLO_OPT=1`, for scale | 318 s | 180/180 |

**Found:** the two rows fail because of `ScatterOpCanon`'s single-point scatter → `dynamic_update_slice` rewrite on `main`, the one #3022 guards. A raised lane-masked scatter sends its dead lanes to index -1, which a scatter drops and a DUS clamps to slot 0; running `AndSimplify` on the kernel at compile time folds the lane mask far enough that the rewrite fires on the DivDiv-diagonal kernel of `bilininteg_hdiv_kernels.cpp` at runtime. Reproduced offline: the runtime pipeline (`refine-arguments, refine-shapes, canonicalize-dynamism, enzyme-hlo-opt`) on that kernel with the recorded inputs of the failing execution gives the wrong diagonal with `main`'s optimizer, and the right one with `ScatterOpCanon` disabled, or with #3022's guard. `main`'s optimizer gets it wrong on the kernel as raised too; today the runtime only avoids it because the tree it is built from carries #3022.

With the runtime rebuilt from a tree that carries #3022 (the union branch), both rows pass on the same compile-time-optimized binary; its H1 timing and full suite are running. So this PR depends on #3022 as well: with the compile-time optimizer feeding the runtime kernels it has already simplified, the unguarded rewrite is reachable. Object-swap and pattern bisections, and the offline reproducer, are in the campaign notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
