### PR TITLE
Carry dynamic while conditions into the loop body

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -21234,6 +21234,113 @@ struct WhileScatterAccumulatorNoAdd final
   }
 };
 
+// Evaluate a dynamic counted loop's next condition in its body, where the
+// comparison can fuse with the counter update. The condition region then just
+// returns a carried predicate, avoiding a separate device kernel per test.
+struct WhileConditionToBody final
+    : CheckedOpRewritePattern<stablehlo::WhileOp, WhileConditionToBody> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::WhileOp op,
+                                    PatternRewriter &rewriter) const {
+    // Adding a result would require extending an explicit sharding contract.
+    if (op->hasAttr("mhlo.sharding") || op->hasAttr("sdy.sharding"))
+      return failure();
+    // Checkpointing (including later differentiation of generated segments)
+    // needs the counted-loop condition to recover the induction variable.
+    if (op->hasAttr("enzyme.enable_checkpointing") ||
+        op->hasAttr("enzyme.binomial_checkpointing") ||
+        op->hasAttr("enzyme.checkpoint_period") ||
+        op->hasAttr("enzymexla.checkpoint_segment"))
+      return failure();
+    Block &cond = op.getCond().front();
+    auto condReturn = cast<stablehlo::ReturnOp>(cond.getTerminator());
+    auto compare =
+        condReturn.getOperand(0).getDefiningOp<stablehlo::CompareOp>();
+    if (!compare)
+      return failure();
+    // Clone only the scalar comparison and its constants. In particular, do
+    // not duplicate effects, nested control flow, or expensive conditions.
+    for (Operation &operation : cond.without_terminator())
+      if (&operation != compare.getOperation() &&
+          !isa<stablehlo::ConstantOp>(operation))
+        return failure();
+
+    // Look for a counter update that the next comparison can consume in the
+    // same fusion. Either operand order and signed/unsigned comparisons are
+    // supported: the comparison itself will be cloned without modification.
+    Block &oldBody = op.getBody().front();
+    auto oldReturn = cast<stablehlo::ReturnOp>(oldBody.getTerminator());
+    bool dynamicCounter = false;
+    for (unsigned side = 0; side < 2; ++side) {
+      auto arg = dyn_cast<BlockArgument>(compare->getOperand(side));
+      Value limit = compare->getOperand(1 - side);
+      if (!arg || arg.getOwner() != &cond ||
+          !(definedOutside(limit, op) || matchPattern(limit, m_Constant())))
+        continue;
+      auto next = oldReturn.getOperand(arg.getArgNumber())
+                      .getDefiningOp<stablehlo::AddOp>();
+      if (!next)
+        continue;
+      Value bodyArg = oldBody.getArgument(arg.getArgNumber());
+      Value step;
+      if (next.getLhs() == bodyArg)
+        step = next.getRhs();
+      else if (next.getRhs() == bodyArg)
+        step = next.getLhs();
+      DenseIntElementsAttr stepAttr;
+      if (!step || !matchPattern(step, m_Constant(&stepAttr)) ||
+          !stepAttr.isSplat() || stepAttr.getSplatValue<APInt>().isZero())
+        continue;
+      // Keep static trip counts recognizable for downstream unrolling.
+      if (matchPattern(op->getOperand(arg.getArgNumber()), m_Constant()) &&
+          matchPattern(limit, m_Constant()))
+        continue;
+      dynamicCounter = true;
+      break;
+    }
+    if (!dynamicCounter)
+      return failure();
+
+    auto cloneCondition = [&](ValueRange arguments) {
+      IRMapping mapping;
+      for (auto [arg, value] : llvm::zip(cond.getArguments(), arguments))
+        mapping.map(arg, value);
+      for (Operation &operation : cond.without_terminator())
+        rewriter.clone(operation, mapping);
+      return mapping.lookupOrDefault(condReturn.getOperand(0));
+    };
+
+    Value initialPredicate = cloneCondition(op.getOperands());
+    SmallVector<Value> inputs(op.getOperands());
+    inputs.push_back(initialPredicate);
+    auto nextWhile = stablehlo::WhileOp::create(rewriter, op.getLoc(), inputs,
+                                                op->getAttrs());
+    nextWhile.getBody().takeBody(op.getBody());
+    Block &body = nextWhile.getBody().front();
+    body.addArgument(initialPredicate.getType(), op.getLoc());
+
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      auto bodyReturn = cast<stablehlo::ReturnOp>(body.getTerminator());
+      rewriter.setInsertionPoint(bodyReturn);
+      Value nextPredicate = cloneCondition(bodyReturn.getOperands());
+      SmallVector<Value> outputs(bodyReturn.getOperands());
+      outputs.push_back(nextPredicate);
+      rewriter.replaceOpWithNewOp<stablehlo::ReturnOp>(bodyReturn, outputs);
+
+      Block *nextCond = rewriter.createBlock(&nextWhile.getCond());
+      for (Value input : inputs)
+        nextCond->addArgument(input.getType(), op.getLoc());
+      rewriter.setInsertionPointToEnd(nextCond);
+      stablehlo::ReturnOp::create(rewriter, op.getLoc(),
+                                  nextCond->getArguments().take_back());
+    }
+    rewriter.replaceOp(op, nextWhile.getResults().drop_back());
+    return success();
+  }
+};
+
 // Replace while op iteration variables which are not updated with their
 // upcoming value
 struct WhileSimplify
@@ -37479,7 +37586,16 @@ struct EnzymeHLOOptPass
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
                                      config))) {
       signalPassFailure();
+      return;
     }
+
+    // Preserve recognizable induction variables throughout the main rewrite
+    // pipeline. Only move conditions once loop optimizations have converged.
+    RewritePatternSet loopConditions(context);
+    loopConditions.add<WhileConditionToBody>(context);
+    if (failed(applyPatternsGreedily(getOperation(), std::move(loopConditions),
+                                     config)))
+      signalPassFailure();
   }
 };
 

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_nested.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_nested.mlir
@@ -34,91 +34,96 @@ module @reactant_gradmyfunc attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
   }
 }
 
-// CHECK:  func.func private @"diffeConst{typeof(myfunc)}_autodiff"(%arg0: tensor<3xf64> {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: tensor<3xf64>) -> (tensor<3xf64>, tensor<3xf64>) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
-// CHECK-NEXT:    %c = stablehlo.constant dense<-4> : tensor<i64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<2> : tensor<i64>
-// CHECK-NEXT:    %c_1 = stablehlo.constant dense<3> : tensor<i64>
-// CHECK-NEXT:    %c_2 = stablehlo.constant dense<4> : tensor<i64>
-// CHECK-NEXT:    %c_3 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %c_4 = stablehlo.constant dense<10> : tensor<i64>
-// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<3xf64>
-// CHECK-NEXT:    %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
-// CHECK-NEXT:    %0:2 = stablehlo.while(%iterArg = %c_5, %iterArg_7 = %arg0) : tensor<i64>, tensor<3xf64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
-// CHECK-NEXT:    cond {
-// CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %2 = stablehlo.multiply %iterArg, %c {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      %3 = stablehlo.add %c_4, %2 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      %4 = stablehlo.minimum %c_2, %3 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      %5:2 = stablehlo.while(%iterArg_8 = %c_5, %iterArg_9 = %iterArg_7) : tensor<i64>, tensor<3xf64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
-// CHECK-NEXT:      cond {
-// CHECK-NEXT:        %7 = stablehlo.compare LT, %iterArg_8, %4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %7 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %7:2 = stablehlo.while(%iterArg_10 = %c_5, %iterArg_11 = %iterArg_9) : tensor<i64>, tensor<3xf64> attributes {enzyme.checkpoint_period = 3 : i64, enzyme.disable_mincut, enzyme.enable_checkpointing = true, enzymexla.checkpoint_segment}
-// CHECK-NEXT:        cond {
-// CHECK-NEXT:          %9 = stablehlo.compare LT, %iterArg_10, %c_4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:          stablehlo.return %9 : tensor<i1>
-// CHECK-NEXT:        } do {
-// CHECK-NEXT:          %9 = stablehlo.add %iterArg_10, %c_3 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:          %10 = stablehlo.multiply %cst, %iterArg_11 : tensor<3xf64>
-// CHECK-NEXT:          %11 = stablehlo.add %iterArg_11, %10 : tensor<3xf64>
-// CHECK-NEXT:          stablehlo.return %9, %11 : tensor<i64>, tensor<3xf64>
-// CHECK-NEXT:        }
-// CHECK-NEXT:        %8 = stablehlo.add %iterArg_8, %c_3 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %8, %7#1 : tensor<i64>, tensor<3xf64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %6 = stablehlo.add %iterArg, %c_3 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %6, %5#1 : tensor<i64>, tensor<3xf64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %1:7 = stablehlo.while(%iterArg = %c_5, %iterArg_7 = %arg1, %iterArg_8 = %cst_6, %iterArg_9 = %cst_6, %iterArg_10 = %cst_6, %iterArg_11 = %cst_6, %iterArg_12 = %cst_6) : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:    cond {
-// CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %2 = stablehlo.subtract %c_0, %iterArg {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      %3 = stablehlo.multiply %c, %2 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      %4 = stablehlo.add %c_4, %3 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      %5 = stablehlo.minimum %c_2, %4 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      %6:7 = stablehlo.while(%iterArg_13 = %c_5, %iterArg_14 = %iterArg_7, %iterArg_15 = %iterArg_8, %iterArg_16 = %iterArg_9, %iterArg_17 = %iterArg_10, %iterArg_18 = %iterArg_11, %iterArg_19 = %iterArg_12) : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:      cond {
-// CHECK-NEXT:        %8 = stablehlo.compare LT, %iterArg_13, %5 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %8 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %8 = stablehlo.add %iterArg_15, %iterArg_14 : tensor<3xf64>
-// CHECK-NEXT:        %9:5 = stablehlo.while(%iterArg_20 = %c_5, %iterArg_21 = %8, %iterArg_22 = %iterArg_16, %iterArg_23 = %iterArg_17, %iterArg_24 = %iterArg_18) : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:        cond {
-// CHECK-NEXT:          %12 = stablehlo.compare LT, %iterArg_20, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:          stablehlo.return %12 : tensor<i1>
-// CHECK-NEXT:        } do {
-// CHECK-NEXT:          %12 = stablehlo.subtract %c_0, %iterArg_20 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:          %13 = stablehlo.multiply %c, %12 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:          %14 = stablehlo.add %c_4, %13 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:          %15 = stablehlo.minimum %c_2, %14 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:          %16:5 = stablehlo.while(%iterArg_25 = %c_5, %iterArg_26 = %iterArg_21, %iterArg_27 = %iterArg_22, %iterArg_28 = %iterArg_23, %iterArg_29 = %iterArg_24) : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:          cond {
-// CHECK-NEXT:            %18 = stablehlo.compare LT, %iterArg_25, %15 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:            stablehlo.return %18 : tensor<i1>
-// CHECK-NEXT:          } do {
-// CHECK-NEXT:            %18 = stablehlo.add %iterArg_27, %iterArg_26 : tensor<3xf64>
-// CHECK-NEXT:            %19 = stablehlo.add %iterArg_28, %18 : tensor<3xf64>
-// CHECK-NEXT:            %20 = stablehlo.add %iterArg_29, %18 : tensor<3xf64>
-// CHECK-NEXT:            %21 = stablehlo.multiply %20, %cst : tensor<3xf64>
-// CHECK-NEXT:            %22 = stablehlo.add %19, %21 : tensor<3xf64>
-// CHECK-NEXT:            %23 = stablehlo.add %iterArg_25, %c_3 : tensor<i64>
-// CHECK-NEXT:            stablehlo.return %23, %22, %cst_6, %cst_6, %cst_6 : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:          }
-// CHECK-NEXT:          %17 = stablehlo.add %iterArg_20, %c_3 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:          stablehlo.return %17, %16#1, %16#2, %16#3, %16#4 : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:        }
-// CHECK-NEXT:        %10 = stablehlo.add %iterArg_19, %9#1 : tensor<3xf64>
-// CHECK-NEXT:        %11 = stablehlo.add %iterArg_13, %c_3 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %11, %10, %cst_6, %9#2, %9#3, %9#4, %cst_6 : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %7 = stablehlo.add %iterArg, %c_3 {enzymexla.bounds = {{.*}} : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %7, %6#1, %6#2, %6#3, %6#4, %6#5, %6#6 : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    return %0#1, %1#1 : tensor<3xf64>, tensor<3xf64>
-// CHECK-NEXT:  }
+// Checkpointed forward/recomputation loops retain their induction comparison.
+// Unannotated dynamic reverse loops can carry the condition after differentiation;
+// check the initial predicate, the returned next predicate, and all data results.
+// CHECK-LABEL: func.func private @"diffeConst{typeof(myfunc)}_autodiff"(%arg0: tensor<3xf64> {enzymexla.memory_effects = ["read", "write", "allocate", "free"]}, %arg1: tensor<3xf64>) -> (tensor<3xf64>, tensor<3xf64>) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// CHECK-NEXT:     %c = stablehlo.constant dense<-4> : tensor<i64>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:     %c_1 = stablehlo.constant dense<3> : tensor<i64>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<4> : tensor<i64>
+// CHECK-NEXT:     %c_3 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %c_4 = stablehlo.constant dense<10> : tensor<i64>
+// CHECK-NEXT:     %c_5 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<2.000000e+00> : tensor<3xf64>
+// CHECK-NEXT:     %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<3xf64>
+// CHECK-NEXT:     %0:2 = stablehlo.while(%iterArg = %c_5, %iterArg_7 = %arg0) : tensor<i64>, tensor<3xf64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.multiply %iterArg, %c {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.add %c_4, %2 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       %4 = stablehlo.minimum %c_2, %3 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       %5:2 = stablehlo.while(%iterArg_8 = %c_5, %iterArg_9 = %iterArg_7) : tensor<i64>, tensor<3xf64> attributes {enzyme.disable_mincut, enzymexla.checkpoint_segment}
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %7 = stablehlo.compare LT, %iterArg_8, %4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %7 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %7:2 = stablehlo.while(%iterArg_10 = %c_5, %iterArg_11 = %iterArg_9) : tensor<i64>, tensor<3xf64> attributes {enzyme.checkpoint_period = 3 : i64, enzyme.disable_mincut, enzyme.enable_checkpointing = true, enzymexla.checkpoint_segment}
+// CHECK-NEXT:         cond {
+// CHECK-NEXT:           %9 = stablehlo.compare LT, %iterArg_10, %c_4 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:           stablehlo.return %9 : tensor<i1>
+// CHECK-NEXT:         } do {
+// CHECK-NEXT:           %9 = stablehlo.add %iterArg_10, %c_3 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:           %10 = stablehlo.multiply %cst, %iterArg_11 : tensor<3xf64>
+// CHECK-NEXT:           %11 = stablehlo.add %iterArg_11, %10 : tensor<3xf64>
+// CHECK-NEXT:           stablehlo.return %9, %11 : tensor<i64>, tensor<3xf64>
+// CHECK-NEXT:         }
+// CHECK-NEXT:         %8 = stablehlo.add %iterArg_8, %c_3 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %8, %7#1 : tensor<i64>, tensor<3xf64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %6 = stablehlo.add %iterArg, %c_3 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %6, %5#1 : tensor<i64>, tensor<3xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %1:7 = stablehlo.while(%iterArg = %c_5, %iterArg_7 = %arg1, %iterArg_8 = %cst_6, %iterArg_9 = %cst_6, %iterArg_10 = %cst_6, %iterArg_11 = %cst_6, %iterArg_12 = %cst_6) : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %2 = stablehlo.compare LT, %iterArg, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %2 = stablehlo.subtract %c_0, %iterArg {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       %3 = stablehlo.multiply %c, %2 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       %4 = stablehlo.add %c_4, %3 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       %5 = stablehlo.minimum %c_2, %4 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       %6 = stablehlo.compare LT, %c_5, %5 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       %7:8 = stablehlo.while(%iterArg_13 = %c_5, %iterArg_14 = %iterArg_7, %iterArg_15 = %iterArg_8, %iterArg_16 = %iterArg_9, %iterArg_17 = %iterArg_10, %iterArg_18 = %iterArg_11, %iterArg_19 = %iterArg_12, %iterArg_20 = %6) : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<i1>
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         stablehlo.return %iterArg_20 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %9 = stablehlo.add %iterArg_15, %iterArg_14 : tensor<3xf64>
+// CHECK-NEXT:         %10:5 = stablehlo.while(%iterArg_21 = %c_5, %iterArg_22 = %9, %iterArg_23 = %iterArg_16, %iterArg_24 = %iterArg_17, %iterArg_25 = %iterArg_18) : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
+// CHECK-NEXT:         cond {
+// CHECK-NEXT:           %14 = stablehlo.compare LT, %iterArg_21, %c_1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:           stablehlo.return %14 : tensor<i1>
+// CHECK-NEXT:         } do {
+// CHECK-NEXT:           %14 = stablehlo.subtract %c_0, %iterArg_21 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:           %15 = stablehlo.multiply %c, %14 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:           %16 = stablehlo.add %c_4, %15 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:           %17 = stablehlo.minimum %c_2, %16 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:           %18 = stablehlo.compare LT, %c_5, %17 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:           %19:6 = stablehlo.while(%iterArg_26 = %c_5, %iterArg_27 = %iterArg_22, %iterArg_28 = %iterArg_23, %iterArg_29 = %iterArg_24, %iterArg_30 = %iterArg_25, %iterArg_31 = %18) : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<i1>
+// CHECK-NEXT:           cond {
+// CHECK-NEXT:             stablehlo.return %iterArg_31 : tensor<i1>
+// CHECK-NEXT:           } do {
+// CHECK-NEXT:             %21 = stablehlo.add %iterArg_28, %iterArg_27 : tensor<3xf64>
+// CHECK-NEXT:             %22 = stablehlo.add %iterArg_29, %21 : tensor<3xf64>
+// CHECK-NEXT:             %23 = stablehlo.add %iterArg_30, %21 : tensor<3xf64>
+// CHECK-NEXT:             %24 = stablehlo.multiply %23, %cst : tensor<3xf64>
+// CHECK-NEXT:             %25 = stablehlo.add %22, %24 : tensor<3xf64>
+// CHECK-NEXT:             %26 = stablehlo.add %iterArg_26, %c_3 : tensor<i64>
+// CHECK-NEXT:             %27 = stablehlo.compare LT, %26, %17 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:             stablehlo.return %26, %25, %cst_6, %cst_6, %cst_6, %27 : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<i1>
+// CHECK-NEXT:           }
+// CHECK-NEXT:           %20 = stablehlo.add %iterArg_21, %c_3 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:           stablehlo.return %20, %19#1, %19#2, %19#3, %19#4 : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
+// CHECK-NEXT:         }
+// CHECK-NEXT:         %11 = stablehlo.add %iterArg_19, %10#1 : tensor<3xf64>
+// CHECK-NEXT:         %12 = stablehlo.add %iterArg_13, %c_3 : tensor<i64>
+// CHECK-NEXT:         %13 = stablehlo.compare LT, %12, %5 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %12, %11, %cst_6, %10#2, %10#3, %10#4, %cst_6, %13 : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<i1>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %8 = stablehlo.add %iterArg, %c_3 {enzymexla.bounds = {{.*}} : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %8, %7#1, %7#2, %7#3, %7#4, %7#5, %7#6 : tensor<i64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>, tensor<3xf64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return %0#1, %1#1 : tensor<3xf64>, tensor<3xf64>
+// CHECK-NEXT:   }

--- a/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_nested_full.mlir
+++ b/test/lit_tests/diffrules/stablehlo/while_checkpointing_binomial_nested_full.mlir
@@ -30,131 +30,135 @@ module {
   }
 }
 
-// CHECK:  func.func @main(%arg0: tensor<f32>, %arg1: tensor<i64>, %arg2: tensor<f32>) -> tensor<f32> {
-// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<4xi64>
-// CHECK-NEXT:    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<4xf32>
-// CHECK-NEXT:    %c_2 = stablehlo.constant dense<4> : tensor<i64>
-// CHECK-NEXT:    %c_3 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %0 = stablehlo.minimum %c_2, %arg1 : tensor<i64>
-// CHECK-NEXT:    %1:5 = stablehlo.while(%iterArg = %c_4, %iterArg_5 = %c_4, %iterArg_6 = %arg0, %iterArg_7 = %cst_1, %iterArg_8 = %c_0) : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>
-// CHECK-NEXT:    cond {
-// CHECK-NEXT:      %4 = stablehlo.compare LT, %iterArg, %0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %4 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %4 = stablehlo.reshape %iterArg_6 : (tensor<f32>) -> tensor<1xf32>
-// CHECK-NEXT:      %5 = stablehlo.dynamic_update_slice %iterArg_7, %4, %iterArg : (tensor<4xf32>, tensor<1xf32>, tensor<i64>) -> tensor<4xf32>
-// CHECK-NEXT:      %6 = stablehlo.reshape %iterArg_5 : (tensor<i64>) -> tensor<1xi64>
-// CHECK-NEXT:      %7 = stablehlo.dynamic_update_slice %iterArg_8, %6, %iterArg : (tensor<4xi64>, tensor<1xi64>, tensor<i64>) -> tensor<4xi64>
-// CHECK-NEXT:      %8 = stablehlo.subtract %arg1, %iterArg_5 : tensor<i64>
-// CHECK-NEXT:      %9 = stablehlo.subtract %0, %iterArg : tensor<i64>
-// CHECK-NEXT:      %10 = stablehlo.minimum %9, %8 : tensor<i64>
-// CHECK-NEXT:      %11 = enzyme.binomial_progress %8, %10 : tensor<i64>
-// CHECK-NEXT:      %12:2 = stablehlo.while(%iterArg_9 = %c_4, %iterArg_10 = %iterArg_6) : tensor<i64>, tensor<f32>
-// CHECK-NEXT:      cond {
-// CHECK-NEXT:        %15 = stablehlo.compare LT, %iterArg_9, %11 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %15 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %15:2 = stablehlo.while(%iterArg_11 = %c_4, %iterArg_12 = %iterArg_10) : tensor<i64>, tensor<f32>
-// CHECK-NEXT:        cond {
-// CHECK-NEXT:          %17 = stablehlo.compare LT, %iterArg_11, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:          stablehlo.return %17 : tensor<i1>
-// CHECK-NEXT:        } do {
-// CHECK-NEXT:          %17 = stablehlo.multiply %arg0, %iterArg_12 : tensor<f32>
-// CHECK-NEXT:          %18 = stablehlo.add %iterArg_11, %c_3 : tensor<i64>
-// CHECK-NEXT:          stablehlo.return %18, %17 : tensor<i64>, tensor<f32>
-// CHECK-NEXT:        }
-// CHECK-NEXT:        %16 = stablehlo.add %iterArg_9, %c_3 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %16, %15#1 : tensor<i64>, tensor<f32>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %13 = stablehlo.add %iterArg_5, %11 : tensor<i64>
-// CHECK-NEXT:      %14 = stablehlo.add %iterArg, %c_3 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %14, %13, %12#1, %5, %7 : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %2:6 = stablehlo.while(%iterArg = %c_4, %iterArg_5 = %0, %iterArg_6 = %arg2, %iterArg_7 = %1#3, %iterArg_8 = %1#4, %iterArg_9 = %cst) : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>, tensor<f32>
-// CHECK-NEXT:    cond {
-// CHECK-NEXT:      %4 = stablehlo.compare LT, %iterArg, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %4 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %4 = stablehlo.subtract %iterArg_5, %c_3 : tensor<i64>
-// CHECK-NEXT:      %5 = stablehlo.subtract %arg1, %iterArg : tensor<i64>
-// CHECK-NEXT:      %6 = stablehlo.dynamic_slice %iterArg_7, %4, sizes = [1] : (tensor<4xf32>, tensor<i64>) -> tensor<1xf32>
-// CHECK-NEXT:      %7 = stablehlo.reshape %6 : (tensor<1xf32>) -> tensor<f32>
-// CHECK-NEXT:      %8 = stablehlo.dynamic_slice %iterArg_8, %4, sizes = [1] : (tensor<4xi64>, tensor<i64>) -> tensor<1xi64>
-// CHECK-NEXT:      %9 = stablehlo.reshape %8 : (tensor<1xi64>) -> tensor<i64>
-// CHECK-NEXT:      %10:5 = stablehlo.while(%iterArg_10 = %9, %iterArg_11 = %4, %iterArg_12 = %7, %iterArg_13 = %iterArg_7, %iterArg_14 = %iterArg_8) : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>
-// CHECK-NEXT:      cond {
-// CHECK-NEXT:        %18 = stablehlo.add %iterArg_10, %c_3 : tensor<i64>
-// CHECK-NEXT:        %19 = stablehlo.compare LT, %18, %5 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %19 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %18 = stablehlo.subtract %5, %iterArg_10 : tensor<i64>
-// CHECK-NEXT:        %19 = stablehlo.subtract %0, %iterArg_11 : tensor<i64>
-// CHECK-NEXT:        %20 = stablehlo.minimum %19, %18 : tensor<i64>
-// CHECK-NEXT:        %21 = enzyme.binomial_progress %18, %20 : tensor<i64>
-// CHECK-NEXT:        %22 = stablehlo.reshape %iterArg_12 : (tensor<f32>) -> tensor<1xf32>
-// CHECK-NEXT:        %23 = stablehlo.dynamic_update_slice %iterArg_13, %22, %iterArg_11 : (tensor<4xf32>, tensor<1xf32>, tensor<i64>) -> tensor<4xf32>
-// CHECK-NEXT:        %24 = stablehlo.reshape %iterArg_10 : (tensor<i64>) -> tensor<1xi64>
-// CHECK-NEXT:        %25 = stablehlo.dynamic_update_slice %iterArg_14, %24, %iterArg_11 : (tensor<4xi64>, tensor<1xi64>, tensor<i64>) -> tensor<4xi64>
-// CHECK-NEXT:        %26 = stablehlo.add %iterArg_10, %21 : tensor<i64>
-// CHECK-NEXT:        %27 = stablehlo.compare EQ, %26, %5 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        %28 = stablehlo.subtract %26, %c_3 : tensor<i64>
-// CHECK-NEXT:        %29 = stablehlo.select %27, %28, %26 : tensor<i1>, tensor<i64>
-// CHECK-NEXT:        %30:2 = stablehlo.while(%iterArg_15 = %iterArg_10, %iterArg_16 = %iterArg_12) : tensor<i64>, tensor<f32>
-// CHECK-NEXT:        cond {
-// CHECK-NEXT:          %32 = stablehlo.compare LT, %iterArg_15, %29 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:          stablehlo.return %32 : tensor<i1>
-// CHECK-NEXT:        } do {
-// CHECK-NEXT:          %32:2 = stablehlo.while(%iterArg_17 = %c_4, %iterArg_18 = %iterArg_16) : tensor<i64>, tensor<f32>
-// CHECK-NEXT:          cond {
-// CHECK-NEXT:            %34 = stablehlo.compare LT, %iterArg_17, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:            stablehlo.return %34 : tensor<i1>
-// CHECK-NEXT:          } do {
-// CHECK-NEXT:            %34 = stablehlo.multiply %arg0, %iterArg_18 : tensor<f32>
-// CHECK-NEXT:            %35 = stablehlo.add %iterArg_17, %c_3 : tensor<i64>
-// CHECK-NEXT:            stablehlo.return %35, %34 : tensor<i64>, tensor<f32>
-// CHECK-NEXT:          }
-// CHECK-NEXT:          %33 = stablehlo.add %iterArg_15, %c_3 : tensor<i64>
-// CHECK-NEXT:          stablehlo.return %33, %32#1 : tensor<i64>, tensor<f32>
-// CHECK-NEXT:        }
-// CHECK-NEXT:        %31 = stablehlo.add %iterArg_11, %c_3 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %26, %31, %30#1, %23, %25 : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %11 = stablehlo.reshape %arg1 : (tensor<i64>) -> tensor<1xi64>
-// CHECK-NEXT:      %12 = tensor.empty() : tensor<0xf32>
-// CHECK-NEXT:      %13 = stablehlo.dynamic_pad %12, %cst, %c, %11, %c : (tensor<0xf32>, tensor<f32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
-// CHECK-NEXT:      %14:3 = stablehlo.while(%iterArg_10 = %c_4, %iterArg_11 = %10#2, %iterArg_12 = %13) : tensor<i64>, tensor<f32>, tensor<?xf32>
-// CHECK-NEXT:      cond {
-// CHECK-NEXT:        %18 = stablehlo.compare LT, %iterArg_10, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %18 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %18 = stablehlo.reshape %iterArg_11 : (tensor<f32>) -> tensor<1xf32>
-// CHECK-NEXT:        %19 = stablehlo.dynamic_update_slice %iterArg_12, %18, %iterArg_10 : (tensor<?xf32>, tensor<1xf32>, tensor<i64>) -> tensor<?xf32>
-// CHECK-NEXT:        %20 = stablehlo.multiply %arg0, %iterArg_11 : tensor<f32>
-// CHECK-NEXT:        %21 = stablehlo.add %iterArg_10, %c_3 : tensor<i64>
-// CHECK-NEXT:        stablehlo.return %21, %20, %19 : tensor<i64>, tensor<f32>, tensor<?xf32>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %15 = stablehlo.subtract %arg1, %c_3 : tensor<i64>
-// CHECK-NEXT:      %16:3 = stablehlo.while(%iterArg_10 = %c_4, %iterArg_11 = %iterArg_6, %iterArg_12 = %iterArg_9) : tensor<i64>, tensor<f32>, tensor<f32>
-// CHECK-NEXT:      cond {
-// CHECK-NEXT:        %18 = stablehlo.compare LT, %iterArg_10, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:        stablehlo.return %18 : tensor<i1>
-// CHECK-NEXT:      } do {
-// CHECK-NEXT:        %18 = stablehlo.subtract %15, %iterArg_10 : tensor<i64>
-// CHECK-NEXT:        %19 = stablehlo.dynamic_slice %14#2, %18, sizes = [1] : (tensor<?xf32>, tensor<i64>) -> tensor<1xf32>
-// CHECK-NEXT:        %20 = stablehlo.reshape %19 : (tensor<1xf32>) -> tensor<f32>
-// CHECK-NEXT:        %21 = stablehlo.add %iterArg_10, %c_3 : tensor<i64>
-// CHECK-NEXT:        %22 = stablehlo.multiply %iterArg_11, %20 : tensor<f32>
-// CHECK-NEXT:        %23 = stablehlo.add %iterArg_12, %22 : tensor<f32>
-// CHECK-NEXT:        %24 = stablehlo.multiply %iterArg_11, %arg0 : tensor<f32>
-// CHECK-NEXT:        stablehlo.return %21, %24, %23 : tensor<i64>, tensor<f32>, tensor<f32>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %17 = stablehlo.add %iterArg, %c_3 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %17, %10#1, %16#1, %10#3, %10#4, %16#2 : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>, tensor<f32>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %3 = stablehlo.add %2#5, %2#2 : tensor<f32>
-// CHECK-NEXT:    return %3 : tensor<f32>
-// CHECK-NEXT:  }
-
+// Checkpointed forward/recomputation loops retain their induction comparison.
+// Unannotated dynamic reverse loops can carry the condition after differentiation;
+// check the initial predicate, the returned next predicate, and all data results.
+// CHECK-LABEL: func.func @main(%arg0: tensor<f32>, %arg1: tensor<i64>, %arg2: tensor<f32>) -> tensor<f32> {
+// CHECK-NEXT:     %c = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:     %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+// CHECK-NEXT:     %c_0 = stablehlo.constant dense<0> : tensor<4xi64>
+// CHECK-NEXT:     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<4xf32>
+// CHECK-NEXT:     %c_2 = stablehlo.constant dense<4> : tensor<i64>
+// CHECK-NEXT:     %c_3 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:     %c_4 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:     %0 = stablehlo.minimum %c_2, %arg1 : tensor<i64>
+// CHECK-NEXT:     %1:5 = stablehlo.while(%iterArg = %c_4, %iterArg_5 = %c_4, %iterArg_6 = %arg0, %iterArg_7 = %cst_1, %iterArg_8 = %c_0) : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64> attributes {enzymexla.checkpoint_segment}
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       %5 = stablehlo.compare LT, %iterArg, %0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %5 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %5 = stablehlo.reshape %iterArg_6 : (tensor<f32>) -> tensor<1xf32>
+// CHECK-NEXT:       %6 = stablehlo.dynamic_update_slice %iterArg_7, %5, %iterArg : (tensor<4xf32>, tensor<1xf32>, tensor<i64>) -> tensor<4xf32>
+// CHECK-NEXT:       %7 = stablehlo.reshape %iterArg_5 : (tensor<i64>) -> tensor<1xi64>
+// CHECK-NEXT:       %8 = stablehlo.dynamic_update_slice %iterArg_8, %7, %iterArg : (tensor<4xi64>, tensor<1xi64>, tensor<i64>) -> tensor<4xi64>
+// CHECK-NEXT:       %9 = stablehlo.subtract %arg1, %iterArg_5 : tensor<i64>
+// CHECK-NEXT:       %10 = stablehlo.subtract %0, %iterArg : tensor<i64>
+// CHECK-NEXT:       %11 = stablehlo.minimum %10, %9 : tensor<i64>
+// CHECK-NEXT:       %12 = enzyme.binomial_progress %9, %11 : tensor<i64>
+// CHECK-NEXT:       %13:2 = stablehlo.while(%iterArg_9 = %c_4, %iterArg_10 = %iterArg_6) : tensor<i64>, tensor<f32> attributes {enzymexla.checkpoint_segment}
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %16 = stablehlo.compare LT, %iterArg_9, %12 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %16 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %16:2 = stablehlo.while(%iterArg_11 = %c_4, %iterArg_12 = %iterArg_10) : tensor<i64>, tensor<f32> attributes {enzymexla.checkpoint_segment}
+// CHECK-NEXT:         cond {
+// CHECK-NEXT:           %18 = stablehlo.compare LT, %iterArg_11, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:           stablehlo.return %18 : tensor<i1>
+// CHECK-NEXT:         } do {
+// CHECK-NEXT:           %18 = stablehlo.multiply %arg0, %iterArg_12 : tensor<f32>
+// CHECK-NEXT:           %19 = stablehlo.add %iterArg_11, %c_3 : tensor<i64>
+// CHECK-NEXT:           stablehlo.return %19, %18 : tensor<i64>, tensor<f32>
+// CHECK-NEXT:         }
+// CHECK-NEXT:         %17 = stablehlo.add %iterArg_9, %c_3 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %17, %16#1 : tensor<i64>, tensor<f32>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %14 = stablehlo.add %iterArg_5, %12 : tensor<i64>
+// CHECK-NEXT:       %15 = stablehlo.add %iterArg, %c_3 : tensor<i64>
+// CHECK-NEXT:       stablehlo.return %15, %14, %13#1, %6, %8 : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %2 = stablehlo.compare LT, %c_4, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:     %3:7 = stablehlo.while(%iterArg = %c_4, %iterArg_5 = %0, %iterArg_6 = %arg2, %iterArg_7 = %1#3, %iterArg_8 = %1#4, %iterArg_9 = %cst, %iterArg_10 = %2) : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>, tensor<f32>, tensor<i1>
+// CHECK-NEXT:     cond {
+// CHECK-NEXT:       stablehlo.return %iterArg_10 : tensor<i1>
+// CHECK-NEXT:     } do {
+// CHECK-NEXT:       %5 = stablehlo.subtract %iterArg_5, %c_3 : tensor<i64>
+// CHECK-NEXT:       %6 = stablehlo.subtract %arg1, %iterArg : tensor<i64>
+// CHECK-NEXT:       %7 = stablehlo.dynamic_slice %iterArg_7, %5, sizes = [1] : (tensor<4xf32>, tensor<i64>) -> tensor<1xf32>
+// CHECK-NEXT:       %8 = stablehlo.reshape %7 : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:       %9 = stablehlo.dynamic_slice %iterArg_8, %5, sizes = [1] : (tensor<4xi64>, tensor<i64>) -> tensor<1xi64>
+// CHECK-NEXT:       %10 = stablehlo.reshape %9 : (tensor<1xi64>) -> tensor<i64>
+// CHECK-NEXT:       %11:5 = stablehlo.while(%iterArg_11 = %10, %iterArg_12 = %5, %iterArg_13 = %8, %iterArg_14 = %iterArg_7, %iterArg_15 = %iterArg_8) : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64> attributes {enzymexla.checkpoint_segment}
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %21 = stablehlo.add %iterArg_11, %c_3 : tensor<i64>
+// CHECK-NEXT:         %22 = stablehlo.compare LT, %21, %6 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %22 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %21 = stablehlo.subtract %6, %iterArg_11 : tensor<i64>
+// CHECK-NEXT:         %22 = stablehlo.subtract %0, %iterArg_12 : tensor<i64>
+// CHECK-NEXT:         %23 = stablehlo.minimum %22, %21 : tensor<i64>
+// CHECK-NEXT:         %24 = enzyme.binomial_progress %21, %23 : tensor<i64>
+// CHECK-NEXT:         %25 = stablehlo.reshape %iterArg_13 : (tensor<f32>) -> tensor<1xf32>
+// CHECK-NEXT:         %26 = stablehlo.dynamic_update_slice %iterArg_14, %25, %iterArg_12 : (tensor<4xf32>, tensor<1xf32>, tensor<i64>) -> tensor<4xf32>
+// CHECK-NEXT:         %27 = stablehlo.reshape %iterArg_11 : (tensor<i64>) -> tensor<1xi64>
+// CHECK-NEXT:         %28 = stablehlo.dynamic_update_slice %iterArg_15, %27, %iterArg_12 : (tensor<4xi64>, tensor<1xi64>, tensor<i64>) -> tensor<4xi64>
+// CHECK-NEXT:         %29 = stablehlo.add %iterArg_11, %24 : tensor<i64>
+// CHECK-NEXT:         %30 = stablehlo.compare EQ, %29, %6 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         %31 = stablehlo.subtract %29, %c_3 : tensor<i64>
+// CHECK-NEXT:         %32 = stablehlo.select %30, %31, %29 : tensor<i1>, tensor<i64>
+// CHECK-NEXT:         %33:2 = stablehlo.while(%iterArg_16 = %iterArg_11, %iterArg_17 = %iterArg_13) : tensor<i64>, tensor<f32> attributes {enzymexla.checkpoint_segment}
+// CHECK-NEXT:         cond {
+// CHECK-NEXT:           %35 = stablehlo.compare LT, %iterArg_16, %32 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:           stablehlo.return %35 : tensor<i1>
+// CHECK-NEXT:         } do {
+// CHECK-NEXT:           %35:2 = stablehlo.while(%iterArg_18 = %c_4, %iterArg_19 = %iterArg_17) : tensor<i64>, tensor<f32> attributes {enzymexla.checkpoint_segment}
+// CHECK-NEXT:           cond {
+// CHECK-NEXT:             %37 = stablehlo.compare LT, %iterArg_18, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:             stablehlo.return %37 : tensor<i1>
+// CHECK-NEXT:           } do {
+// CHECK-NEXT:             %37 = stablehlo.multiply %arg0, %iterArg_19 : tensor<f32>
+// CHECK-NEXT:             %38 = stablehlo.add %iterArg_18, %c_3 : tensor<i64>
+// CHECK-NEXT:             stablehlo.return %38, %37 : tensor<i64>, tensor<f32>
+// CHECK-NEXT:           }
+// CHECK-NEXT:           %36 = stablehlo.add %iterArg_16, %c_3 : tensor<i64>
+// CHECK-NEXT:           stablehlo.return %36, %35#1 : tensor<i64>, tensor<f32>
+// CHECK-NEXT:         }
+// CHECK-NEXT:         %34 = stablehlo.add %iterArg_12, %c_3 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %29, %34, %33#1, %26, %28 : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %12 = stablehlo.reshape %arg1 : (tensor<i64>) -> tensor<1xi64>
+// CHECK-NEXT:       %13 = tensor.empty() : tensor<0xf32>
+// CHECK-NEXT:       %14 = stablehlo.dynamic_pad %13, %cst, %c, %12, %c : (tensor<0xf32>, tensor<f32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
+// CHECK-NEXT:       %15:3 = stablehlo.while(%iterArg_11 = %c_4, %iterArg_12 = %11#2, %iterArg_13 = %14) : tensor<i64>, tensor<f32>, tensor<?xf32>
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         %21 = stablehlo.compare LT, %iterArg_11, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %21 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %21 = stablehlo.reshape %iterArg_12 : (tensor<f32>) -> tensor<1xf32>
+// CHECK-NEXT:         %22 = stablehlo.dynamic_update_slice %iterArg_13, %21, %iterArg_11 : (tensor<?xf32>, tensor<1xf32>, tensor<i64>) -> tensor<?xf32>
+// CHECK-NEXT:         %23 = stablehlo.multiply %arg0, %iterArg_12 : tensor<f32>
+// CHECK-NEXT:         %24 = stablehlo.add %iterArg_11, %c_3 : tensor<i64>
+// CHECK-NEXT:         stablehlo.return %24, %23, %22 : tensor<i64>, tensor<f32>, tensor<?xf32>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %16 = stablehlo.subtract %arg1, %c_3 : tensor<i64>
+// CHECK-NEXT:       %17 = stablehlo.compare LT, %c_4, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       %18:4 = stablehlo.while(%iterArg_11 = %c_4, %iterArg_12 = %iterArg_6, %iterArg_13 = %iterArg_9, %iterArg_14 = %17) : tensor<i64>, tensor<f32>, tensor<f32>, tensor<i1>
+// CHECK-NEXT:       cond {
+// CHECK-NEXT:         stablehlo.return %iterArg_14 : tensor<i1>
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:         %21 = stablehlo.subtract %16, %iterArg_11 : tensor<i64>
+// CHECK-NEXT:         %22 = stablehlo.dynamic_slice %15#2, %21, sizes = [1] : (tensor<?xf32>, tensor<i64>) -> tensor<1xf32>
+// CHECK-NEXT:         %23 = stablehlo.reshape %22 : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:         %24 = stablehlo.add %iterArg_11, %c_3 : tensor<i64>
+// CHECK-NEXT:         %25 = stablehlo.multiply %iterArg_12, %23 : tensor<f32>
+// CHECK-NEXT:         %26 = stablehlo.add %iterArg_13, %25 : tensor<f32>
+// CHECK-NEXT:         %27 = stablehlo.multiply %iterArg_12, %arg0 : tensor<f32>
+// CHECK-NEXT:         %28 = stablehlo.compare LT, %24, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:         stablehlo.return %24, %27, %26, %28 : tensor<i64>, tensor<f32>, tensor<f32>, tensor<i1>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %19 = stablehlo.add %iterArg, %c_3 : tensor<i64>
+// CHECK-NEXT:       %20 = stablehlo.compare LT, %19, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:       stablehlo.return %19, %11#1, %18#1, %11#3, %11#4, %18#2, %20 : tensor<i64>, tensor<i64>, tensor<f32>, tensor<4xf32>, tensor<4xi64>, tensor<f32>, tensor<i1>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     %4 = stablehlo.add %3#5, %3#2 : tensor<f32>
+// CHECK-NEXT:     return %4 : tensor<f32>
+// CHECK-NEXT:   }

--- a/test/lit_tests/whileInductionStableHlo.mlir
+++ b/test/lit_tests/whileInductionStableHlo.mlir
@@ -41,10 +41,11 @@ func.func @test_while_induction_2(%other_value: tensor<i32>, %dynamic_limit: ten
 // CHECK-DAG: %[[C5:.*]] = stablehlo.constant dense<5> : tensor<i32>
 // CHECK: %[[CUSTOM_INIT:.*]] = "test.unknown_state"() : () -> tensor<i32>
 
-// CHECK: %[[WHILE:.*]]:2 = stablehlo.while(%[[ITER_CTR:.*]] = %[[C7]], %[[ITER_CUSTOM:.*]] = %[[CUSTOM_INIT]])
+// The induction rewrite runs before the condition is moved into the body.
+// CHECK: %[[INITIAL_TEST:.*]] = stablehlo.compare LT, %[[C7]], %[[ARG1]]
+// CHECK: %[[WHILE:.*]]:3 = stablehlo.while(%[[ITER_CTR:.*]] = %[[C7]], %[[ITER_CUSTOM:.*]] = %[[CUSTOM_INIT]], %[[PRED:.*]] = %[[INITIAL_TEST]])
 // CHECK: cond {
-// CHECK:   %[[CMP:.*]] = stablehlo.compare LT, %[[ITER_CTR]], %[[ARG1]]
-// CHECK:   stablehlo.return %[[CMP]] : tensor<i1>
+// CHECK-NEXT:   stablehlo.return %[[PRED]] : tensor<i1>
 // CHECK: } do {
 // CHECK:   %[[OFFSET:.*]] = stablehlo.subtract %[[ITER_CTR]], %[[C7]]
 // CHECK:   %[[SCALED:.*]] = stablehlo.multiply %[[OFFSET]], %[[C5]]
@@ -53,7 +54,8 @@ func.func @test_while_induction_2(%other_value: tensor<i32>, %dynamic_limit: ten
 // CHECK:   %[[CALCULATED_SUM:.*]] = stablehlo.add %[[DIV]], %[[C8]]
 // CHECK:   %[[UPDATE1:.*]] = "test.unknown_update"(%[[ITER_CUSTOM]], %[[ITER_CTR]])
 // CHECK:   %[[UPDATE2:.*]] = "test.unknown_update"(%[[UPDATE1]], %[[CALCULATED_SUM]])
-// CHECK:   stablehlo.return %[[NEW_CTR]], %[[UPDATE2]]
+// CHECK:   %[[NEXT_TEST:.*]] = stablehlo.compare LT, %[[NEW_CTR]], %[[ARG1]]
+// CHECK:   stablehlo.return %[[NEW_CTR]], %[[UPDATE2]], %[[NEXT_TEST]]
 // CHECK: }
 
 // CHECK: %[[TOTAL_ITER:.*]] = stablehlo.subtract %[[ARG1]], %[[C7]]

--- a/test/lit_tests/while_condition_to_body.mlir
+++ b/test/lit_tests/while_condition_to_body.mlir
@@ -1,0 +1,202 @@
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt %s | FileCheck %s --check-prefixes=CHECK,ONCE
+// RUN: enzymexlamlir-opt --enzyme-hlo-opt --enzyme-hlo-opt %s | FileCheck %s --check-prefixes=CHECK,TWICE
+
+// Before: test i < limit in the condition, then increment i in the body.
+// After: test 0 < limit once before entering, and return the next comparison
+// from the body alongside i + 1. The condition only returns the carried bool.
+// This lets a GPU backend fuse the comparison with the increment and avoids
+// a separate condition kernel. A nonpositive limit still executes zero times.
+// CHECK-LABEL: func.func @dynamic_limit
+// CHECK-DAG: %[[ZERO:.*]] = stablehlo.constant dense<0> : tensor<i32>
+// CHECK-DAG: %[[ONE:.*]] = stablehlo.constant dense<1> : tensor<i32>
+// ONCE: %[[INIT:.*]] = stablehlo.compare LT, %[[ZERO]], %arg0
+// A subsequent optimizer invocation may put the constant on the right, but
+// must not add another predicate argument to the loop.
+// TWICE: %[[INIT:.*]] = stablehlo.compare GT, %arg0, %[[ZERO]]
+// CHECK: %[[RESULT:.*]]:3 = stablehlo.while(%[[I:.*]] = %[[ZERO]], %[[X:.*]] = %arg1, %[[P:.*]] = %[[INIT]])
+// CHECK-NEXT: cond {
+// CHECK-NEXT: stablehlo.return %[[P]] : tensor<i1>
+// CHECK-NEXT: } do {
+// CHECK: %[[NEXT:.*]] = stablehlo.add %[[I]], %[[ONE]]
+// CHECK: %[[SQUARE:.*]] = stablehlo.multiply %[[X]], %[[X]]
+// CHECK: %[[TEST:.*]] = stablehlo.compare LT, %[[NEXT]], %arg0
+// CHECK: stablehlo.return %[[NEXT]], %[[SQUARE]], %[[TEST]]
+// CHECK: return %[[RESULT]]#1
+func.func @dynamic_limit(%limit: tensor<i32>, %input: tensor<8xf32>) -> tensor<8xf32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %result:2 = stablehlo.while(%i = %zero, %values = %input) : tensor<i32>, tensor<8xf32>
+  cond {
+    %test = stablehlo.compare LT, %i, %limit, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %test : tensor<i1>
+  } do {
+    %next = stablehlo.add %i, %one : tensor<i32>
+    %square = stablehlo.multiply %values, %values : tensor<8xf32>
+    stablehlo.return %next, %square : tensor<i32>, tensor<8xf32>
+  }
+  return %result#1 : tensor<8xf32>
+}
+
+// The initial comparison must use the actual initial counter, and the next
+// comparison must use the actual updated counter. Do not assume start=0 or
+// step=1. The data result must still be returned to the caller.
+// CHECK-LABEL: func.func @dynamic_start_and_step_two
+// CHECK: %[[INIT:.*]] = stablehlo.compare LT, %arg0, %arg1
+// CHECK: %[[RESULT:.*]]:3 = stablehlo.while(%[[I:.*]] = %arg0, %[[X:.*]] = %arg2, %[[P:.*]] = %[[INIT]])
+// CHECK-NEXT: cond {
+// CHECK-NEXT: stablehlo.return %[[P]]
+// CHECK-NEXT: } do {
+// CHECK: %[[NEXT:.*]] = stablehlo.add %[[I]],
+// CHECK: %[[TEST:.*]] = stablehlo.compare LT, %[[NEXT]], %arg1
+// CHECK: stablehlo.return %[[NEXT]], %{{.*}}, %[[TEST]]
+// CHECK: return %[[RESULT]]#1
+func.func @dynamic_start_and_step_two(%start: tensor<i32>, %limit: tensor<i32>, %input: tensor<8xf32>) -> tensor<8xf32> {
+  %two = stablehlo.constant dense<2> : tensor<i32>
+  %result:2 = stablehlo.while(%i = %start, %values = %input) : tensor<i32>, tensor<8xf32>
+  cond {
+    %test = stablehlo.compare LT, %i, %limit, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %test : tensor<i1>
+  } do {
+    %next = stablehlo.add %i, %two : tensor<i32>
+    %square = stablehlo.multiply %values, %values : tensor<8xf32>
+    stablehlo.return %next, %square : tensor<i32>, tensor<8xf32>
+  }
+  return %result#1 : tensor<8xf32>
+}
+
+// Preserve unsigned comparison semantics, including values whose signed
+// interpretation is negative. The comparison is cloned, not reconstructed.
+// CHECK-LABEL: func.func @unsigned_limit
+// CHECK: stablehlo.compare {{(LT|GT)}}, {{.*}}, UNSIGNED
+// CHECK: stablehlo.while
+// CHECK-NEXT: cond {
+// CHECK-NEXT: stablehlo.return %{{.*}} : tensor<i1>
+// CHECK-NEXT: } do {
+// CHECK: stablehlo.compare {{(LT|GT)}}, {{.*}}, UNSIGNED
+func.func @unsigned_limit(%start: tensor<i32>, %limit: tensor<i32>, %input: tensor<8xf32>) -> tensor<8xf32> {
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %result:2 = stablehlo.while(%i = %start, %values = %input) : tensor<i32>, tensor<8xf32>
+  cond {
+    %test = stablehlo.compare GT, %limit, %i, UNSIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %test : tensor<i1>
+  } do {
+    %next = stablehlo.add %i, %one : tensor<i32>
+    %square = stablehlo.multiply %values, %values : tensor<8xf32>
+    stablehlo.return %next, %square : tensor<i32>, tensor<8xf32>
+  }
+  return %result#1 : tensor<8xf32>
+}
+
+// Static trip counts should remain recognizable to downstream unrolling.
+// CHECK-LABEL: func.func @static_limit
+// CHECK: :2 = stablehlo.while
+// CHECK-NEXT: cond {
+// CHECK-NEXT: %[[TEST:.*]] = stablehlo.compare
+// CHECK-NEXT: stablehlo.return %[[TEST]]
+func.func @static_limit(%input: tensor<8xf32>) -> tensor<8xf32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %three = stablehlo.constant dense<3> : tensor<i32>
+  %result:2 = stablehlo.while(%i = %zero, %values = %input) : tensor<i32>, tensor<8xf32>
+  cond {
+    %test = stablehlo.compare LT, %i, %three, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %test : tensor<i1>
+  } do {
+    %next = stablehlo.add %i, %one : tensor<i32>
+    %square = stablehlo.multiply %values, %values : tensor<8xf32>
+    stablehlo.return %next, %square : tensor<i32>, tensor<8xf32>
+  }
+  return %result#1 : tensor<8xf32>
+}
+
+// An effect in the condition is outside the scope of this lowering. Keep it
+// in the condition region, including its evaluation when the loop exits.
+// CHECK-LABEL: func.func @effectful_condition
+// CHECK: :2 = stablehlo.while
+// CHECK-NEXT: cond {
+// CHECK: stablehlo.custom_call @observe
+// CHECK: %[[TEST:.*]] = stablehlo.compare
+// CHECK: stablehlo.return %[[TEST]]
+func.func @effectful_condition(%limit: tensor<i32>, %input: tensor<8xf32>) -> tensor<8xf32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %result:2 = stablehlo.while(%i = %zero, %values = %input) : tensor<i32>, tensor<8xf32>
+  cond {
+    stablehlo.custom_call @observe(%i) {has_side_effect = true} : (tensor<i32>) -> ()
+    %test = stablehlo.compare LT, %i, %limit, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %test : tensor<i1>
+  } do {
+    %next = stablehlo.add %i, %one : tensor<i32>
+    %square = stablehlo.multiply %values, %values : tensor<8xf32>
+    stablehlo.return %next, %square : tensor<i32>, tensor<8xf32>
+  }
+  return %result#1 : tensor<8xf32>
+}
+
+// An explicit result-sharding contract needs a corresponding entry for the
+// added predicate. Leave such loops alone until that contract can be updated.
+// CHECK-LABEL: func.func @sharded_loop
+// CHECK: :2 = stablehlo.while
+// CHECK-SAME: mhlo.sharding
+// CHECK-NEXT: cond {
+// CHECK-NEXT: %[[TEST:.*]] = stablehlo.compare
+// CHECK-NEXT: stablehlo.return %[[TEST]]
+func.func @sharded_loop(%limit: tensor<i32>, %input: tensor<8xf32>) -> tensor<8xf32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %result:2 = "stablehlo.while"(%zero, %input) ({
+  ^bb0(%i: tensor<i32>, %values: tensor<8xf32>):
+    %test = stablehlo.compare LT, %i, %limit, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %test : tensor<i1>
+  }, {
+  ^bb0(%i: tensor<i32>, %values: tensor<8xf32>):
+    %next = stablehlo.add %i, %one : tensor<i32>
+    %square = stablehlo.multiply %values, %values : tensor<8xf32>
+    stablehlo.return %next, %square : tensor<i32>, tensor<8xf32>
+  }) {mhlo.sharding = "{{replicated}, {replicated}}"} : (tensor<i32>, tensor<8xf32>) -> (tensor<i32>, tensor<8xf32>)
+  return %result#1 : tensor<8xf32>
+}
+
+// Checkpointing must still recognize the original induction comparison when
+// EnzymeHLOOpt runs before differentiation.
+// CHECK-LABEL: func.func @checkpointed_loop
+// CHECK: :2 = stablehlo.while
+// CHECK-NEXT: cond {
+// CHECK-NEXT: %[[TEST:.*]] = stablehlo.compare
+// CHECK-NEXT: stablehlo.return %[[TEST]]
+func.func @checkpointed_loop(%limit: tensor<i32>, %input: tensor<8xf32>) -> tensor<8xf32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %result:2 = stablehlo.while(%i = %zero, %values = %input) : tensor<i32>, tensor<8xf32> attributes {enzyme.enable_checkpointing = true, enzyme.binomial_checkpointing, enzyme.checkpoint_period = 3 : i64}
+  cond {
+    %test = stablehlo.compare LT, %i, %limit, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %test : tensor<i1>
+  } do {
+    %next = stablehlo.add %i, %one : tensor<i32>
+    %square = stablehlo.multiply %values, %values : tensor<8xf32>
+    stablehlo.return %next, %square : tensor<i32>, tensor<8xf32>
+  }
+  return %result#1 : tensor<8xf32>
+}
+
+// Generated checkpoint segments may be differentiated again. Preserve their
+// counted-loop form as well.
+// CHECK-LABEL: func.func @checkpoint_segment
+// CHECK: :2 = stablehlo.while
+// CHECK-NEXT: cond {
+// CHECK-NEXT: %[[TEST:.*]] = stablehlo.compare
+// CHECK-NEXT: stablehlo.return %[[TEST]]
+func.func @checkpoint_segment(%limit: tensor<i32>, %input: tensor<8xf32>) -> tensor<8xf32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %result:2 = stablehlo.while(%i = %zero, %values = %input) : tensor<i32>, tensor<8xf32> attributes {enzymexla.checkpoint_segment}
+  cond {
+    %test = stablehlo.compare LT, %i, %limit, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %test : tensor<i1>
+  } do {
+    %next = stablehlo.add %i, %one : tensor<i32>
+    %square = stablehlo.multiply %values, %values : tensor<8xf32>
+    stablehlo.return %next, %square : tensor<i32>, tensor<8xf32>
+  }
+  return %result#1 : tensor<8xf32>
+}

--- a/test/lit_tests/while_dus3.mlir
+++ b/test/lit_tests/while_dus3.mlir
@@ -24,24 +24,28 @@ module @"reactant_loop!" attributes {mhlo.num_partitions = 1 : i64, mhlo.num_rep
   }
 }
 
-// CHECK:  func.func @main(%arg0: tensor<24x38x62xf32>, %arg1: tensor<i64>) -> tensor<24x38x62xf32> {
-// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [0:24, 14:38, 0:62] : (tensor<24x38x62xf32>) -> tensor<24x24x62xf32>
-// CHECK-NEXT:    %1:2 = stablehlo.while(%iterArg = %c, %iterArg_1 = %0) : tensor<i64>, tensor<24x24x62xf32>
-// CHECK-NEXT:     cond {
-// CHECK-NEXT:      %4 = stablehlo.compare  LT, %iterArg, %arg1 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %4 : tensor<i1>
-// CHECK-NEXT:    } do {
-// CHECK-NEXT:      %4 = stablehlo.slice %arg0 [7:17, 7:14, 7:55] : (tensor<24x38x62xf32>) -> tensor<10x7x48xf32>
-// CHECK-NEXT:      %5 = stablehlo.slice %iterArg_1 [7:17, 0:17, 7:55] : (tensor<24x24x62xf32>) -> tensor<10x17x48xf32>
-// CHECK-NEXT:      %6 = stablehlo.concatenate %4, %5, dim = 1 : (tensor<10x7x48xf32>, tensor<10x17x48xf32>) -> tensor<10x24x48xf32>
-// CHECK-NEXT:      "test.use"(%6) : (tensor<10x24x48xf32>) -> ()
-// CHECK-NEXT:      %7 = "test.update"() : () -> tensor<24x24x62xf32>
-// CHECK-NEXT:      %8 = stablehlo.add %iterArg, %c_0 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %8, %7 : tensor<i64>, tensor<24x24x62xf32>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %2 = stablehlo.slice %arg0 [0:24, 0:14, 0:62] : (tensor<24x38x62xf32>) -> tensor<24x14x62xf32>
-// CHECK-NEXT:    %3 = stablehlo.concatenate %2, %1#1, dim = 1 : (tensor<24x14x62xf32>, tensor<24x24x62xf32>) -> tensor<24x38x62xf32>
-// CHECK-NEXT:    return %3 : tensor<24x38x62xf32>
-// CHECK-NEXT:  }
+// Only the updated trailing 24 columns remain loop-carried. The leading 14
+// columns are recovered from the input, including for the slice inside the
+// body. Condition carrying happens after this buffer-shape optimization.
+// CHECK-LABEL: func.func @main(%arg0: tensor<24x38x62xf32>, %arg1: tensor<i64>) -> tensor<24x38x62xf32> {
+// CHECK-NEXT: %[[ZERO:.*]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT: %[[ONE:.*]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT: %[[INITIAL:.*]] = stablehlo.slice %arg0 [0:24, 14:38, 0:62] : (tensor<24x38x62xf32>) -> tensor<24x24x62xf32>
+// CHECK-NEXT: %[[FIRST_TEST:.*]] = stablehlo.compare LT, %[[ZERO]], %arg1
+// CHECK-NEXT: %[[WHILE:.*]]:3 = stablehlo.while(%[[I:.*]] = %[[ZERO]], %[[DATA:.*]] = %[[INITIAL]], %[[PRED:.*]] = %[[FIRST_TEST]]) : tensor<i64>, tensor<24x24x62xf32>, tensor<i1>
+// CHECK-NEXT: cond {
+// CHECK-NEXT: stablehlo.return %[[PRED]] : tensor<i1>
+// CHECK-NEXT: } do {
+// CHECK-NEXT: %[[LEFT:.*]] = stablehlo.slice %arg0 [7:17, 7:14, 7:55] : (tensor<24x38x62xf32>) -> tensor<10x7x48xf32>
+// CHECK-NEXT: %[[RIGHT:.*]] = stablehlo.slice %[[DATA]] [7:17, 0:17, 7:55] : (tensor<24x24x62xf32>) -> tensor<10x17x48xf32>
+// CHECK-NEXT: %[[SLICE:.*]] = stablehlo.concatenate %[[LEFT]], %[[RIGHT]], dim = 1 : (tensor<10x7x48xf32>, tensor<10x17x48xf32>) -> tensor<10x24x48xf32>
+// CHECK-NEXT: "test.use"(%[[SLICE]]) : (tensor<10x24x48xf32>) -> ()
+// CHECK-NEXT: %[[UPDATE:.*]] = "test.update"() : () -> tensor<24x24x62xf32>
+// CHECK-NEXT: %[[NEXT_I:.*]] = stablehlo.add %[[I]], %[[ONE]] : tensor<i64>
+// CHECK-NEXT: %[[NEXT_TEST:.*]] = stablehlo.compare LT, %[[NEXT_I]], %arg1
+// CHECK-NEXT: stablehlo.return %[[NEXT_I]], %[[UPDATE]], %[[NEXT_TEST]] : tensor<i64>, tensor<24x24x62xf32>, tensor<i1>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[PREFIX:.*]] = stablehlo.slice %arg0 [0:24, 0:14, 0:62] : (tensor<24x38x62xf32>) -> tensor<24x14x62xf32>
+// CHECK-NEXT: %[[RESULT:.*]] = stablehlo.concatenate %[[PREFIX]], %[[WHILE]]#1, dim = 1 : (tensor<24x14x62xf32>, tensor<24x24x62xf32>) -> tensor<24x38x62xf32>
+// CHECK-NEXT: return %[[RESULT]] : tensor<24x38x62xf32>
+// CHECK-NEXT: }


### PR DESCRIPTION
A dynamic StableHLO while can launch separate GPU kernels for its counter increment and condition comparison. Carry the condition as an extra loop value: compute the initial predicate before entering, then compute the next predicate from the body's yielded values. The condition region only returns that predicate, and XLA can fuse the next comparison with the increment.

The rewrite is enabled by default after EnzymeHLOOpt's existing greedy optimization phase, preserving the recognizable counted-loop form during induction and buffer-shape optimizations. It targets scalar comparisons with a nonzero constant integer counter increment, clones comparison semantics, and preserves zero-iteration behavior. Static initial counters and bounds, conditions containing effects or additional operations, explicitly sharded loops, and loops marked for checkpointing retain their existing form. The checkpointing exclusion preserves the induction comparison that later differentiation uses to recover the loop bounds.

Validation:

- All 92 related while/scatter/gather LIT files pass, including checkpointing, differentiation, and batching tests. New coverage includes dynamic starts, non-unit steps, unsigned/reversed comparisons, exclusions, and repeat-pass stability; existing induction and buffer-shape checks verify those optimizations still run first. Checkpointing tests verify that marked loops keep their induction comparisons and that eligible unannotated reverse loops carry predicates.
- Six GPU runtime cases with dynamic starts/bounds and step 2 match their references, including zero and one iteration.
- Combined with the scatter/layout rewrite in #3130, the normal 20-timestep LBM executable records **51 launches instead of 61**: one initial comparison, ten counter/next-comparison kernels, twenty moments kernels, and twenty scatter kernels. The condition has no device thunks.
- All 6,480,000 LBM output float32 values are byte-identical to the preceding XLA result and agree with CUDA within `atol=1e-6, rtol=1e-5` (maximum absolute error `5.96e-7`).

This PR is independent of #3130. It adds no custom call or XLA backend change. The loop remains host-controlled and still copies its predicate to the host each iteration; this result establishes fewer launches, not a controlled steady-state speedup.
