### PR TITLE
mem2reg: split an access through a branch between buffers a kernel was handed

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -3195,6 +3195,11 @@ static bool isAllocation(Value v) {
 struct BufferBranch {
   Operation *op;
   unsigned resultNo;
+  // Whether an arm is an allocation. Otherwise the branch chooses between
+  // buffers the function was handed, and only its accesses inside a GPU
+  // wrapper are split: those become a kernel, and the kernel's raising has
+  // no tensor that stands for one of two buffers.
+  bool anyAllocation = true;
 
   Value result() const { return op->getResult(resultNo); }
   Value armValue(unsigned arm) const {
@@ -3283,10 +3288,12 @@ static bool splitBufferBranchAccesses(Operation *f) {
   SmallVector<BufferBranch> work;
   f->walk([&](Operation *op) {
     for (Value res : op->getResults())
-      if (auto br = bufferBranch(res))
-        if (isAllocation(bufferRoot(br->armValue(0))) ||
-            isAllocation(bufferRoot(br->armValue(1))))
+      if (auto br = bufferBranch(res)) {
+        br->anyAllocation = isAllocation(bufferRoot(br->armValue(0))) ||
+                            isAllocation(bufferRoot(br->armValue(1)));
+        if (br->anyAllocation || op->getParentOfType<GPUWrapperOp>())
           work.push_back(*br);
+      }
   });
 
   bool changed = false;
@@ -3300,6 +3307,8 @@ static bool splitBufferBranchAccesses(Operation *f) {
       Operation *user = use.getOwner();
       auto operand = bufferOperand(user, br.result());
       if (!operand)
+        continue;
+      if (!br.anyAllocation && !user->getParentOfType<GPUWrapperOp>())
         continue;
 
       OpBuilder b(user);
@@ -3336,8 +3345,10 @@ static bool splitBufferBranchAccesses(Operation *f) {
       // A respelling of the branch's result is a branch between buffers again,
       // whose own accesses want splitting.
       if (newBr->getNumResults())
-        if (auto inner = bufferBranch(newBr->getResult(0)))
+        if (auto inner = bufferBranch(newBr->getResult(0))) {
+          inner->anyAllocation = br.anyAllocation;
           work.push_back(*inner);
+        }
     }
 
     // A branch nothing is left to ask goes, so long as it did nothing but

--- a/test/lit_tests/mem2reg_buffer_branch.mlir
+++ b/test/lit_tests/mem2reg_buffer_branch.mlir
@@ -83,6 +83,33 @@ module {
     %r = affine.load %buf[0] : memref<4xf64>
     return %r : f64
   }
+
+  // The same choice between two buffers the kernel was handed, not allocated:
+  // `const real_t wx = (c == 0) ? Bct(dx,qx) : Bot(dx,qx)` in MFEM's H(curl)/H(div)
+  // kernels arrives as an affine.if yielding one of two pointer arguments, and
+  // the access sits inside a GPU wrapper. Nothing owns those buffers, but the
+  // kernel's raising has no tensor standing for one of two buffers, so the
+  // access is done in each arm here as well.
+  func.func @args_in_wrapper(%bc: !llvm.ptr, %bo: !llvm.ptr, %out: memref<?xf64>, %n: index) {
+    %c1 = arith.constant 1 : index
+    "enzymexla.gpu_wrapper"(%n, %c1, %c1, %c1, %c1, %c1) ({
+      affine.parallel (%e) = (0) to (symbol(%n)) {
+        %acc = affine.for %c = 0 to 3 iter_args(%a = %e) -> index {
+          %p = affine.if #set(%c) -> !llvm.ptr {
+            affine.yield %bc : !llvm.ptr
+          } else {
+            affine.yield %bo : !llvm.ptr
+          }
+          %m = "enzymexla.pointer2memref"(%p) : (!llvm.ptr) -> memref<?xf64>
+          %v = affine.load %m[%c + %e * 3] : memref<?xf64>
+          affine.store %v, %out[%c + %e * 3] : memref<?xf64>
+          affine.yield %a : index
+        }
+      }
+      "enzymexla.polygeist_yield"() : () -> ()
+    }) : (index, index, index, index, index, index) -> index
+    return
+  }
 }
 
 // CHECK-LABEL: func.func @load_through_if(
@@ -128,3 +155,26 @@ module {
 // CHECK-LABEL: func.func @not_allocations(
 // CHECK:         %[[buf:.+]] = arith.select %arg0, %arg1, %arg2
 // CHECK-NEXT:    affine.load %[[buf]][0]
+
+// CHECK:    func.func @args_in_wrapper(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: memref<?xf64>, %arg3: index) {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %0 = "enzymexla.gpu_wrapper"(%arg3, %c1, %c1, %c1, %c1, %c1) ({
+// CHECK-NEXT:      affine.parallel (%arg4) = (0) to (symbol(%arg3)) {
+// CHECK-NEXT:        %1 = affine.for %arg5 = 0 to 3 iter_args(%arg6 = %arg4) -> (index) {
+// CHECK-NEXT:          %2 = affine.if #set(%arg5) -> f64 {
+// CHECK-NEXT:            %3 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:            %4 = affine.load %3[%arg5 + %arg4 * 3] : memref<?xf64>
+// CHECK-NEXT:            affine.yield %4 : f64
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %3 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?xf64>
+// CHECK-NEXT:            %4 = affine.load %3[%arg5 + %arg4 * 3] : memref<?xf64>
+// CHECK-NEXT:            affine.yield %4 : f64
+// CHECK-NEXT:          }
+// CHECK-NEXT:          affine.store %2, %arg2[%arg5 + %arg4 * 3] : memref<?xf64>
+// CHECK-NEXT:          affine.yield %arg6 : index
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:      "enzymexla.polygeist_yield"() : () -> ()
+// CHECK-NEXT:    }) : (index, index, index, index, index, index) -> index
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }


### PR DESCRIPTION
#3116 does an access through a branch between two allocations in each arm, so each allocation gets accesses of its own. MFEM's H(curl)/H(div) kernels (`bilininteg_hcurlhdiv_kernels.hpp`, `bilininteg_hdiv_kernels.cpp`, `bilininteg_hcurl_kernels.cpp`, `bilininteg_curlcurl_pa.cpp`, `bilininteg_mixedcurl_pa.cpp`, `bilininteg_mixedvecgrad_pa.cpp`) make the same choice between two buffers the kernel was handed rather than allocated:

```cpp
const real_t wx = (c == 0) ? Bct(dx,qx) : Bot(dx,qx);
```

LLVM hoists the two loads into one load from a selected address, and by the time control flow is lifted it is an `affine.if` on the component loop's index yielding one of two pointer arguments, inside a GPU wrapper:

```mlir
%822 = affine.if #set6(%arg13) -> !llvm.ptr { affine.yield %176 } else { affine.yield %169 }
%823 = "enzymexla.pointer2memref"(%822) : (!llvm.ptr) -> memref<?xf64>
%827 = memref.load %823[%826] : memref<?xf64>
```

Nothing owns those buffers, so mem2reg has no slot to split, but the kernel's raising has no tensor standing for one of two buffers either; that is what the raiser-side expansion in #3027 / #3105 exists for. Doing it here instead, before raising, is the plain inverse of LLVM's hoist: when the access lies inside a GPU wrapper, the branch between buffers is split the same way as one between allocations, casts and offsets pushed into the arms. Outside a wrapper a branch between non-allocation buffers stays as it was (the existing `@not_allocations` case).

Test: the wrapper shape above, checked line for line. Lit: all tests pass. On the union tree with the raiser-side expansion switched off (`expandBufferBranches` returning early), the five mfem translation units that needed it (`curlcurl_pa`, `hcurl_kernels`, `hdiv_kernels`, `mixedcurl_pa`, `mixedvecgrad_pa`) all compile strict with this in mem2reg instead; without either they fail with `non pointermemref user of pointer arg in kernel: affine.yield … : !llvm.ptr`. So this replaces #3027 and #3105 for mfem; the union's GPU suite on objects built that way is the remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
