### PR TITLE
Fuse disjoint point-scatter chains in EnzymeHLOOpt

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -55,12 +55,14 @@
 
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/IR/ConstantRange.h"
 
 #include "llvm/ADT/MapVector.h"
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <limits>
 #include <llvm/ADT/MapVector.h>
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
@@ -27711,6 +27713,265 @@ struct ScatterSubSimplify final
   }
 };
 
+// Combine independent point writes into a single scatter. In particular, this
+// avoids turning a chain of disjoint scatters into a chain of in-place updates
+// which a downstream GPU backend may be unable to fuse.
+struct ScatterDisjointConcat final
+    : CheckedOpRewritePattern<stablehlo::ScatterOp, ScatterDisjointConcat> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ScatterOp outer,
+                                    PatternRewriter &rewriter) const {
+    if (!isPointWrite(outer))
+      return failure();
+    auto inner = outer.getInputs()[0].getDefiningOp<stablehlo::ScatterOp>();
+    if (!inner || !isPointWrite(inner) || !inner->hasOneUse())
+      return failure();
+
+    auto innerIndices = inner.getScatterIndices();
+    auto outerIndices = outer.getScatterIndices();
+    if (innerIndices.getType().getElementType() !=
+        outerIndices.getType().getElementType())
+      return failure();
+
+    // unique_indices on each scatter does not establish uniqueness across
+    // scatters. Prove that their index sets are disjoint before combining them.
+    // ConstantRange models the index type's modular arithmetic, including
+    // overflow; mathematical integer bounds would not be sufficient here.
+    DenseMap<Value, llvm::ConstantRange> ranges;
+    if (!getIndexRange(innerIndices, ranges)
+             .intersectWith(getIndexRange(outerIndices, ranges))
+             .isEmptySet())
+      return failure();
+
+    int64_t innerCount = cast<RankedTensorType>(inner.getUpdates()[0].getType())
+                             .getNumElements();
+    int64_t outerCount = cast<RankedTensorType>(outer.getUpdates()[0].getType())
+                             .getNumElements();
+    if (innerCount > std::numeric_limits<int64_t>::max() - outerCount)
+      return failure();
+
+    auto loc = outer.getLoc();
+    // A point scatter's batch dimensions can be flattened without changing
+    // which update belongs to each index. This also handles different batch
+    // shapes and explicit/implicit singleton index-vector dimensions.
+    auto [innerIndex, innerUpdate] = flattenPointWrite(inner, rewriter);
+    auto [outerIndex, outerUpdate] = flattenPointWrite(outer, rewriter);
+    Value indices[] = {innerIndex, outerIndex};
+    Value updates[] = {innerUpdate, outerUpdate};
+    auto combinedIndices =
+        stablehlo::ConcatenateOp::create(rewriter, loc, indices, 0);
+    auto combinedUpdates =
+        stablehlo::ConcatenateOp::create(rewriter, loc, updates, 0);
+    auto dims = stablehlo::ScatterDimensionNumbersAttr::get(
+        rewriter.getContext(), /*updateWindowDims=*/{},
+        /*insertedWindowDims=*/{0}, /*inputBatchingDims=*/{},
+        /*scatterIndicesBatchingDims=*/{}, /*scatterDimsToOperandDims=*/{0},
+        /*indexVectorDim=*/1);
+    auto combined = stablehlo::ScatterOp::create(
+        rewriter, loc, outer.getResultTypes(), inner.getInputs(),
+        combinedIndices, ValueRange{combinedUpdates}, dims,
+        /*indicesAreSorted=*/false, /*uniqueIndices=*/true);
+    rewriter.cloneRegionBefore(outer.getUpdateComputation(),
+                               combined.getUpdateComputation(),
+                               combined.getUpdateComputation().end());
+    rewriter.replaceOp(outer, combined);
+    rewriter.eraseOp(inner);
+    return success();
+  }
+
+private:
+  static Value transposeIndexGrid(Value value, ArrayRef<int64_t> permutation,
+                                  PatternRewriter &rewriter,
+                                  DenseMap<Value, Value> &cache) {
+    if (auto found = cache.find(value); found != cache.end())
+      return found->second;
+    auto type = cast<RankedTensorType>(value.getType());
+    SmallVector<int64_t> shape;
+    for (int64_t dim : permutation)
+      shape.push_back(type.getDimSize(dim));
+    auto transposedType = type.clone(shape);
+    auto inverse = getInversePermutation(permutation);
+    auto loc = value.getLoc();
+    Value result;
+    if (auto iota = value.getDefiningOp<stablehlo::IotaOp>()) {
+      result = stablehlo::IotaOp::create(rewriter, loc, transposedType,
+                                         inverse[iota.getIotaDimension()]);
+    } else if (auto broadcast =
+                   value.getDefiningOp<stablehlo::BroadcastInDimOp>()) {
+      SmallVector<int64_t> dims;
+      for (int64_t dim : broadcast.getBroadcastDimensions())
+        dims.push_back(inverse[dim]);
+      if (llvm::is_sorted(dims))
+        result = stablehlo::BroadcastInDimOp::create(
+            rewriter, loc, transposedType, broadcast.getOperand(), dims);
+    } else if (auto *def = value.getDefiningOp();
+               isa_and_nonnull<stablehlo::AddOp, stablehlo::SubtractOp,
+                               stablehlo::MulOp, stablehlo::ConvertOp>(def)) {
+      SmallVector<Value> operands;
+      for (Value operand : def->getOperands())
+        operands.push_back(
+            transposeIndexGrid(operand, permutation, rewriter, cache));
+      result = rewriter
+                   .create(loc, def->getName().getIdentifier(), operands,
+                           TypeRange{transposedType}, def->getAttrs(), {}, {})
+                   ->getResult(0);
+    }
+    if (!result)
+      result =
+          stablehlo::TransposeOp::create(rewriter, loc, value, permutation);
+    cache[value] = result;
+    return result;
+  }
+
+  static std::pair<Value, Value> flattenPointWrite(stablehlo::ScatterOp op,
+                                                   PatternRewriter &rewriter) {
+    Value indices = op.getScatterIndices();
+    Value updates = op.getUpdates()[0];
+    int64_t count = cast<RankedTensorType>(updates.getType()).getNumElements();
+    Value grid = indices;
+    if (auto reshape = grid.getDefiningOp<stablehlo::ReshapeOp>())
+      grid = reshape.getOperand();
+    auto gridTy = cast<RankedTensorType>(grid.getType());
+    SmallVector<IotaLikeTensor> iotas;
+    if (gridTy.getRank() > 1 && extractGridIotas(grid, iotas) &&
+        llvm::all_of(iotas, [&](const auto &iota) {
+          return iota.dimension >= 0 && iota.dimension < gridTy.getRank();
+        })) {
+      unsigned width = gridTy.getElementType().getIntOrFloatBitWidth();
+      SmallVector<APInt> strides(gridTy.getRank(), APInt(width, 0));
+      for (const auto &iota : iotas)
+        strides[iota.dimension] +=
+            cast<IntegerAttr>(iota.scale).getValue().sextOrTrunc(width);
+      SmallVector<int64_t> permutation;
+      for (int64_t d = 0; d < gridTy.getRank(); ++d)
+        permutation.push_back(d);
+      // Visit the smallest-stride dimension fastest before flattening. This
+      // lets update producers keep the layout matching their destination
+      // accesses instead of materializing transposes for the concatenation.
+      // Strides are only a layout heuristic: any common permutation preserves
+      // the index/update pairing and is legal for these unique point writes.
+      llvm::stable_sort(permutation, [&](int64_t a, int64_t b) {
+        return strides[a].abs().ugt(strides[b].abs());
+      });
+      if (!isIotaRange(permutation)) {
+        updates = stablehlo::ReshapeOpCreate(rewriter, op.getLoc(), updates,
+                                             gridTy.getShape());
+        updates = stablehlo::TransposeOp::create(rewriter, op.getLoc(), updates,
+                                                 permutation);
+        // Commute the permutation through inexpensive index arithmetic even
+        // when it is shared. Leaving a transpose of an iota expression here
+        // can make the backend materialize the entire index tensor. Preserve
+        // the arithmetic itself (including conversions and integer overflow),
+        // rather than reconstructing it from the layout heuristic's strides.
+        DenseMap<Value, Value> cache;
+        indices = transposeIndexGrid(grid, permutation, rewriter, cache);
+      }
+    }
+    return {
+        stablehlo::ReshapeOpCreate(rewriter, op.getLoc(), indices, {count, 1}),
+        stablehlo::ReshapeOpCreate(rewriter, op.getLoc(), updates, {count})};
+  }
+
+  static bool isPointWrite(stablehlo::ScatterOp op) {
+    if (op.getInputs().size() != 1 || !op.getUniqueIndices() ||
+        !isSetindexBlock(&op.getUpdateComputation().front()))
+      return false;
+    auto inputTy = cast<RankedTensorType>(op.getInputs()[0].getType());
+    auto indicesTy = op.getScatterIndices().getType();
+    auto updateTy = cast<RankedTensorType>(op.getUpdates()[0].getType());
+    if (inputTy.getRank() != 1 || !inputTy.hasStaticShape() ||
+        !indicesTy.hasStaticShape() || !updateTy.hasStaticShape() ||
+        updateTy.getNumElements() == 0)
+      return false;
+    auto dims = op.getScatterDimensionNumbers();
+    if (!dims.getUpdateWindowDims().empty() ||
+        dims.getInsertedWindowDims() != ArrayRef<int64_t>{0} ||
+        !dims.getInputBatchingDims().empty() ||
+        !dims.getScatterIndicesBatchingDims().empty() ||
+        dims.getScatterDimsToOperandDims() != ArrayRef<int64_t>{0})
+      return false;
+    return indicesTy.getNumElements() == updateTy.getNumElements();
+  }
+
+  static llvm::ConstantRange
+  getIndexRange(Value value, DenseMap<Value, llvm::ConstantRange> &cache,
+                unsigned depth = 0) {
+    if (auto found = cache.find(value); found != cache.end())
+      return found->second;
+    auto type = cast<RankedTensorType>(value.getType());
+    unsigned width = type.getElementType().getIntOrFloatBitWidth();
+    auto full = llvm::ConstantRange::getFull(width);
+    // Boolean conversion uses nonzero tests, not integer truncation. Keep its
+    // range conservative instead of applying modular arithmetic to i1 values.
+    if (depth == 64 || width == 1)
+      return full;
+    auto infer = [&]() -> llvm::ConstantRange {
+      if (!type.hasStaticShape())
+        return full;
+      if (type.getNumElements() == 0)
+        return llvm::ConstantRange::getEmpty(width);
+      DenseIntElementsAttr constant;
+      if (matchPattern(value, m_Constant(&constant))) {
+        if (constant.isSplat())
+          return llvm::ConstantRange(constant.getSplatValue<APInt>());
+        auto values = constant.getValues<APInt>();
+        APInt lower = *values.begin(), upper = lower;
+        for (const APInt &element : values) {
+          if (element.ult(lower))
+            lower = element;
+          if (element.ugt(upper))
+            upper = element;
+        }
+        return llvm::ConstantRange::getNonEmpty(lower, upper + 1);
+      }
+      if (auto iota = value.getDefiningOp<stablehlo::IotaOp>()) {
+        uint64_t size = type.getDimSize(iota.getIotaDimension());
+        if (APInt(64, size).getActiveBits() > width)
+          return full;
+        return llvm::ConstantRange::getNonEmpty(APInt(width, 0),
+                                                APInt(width, size));
+      }
+      auto range = [&](Value operand) {
+        return getIndexRange(operand, cache, depth + 1);
+      };
+      auto *op = value.getDefiningOp();
+      if (!op)
+        return full;
+      if (isa<stablehlo::ReshapeOp, stablehlo::TransposeOp,
+              stablehlo::BroadcastInDimOp, stablehlo::ReverseOp,
+              stablehlo::SliceOp, stablehlo::DynamicSliceOp>(op))
+        return range(op->getOperand(0));
+      if (auto convert = dyn_cast<stablehlo::ConvertOp>(op)) {
+        auto sourceType = dyn_cast<IntegerType>(
+            convert.getOperand().getType().getElementType());
+        if (!sourceType)
+          return full;
+        auto sourceRange = range(convert.getOperand());
+        return sourceType.isUnsigned() || sourceType.getWidth() == 1
+                   ? sourceRange.zextOrTrunc(width)
+                   : sourceRange.sextOrTrunc(width);
+      }
+      if (isa<stablehlo::AddOp>(op))
+        return range(op->getOperand(0)).add(range(op->getOperand(1)));
+      if (isa<stablehlo::SubtractOp>(op))
+        return range(op->getOperand(0)).sub(range(op->getOperand(1)));
+      if (isa<stablehlo::MulOp>(op))
+        return range(op->getOperand(0)).multiply(range(op->getOperand(1)));
+      if (auto concat = dyn_cast<stablehlo::ConcatenateOp>(op)) {
+        auto result = llvm::ConstantRange::getEmpty(width);
+        for (Value operand : concat.getOperands())
+          result = result.unionWith(range(operand));
+        return result;
+      }
+      return full;
+    };
+    auto result = infer();
+    cache.try_emplace(value, result);
+    return result;
+  }
+};
+
 // Fuse scatter(scatter(input, indices, updates1) { body1 }, indices, updates2)
 // { body2 } into a single scatter when both use the same indices and scatter
 // dimension numbers.
@@ -36975,6 +37236,10 @@ struct EnzymeHLOOptPass
 
     RewritePatternSet patterns(context);
     mlir::enzyme::populateWithGenerated(patterns);
+
+    // Combine disjoint writes before individual scatters become in-place DUS
+    // operations. This is enabled in the normal optimization pipeline.
+    patterns.add<ScatterDisjointConcat>(context, PatternBenefit(2));
 
     patterns.add<SliceExtend>(context);
     patterns.add<SliceRotate>(context);

--- a/test/lit_tests/scatter_concat_layout.mlir
+++ b/test/lit_tests/scatter_concat_layout.mlir
@@ -1,0 +1,57 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt %s | FileCheck %s
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt='max_constant_expansion=0' %s | FileCheck %s --check-prefix=SYMBOLIC --implicit-check-not='stablehlo.transpose{{.*}}xi32'
+
+// The original batch order visits x first, then y:
+//   indices_a = [[0, 8, 16], [1, 9, 17]]
+//   indices_b = [[32, 40, 48], [33, 41, 49]]
+//
+// The destination stride is 1 along x and 8 along y. Before concatenating,
+// visit x fastest by transposing BOTH indices and updates. This preserves
+// the association of each value with its destination while allowing update
+// producers to use the layout of contiguous destination accesses.
+//
+// The combined indices must be [0,1,8,9,16,17,32,33,40,41,48,49], with updates
+// taken from transpose(a), then transpose(b), in exactly that order.
+//
+// Also disable constant expansion to model a large index grid. Generate its
+// iotas in the new order directly, even though the original grid is shared by
+// both scatters. A transpose of the integer grid would invite an extra kernel
+// to materialize indices; transposes of the update tensors remain legal.
+// SYMBOLIC-LABEL: func.func @contiguous_dimension_fastest
+// SYMBOLIC-DAG: %[[STRIDE:.*]] = stablehlo.constant dense<8> : tensor<3x2xi32>
+// SYMBOLIC: %[[X:.*]] = stablehlo.iota dim = 1 : tensor<3x2xi32>
+// SYMBOLIC: %[[Y:.*]] = stablehlo.iota dim = 0 : tensor<3x2xi32>
+// SYMBOLIC: %[[SY:.*]] = stablehlo.multiply %[[Y]], %[[STRIDE]]
+// SYMBOLIC: %[[GRID:.*]] = stablehlo.add %[[X]], %[[SY]]
+// SYMBOLIC: stablehlo.reshape %[[GRID]] : (tensor<3x2xi32>) -> tensor<6x1xi32>
+// SYMBOLIC: "stablehlo.scatter"
+// CHECK-LABEL: func.func @contiguous_dimension_fastest
+// CHECK-DAG: %[[INDICES:.*]] = stablehlo.constant dense<{{\[}}[0], [1], [8], [9], [16], [17], [32], [33], [40], [41], [48], [49]]> : tensor<12x1xi32>
+// CHECK-DAG: %[[AT:.*]] = stablehlo.transpose %arg1, dims = [1, 0] : (tensor<2x3xf32>) -> tensor<3x2xf32>
+// CHECK-DAG: %[[BT:.*]] = stablehlo.transpose %arg2, dims = [1, 0] : (tensor<2x3xf32>) -> tensor<3x2xf32>
+// CHECK-DAG: %[[AF:.*]] = stablehlo.reshape %[[AT]] : (tensor<3x2xf32>) -> tensor<6xf32>
+// CHECK-DAG: %[[BF:.*]] = stablehlo.reshape %[[BT]] : (tensor<3x2xf32>) -> tensor<6xf32>
+// CHECK: %[[UPDATES:.*]] = stablehlo.concatenate %[[AF]], %[[BF]], dim = 0
+// CHECK-NEXT: %[[RESULT:.*]] = "stablehlo.scatter"(%arg0, %[[INDICES]], %[[UPDATES]])
+// CHECK-SAME: unique_indices = true
+// CHECK: return %[[RESULT]]
+func.func @contiguous_dimension_fastest(%destination: tensor<80xf32>, %a: tensor<2x3xf32>, %b: tensor<2x3xf32>) -> tensor<80xf32> {
+  %x = stablehlo.iota dim = 0 : tensor<2x3xi32>
+  %y = stablehlo.iota dim = 1 : tensor<2x3xi32>
+  %stride = stablehlo.constant dense<8> : tensor<2x3xi32>
+  %offset = stablehlo.constant dense<32> : tensor<2x3xi32>
+  %scaled_y = stablehlo.multiply %y, %stride : tensor<2x3xi32>
+  %grid = stablehlo.add %x, %scaled_y : tensor<2x3xi32>
+  %shifted = stablehlo.add %grid, %offset : tensor<2x3xi32>
+  %indices_a = stablehlo.reshape %grid : (tensor<2x3xi32>) -> tensor<2x3x1xi32>
+  %indices_b = stablehlo.reshape %shifted : (tensor<2x3xi32>) -> tensor<2x3x1xi32>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<80xf32>, tensor<2x3x1xi32>, tensor<2x3xf32>) -> tensor<80xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<80xf32>, tensor<2x3x1xi32>, tensor<2x3xf32>) -> tensor<80xf32>
+  return %second : tensor<80xf32>
+}

--- a/test/lit_tests/scatter_disjoint_concat.mlir
+++ b/test/lit_tests/scatter_disjoint_concat.mlir
@@ -1,0 +1,245 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt %s | FileCheck %s
+
+// A set-index scatter assigns updates[k] to destination[indices[k]]. The new
+// rewrite combines a chain of these assignments when the index sets are
+// provably disjoint, so their relative order cannot affect the result:
+//
+//   first  = scatter(destination, indices_a, updates_a)
+//   result = scatter(first,       indices_b, updates_b)
+//     =>
+//   result = scatter(destination, concat(indices_a, indices_b),
+//                                 concat(updates_a, updates_b))
+//
+// Both scatters must already promise unique indices, and the intermediate
+// destination must have no other uses. This runs through the normal optimizer,
+// so the checks include constant folding and other existing canonicalizations.
+
+// Three disjoint writes combine even though their batch shapes differ:
+//
+//   write   index shape   update shape   destination indices
+//     a       2x3x1          2x3         [3, 5, 7, 9, 11, 13]
+//     b       1x4             4         [30, 33, 36, 39]
+//     c       2x2            2x2        [60, 62, 64, 66]
+//
+// The index-vector dimension is last in a, first in b, and implicit in c.
+// Each is a point write into a rank-one destination. Flattening must keep
+// every index paired with its original update. Check the complete combined
+// index tensor, the matching update order a/b/c, and the set-index region.
+// CHECK-LABEL: func.func @disjoint_chain
+// CHECK-SAME: (%[[DEST:[^:]+]]: tensor<101xf32>, %[[A:[^:]+]]: tensor<2x3xf32>, %[[B:[^:]+]]: tensor<4xf32>, %[[C:[^:]+]]: tensor<2x2xf32>)
+// CHECK-DAG: %[[INDICES:.*]] = stablehlo.constant dense<{{\[}}[3], [5], [7], [9], [11], [13], [30], [33], [36], [39], [60], [62], [64], [66]]> : tensor<14x1xi32>
+// CHECK-DAG: %[[FLAT_A:.*]] = stablehlo.reshape %[[A]] : (tensor<2x3xf32>) -> tensor<6xf32>
+// CHECK-DAG: %[[FLAT_C:.*]] = stablehlo.reshape %[[C]] : (tensor<2x2xf32>) -> tensor<4xf32>
+// CHECK: %[[UPDATES:.*]] = stablehlo.concatenate %[[FLAT_A]], %[[B]], %[[FLAT_C]], dim = 0 : (tensor<6xf32>, tensor<4xf32>, tensor<4xf32>) -> tensor<14xf32>
+// CHECK-NEXT: %[[RESULT:.*]] = "stablehlo.scatter"(%[[DEST]], %[[INDICES]], %[[UPDATES]])
+// CHECK-SAME: indices_are_sorted = false
+// CHECK-SAME: scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>
+// CHECK-SAME: unique_indices = true
+// CHECK-NEXT: ^bb0(%[[OLD:[^:]+]]: tensor<f32>, %[[NEW:[^:]+]]: tensor<f32>):
+// CHECK-NEXT: stablehlo.return %[[NEW]] : tensor<f32>
+// CHECK-NEXT: }) : (tensor<101xf32>, tensor<14x1xi32>, tensor<14xf32>) -> tensor<101xf32>
+// CHECK-NOT: "stablehlo.scatter"
+// CHECK: return %[[RESULT]]
+func.func @disjoint_chain(%destination: tensor<101xf32>, %updates_a: tensor<2x3xf32>, %updates_b: tensor<4xf32>, %updates_c: tensor<2x2xf32>) -> tensor<101xf32> {
+  %i = stablehlo.iota dim = 0 : tensor<6xi32>
+  %two = stablehlo.constant dense<2> : tensor<6xi32>
+  %three = stablehlo.constant dense<3> : tensor<6xi32>
+  %scaled = stablehlo.multiply %i, %two : tensor<6xi32>
+  %offset = stablehlo.add %scaled, %three : tensor<6xi32>
+  %indices_a = stablehlo.reshape %offset : (tensor<6xi32>) -> tensor<2x3x1xi32>
+  %indices_b = stablehlo.constant dense<[[30, 33, 36, 39]]> : tensor<1x4xi32>
+  %indices_c = stablehlo.constant dense<[[60, 62], [64, 66]]> : tensor<2x2xi32>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<2x3x1xi32>, tensor<2x3xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 0>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<1x4xi32>, tensor<4xf32>) -> tensor<101xf32>
+  %third = "stablehlo.scatter"(%second, %indices_c, %updates_c) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<2x2xi32>, tensor<2x2xf32>) -> tensor<101xf32>
+  return %third : tensor<101xf32>
+}
+
+// a writes [3, 5, 7]; b writes [7, 9, 11]. Both touch destination[7],
+// where b must win. A combined unordered scatter would lose that guarantee.
+// Keep the two scatters and check that b still consumes the result of a.
+// CHECK-LABEL: func.func @overlapping
+// CHECK: %[[FIRST:.*]] = "stablehlo.scatter"(%arg0,
+// CHECK: "stablehlo.scatter"(%[[FIRST]],
+func.func @overlapping(%destination: tensor<101xf32>, %updates_a: tensor<3xf32>, %updates_b: tensor<3xf32>) -> tensor<101xf32> {
+  %indices_a = stablehlo.constant dense<[[3], [5], [7]]> : tensor<3x1xi32>
+  %indices_b = stablehlo.constant dense<[[7], [9], [11]]> : tensor<3x1xi32>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  return %second : tensor<101xf32>
+}
+
+// The caller supplies both index tensors. Each set promises uniqueness, but
+// that says nothing about overlap between sets. Without a disjointness proof,
+// retain the chain so any overlapping elements still get their last update.
+// CHECK-LABEL: func.func @unknown_indices
+// CHECK: %[[FIRST:.*]] = "stablehlo.scatter"(%arg0,
+// CHECK: "stablehlo.scatter"(%[[FIRST]],
+func.func @unknown_indices(%destination: tensor<101xf32>, %indices_a: tensor<3x1xi32>, %indices_b: tensor<3x1xi32>, %updates_a: tensor<3xf32>, %updates_b: tensor<3xf32>) -> tensor<101xf32> {
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  return %second : tensor<101xf32>
+}
+
+// a writes [3, 3, 7]; b writes [20, 22, 24]. Their ranges are disjoint, but a
+// writes index 3 twice. The new scatter would promise unique_indices=true,
+// so reject the rewrite and preserve a's existing unique_indices=false.
+// CHECK-LABEL: func.func @non_unique
+// CHECK: %[[FIRST:.*]] = "stablehlo.scatter"(%arg0, {{.*}}unique_indices = false
+// CHECK: "stablehlo.scatter"(%[[FIRST]],
+func.func @non_unique(%destination: tensor<101xf32>, %updates_a: tensor<3xf32>, %updates_b: tensor<3xf32>) -> tensor<101xf32> {
+  %indices_a = stablehlo.constant dense<[[3], [3], [7]]> : tensor<3x1xi32>
+  %indices_b = stablehlo.constant dense<[[20], [22], [24]]> : tensor<3x1xi32>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  return %second : tensor<101xf32>
+}
+
+// a ADDS to [3, 5, 7]; b ASSIGNS to [20, 22, 24]. The index sets are disjoint,
+// but the combined scatter would use b's assignment region for every update.
+// That would incorrectly discard a's addition to the old destination values.
+// Keep both scatters, including the first scatter's addition.
+// CHECK-LABEL: func.func @different_combiners
+// CHECK: %[[FIRST:.*]] = "stablehlo.scatter"(%arg0,
+// CHECK: stablehlo.add
+// CHECK: "stablehlo.scatter"(%[[FIRST]],
+func.func @different_combiners(%destination: tensor<101xf32>, %updates_a: tensor<3xf32>, %updates_b: tensor<3xf32>) -> tensor<101xf32> {
+  %indices_a = stablehlo.constant dense<[[3], [5], [7]]> : tensor<3x1xi32>
+  %indices_b = stablehlo.constant dense<[[20], [22], [24]]> : tensor<3x1xi32>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    %sum = stablehlo.add %old, %new : tensor<f32>
+    stablehlo.return %sum : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  return %second : tensor<101xf32>
+}
+
+// a writes [3, 5, 7]; b writes [20, 22, 24]. These assignments could otherwise
+// combine, but the function also returns the destination after only a's writes.
+// Preserve both returned states: the first must not include b's updates.
+// CHECK-LABEL: func.func @multiple_uses
+// CHECK: %[[FIRST:.*]] = "stablehlo.scatter"(%arg0,
+// CHECK: %[[SECOND:.*]] = "stablehlo.scatter"(%[[FIRST]],
+// CHECK: return %[[FIRST]], %[[SECOND]]
+func.func @multiple_uses(%destination: tensor<101xf32>, %updates_a: tensor<3xf32>, %updates_b: tensor<3xf32>) -> (tensor<101xf32>, tensor<101xf32>) {
+  %indices_a = stablehlo.constant dense<[[3], [5], [7]]> : tensor<3x1xi32>
+  %indices_b = stablehlo.constant dense<[[20], [22], [24]]> : tensor<3x1xi32>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3xf32>) -> tensor<101xf32>
+  return %first, %second : tensor<101xf32>, tensor<101xf32>
+}
+
+// In mathematical integers a would write [252, 254, 256], disjoint from b's
+// [0, 2, 4]. But the indices use i8: 2*iota + 126 + 126 wraps to [-4, -2, 0].
+// The sets overlap at zero, where b must win. Range inference must account for
+// modular arithmetic; check the wrapped indices and retain the write order.
+// CHECK-LABEL: func.func @overflow_overlap
+// CHECK-DAG: %[[WRAPPED:.*]] = stablehlo.constant dense<{{\[}}[-4], [-2], [0]]> : tensor<3x1xi8>
+// CHECK-DAG: %[[SECOND_INDICES:.*]] = stablehlo.constant dense<{{\[}}[0], [2], [4]]> : tensor<3x1xi8>
+// CHECK: %[[FIRST:.*]] = "stablehlo.scatter"(%arg0, %[[WRAPPED]], %arg1)
+// CHECK: %[[SECOND:.*]] = "stablehlo.scatter"(%[[FIRST]], %[[SECOND_INDICES]], %arg2)
+// CHECK: return %[[SECOND]]
+func.func @overflow_overlap(%destination: tensor<101xf32>, %updates_a: tensor<3xf32>, %updates_b: tensor<3xf32>) -> tensor<101xf32> {
+  %i = stablehlo.iota dim = 0 : tensor<3xi8>
+  %two = stablehlo.constant dense<2> : tensor<3xi8>
+  %offset = stablehlo.constant dense<126> : tensor<3xi8>
+  %scaled = stablehlo.multiply %i, %two : tensor<3xi8>
+  %shifted = stablehlo.add %scaled, %offset : tensor<3xi8>
+  %wrapped = stablehlo.add %shifted, %offset : tensor<3xi8>
+  %indices_a = stablehlo.reshape %wrapped : (tensor<3xi8>) -> tensor<3x1xi8>
+  %indices_b = stablehlo.constant dense<[[0], [2], [4]]> : tensor<3x1xi8>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi8>, tensor<3xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi8>, tensor<3xf32>) -> tensor<101xf32>
+  return %second : tensor<101xf32>
+}
+
+// Converting integer 2 to boolean produces true, then converting back gives 1.
+// Treating that conversion as bit truncation would incorrectly infer index 0
+// and allow fusion with b's write to index 1. Both actually target index 1.
+// Existing canonicalizations eliminate a's overwritten value entirely:
+// result = concat(destination[0:1], b, destination[2:101]). Check that result.
+// CHECK-LABEL: func.func @boolean_conversion_overlap
+// CHECK: %[[BEFORE:.*]] = stablehlo.slice %arg0 [0:1]
+// CHECK-NEXT: %[[AFTER:.*]] = stablehlo.slice %arg0 [2:101]
+// CHECK-NEXT: %[[RESULT:.*]] = stablehlo.concatenate %[[BEFORE]], %arg2, %[[AFTER]], dim = 0
+// CHECK-NEXT: return %[[RESULT]]
+func.func @boolean_conversion_overlap(%destination: tensor<101xf32>, %updates_a: tensor<1xf32>, %updates_b: tensor<1xf32>) -> tensor<101xf32> {
+  %two = stablehlo.constant dense<2> : tensor<1xi32>
+  %boolean = stablehlo.convert %two : (tensor<1xi32>) -> tensor<1xi1>
+  %integer = stablehlo.convert %boolean : (tensor<1xi1>) -> tensor<1xi32>
+  %indices_a = stablehlo.reshape %integer : (tensor<1xi32>) -> tensor<1x1xi32>
+  %indices_b = stablehlo.constant dense<1> : tensor<1x1xi32>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<1x1xi32>, tensor<1xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<1x1xi32>, tensor<1xf32>) -> tensor<101xf32>
+  return %second : tensor<101xf32>
+}
+
+// a starts at [3, 7, 11]; b starts at [12, 16, 20]. The start-index ranges are
+// disjoint, but each update writes TWO elements. a's last window [11, 12]
+// overlaps b's first window [12, 13], so b must win at destination[12].
+// This rewrite only handles point updates; keep the window-update chain.
+// CHECK-LABEL: func.func @window_updates
+// CHECK: %[[FIRST:.*]] = "stablehlo.scatter"(%arg0,
+// CHECK: "stablehlo.scatter"(%[[FIRST]],
+func.func @window_updates(%destination: tensor<101xf32>, %updates_a: tensor<3x2xf32>, %updates_b: tensor<3x2xf32>) -> tensor<101xf32> {
+  %indices_a = stablehlo.constant dense<[[3], [7], [11]]> : tensor<3x1xi32>
+  %indices_b = stablehlo.constant dense<[[12], [16], [20]]> : tensor<3x1xi32>
+  %first = "stablehlo.scatter"(%destination, %indices_a, %updates_a) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3x2xf32>) -> tensor<101xf32>
+  %second = "stablehlo.scatter"(%first, %indices_b, %updates_b) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+  ^bb0(%old: tensor<f32>, %new: tensor<f32>):
+    stablehlo.return %new : tensor<f32>
+  }) : (tensor<101xf32>, tensor<3x1xi32>, tensor<3x2xf32>) -> tensor<101xf32>
+  return %second : tensor<101xf32>
+}


### PR DESCRIPTION
Independent scatters into the same destination currently lower separately, often becoming a chain of in-place updates that the GPU backend cannot fuse. Combine unique set-index scatters into a single scatter when their index ranges are provably disjoint, before individual scatters become dynamic-update-slice operations.

The rewrite handles one-dimensional destinations with arbitrary point-scatter batch shapes and index-vector positions. It concatenates consistently flattened indices and updates and uses LLVM ConstantRange to account for modular integer arithmetic. For affine index grids, it visits the smallest-stride destination dimension fastest and generates the index arithmetic in that order, avoiding materialized transposes. Both indices and updates receive the same permutation; stride inference is only a layout heuristic and does not replace the disjointness proof.

Unknown or overlapping ranges, observable intermediate destinations, non-unique writes, update windows, and other update computations retain their original handling.

Validation:

- All 31 top-level scatter/gather LIT files pass. The tests explain the transformation, check exact combined indices and matching update order, cover the legality boundaries, and disable constant expansion to verify symbolic index-layout normalization.
- The rebuilt ReactantExtra runtime's default EnzymeHLOOpt pipeline produces two scatters, zero gathers, and zero dynamic-update-slice operations for LBM, replacing ten scatters and 28 dynamic-update-slice operations.
- A normal 20-step LBM run on an RTX 5090 produces output byte-identical to the previous validated XLA output, with maximum absolute difference 5.96e-7 from CUDA. Nsight records 61 kernel launches, down from 441 before scatter fusion: 20 shared-arithmetic kernels, 20 combined-scatter kernels, 10 loop-counter kernels, and 11 condition kernels.

XLA still computes the shared density/velocity expressions separately and executes the while condition and body separately. This establishes correctness and fewer launches; a controlled steady-state speedup has not been established.

Related to #2773.
