### PR TITLE
Raising: pad a barrier-spanning dynamic lane axis to the launch budget

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -5421,15 +5421,33 @@ struct AffineToStableHLORaisingPass
   // `if (v REL C) <noreturn>` leaves the complementary relation holding on
   // every path that reaches the anchor, and inside the surviving branch of an
   // enclosing `if (v REL C)` the relation holds.
-  static std::optional<int64_t> guardBound(Value v, Operation *anchor) {
-    if (!anchor)
-      return std::nullopt;
-    std::optional<int64_t> bound;
+  // Whether `ifOp` is a verify dominating `anchor`: exactly one arm aborts,
+  // so on every path reaching the anchor the condition holds (true) or its
+  // negation does (false).
+  static std::optional<bool> dominatingVerify(scf::IfOp ifOp,
+                                              Operation *anchor) {
     auto aborts = [](Region &region) {
       return region
           .walk([](LLVM::UnreachableOp) { return WalkResult::interrupt(); })
           .wasInterrupted();
     };
+    bool thenAborts = aborts(ifOp.getThenRegion());
+    bool elseAborts =
+        !ifOp.getElseRegion().empty() && aborts(ifOp.getElseRegion());
+    if (thenAborts == elseAborts)
+      return std::nullopt;
+    Operation *a = anchor;
+    while (a && a->getBlock() != ifOp->getBlock())
+      a = a->getParentOp();
+    if (!a || a == ifOp || !ifOp->isBeforeInBlock(a))
+      return std::nullopt;
+    return elseAborts;
+  }
+
+  static std::optional<int64_t> guardBound(Value v, Operation *anchor) {
+    if (!anchor)
+      return std::nullopt;
+    std::optional<int64_t> bound;
     for (Operation *user : v.getUsers()) {
       auto cmp = dyn_cast<arith::CmpIOp>(user);
       if (!cmp)
@@ -5438,17 +5456,10 @@ struct AffineToStableHLORaisingPass
         auto ifOp = dyn_cast<scf::IfOp>(condUser);
         if (!ifOp || ifOp.getCondition() != cmp.getResult())
           continue;
-        bool thenAborts = aborts(ifOp.getThenRegion());
-        bool elseAborts =
-            !ifOp.getElseRegion().empty() && aborts(ifOp.getElseRegion());
-        if (thenAborts == elseAborts)
+        auto holds = dominatingVerify(ifOp, anchor);
+        if (!holds)
           continue;
-        Operation *a = anchor;
-        while (a && a->getBlock() != ifOp->getBlock())
-          a = a->getParentOp();
-        if (!a || a == ifOp || !ifOp->isBeforeInBlock(a))
-          continue;
-        if (auto b = relationBound(cmp, v, /*holds=*/elseAborts))
+        if (auto b = relationBound(cmp, v, *holds))
           bound = std::min(bound.value_or(*b), *b);
       }
     }
@@ -5668,9 +5679,96 @@ struct AffineToStableHLORaisingPass
     }
   }
 
+  // A launch dimension stripped of the casts between the host value and the
+  // launch operand.
+  static Value launchDimRoot(Value v) {
+    while (isa_and_nonnull<arith::IndexCastOp, arith::IndexCastUIOp,
+                           arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp>(
+        v.getDefiningOp()))
+      v = v.getDefiningOp()->getOperand(0);
+    return v;
+  }
+
+  // Two values a dominating noreturn verify pins equal (MFEM_VERIFY(q == d))
+  // share their launch-budget dimension.
+  static bool guardEqual(Value a, Value b, Operation *anchor) {
+    if (a == b)
+      return true;
+    auto fn = anchor->getParentOfType<FunctionOpInterface>();
+    if (!fn)
+      return false;
+    bool eq = false;
+    fn->walk([&](arith::CmpIOp cmp) {
+      if (eq || !((cmp.getLhs() == a && cmp.getRhs() == b) ||
+                  (cmp.getLhs() == b && cmp.getRhs() == a)))
+        return;
+      for (Operation *condUser : cmp->getUsers()) {
+        auto ifOp = dyn_cast<scf::IfOp>(condUser);
+        if (!ifOp || ifOp.getCondition() != cmp.getResult())
+          continue;
+        auto holds = dominatingVerify(ifOp, anchor);
+        if (!holds)
+          continue;
+        auto pred = *holds ? cmp.getPredicate()
+                           : arith::invertPredicate(cmp.getPredicate());
+        if (pred == arith::CmpIPredicate::eq)
+          eq = true;
+      }
+    });
+    return eq;
+  }
+
+  // A CUDA launch whose block exceeds 1024 threads fails, so the reference
+  // execution only ever runs block extents within the hardware budget.
+  // When this extent is one of the launch's block dimensions, split the
+  // budget over the dimensions sharing its value; other constant block
+  // dims consume their share, and unmatched dynamic ones count as >= 1.
+  static std::optional<int64_t> launchDimBound(Value ext,
+                                               enzymexla::GPUWrapperOp g) {
+    Value root = launchDimRoot(ext);
+    if (g->getNumOperands() < 6)
+      return std::nullopt;
+    int64_t budget = 1024;
+    unsigned sharing = 0;
+    for (unsigned i = 3; i < 6; ++i) {
+      Value bd = g->getOperand(i);
+      APInt c;
+      if (matchPattern(bd, m_ConstantInt(&c))) {
+        budget /= std::max<int64_t>(1, c.getSExtValue());
+        continue;
+      }
+      if (guardEqual(launchDimRoot(bd), root, g))
+        ++sharing;
+    }
+    if (!sharing || budget <= 0)
+      return std::nullopt;
+    // The largest b with b^sharing <= budget.
+    int64_t b = budget;
+    if (sharing == 2)
+      b = (int64_t)std::sqrt((double)budget);
+    else if (sharing == 3)
+      b = (int64_t)std::cbrt((double)budget);
+    while (b > 1) {
+      int64_t prod = 1;
+      bool over = false;
+      for (unsigned i = 0; i < sharing; ++i) {
+        if (prod > budget / b) {
+          over = true;
+          break;
+        }
+        prod *= b;
+      }
+      if (!over && prod <= budget)
+        break;
+      --b;
+    }
+    return b;
+  }
+
   // A parallel axis whose extent is dynamic but provably bounded (a block
   // size clamped by a min against a constant, capped by a guard, indexing a
-  // static scratch buffer, or an affine expression of such values) batches
+  // static scratch buffer, an affine expression of such values, or limited
+  // by the launch budget) batches
   // at the bound instead of peeling to a serial loop: the axis becomes
   // constant-extent and the body sits behind an `iv < extent` guard, which
   // the masking machinery already understands. Barriers over the axis then
@@ -5727,11 +5825,14 @@ struct AffineToStableHLORaisingPass
         if (!bound)
           bound = allocaIndexBound(par.getOperation(), par.getBody(),
                                    par.getBody()->getArgument(i));
-        if (!bound)
-          continue;
         OpBuilder pre(par);
         Value ext =
             pre.createOrFold<affine::AffineApplyOp>(par.getLoc(), um, operands);
+        if (auto g = par->getParentOfType<enzymexla::GPUWrapperOp>())
+          if (auto launch = launchDimBound(ext, g))
+            bound = std::min(bound.value_or(*launch), *launch);
+        if (!bound)
+          continue;
         bounded.push_back({i, *bound, ext});
       }
       if (bounded.empty())

--- a/test/lit_tests/raising/raise_barrier_budget.mlir
+++ b/test/lit_tests/raising/raise_barrier_budget.mlir
@@ -1,0 +1,131 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo --split-input-file | FileCheck %s
+
+// Two lane axes share the block extent Q: a block of Q*Q threads never
+// launches past 1024, so each axis is bounded by 32 and pads to that behind
+// an iv < Q guard; the barrier between the scratch fill and the read raises.
+func.func @budget(%out: memref<1024xf64, 1>, %in: memref<1024xf64, 1>, %qbuf: memref<i32, 1>, %unused: index) {
+  %c1 = arith.constant 1 : index
+  %q = affine.load %qbuf[] : memref<i32, 1>
+  %qi = arith.index_cast %q : i32 to index
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %qi, %qi, %c1) ({
+    affine.parallel (%e) = (0) to (1) {
+      %scr = memref.alloca() : memref<32x32xf64>
+      affine.parallel (%tx, %ty) = (0, 0) to (symbol(%qi), symbol(%qi)) {
+        %v = affine.load %in[%tx * 32 + %ty] : memref<1024xf64, 1>
+        affine.store %v, %scr[%tx, %ty] : memref<32x32xf64>
+        "enzymexla.barrier"(%tx, %ty, %c1) : (index, index, index) -> ()
+        %w = affine.load %scr[%ty, %tx] : memref<32x32xf64>
+        affine.store %w, %out[%tx * 32 + %ty] : memref<1024xf64, 1>
+      }
+    }
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// CHECK:    func.func @budget(%arg0: memref<1024xf64, 1>, %arg1: memref<1024xf64, 1>, %arg2: memref<i32, 1>, %arg3: index) {
+// CHECK-NEXT:    %alloca = memref.alloca() : memref<i32>
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %0 = affine.load %arg2[] : memref<i32, 1>
+// CHECK-NEXT:    %1 = arith.index_cast %0 : i32 to index
+// CHECK-NEXT:    %memref = gpu.alloc  () : memref<i32, 1>
+// CHECK-NEXT:    affine.store %0, %alloca[] : memref<i32>
+// CHECK-NEXT:    %c4 = arith.constant 4 : index
+// CHECK-NEXT:    enzymexla.memcpy  %memref, %alloca, %c4 : memref<i32, 1>, memref<i32>
+// CHECK-NEXT:    enzymexla.xla_wrapper @rxla$raised_0 (%arg1, %arg0, %memref) : (memref<1024xf64, 1>, memref<1024xf64, 1>, memref<i32, 1>) -> ()
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    gpu.dealloc  %memref : memref<i32, 1>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @rxla$raised_0(%arg0: tensor<1024xf64>, %arg1: tensor<1024xf64>, %arg2: tensor<i32>) -> (tensor<1024xf64>, tensor<1024xf64>, tensor<i32>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %0 = stablehlo.convert %arg2 : (tensor<i32>) -> tensor<i64>
+// CHECK-NEXT:    %1 = stablehlo.iota dim = 0 : tensor<1xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %2 = stablehlo.add %1, %c_0 : tensor<1xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<1xi64>
+// CHECK-NEXT:    %3 = stablehlo.multiply %2, %c_1 : tensor<1xi64>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<1x32x32xf64>
+// CHECK-NEXT:    %4 = stablehlo.iota dim = 0 : tensor<32xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<32xi64>
+// CHECK-NEXT:    %5 = stablehlo.add %4, %c_2 : tensor<32xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<1> : tensor<32xi64>
+// CHECK-NEXT:    %6 = stablehlo.multiply %5, %c_3 : tensor<32xi64>
+// CHECK-NEXT:    %7 = stablehlo.iota dim = 0 : tensor<32xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<32xi64>
+// CHECK-NEXT:    %8 = stablehlo.add %7, %c_4 : tensor<32xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<1> : tensor<32xi64>
+// CHECK-NEXT:    %9 = stablehlo.multiply %8, %c_5 : tensor<32xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<-1> : tensor<i64>
+// CHECK-NEXT:    %10 = stablehlo.broadcast_in_dim %c_6, dims = [] : (tensor<i64>) -> tensor<32xi64>
+// CHECK-NEXT:    %11 = stablehlo.multiply %6, %10 : tensor<32xi64>
+// CHECK-NEXT:    %12 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<i64>) -> tensor<32xi64>
+// CHECK-NEXT:    %13 = stablehlo.add %11, %12 : tensor<32xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<-1> : tensor<i64>
+// CHECK-NEXT:    %14 = stablehlo.broadcast_in_dim %c_7, dims = [] : (tensor<i64>) -> tensor<32xi64>
+// CHECK-NEXT:    %15 = stablehlo.add %13, %14 : tensor<32xi64>
+// CHECK-NEXT:    %c_8 = stablehlo.constant dense<0> : tensor<32xi64>
+// CHECK-NEXT:    %16 = stablehlo.compare GE, %15, %c_8 : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi1>
+// CHECK-NEXT:    %c_9 = stablehlo.constant dense<-1> : tensor<i64>
+// CHECK-NEXT:    %17 = stablehlo.broadcast_in_dim %c_9, dims = [] : (tensor<i64>) -> tensor<32xi64>
+// CHECK-NEXT:    %18 = stablehlo.multiply %9, %17 : tensor<32xi64>
+// CHECK-NEXT:    %19 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<i64>) -> tensor<32xi64>
+// CHECK-NEXT:    %20 = stablehlo.add %18, %19 : tensor<32xi64>
+// CHECK-NEXT:    %c_10 = stablehlo.constant dense<-1> : tensor<i64>
+// CHECK-NEXT:    %21 = stablehlo.broadcast_in_dim %c_10, dims = [] : (tensor<i64>) -> tensor<32xi64>
+// CHECK-NEXT:    %22 = stablehlo.add %20, %21 : tensor<32xi64>
+// CHECK-NEXT:    %c_11 = stablehlo.constant dense<0> : tensor<32xi64>
+// CHECK-NEXT:    %23 = stablehlo.compare GE, %22, %c_11 : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi1>
+// CHECK-NEXT:    %24 = stablehlo.broadcast_in_dim %16, dims = [0] : (tensor<32xi1>) -> tensor<32x32xi1>
+// CHECK-NEXT:    %25 = stablehlo.broadcast_in_dim %23, dims = [1] : (tensor<32xi1>) -> tensor<32x32xi1>
+// CHECK-NEXT:    %26 = stablehlo.and %24, %25 : tensor<32x32xi1>
+// CHECK-NEXT:    %c_12 = stablehlo.constant dense<32> : tensor<i64>
+// CHECK-NEXT:    %27 = stablehlo.broadcast_in_dim %c_12, dims = [] : (tensor<i64>) -> tensor<32xi64>
+// CHECK-NEXT:    %28 = stablehlo.multiply %6, %27 : tensor<32xi64>
+// CHECK-NEXT:    %29 = stablehlo.broadcast_in_dim %28, dims = [0] : (tensor<32xi64>) -> tensor<32x32xi64>
+// CHECK-NEXT:    %30 = stablehlo.broadcast_in_dim %9, dims = [1] : (tensor<32xi64>) -> tensor<32x32xi64>
+// CHECK-NEXT:    %31 = stablehlo.add %29, %30 : tensor<32x32xi64>
+// CHECK-NEXT:    %32 = stablehlo.reshape %31 : (tensor<32x32xi64>) -> tensor<32x32x1xi64>
+// CHECK-NEXT:    %33 = "stablehlo.gather"(%arg0, %32) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<1024xf64>, tensor<32x32x1xi64>) -> tensor<32x32xf64>
+// CHECK-NEXT:    %c_13 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_14 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_15 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_16 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_17 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_18 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_19 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_20 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_21 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_22 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_23 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_24 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_25 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_26 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_27 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_28 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_29 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_30 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %34 = stablehlo.broadcast_in_dim %33, dims = [1, 2] : (tensor<32x32xf64>) -> tensor<1x32x32xf64>
+// CHECK-NEXT:    %35 = stablehlo.broadcast_in_dim %26, dims = [0, 1] : (tensor<32x32xi1>) -> tensor<32x32x1xi1>
+// CHECK-NEXT:    %36 = stablehlo.broadcast_in_dim %34, dims = [2, 0, 1] : (tensor<1x32x32xf64>) -> tensor<32x32x1xf64>
+// CHECK-NEXT:    %37 = stablehlo.broadcast_in_dim %cst, dims = [2, 0, 1] : (tensor<1x32x32xf64>) -> tensor<32x32x1xf64>
+// CHECK-NEXT:    %38 = stablehlo.select %35, %36, %37 : tensor<32x32x1xi1>, tensor<32x32x1xf64>
+// CHECK-NEXT:    %39 = stablehlo.broadcast_in_dim %38, dims = [1, 2, 0] : (tensor<32x32x1xf64>) -> tensor<1x32x32xf64>
+// CHECK-NEXT:    %40 = stablehlo.dynamic_update_slice %cst, %39, %c_18, %c_24, %c_30 : (tensor<1x32x32xf64>, tensor<1x32x32xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x32x32xf64>
+// CHECK-NEXT:    %c_31 = stablehlo.constant dense<32> : tensor<i64>
+// CHECK-NEXT:    %41 = stablehlo.broadcast_in_dim %c_31, dims = [] : (tensor<i64>) -> tensor<32xi64>
+// CHECK-NEXT:    %42 = stablehlo.multiply %6, %41 : tensor<32xi64>
+// CHECK-NEXT:    %43 = stablehlo.broadcast_in_dim %42, dims = [0] : (tensor<32xi64>) -> tensor<32x32xi64>
+// CHECK-NEXT:    %44 = stablehlo.broadcast_in_dim %9, dims = [1] : (tensor<32xi64>) -> tensor<32x32xi64>
+// CHECK-NEXT:    %45 = stablehlo.add %43, %44 : tensor<32x32xi64>
+// CHECK-NEXT:    %46 = stablehlo.reshape %45 : (tensor<32x32xi64>) -> tensor<32x32x1xi64>
+// CHECK-NEXT:    %47 = stablehlo.reshape %40 : (tensor<1x32x32xf64>) -> tensor<32x32xf64>
+// CHECK-NEXT:    %48 = stablehlo.broadcast_in_dim %47, dims = [1, 0] : (tensor<32x32xf64>) -> tensor<32x32xf64>
+// CHECK-NEXT:    %49 = "stablehlo.gather"(%arg1, %46) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<1024xf64>, tensor<32x32x1xi64>) -> tensor<32x32xf64>
+// CHECK-NEXT:    %50 = stablehlo.select %26, %48, %49 : tensor<32x32xi1>, tensor<32x32xf64>
+// CHECK-NEXT:    %51 = "stablehlo.scatter"(%arg1, %46, %50) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
+// CHECK-NEXT:      stablehlo.return %arg4 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<1024xf64>, tensor<32x32x1xi64>, tensor<32x32xf64>) -> tensor<1024xf64>
+// CHECK-NEXT:    return %arg0, %51, %arg2 : tensor<1024xf64>, tensor<1024xf64>, tensor<i32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
A barrier over a dynamically sized lane axis cannot raise. One bound the extent derivation cannot read covers the axes left in the MFEM suite after #2991 (guards), #3177 (scratch shapes), the launch-dimension canonicalizations (#3178, #3180, #3182) and the composite maps (#3185): a CUDA block never exceeds 1024 threads, so the reference execution only ever ran a block extent within that budget split over the dimensions sharing its value (`forall_2D(NF, Q1D, Q1D)` bounds each axis at 32; values a dominating noreturn verify pins equal, `MFEM_VERIFY(q == d)`, share a dimension). The axis pads to the bound behind an `iv < extent` guard and the barrier raises.

The TUs that need it launch from MFEM's dispatch-table kernels, `internal` functions that are address-taken and never called directly, so `Q1D` arrives as a plain argument or member load with the `MFEM_VERIFY` in the dispatcher and no guard in scope: lininteg_domain, normal_deriv_restriction, dgdiffusion_pa fail with `barrier over a dynamically sized parallel axis` without it. Beyond those, the budget is the tightest bound available on many other block axes: without it sixteen of the 25 runtime-dispatch TUs raise with wider pads or more serial loops (mixedcurl_pa 1342 → 1360 whiles, lininteg_domain_vectorfe's 22-wide pads become 24, and so on).

Earlier revisions carried more derivations (write-once singleton loads, same-member-load matching, non-literal verify compares, shl / dim3 high half, the composite maps now in #3185); switching each off on the union changed neither compilation nor the raised IR, so they are gone or moved out.

Test `raise_barrier_budget.mlir`: two lane axes sharing the block extent, bounded at 32 by the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
