### PR TITLE
EnzymeHLOOpt: bound the provenance walk behind DUSDUSSubsuming; fix its dangling insert

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -84,6 +84,12 @@ using namespace mlir;
 using namespace mlir::enzyme;
 using namespace mlir::stablehlo;
 
+// Steps the tensor provenance walk (DUSDUSSubsuming) takes through a chain of
+// slices, updates and pads before treating the rest as an opaque source. Each
+// step is Presburger work on a relation that grows with the chain; the cutoff
+// only loses precision.
+constexpr size_t kProvenanceWalkBudget = 128;
+
 namespace mlir {
 // Implementation of helper function to lower MultiRotateOp into individual
 // RotateOps
@@ -19119,10 +19125,15 @@ addSelfProvenance(Value value,
 void computeTensorValueProvenanceImpl(
     SmallVectorImpl<Value> &pendingValues,
     DenseMap<Value, TensorValueProvenance> &provenanceInfo2) {
+  size_t steps = 0;
   while (!pendingValues.empty()) {
     Value value = pendingValues.pop_back_val();
     if (provenanceInfo2.contains(value))
       continue;
+    if (steps++ >= kProvenanceWalkBudget) {
+      addSelfProvenance(value, provenanceInfo2);
+      continue;
+    }
 
     if (auto slice = value.getDefiningOp<stablehlo::SliceOp>()) {
       // If we don't know the provenance of the operand, figure it out before
@@ -19143,8 +19154,12 @@ void computeTensorValueProvenanceImpl(
       presburger::IntegerRelation offset =
           getOffsetRelation(domainSpace, slice.getStartIndices());
 
+      // The insertion may rehash the map and invalidate references into it.
+      SmallVector<Value> operandSources = it->second.sources;
+      presburger::PresburgerRelation operandProvenance =
+          it->second.provenanceRelation;
       auto [insertIt, _] = provenanceInfo2.try_emplace(
-          value, it->second.sources, it->second.provenanceRelation);
+          value, std::move(operandSources), std::move(operandProvenance));
       insertIt->second.provenanceRelation =
           insertIt->second.provenanceRelation.intersectDomain(
               presburger::PresburgerSet(restriction));

--- a/test/lit_tests/dus_chain_provenance.mlir
+++ b/test/lit_tests/dus_chain_provenance.mlir
@@ -1,0 +1,39 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// Three updates into one buffer, each read back through a slice that
+// overlaps the next update: the provenance walk behind DUSDUSSubsuming
+// follows the whole chain.
+func.func @chain(%arg0: tensor<16xf64>, %arg1: tensor<4xf64>, %arg2: tensor<4xf64>, %arg3: tensor<4xf64>) -> (tensor<16xf64>, tensor<4xf64>) {
+  %c0 = stablehlo.constant dense<2> : tensor<i64>
+  %d0 = stablehlo.dynamic_update_slice %arg0, %arg1, %c0 : (tensor<16xf64>, tensor<4xf64>, tensor<i64>) -> tensor<16xf64>
+  %s0 = stablehlo.slice %d0 [3:7] : (tensor<16xf64>) -> tensor<4xf64>
+  %c1 = stablehlo.constant dense<4> : tensor<i64>
+  %d1 = stablehlo.dynamic_update_slice %d0, %arg2, %c1 : (tensor<16xf64>, tensor<4xf64>, tensor<i64>) -> tensor<16xf64>
+  %s1 = stablehlo.slice %d1 [5:9] : (tensor<16xf64>) -> tensor<4xf64>
+  %a1 = stablehlo.add %s0, %s1 : tensor<4xf64>
+  %c2 = stablehlo.constant dense<6> : tensor<i64>
+  %d2 = stablehlo.dynamic_update_slice %d1, %arg3, %c2 : (tensor<16xf64>, tensor<4xf64>, tensor<i64>) -> tensor<16xf64>
+  %s2 = stablehlo.slice %d2 [7:11] : (tensor<16xf64>) -> tensor<4xf64>
+  %a2 = stablehlo.add %a1, %s2 : tensor<4xf64>
+  return %d2, %a2 : tensor<16xf64>, tensor<4xf64>
+}
+
+// CHECK:    func.func @chain(%arg0: tensor<16xf64>, %arg1: tensor<4xf64>, %arg2: tensor<4xf64>, %arg3: tensor<4xf64>) -> (tensor<16xf64>, tensor<4xf64>) {
+// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [0:2] : (tensor<16xf64>) -> tensor<2xf64>
+// CHECK-NEXT:    %1 = stablehlo.slice %arg1 [1:4] : (tensor<4xf64>) -> tensor<3xf64>
+// CHECK-NEXT:    %2 = stablehlo.slice %arg0 [6:7] : (tensor<16xf64>) -> tensor<1xf64>
+// CHECK-NEXT:    %3 = stablehlo.concatenate %1, %2, dim = 0 : (tensor<3xf64>, tensor<1xf64>) -> tensor<4xf64>
+// CHECK-NEXT:    %4 = stablehlo.slice %arg1 [0:2] : (tensor<4xf64>) -> tensor<2xf64>
+// CHECK-NEXT:    %5 = stablehlo.slice %arg2 [1:4] : (tensor<4xf64>) -> tensor<3xf64>
+// CHECK-NEXT:    %6 = stablehlo.slice %arg0 [8:9] : (tensor<16xf64>) -> tensor<1xf64>
+// CHECK-NEXT:    %7 = stablehlo.concatenate %5, %6, dim = 0 : (tensor<3xf64>, tensor<1xf64>) -> tensor<4xf64>
+// CHECK-NEXT:    %8 = stablehlo.add %3, %7 : tensor<4xf64>
+// CHECK-NEXT:    %9 = stablehlo.slice %arg2 [0:2] : (tensor<4xf64>) -> tensor<2xf64>
+// CHECK-NEXT:    %10 = stablehlo.slice %arg0 [10:16] : (tensor<16xf64>) -> tensor<6xf64>
+// CHECK-NEXT:    %11 = stablehlo.concatenate %0, %4, %9, %arg3, %10, dim = 0 : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<4xf64>, tensor<6xf64>) -> tensor<16xf64>
+// CHECK-NEXT:    %12 = stablehlo.slice %arg3 [1:4] : (tensor<4xf64>) -> tensor<3xf64>
+// CHECK-NEXT:    %13 = stablehlo.slice %arg0 [10:11] : (tensor<16xf64>) -> tensor<1xf64>
+// CHECK-NEXT:    %14 = stablehlo.concatenate %12, %13, dim = 0 : (tensor<3xf64>, tensor<1xf64>) -> tensor<4xf64>
+// CHECK-NEXT:    %15 = stablehlo.add %8, %14 : tensor<4xf64>
+// CHECK-NEXT:    return %11, %15 : tensor<16xf64>, tensor<4xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
`computeTensorValueProvenanceImpl` follows a chain of slices, updates and pads back to its sources with a Presburger relation that grows with the chain, and `DUSDUSSubsuming` recomputes it from scratch for every update it visits: cubic in the chain. mfem's TMOP metric kernels write a scratch buffer a few hundred times. One such kernel (270 updates, 14k lines) spends 132 s in this pattern and 3 s in everything else (`passses` without bit 512), and the eight `fem/tmop/metrics/3xx.cpp` translation units carry the whole cost of running `enzyme-hlo-opt` on raised kernels at compile time (#3129): 464 s of a 533 s compile, per the pass timing.

The walk now stops after 128 steps and treats what is left as an opaque source. That only loses precision: both provenances the pattern compares are computed against the same sources, so an opaque prefix makes the comparison conservative, never wrong. The kernel takes 3 s; the 45-kernel translation unit's optimizer time goes from 411 s to 78 s.

The slice case also inserted into the provenance map with arguments that were references into that map (`try_emplace(value, it->second.sources, it->second.provenanceRelation)`); the insertion can rehash, after which they dangle and the copy reads freed memory. Nine of the 45 kernels segfault on that, in `PresburgerRelation`'s copy constructor. Copy first.

Test: a three-update chain read back through overlapping slices, checked line for line. The reduced shapes that exercise the pattern fold before the walk gets deep, and the kernels that hit the cost and the crash are 8-14k lines each (`fem/tmop/metrics/315.cpp`, kernels 43 and 44 of its pre-optimizer dump; I can attach them if useful). Lit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
