### PR TITLE
Raising: build reshape/broadcast/transpose/concat/slice through the no-op-avoiding helpers

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -369,8 +369,8 @@ struct ParallelContext {
       if (bdim == -1)
         return std::nullopt;
 
-    Value br = stablehlo::BroadcastInDimOp::create(b, v.getLoc(), TT, v,
-                                                   broadcastDims);
+    Value br = stablehlo::BroadcastInDimOpCreate(b, v.getLoc(), v,
+                                                 TT.getShape(), broadcastDims);
 
     affine::AffineValueMap TMap(
         AffineMap::getMultiDimIdentityMap(TT.getRank(), b.getContext()), ivs);
@@ -611,14 +611,10 @@ alignMemoryAccess(Value &a, affine::AffineValueMap src, Value *bs,
     }
   }
 
-  auto TA = cast<RankedTensorType>(a.getType());
-
   if (needsBroadcastA) {
-    a = stablehlo::BroadcastInDimOp::create(
-            builder,
-            rewriteLocation(a.getLoc(), pc.options.strip_llvm_debuginfo),
-            TA.clone(outputShape), a, broadcastDimensionsA)
-            .getResult();
+    a = stablehlo::BroadcastInDimOpCreate(
+        builder, rewriteLocation(a.getLoc(), pc.options.strip_llvm_debuginfo),
+        a, outputShape, broadcastDimensionsA);
   }
 
   for (size_t i = 0; i < dsts.size(); i++) {
@@ -636,12 +632,10 @@ alignMemoryAccess(Value &a, affine::AffineValueMap src, Value *bs,
       needsBroadcast = true;
 
     if (needsBroadcast)
-      bs[i] =
-          stablehlo::BroadcastInDimOp::create(
-              builder,
-              rewriteLocation(bs[i].getLoc(), pc.options.strip_llvm_debuginfo),
-              TB.clone(outputShape), bs[i], broadcastDimensionsBs[i])
-              .getResult();
+      bs[i] = stablehlo::BroadcastInDimOpCreate(
+          builder,
+          rewriteLocation(bs[i].getLoc(), pc.options.strip_llvm_debuginfo),
+          bs[i], outputShape, broadcastDimensionsBs[i]);
   }
 
   // One result per output dimension: an identity dim for each operand, a
@@ -1169,8 +1163,8 @@ static Value buildGatherScatterIndices(
 
       raisedIdxShape.push_back(1);
 
-      raisedIdx = stablehlo::BroadcastInDimOp::create(
-          builder, loc, Ty.clone(raisedIdxShape), raisedIdx, dimsToBroadcast);
+      raisedIdx = stablehlo::BroadcastInDimOpCreate(
+          builder, loc, raisedIdx, raisedIdxShape, dimsToBroadcast);
 
       SmallVector<int64_t> shape(indicesTy.getShape().drop_back().begin(),
                                  indicesTy.getShape().drop_back().end());
@@ -1187,8 +1181,8 @@ static Value buildGatherScatterIndices(
         bDims.push_back(i);
       bDims.push_back(shape.size() - 1);
 
-      indices = stablehlo::BroadcastInDimOp::create(
-          builder, loc, Ty.clone(shape), indices, bDims);
+      indices = stablehlo::BroadcastInDimOpCreate(builder, loc, indices, shape,
+                                                  bDims);
 
       indicesTy = cast<RankedTensorType>(indices.getType());
       SmallVector<int64_t> newIndicesShape(
@@ -1197,17 +1191,16 @@ static Value buildGatherScatterIndices(
       newIndicesShape.push_back(
           indicesTy.getShape()[indicesTy.getShape().size() - 1] + 1);
 
-      indices = stablehlo::ConcatenateOp::create(
-          builder, loc, Ty.clone(newIndicesShape),
-          ValueRange{indices, raisedIdx}, (int64_t)newIndicesShape.size() - 1);
+      indices = stablehlo::ConcatenateOpCreate(
+          builder, loc, ArrayRef<Value>{indices, raisedIdx},
+          (int64_t)newIndicesShape.size() - 1);
     } else {
 
       auto S = cast<RankedTensorType>(raisedIdx.getType()).getShape();
       SmallVector<int64_t> shape(S.begin(), S.end());
       shape.push_back(1);
 
-      indices = stablehlo::ReshapeOp::create(builder, loc, Ty.clone(shape),
-                                             raisedIdx);
+      indices = stablehlo::ReshapeOpCreate(builder, loc, raisedIdx, shape);
     }
   }
 
@@ -1325,8 +1318,8 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
         SmallVector<int64_t> ones(UTy.getRank(), 1);
         for (int64_t ri : raceDims)
           limits[ri] = 1;
-        newUpdate = stablehlo::SliceOp::create(builder, loc, update, starts,
-                                               limits, ones);
+        newUpdate = stablehlo::SliceOpCreate(builder, loc, update, starts,
+                                             limits, ones);
         SmallVector<int64_t> keptShape;
         SmallVector<AffineExpr> keptExprs;
         SmallVector<int64_t> keptBroadcastDims;
@@ -1338,9 +1331,7 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
               updateValueMap.getAffineMap().getResult(updateIdx));
           keptBroadcastDims.push_back(dim);
         }
-        update = stablehlo::ReshapeOp::create(
-            builder, loc,
-            RankedTensorType::get(keptShape, UTy.getElementType()), newUpdate);
+        update = stablehlo::ReshapeOpCreate(builder, loc, newUpdate, keptShape);
         updateValueMap = affine::AffineValueMap(
             AffineMap::get(updateValueMap.getAffineMap().getNumDims(),
                            updateValueMap.getAffineMap().getNumSymbols(),
@@ -1412,9 +1403,8 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
           Value m = stablehlo::OrOp::create(builder, loc, am, bm);
           stablehlo::ReturnOp::create(builder, loc, ValueRange{v, m});
         }
-        update = stablehlo::ReshapeOp::create(
-            builder, loc, RankedTensorType::get(keptShape, AT.getElementType()),
-            reduce.getResult(0));
+        update = stablehlo::ReshapeOpCreate(builder, loc, reduce.getResult(0),
+                                            keptShape);
         updateValueMap = affine::AffineValueMap(
             AffineMap::get(unionMap.getAffineMap().getNumDims(),
                            unionMap.getAffineMap().getNumSymbols(), keptExprs,
@@ -1434,8 +1424,8 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
 
   // Align update to the store indices grid; the grid axes act as implicit
   // batch dimensions of the scatter.
-  update = stablehlo::BroadcastInDimOp::create(
-      builder, loc, UTy.clone(gridShape), update, broadcastDims);
+  update = stablehlo::BroadcastInDimOpCreate(builder, loc, update, gridShape,
+                                             broadcastDims);
 
   if (pc.mask) {
     SmallVector<int64_t> collapsedDims(scatterDimsToOperandDims.begin(),
@@ -1469,8 +1459,8 @@ emitStoreAsScatter(Location loc, Value update, Value input, ValueRange sIndices,
     auto gridTy = cast<RankedTensorType>(update.getType());
     auto maskGridTy =
         RankedTensorType::get(gridTy.getShape(), builder.getI1Type());
-    Value broadcastedMask = stablehlo::BroadcastInDimOp::create(
-        builder, loc, maskGridTy, mask, maskBroadcastDims);
+    Value broadcastedMask = stablehlo::BroadcastInDimOpCreate(
+        builder, loc, mask, maskGridTy.getShape(), maskBroadcastDims);
 
     update = stablehlo::SelectOp::create(builder, loc, broadcastedMask, update,
                                          orig);
@@ -1816,9 +1806,9 @@ static LogicalResult tryRaisingForOpToStableHLOWhile(
       }
 
       if (!std::is_sorted(perm->begin(), perm->end()))
-        raisedYieldedIterArg = stablehlo::TransposeOp::create(
-            builder, raisedYieldedIterArg.getLoc(), raisedYieldedIterArg,
-            *perm);
+        raisedYieldedIterArg =
+            stablehlo::TransposeOpCreate(builder, raisedYieldedIterArg.getLoc(),
+                                         raisedYieldedIterArg, *perm);
 
       loopCarried.push_back(raisedYieldedIterArg);
     }
@@ -2115,7 +2105,7 @@ static LogicalResult tryRaisingSCFForOpToStableHLOWhile(
         return failure();
       }
       if (!std::is_sorted(perm->begin(), perm->end()))
-        raisedYielded = stablehlo::TransposeOp::create(
+        raisedYielded = stablehlo::TransposeOpCreate(
             builder, raisedYielded.getLoc(), raisedYielded, *perm);
       loopCarried.push_back(raisedYielded);
     }
@@ -2319,8 +2309,8 @@ static LogicalResult raiseLoopToMaskedWhile(
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(body);
 
-    Value kLane = stablehlo::BroadcastInDimOp::create(
-        builder, wloc, laneTy, kInBody, ArrayRef<int64_t>{});
+    Value kLane = stablehlo::BroadcastInDimOpCreate(
+        builder, wloc, kInBody, laneTy.getShape(), ArrayRef<int64_t>{});
     Value ivT = stablehlo::AddOp::create(
         builder, wloc, lb,
         stablehlo::MulOp::create(builder, wloc, kLane, step));
@@ -2384,7 +2374,7 @@ static LogicalResult raiseLoopToMaskedWhile(
       auto perm =
           memoryEquivalentPermutation(*outMap, maps.lookup(raisedIterArg));
       if (perm.has_value() && !std::is_sorted(perm->begin(), perm->end()))
-        sel = stablehlo::TransposeOp::create(builder, wloc, sel, *perm);
+        sel = stablehlo::TransposeOpCreate(builder, wloc, sel, *perm);
       if (sel.getType() != raisedIterArg.getType())
         return failure();
       loopCarried.push_back(sel);
@@ -2700,22 +2690,22 @@ static LogicalResult tryRaisingParallelOpToStableHLO(
           vals.push_back(v);
         }
 
-        auto newVal = stablehlo::SliceOp::create(
+        auto newVal = stablehlo::SliceOpCreate(
             builder,
             rewriteLocation(res.getLoc(), pc.options.strip_llvm_debuginfo), val,
             startIndices, limitIndices, strides);
 
         SmallVector<int64_t> newShape;
-        for (auto &&[i, sz] : llvm::enumerate(newVal.getType().getShape())) {
+        for (auto &&[i, sz] : llvm::enumerate(
+                 cast<RankedTensorType>(newVal.getType()).getShape())) {
           if (i != idx_to_reduce) {
             newShape.push_back(sz);
           }
         }
-        auto newVal2 = stablehlo::ReshapeOp::create(
+        auto newVal2 = stablehlo::ReshapeOpCreate(
             builder,
             rewriteLocation(res.getLoc(), pc.options.strip_llvm_debuginfo),
-            RankedTensorType::get(newShape, newVal.getType().getElementType()),
-            newVal);
+            newVal, newShape);
         mapping.map(res, newVal2);
         maps[newVal2] = affine::AffineValueMap(
             AffineMap::get(outputMap.getAffineMap().getNumDims(),
@@ -3172,16 +3162,15 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       if (startIndices.empty())
         newVal = inputTen.getType() == T
                      ? inputTen
-                     : stablehlo::ReshapeOp::create(
+                     : stablehlo::ReshapeOpCreate(
                            builder,
                            rewriteLocation(op->getLoc(),
                                            pc.options.strip_llvm_debuginfo),
-                           T, inputTen)
-                           .getResult();
+                           inputTen, T.getShape());
       else
-        newVal = stablehlo::DynamicSliceOp::create(
+        newVal = stablehlo::DynamicSliceOpCreate(
             builder,
-            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo), T,
+            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             inputTen, startIndices, outputShape);
     } else {
       bool needSlice = false;
@@ -3253,10 +3242,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
               RankedTensorType::get({}, builder.getI64Type()), szVal);
 
-          auto szVal1D_Cast = stablehlo::ReshapeOp::create(
+          auto szVal1D_Cast = stablehlo::ReshapeOpCreate(
               builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-              ti64Ty, szVal64);
+              szVal64, ti64Ty.getShape());
 
           auto limitVal = stablehlo::ConstantOp::create(
               builder,
@@ -3310,11 +3299,11 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
             tensorType, cast<ElementsAttr>(builder.getZeroAttr(tensorType)));
 
         if (hasDynamicEdgePadding) {
-          auto edgePaddingLow = stablehlo::ConcatenateOp::create(
+          auto edgePaddingLow = stablehlo::ConcatenateOpCreate(
               builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
               dynPadLow, 0);
-          auto edgePaddingHigh = stablehlo::ConcatenateOp::create(
+          auto edgePaddingHigh = stablehlo::ConcatenateOpCreate(
               builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
               dynPadHigh, 0);
@@ -3324,7 +3313,7 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
               ti64Ty, cast<ElementsAttr>(builder.getI64TensorAttr({0})));
 
-          auto interiorPadding = stablehlo::ConcatenateOp::create(
+          auto interiorPadding = stablehlo::ConcatenateOpCreate(
               builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
               SmallVector<Value>(dynPadLow.size(), interiorPadding0), 0);
@@ -3358,9 +3347,9 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       }
 
       if (needSlice) {
-        newVal = stablehlo::SliceOp::create(
+        newVal = stablehlo::SliceOpCreate(
             builder,
-            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo), T,
+            rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             inputTen, startIndices, limitIndices, strides);
       } else {
         newVal = inputTen;
@@ -3387,12 +3376,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
 
     auto val = loadOp.getResult();
 
-    newVal =
-        stablehlo::ReshapeOp::create(
-            builder,
-            rewriteLocation(newVal.getLoc(), pc.options.strip_llvm_debuginfo),
-            cast<RankedTensorType>(newVal.getType()).clone(dynShape), newVal)
-            .getResult();
+    newVal = stablehlo::ReshapeOpCreate(
+        builder,
+        rewriteLocation(newVal.getLoc(), pc.options.strip_llvm_debuginfo),
+        newVal, dynShape);
     mapping.map(val, newVal);
 
     affine::AffineValueMap dynAffineValueMap(
@@ -3552,10 +3539,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
               RankedTensorType::get({}, builder.getI64Type()), szVal);
 
-          auto szVal1D_Cast = stablehlo::ReshapeOp::create(
+          auto szVal1D_Cast = stablehlo::ReshapeOpCreate(
               builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-              ti64Ty, szVal64);
+              szVal64, ti64Ty.getShape());
 
           auto limitVal = stablehlo::ConstantOp::create(
               builder,
@@ -3834,10 +3821,8 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
               Value m = stablehlo::OrOp::create(builder, loc, am, bm);
               stablehlo::ReturnOp::create(builder, loc, ValueRange{v, m});
             }
-            update = stablehlo::ReshapeOp::create(
-                builder, loc,
-                RankedTensorType::get(keptShape, AT.getElementType()),
-                reduce.getResult(0));
+            update = stablehlo::ReshapeOpCreate(builder, loc,
+                                                reduce.getResult(0), keptShape);
             updateValueMap = affine::AffineValueMap(
                 AffineMap::get(unionMap.getAffineMap().getNumDims(),
                                unionMap.getAffineMap().getNumSymbols(),
@@ -3889,10 +3874,8 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
                                          UT.getShape().end());
           for (int64_t ri : raceDims)
             unitShape[ri] = 1;
-          update = stablehlo::ReshapeOp::create(
-              builder, loc,
-              RankedTensorType::get(unitShape, UT.getElementType()),
-              reduce.getResult(0));
+          update = stablehlo::ReshapeOpCreate(builder, loc, reduce.getResult(0),
+                                              unitShape);
           maskedPick = true;
           refine = true;
         }
@@ -3911,7 +3894,7 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
           SmallVector<int64_t> ones(UT.getRank(), 1);
           for (int64_t ri : raceDims)
             limits[ri] = 1;
-          update = stablehlo::SliceOp::create(
+          update = stablehlo::SliceOpCreate(
               builder,
               rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
               update, starts, limits, ones);
@@ -3927,10 +3910,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
               updateValueMap.getAffineMap().getResult(updateIdx));
           keptBroadcastDims.push_back(dim);
         }
-        update = stablehlo::ReshapeOp::create(
+        update = stablehlo::ReshapeOpCreate(
             builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-            RankedTensorType::get(keptShape, UT.getElementType()), update);
+            update, keptShape);
         updateValueMap = affine::AffineValueMap(
             AffineMap::get(updateValueMap.getAffineMap().getNumDims(),
                            updateValueMap.getAffineMap().getNumSymbols(),
@@ -3965,10 +3948,9 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       return err;
     }
 
-    update = stablehlo::BroadcastInDimOp::create(
+    update = stablehlo::BroadcastInDimOpCreate(
         builder, rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-        cast<RankedTensorType>(update.getType()).clone(updateShape), update,
-        broadcastDims);
+        update, updateShape, broadcastDims);
 
     if (!update)
       return failure();
@@ -4009,21 +3991,20 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       // rank-0 dynamic_slice prints in a form no parser reads back.
       Value prev = updateShape.empty()
                        ? operand
-                       : stablehlo::DynamicSliceOp::create(
+                       : stablehlo::DynamicSliceOpCreate(
                              builder,
                              rewriteLocation(op->getLoc(),
                                              pc.options.strip_llvm_debuginfo),
-                             operand, startIndicesValues, updateShape)
-                             .getResult();
+                             operand, startIndicesValues, updateShape);
 
-      Value updateWithoutConstantDims = stablehlo::ReshapeOp::create(
+      Value updateWithoutConstantDims = stablehlo::ReshapeOpCreate(
           builder,
           rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-          updateType.clone(updateShapeWithoutConstantDims), update);
-      Value prevWithoutConstantDims = stablehlo::ReshapeOp::create(
+          update, updateShapeWithoutConstantDims);
+      Value prevWithoutConstantDims = stablehlo::ReshapeOpCreate(
           builder,
-          rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-          updateType.clone(updateShapeWithoutConstantDims), prev);
+          rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo), prev,
+          updateShapeWithoutConstantDims);
 
       Value vals[] = {updateWithoutConstantDims, prevWithoutConstantDims};
       affine::AffineValueMap dsts[] = {storeValueMap, storeValueMap};
@@ -4098,10 +4079,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
             "could not align masked update to the store location");
       }
 
-      update = stablehlo::BroadcastInDimOp::create(
+      update = stablehlo::BroadcastInDimOpCreate(
           builder,
           rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-          updateType, maskedUpdate, maskedUpdateBroadcastDims);
+          maskedUpdate, updateType.getShape(), maskedUpdateBroadcastDims);
     }
 
     if (needPad) {
@@ -4114,15 +4095,15 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
           tensorType, cast<ElementsAttr>(builder.getZeroAttr(tensorType)));
 
       if (hasDynamicEdgePadding) {
-        auto edgePaddingLow = stablehlo::ConcatenateOp::create(
+        auto edgePaddingLow = stablehlo::ConcatenateOpCreate(
             builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             dynPadLow, 0);
-        auto edgePaddingHigh = stablehlo::ConcatenateOp::create(
+        auto edgePaddingHigh = stablehlo::ConcatenateOpCreate(
             builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             dynPadHigh, 0);
-        auto interiorPadding = stablehlo::ConcatenateOp::create(
+        auto interiorPadding = stablehlo::ConcatenateOpCreate(
             builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             dynPaddingInterior, 0);
@@ -4170,15 +4151,15 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             tensorType, cast<ElementsAttr>(builder.getZeroAttr(tensorType)));
 
-        auto edgePaddingLow = stablehlo::ConcatenateOp::create(
+        auto edgePaddingLow = stablehlo::ConcatenateOpCreate(
             builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             dynNegPadLow, 0);
-        auto edgePaddingHigh = stablehlo::ConcatenateOp::create(
+        auto edgePaddingHigh = stablehlo::ConcatenateOpCreate(
             builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             dynNegPadHigh, 0);
-        auto interiorPadding = stablehlo::ConcatenateOp::create(
+        auto interiorPadding = stablehlo::ConcatenateOpCreate(
             builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
             dynPaddingInterior, 0);
@@ -4202,12 +4183,9 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
           limitSlice.push_back(low + sz);
           stridesSlice.push_back(1);
         }
-        finalResult = stablehlo::SliceOp::create(
+        finalResult = stablehlo::SliceOpCreate(
             builder,
             rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
-            cast<RankedTensorType>(finalResult.getType())
-                .clone(
-                    cast<ShapedType>(storeOp.getMemref().getType()).getShape()),
             finalResult, startSlice, limitSlice, stridesSlice);
       }
     }
@@ -4566,14 +4544,14 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
                 rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo),
                 vval, cst);
           }
-          vval = stablehlo::ReshapeOp::create(
+          vval = stablehlo::ReshapeOpCreate(
               builder,
               rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo),
-              RankedTensorType::get({1}, val.getType().getElementType()), vval);
+              vval, ArrayRef<int64_t>{1});
           vals.push_back(vval);
         }
 
-        auto idxs = stablehlo::ConcatenateOp::create(
+        auto idxs = stablehlo::ConcatenateOpCreate(
             builder,
             rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo),
             vals, 0);
@@ -4582,10 +4560,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
             rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo), ty,
             res, idxs);
       } else {
-        res = stablehlo::ReshapeOp::create(
+        res = stablehlo::ReshapeOpCreate(
             builder,
-            rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo), ty,
-            res);
+            rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo), res,
+            ty.getShape());
       }
     } else {
       SmallVector<int64_t> dims2 = llvm::to_vector(ty.getShape());
@@ -4594,10 +4572,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       if (oidx != 0 && dims2[oidx - 1] != ShapedType::kDynamic) {
         dims2[oidx - 1] /= outSize / inSize;
       }
-      res = stablehlo::ReshapeOp::create(
+      res = stablehlo::ReshapeOpCreate(
           builder,
-          rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo),
-          RankedTensorType::get(dims2, inTy.getElementType()), input);
+          rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo), input,
+          dims2);
       res = stablehlo::BitcastConvertOp::create(
           builder,
           rewriteLocation(p2m.getLoc(), pc.options.strip_llvm_debuginfo), ty,

--- a/src/enzyme_ad/jax/Utils.cpp
+++ b/src/enzyme_ad/jax/Utils.cpp
@@ -3553,6 +3553,19 @@ Value ConcatenateOpCreate(
   return concatOp.getResult();
 }
 
+Value BroadcastInDimOpCreate(OpBuilder &builder, Location loc, Value input,
+                             ArrayRef<int64_t> shape,
+                             ArrayRef<int64_t> broadcastDimensions) {
+  auto inputTy = cast<RankedTensorType>(input.getType());
+  if (inputTy.getShape() == shape &&
+      llvm::equal(broadcastDimensions,
+                  llvm::seq<int64_t>(0, inputTy.getRank())))
+    return input;
+  return stablehlo::BroadcastInDimOp::create(
+      builder, loc, RankedTensorType::get(shape, inputTy.getElementType()),
+      input, broadcastDimensions);
+}
+
 Value ReshapeOpCreate(OpBuilder &builder, Location loc, Value input,
                       ArrayRef<int64_t> shape,
                       std::optional<sdy::TensorShardingPerValueAttr> sharding) {

--- a/src/enzyme_ad/jax/Utils.h
+++ b/src/enzyme_ad/jax/Utils.h
@@ -1512,6 +1512,12 @@ Value ReshapeOpCreate(
     OpBuilder &builder, Location loc, Value input, ArrayRef<int64_t> shape,
     std::optional<sdy::TensorShardingPerValueAttr> sharding = std::nullopt);
 
+// A broadcast_in_dim to the input's own shape along the identity mapping is
+// the input.
+Value BroadcastInDimOpCreate(OpBuilder &builder, Location loc, Value input,
+                             ArrayRef<int64_t> shape,
+                             ArrayRef<int64_t> broadcastDimensions);
+
 Value TransposeOpCreate(
     OpBuilder &builder, Location loc, Value input,
     ArrayRef<int64_t> permutation,

--- a/test/lit_tests/raising/affine_atomic_scatter.mlir
+++ b/test/lit_tests/raising/affine_atomic_scatter.mlir
@@ -16,21 +16,18 @@ module {
   }
 }
 
-// CHECK:  func.func private @affine_atomic_add_raised(%[[a1:.+]]: tensor<8xf64>, %[[a2:.+]]: tensor<16xi32>, %[[a3:.+]]: tensor<16xf64>) -> (tensor<8xf64>, tensor<16xi32>, tensor<16xf64>) {
-// CHECK-NEXT:  %[[a4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
-// CHECK-NEXT:  %[[a5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
-// CHECK-NEXT:  %[[a6:.+]] = stablehlo.add %[[a4]], %[[a5]] : tensor<16xi64>
-// CHECK-NEXT:  %[[a7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
-// CHECK-NEXT:  %[[a8:.+]] = stablehlo.multiply %[[a6]], %[[a7]] : tensor<16xi64>
-// CHECK-NEXT:  %[[a9:.+]] = stablehlo.reshape %[[a2]] : (tensor<16xi32>) -> tensor<16xi32>
-// CHECK-NEXT:  %[[a10:.+]] = stablehlo.convert %[[a9]] : (tensor<16xi32>) -> tensor<16xi64>
-// CHECK-NEXT:  %[[a11:.+]] = stablehlo.reshape %[[a3]] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[a12:.+]] = stablehlo.reshape %[[a10]] : (tensor<16xi64>) -> tensor<16x1xi64>
-// CHECK-NEXT:  %[[a13:.+]] = stablehlo.broadcast_in_dim %[[a11]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[a14:.+]] = "stablehlo.scatter"(%[[a1]], %[[a12]], %[[a13]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
-// CHECK-NEXT:  ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
-// CHECK-NEXT:  %[[a15:.+]] = stablehlo.add %arg3, %arg4 : tensor<f64>
-// CHECK-NEXT:  stablehlo.return %[[a15]] : tensor<f64>
-// CHECK-NEXT:  }) : (tensor<8xf64>, tensor<16x1xi64>, tensor<16xf64>) -> tensor<8xf64>
-// CHECK-NEXT:  return %[[a14]], %[[a2]], %[[a3]] : tensor<8xf64>, tensor<16xi32>, tensor<16xf64>
+// CHECK:    func.func private @affine_atomic_add_raised(%[[a1:.+]]: tensor<8xf64>, %[[a2:.+]]: tensor<16xi32>, %[[a3:.+]]: tensor<16xf64>) -> (tensor<8xf64>, tensor<16xi32>, tensor<16xf64>) {
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.add %[[a4]], %[[a5]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.multiply %[[a6]], %[[a7]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.convert %[[a2]] : (tensor<16xi32>) -> tensor<16xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.reshape %[[a9]] : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %[[a11:.+]] = "stablehlo.scatter"(%[[a1]], %[[a10]], %[[a3]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%[[a12:.+]]: tensor<f64>, %[[a13:.+]]: tensor<f64>):
+// CHECK-NEXT:      %[[a14:.+]] = stablehlo.add %[[a12]], %[[a13]] : tensor<f64>
+// CHECK-NEXT:      stablehlo.return %[[a14]] : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<8xf64>, tensor<16x1xi64>, tensor<16xf64>) -> tensor<8xf64>
+// CHECK-NEXT:    return %[[a11]], %[[a2]], %[[a3]] : tensor<8xf64>, tensor<16xi32>, tensor<16xf64>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/affine_to_stablehlo18.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo18.mlir
@@ -44,7 +44,8 @@ module {
   }
 }
 
-// CHECK:    func.func @"bad_compute_w_from_continuity!"(%arg0: tensor<1x200x104xf64>, %arg1: tensor<40x200x104xf64>) -> (tensor<1x200x104xf64>, tensor<40x200x104xf64>) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// CHECK:    llvm.module_flags [#llvm.mlir.module_flag<warning, "Dwarf Version", 2 : i32>, #llvm.mlir.module_flag<warning, "Debug Info Version", 3 : i32>]
+// CHECK-NEXT:  func.func @"bad_compute_w_from_continuity!"(%arg0: tensor<1x200x104xf64>, %arg1: tensor<40x200x104xf64>) -> (tensor<1x200x104xf64>, tensor<40x200x104xf64>) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
 // CHECK-NEXT:    %0:2 = call @"##call__Z35gpu__bad_compute_w_from_continuity_16CompilerMetadataI16OffsetStaticSizeI15__2_99___2_195_E12DynamicCheckvv7NDRangeILi2E10StaticSizeI7_7__13_ES4_I8_16__16_E5TupleI5Int64S8_ES0_I8__3___3_EEE11OffsetArrayI7Float64Li3E13CuTracedArrayISE_Li3ELi1E14_104__200__40_EE20ImmersedBoundaryGridISE_8Periodic7BoundedSK_15RectilinearGridISE_SJ_SK_SK_28StaticVerticalDiscretizationISD_ISE_Li1E12StepRangeLenISE_14TwicePrecisionISE_ESP_S8_EESR_SE_SE_ESE_SE_SR_SR_vE16GridFittedBottomI5FieldI6CenterSW_vvvvSD_ISE_Li3ESF_ISE_Li3ELi1E13_104__200__1_EESE_vvvE23CenterImmersedConditionEvvvE#246$par0_raised"(%arg1, %arg0) : (tensor<40x200x104xf64>, tensor<1x200x104xf64>) -> (tensor<40x200x104xf64>, tensor<1x200x104xf64>)
 // CHECK-NEXT:    return %arg0, %0#0 : tensor<1x200x104xf64>, tensor<40x200x104xf64>
 // CHECK-NEXT:  }
@@ -123,10 +124,10 @@ module {
 // CHECK-NEXT:    %40 = stablehlo.broadcast_in_dim %12, dims = [0] : (tensor<4xi64>) -> tensor<4x198x102xi64>
 // CHECK-NEXT:    %41 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f64>) -> tensor<4x198x102xf64>
 // CHECK-NEXT:    %cst_29 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK-NEXT{LITERAL}:    %42 = "stablehlo.reduce_window"(%39, %cst_29) <{base_dilations = array<i64: 1, 1, 1>, padding = dense<[[3, 0], [0, 0], [0, 0]]> : tensor<3x2xi64>, window_dilations = array<i64: 1, 1, 1>, window_dimensions = array<i64: 4, 1, 1>, window_strides = array<i64: 1, 1, 1>}> ({
+// CHECK-NEXT:    %42 = "stablehlo.reduce_window"(%39, %cst_29) <{base_dilations = array<i64: 1, 1, 1>, padding = dense<{{\[\[}}3, 0], [0, 0], [0, 0]]> : tensor<3x2xi64>, window_dilations = array<i64: 1, 1, 1>, window_dimensions = array<i64: 4, 1, 1>, window_strides = array<i64: 1, 1, 1>}> ({
 // CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
-// CHECK-NEXT:      %48 = stablehlo.add %arg2, %arg3 : tensor<f64>
-// CHECK-NEXT:      stablehlo.return %48 : tensor<f64>
+// CHECK-NEXT:      %47 = stablehlo.add %arg2, %arg3 : tensor<f64>
+// CHECK-NEXT:      stablehlo.return %47 : tensor<f64>
 // CHECK-NEXT:    }) : (tensor<4x198x102xf64>, tensor<f64>) -> tensor<4x198x102xf64>
 // CHECK-NEXT:    %43 = stablehlo.subtract %41, %42 : tensor<4x198x102xf64>
 // CHECK-NEXT:    %c_30 = stablehlo.constant dense<0> : tensor<1xi64>
@@ -147,11 +148,9 @@ module {
 // CHECK-NEXT:    %c_45 = stablehlo.constant dense<0> : tensor<1xi64>
 // CHECK-NEXT:    %c_46 = stablehlo.constant dense<0> : tensor<1xi64>
 // CHECK-NEXT:    %c_47 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %44 = stablehlo.broadcast_in_dim %43, dims = [0, 1, 2] : (tensor<4x198x102xf64>) -> tensor<4x198x102xf64>
-// CHECK-NEXT:    %45 = stablehlo.dynamic_update_slice %7, %44, %c_35, %c_41, %c_47 : (tensor<40x200x104xf64>, tensor<4x198x102xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<40x200x104xf64>
+// CHECK-NEXT:    %44 = stablehlo.dynamic_update_slice %7, %43, %c_35, %c_41, %c_47 : (tensor<40x200x104xf64>, tensor<4x198x102xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<40x200x104xf64>
 // CHECK-NEXT:    %c0 = arith.constant 0 : index
-// CHECK-NEXT:    %46 = stablehlo.slice %43 [3:4, 0:198, 0:102] : (tensor<4x198x102xf64>) -> tensor<1x198x102xf64>
-// CHECK-NEXT:    %47 = stablehlo.reshape %46 : (tensor<1x198x102xf64>) -> tensor<198x102xf64>
-// CHECK-NEXT:    return %45, %arg1 : tensor<40x200x104xf64>, tensor<1x200x104xf64>
-// CHECK-NEXT:  }
+// CHECK-NEXT:    %45 = stablehlo.slice %43 [3:4, 0:198, 0:102] : (tensor<4x198x102xf64>) -> tensor<1x198x102xf64>
+// CHECK-NEXT:    %46 = stablehlo.reshape %45 : (tensor<1x198x102xf64>) -> tensor<198x102xf64>
+// CHECK-NEXT:    return %44, %arg1 : tensor<40x200x104xf64>, tensor<1x200x104xf64>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/affine_to_stablehlo_dynmemref.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_dynmemref.mlir
@@ -17,16 +17,17 @@ module {
   }
 }
 
-// CHECK:  func.func @h(%arg0: !llvm.ptr) {
+// CHECK:    func.func @h(%arg0: !llvm.ptr) {
 // CHECK-NEXT:    %c1 = arith.constant 1 : index
 // CHECK-NEXT:    %c256 = arith.constant 256 : index
 // CHECK-NEXT:    %c39063 = arith.constant 39063 : index
 // CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:    %0 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xf32>
 // CHECK-NEXT:    enzymexla.xla_wrapper @rxla$raised_0 (%0) : (memref<?xf32>) -> ()
-// CHECK:    return
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    return
 // CHECK-NEXT:  }
-// CHECK:  func.func private @rxla$raised_0(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+// CHECK-NEXT:  func.func private @rxla$raised_0(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<10000000xi64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<10000000xi64>
@@ -49,15 +50,9 @@ module {
 // CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-NEXT:    %11 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f32>) -> tensor<10000000xf32>
 // CHECK-NEXT:    %cst_7 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK-NEXT:    %12 = stablehlo.concatenate %c_1, dim = 0 : (tensor<1xi64>) -> tensor<1xi64>
-// CHECK-NEXT:    %13 = stablehlo.concatenate %8, dim = 0 : (tensor<1xi64>) -> tensor<1xi64>
-// CHECK-NEXT:    %14 = stablehlo.concatenate %c_5, dim = 0 : (tensor<1xi64>) -> tensor<1xi64>
-// CHECK-NEXT:    %15 = stablehlo.dynamic_pad %arg0, %cst_7, %12, %13, %14 : (tensor<?xf32>, tensor<f32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
-// CHECK-NEXT:    %16 = stablehlo.dynamic_update_slice %15, %11, %c_6 : (tensor<?xf32>, tensor<10000000xf32>, tensor<i64>) -> tensor<?xf32>
+// CHECK-NEXT:    %12 = stablehlo.dynamic_pad %arg0, %cst_7, %c_1, %8, %c_5 : (tensor<?xf32>, tensor<f32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
+// CHECK-NEXT:    %13 = stablehlo.dynamic_update_slice %12, %11, %c_6 : (tensor<?xf32>, tensor<10000000xf32>, tensor<i64>) -> tensor<?xf32>
 // CHECK-NEXT:    %cst_8 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
-// CHECK-NEXT:    %17 = stablehlo.concatenate %9, dim = 0 : (tensor<1xi64>) -> tensor<1xi64>
-// CHECK-NEXT:    %18 = stablehlo.concatenate %10, dim = 0 : (tensor<1xi64>) -> tensor<1xi64>
-// CHECK-NEXT:    %19 = stablehlo.concatenate %c_5, dim = 0 : (tensor<1xi64>) -> tensor<1xi64>
-// CHECK-NEXT:    %20 = stablehlo.dynamic_pad %16, %cst_8, %17, %18, %19 : (tensor<?xf32>, tensor<f32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
-// CHECK-NEXT:    return %20 : tensor<?xf32>
+// CHECK-NEXT:    %14 = stablehlo.dynamic_pad %13, %cst_8, %9, %10, %c_5 : (tensor<?xf32>, tensor<f32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
+// CHECK-NEXT:    return %14 : tensor<?xf32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/affine_to_stablehlo_if_0dim.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_if_0dim.mlir
@@ -10,20 +10,22 @@ func.func @test_if_0(%arg0: memref<10xf32>, %arg1: memref<i1>) {
   return
 }
 
-// CHECK-LABEL:   func.func private @test_if_0_raised(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: tensor<10xf32>,
-// CHECK-SAME:                                        %[[VAL_1:.*]]: tensor<i1>) -> (tensor<10xf32>, tensor<i1>) {
-// CHECK:           %[[VAL_2:.*]] = stablehlo.reshape %[[VAL_1]] : (tensor<i1>) -> tensor<i1>
-// CHECK:           %[[VAL_3:.*]] = stablehlo.slice %[[VAL_0]] [0:1] : (tensor<10xf32>) -> tensor<1xf32>
-// CHECK:           %[[VAL_4:.*]] = stablehlo.reshape %[[VAL_3]] : (tensor<1xf32>) -> tensor<f32>
-// CHECK:           %[[VAL_5:.*]] = arith.addf %[[VAL_4]], %[[VAL_4]] : tensor<f32>
-// CHECK:           %[[VAL_6:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[VAL_7:.*]] = stablehlo.broadcast_in_dim %[[VAL_5]], dims = [] : (tensor<f32>) -> tensor<1xf32>
-// CHECK:           %[[VAL_8:.*]] = stablehlo.dynamic_slice %[[VAL_0]], %[[VAL_6]], sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
-// CHECK:           %[[VAL_9:.*]] = stablehlo.reshape %[[VAL_7]] : (tensor<1xf32>) -> tensor<f32>
-// CHECK:           %[[VAL_10:.*]] = stablehlo.reshape %[[VAL_8]] : (tensor<1xf32>) -> tensor<f32>
-// CHECK:           %[[VAL_11:.*]] = stablehlo.select %[[VAL_2]], %[[VAL_9]], %[[VAL_10]] : tensor<i1>, tensor<f32>
-// CHECK:           %[[VAL_12:.*]] = stablehlo.broadcast_in_dim %[[VAL_11]], dims = [] : (tensor<f32>) -> tensor<1xf32>
-// CHECK:           %[[VAL_13:.*]] = stablehlo.dynamic_update_slice %[[VAL_0]], %[[VAL_12]], %[[VAL_6]] : (tensor<10xf32>, tensor<1xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           return %[[VAL_13]], %[[VAL_1]] : tensor<10xf32>, tensor<i1>
-// CHECK:         }
+// CHECK:    func.func private @test_if_0_raised(%[[a1:.+]]: tensor<10xf32>, %[[a2:.+]]: tensor<i1>) -> (tensor<10xf32>, tensor<i1>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.slice %[[a1]] [0:1] : (tensor<10xf32>) -> tensor<1xf32>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.reshape %[[a3]] : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:    %[[a5:.+]] = arith.addf %[[a4]], %[[a4]] : tensor<f32>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.broadcast_in_dim %[[a5]], dims = [] : (tensor<f32>) -> tensor<1xf32>
+// CHECK-NEXT:    %[[a13:.+]] = stablehlo.slice %[[a1]] [0:1] : (tensor<10xf32>) -> tensor<1xf32>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.reshape %[[a12]] : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.reshape %[[a13]] : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.select %[[a2]], %[[a14]], %[[a15]] : tensor<i1>, tensor<f32>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.broadcast_in_dim %[[a16]], dims = [] : (tensor<f32>) -> tensor<1xf32>
+// CHECK-NEXT:    %[[a18:.+]] = stablehlo.dynamic_update_slice %[[a1]], %[[a17]], %[[a11]] : (tensor<10xf32>, tensor<1xf32>, tensor<i64>) -> tensor<10xf32>
+// CHECK-NEXT:    return %[[a18]], %[[a2]] : tensor<10xf32>, tensor<i1>
+// CHECK-NEXT:  }

--- a/test/lit_tests/raising/affine_to_stablehlo_if_masking.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_if_masking.mlir
@@ -54,124 +54,109 @@ func.func @test_affine_if_masking(%arg0: memref<10xf32>) {
   return
 }
 
-// CHECK-LABEL:   func.func private @test_affine_if_masking_raised(
-// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<10xf32>) -> tensor<10xf32> {
-// CHECK:           %[[V0:.*]] = stablehlo.iota dim = 0 : tensor<10xi64>
-// CHECK:           %[[C0:.*]] = stablehlo.constant dense<0> : tensor<10xi64>
-// CHECK:           %[[V1:.*]] = stablehlo.add %[[V0]], %[[C0]] : tensor<10xi64>
-// CHECK:           %[[C1:.*]] = stablehlo.constant dense<1> : tensor<10xi64>
-// CHECK:           %[[V2:.*]] = stablehlo.multiply %[[V1]], %[[C1]] : tensor<10xi64>
-// CHECK:           %[[CM5:.*]] = stablehlo.constant dense<-5> : tensor<i64>
-// CHECK:           %[[V3:.*]] = stablehlo.broadcast_in_dim %[[CM5]], dims = [] : (tensor<i64>) -> tensor<10xi64>
-// CHECK:           %[[V4:.*]] = stablehlo.add %[[V2]], %[[V3]] : tensor<10xi64>
-// CHECK:           %[[C0B:.*]] = stablehlo.constant dense<0> : tensor<10xi64>
-// CHECK:           %[[V5:.*]] = stablehlo.compare  GE, %[[V4]], %[[C0B]] : (tensor<10xi64>, tensor<10xi64>) -> tensor<10xi1>
-// CHECK:           %[[C0C:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[V6:.*]] = stablehlo.dynamic_slice %[[VAL_0]], %[[C0C]], sizes = [10] : (tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           %[[V7:.*]] = stablehlo.reshape %[[V6]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[V8:.*]] = arith.addf %[[V7]], %[[V7]] : tensor<10xf32>
-// CHECK:           %[[C0D:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[V9:.*]] = stablehlo.broadcast_in_dim %[[V8]], dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[V10:.*]] = stablehlo.dynamic_slice %[[VAL_0]], %[[C0D]], sizes = [10] : (tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           %[[V11:.*]] = stablehlo.reshape %[[V9]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[V12:.*]] = stablehlo.reshape %[[V10]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[V13:.*]] = stablehlo.select %[[V5]], %[[V11]], %[[V12]] : tensor<10xi1>, tensor<10xf32>
-// CHECK:           %[[V14:.*]] = stablehlo.broadcast_in_dim %[[V13]], dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[V15:.*]] = stablehlo.dynamic_update_slice %[[VAL_0]], %[[V14]], %[[C0D]] : (tensor<10xf32>, tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           return %[[V15]] : tensor<10xf32>
-// CHECK:         }
-
-// CHECK-LABEL:   func.func private @test_if_else_masking_raised(
-// CHECK-SAME:                                                   %[[VAL_0:.*]]: tensor<10xf32>, %[[VAL_1:.*]]: tensor<10xi1>) -> (tensor<10xf32>, tensor<10xi1>) {
-// CHECK:           %[[C0:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[C10:.*]] = stablehlo.constant dense<10> : tensor<i64>
-// CHECK:           %[[C1:.*]] = stablehlo.constant dense<1> : tensor<i64>
-// CHECK:           %[[W0:.*]]:3 = stablehlo.while(%iterArg = %[[C0]], %iterArg_2 = %[[VAL_0]], %iterArg_3 = %[[VAL_1]]) : tensor<i64>, tensor<10xf32>, tensor<10xi1>
-// CHECK:           cond {
-// CHECK:           %[[WCOND:.*]] = stablehlo.compare  LT, %iterArg, %[[C10]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK:           stablehlo.return %[[WCOND]] : tensor<i1>
-// CHECK:           } do {
-// CHECK:           %[[DS1:.*]] = stablehlo.dynamic_slice %iterArg_3, %iterArg, sizes = [1] : (tensor<10xi1>, tensor<i64>) -> tensor<1xi1>
-// CHECK:           %[[COND:.*]] = stablehlo.reshape %[[DS1]] : (tensor<1xi1>) -> tensor<i1>
-// CHECK:           %[[DS2:.*]] = stablehlo.dynamic_slice %iterArg_2, %iterArg, sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
-// CHECK:           %[[V1:.*]] = stablehlo.reshape %[[DS2]] : (tensor<1xf32>) -> tensor<f32>
-// CHECK:           %[[V2:.*]] = arith.addf %[[V1]], %[[V1]] : tensor<f32>
-// CHECK:           %[[BID1:.*]] = stablehlo.broadcast_in_dim %[[V2]], dims = [] : (tensor<f32>) -> tensor<1xf32>
-// CHECK:           %[[DS3:.*]] = stablehlo.dynamic_slice %iterArg_2, %iterArg, sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
-// CHECK:           %[[RSH1:.*]] = stablehlo.reshape %[[BID1]] : (tensor<1xf32>) -> tensor<1xf32>
-// CHECK:           %[[RSH2:.*]] = stablehlo.reshape %[[DS3]] : (tensor<1xf32>) -> tensor<1xf32>
-// CHECK:           %[[BID2:.*]] = stablehlo.broadcast_in_dim %[[COND]], dims = [] : (tensor<i1>) -> tensor<1xi1>
-// CHECK:           %[[SEL1:.*]] = stablehlo.select %[[BID2]], %[[RSH1]], %[[RSH2]] : tensor<1xi1>, tensor<1xf32>
-// CHECK:           %[[RSH3:.*]] = stablehlo.broadcast_in_dim %[[SEL1]], dims = [0] : (tensor<1xf32>) -> tensor<1xf32>
-// CHECK:           %[[DUS1:.*]] = stablehlo.dynamic_update_slice %iterArg_2, %[[RSH3]], %iterArg : (tensor<10xf32>, tensor<1xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           %[[NOT:.*]] = stablehlo.not %[[COND]] : tensor<i1>
-// CHECK:           %[[DS4:.*]] = stablehlo.dynamic_slice %[[DUS1]], %iterArg, sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
-// CHECK:           %[[V3:.*]] = stablehlo.reshape %[[DS4]] : (tensor<1xf32>) -> tensor<f32>
-// CHECK:           %[[V4:.*]] = arith.mulf %[[V3]], %[[V3]] : tensor<f32>
-// CHECK:           %[[BID3:.*]] = stablehlo.broadcast_in_dim %[[V4]], dims = [] : (tensor<f32>) -> tensor<1xf32>
-// CHECK:           %[[DS5:.*]] = stablehlo.dynamic_slice %[[DUS1]], %iterArg, sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
-// CHECK:           %[[RSH4:.*]] = stablehlo.reshape %[[BID3]] : (tensor<1xf32>) -> tensor<1xf32>
-// CHECK:           %[[RSH5:.*]] = stablehlo.reshape %[[DS5]] : (tensor<1xf32>) -> tensor<1xf32>
-// CHECK:           %[[BID4:.*]] = stablehlo.broadcast_in_dim %[[NOT]], dims = [] : (tensor<i1>) -> tensor<1xi1>
-// CHECK:           %[[SEL2:.*]] = stablehlo.select %[[BID4]], %[[RSH4]], %[[RSH5]] : tensor<1xi1>, tensor<1xf32>
-// CHECK:           %[[RSH6:.*]] = stablehlo.broadcast_in_dim %[[SEL2]], dims = [0] : (tensor<1xf32>) -> tensor<1xf32>
-// CHECK:           %[[DUS2:.*]] = stablehlo.dynamic_update_slice %[[DUS1]], %[[RSH6]], %iterArg : (tensor<10xf32>, tensor<1xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           %[[INC:.*]] = stablehlo.add %iterArg, %[[C1]] : tensor<i64>
-// CHECK:           stablehlo.return %[[INC]], %[[DUS2]], %iterArg_3 : tensor<i64>, tensor<10xf32>, tensor<10xi1>
-// CHECK:           }
-// CHECK:           return %[[W0]]#1, %[[W0]]#2 : tensor<10xf32>, tensor<10xi1>
-// CHECK:         }
-
-// CHECK-LABEL:   func.func private @test_nested_if_masking_raised(
-// CHECK-SAME:                                                     %[[VAL_0:.*]]: tensor<10xf32>, %[[VAL_1:.*]]: tensor<10xi1>, %[[VAL_2:.*]]: tensor<10xi1>) -> (tensor<10xf32>, tensor<10xi1>, tensor<10xi1>) {
-// CHECK:           %[[V0:.*]] = stablehlo.iota dim = 0 : tensor<10xi64>
-// CHECK:           %[[C0:.*]] = stablehlo.constant dense<0> : tensor<10xi64>
-// CHECK:           %[[V1:.*]] = stablehlo.add %[[V0]], %[[C0]] : tensor<10xi64>
-// CHECK:           %[[C1:.*]] = stablehlo.constant dense<1> : tensor<10xi64>
-// CHECK:           %[[V2:.*]] = stablehlo.multiply %[[V1]], %[[C1]] : tensor<10xi64>
-// CHECK:           %[[C0B:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[DS1:.*]] = stablehlo.dynamic_slice %[[VAL_1]], %[[C0B]], sizes = [10] : (tensor<10xi1>, tensor<i64>) -> tensor<10xi1>
-// CHECK:           %[[V3:.*]] = stablehlo.reshape %[[DS1]] : (tensor<10xi1>) -> tensor<10xi1>
-// CHECK:           %[[C0C:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[DS2:.*]] = stablehlo.dynamic_slice %[[VAL_2]], %[[C0C]], sizes = [10] : (tensor<10xi1>, tensor<i64>) -> tensor<10xi1>
-// CHECK:           %[[V4:.*]] = stablehlo.reshape %[[DS2]] : (tensor<10xi1>) -> tensor<10xi1>
-// CHECK:           %[[COND:.*]] = stablehlo.and %[[V3]], %[[V4]] : tensor<10xi1>
-// CHECK:           %[[C0D:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[DS3:.*]] = stablehlo.dynamic_slice %[[VAL_0]], %[[C0D]], sizes = [10] : (tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           %[[V5:.*]] = stablehlo.reshape %[[DS3]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[V6:.*]] = arith.addf %[[V5]], %[[V5]] : tensor<10xf32>
-// CHECK:           %[[C0E:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[BID1:.*]] = stablehlo.broadcast_in_dim %[[V6]], dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[DS4:.*]] = stablehlo.dynamic_slice %[[VAL_0]], %[[C0E]], sizes = [10] : (tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           %[[RSH1:.*]] = stablehlo.reshape %[[BID1]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[RSH2:.*]] = stablehlo.reshape %[[DS4]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[SEL:.*]] = stablehlo.select %[[COND]], %[[RSH1]], %[[RSH2]] : tensor<10xi1>, tensor<10xf32>
-// CHECK:           %[[RSH3:.*]] = stablehlo.broadcast_in_dim %[[SEL]], dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[DUS:.*]] = stablehlo.dynamic_update_slice %[[VAL_0]], %[[RSH3]], %[[C0E]] : (tensor<10xf32>, tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           return %[[DUS]], %[[VAL_1]], %[[VAL_2]] : tensor<10xf32>, tensor<10xi1>, tensor<10xi1>
-// CHECK:         }
-
-// CHECK-LABEL:   func.func private @test_if_masking_raised(
-// CHECK-SAME:                                              %[[VAL_0:.*]]: tensor<10xf32>, %[[VAL_1:.*]]: tensor<10xi1>) -> (tensor<10xf32>, tensor<10xi1>) {
-// CHECK:           %[[V0:.*]] = stablehlo.iota dim = 0 : tensor<10xi64>
-// CHECK:           %[[C0:.*]] = stablehlo.constant dense<0> : tensor<10xi64>
-// CHECK:           %[[V1:.*]] = stablehlo.add %[[V0]], %[[C0]] : tensor<10xi64>
-// CHECK:           %[[C1:.*]] = stablehlo.constant dense<1> : tensor<10xi64>
-// CHECK:           %[[V2:.*]] = stablehlo.multiply %[[V1]], %[[C1]] : tensor<10xi64>
-// CHECK:           %[[C0B:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[DS1:.*]] = stablehlo.dynamic_slice %[[VAL_1]], %[[C0B]], sizes = [10] : (tensor<10xi1>, tensor<i64>) -> tensor<10xi1>
-// CHECK:           %[[V3:.*]] = stablehlo.reshape %[[DS1]] : (tensor<10xi1>) -> tensor<10xi1>
-// CHECK:           %[[C0C:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[DS2:.*]] = stablehlo.dynamic_slice %[[VAL_0]], %[[C0C]], sizes = [10] : (tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           %[[V4:.*]] = stablehlo.reshape %[[DS2]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[V5:.*]] = arith.addf %[[V4]], %[[V4]] : tensor<10xf32>
-// CHECK:           %[[C0D:.*]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK:           %[[BID1:.*]] = stablehlo.broadcast_in_dim %[[V5]], dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[DS3:.*]] = stablehlo.dynamic_slice %[[VAL_0]], %[[C0D]], sizes = [10] : (tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           %[[RSH1:.*]] = stablehlo.reshape %[[BID1]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[RSH2:.*]] = stablehlo.reshape %[[DS3]] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[SEL:.*]] = stablehlo.select %[[V3]], %[[RSH1]], %[[RSH2]] : tensor<10xi1>, tensor<10xf32>
-// CHECK:           %[[RSH3:.*]] = stablehlo.broadcast_in_dim %[[SEL]], dims = [0] : (tensor<10xf32>) -> tensor<10xf32>
-// CHECK:           %[[DUS:.*]] = stablehlo.dynamic_update_slice %[[VAL_0]], %[[RSH3]], %[[C0D]] : (tensor<10xf32>, tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
-// CHECK:           return %[[DUS]], %[[VAL_1]] : tensor<10xf32>, tensor<10xi1>
-// CHECK:         }
+// CHECK:    func.func private @test_affine_if_masking_raised(%[[a1:.+]]: tensor<10xf32>) -> tensor<10xf32> {
+// CHECK-NEXT:    %[[a2:.+]] = stablehlo.iota dim = 0 : tensor<10xi64>
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<0> : tensor<10xi64>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.add %[[a2]], %[[a3]] : tensor<10xi64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<1> : tensor<10xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.multiply %[[a4]], %[[a5]] : tensor<10xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<-5> : tensor<i64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.broadcast_in_dim %[[a7]], dims = [] : (tensor<i64>) -> tensor<10xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.add %[[a6]], %[[a8]] : tensor<10xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.constant dense<0> : tensor<10xi64>
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.compare GE, %[[a9]], %[[a10]] : (tensor<10xi64>, tensor<10xi64>) -> tensor<10xi1>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a13:.+]] = arith.addf %[[a1]], %[[a1]] : tensor<10xf32>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a18:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a19:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a20:.+]] = stablehlo.select %[[a11]], %[[a13]], %[[a1]] : tensor<10xi1>, tensor<10xf32>
+// CHECK-NEXT:    %[[a21:.+]] = stablehlo.dynamic_update_slice %[[a1]], %[[a20]], %[[a19]] : (tensor<10xf32>, tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
+// CHECK-NEXT:    return %[[a21]] : tensor<10xf32>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @test_if_else_masking_raised(%[[a1]]: tensor<10xf32>, %[[a22:.+]]: tensor<10xi1>) -> (tensor<10xf32>, tensor<10xi1>) {
+// CHECK-NEXT:    %[[a3]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a5]] = stablehlo.constant dense<10> : tensor<i64>
+// CHECK-NEXT:    %[[a7]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %[[a2]]:3 = stablehlo.while(%[[a23:.+]] = %[[a3]], %[[a24:.+]] = %[[a1]], %[[a25:.+]] = %[[a22]]) : tensor<i64>, tensor<10xf32>, tensor<10xi1>
+// CHECK-NEXT:    cond {
+// CHECK-NEXT:      %[[a4]] = stablehlo.compare LT, %[[a23]], %[[a5]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      stablehlo.return %[[a4]] : tensor<i1>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      %[[a4]] = stablehlo.dynamic_slice %[[a25]], %[[a23]], sizes = [1] : (tensor<10xi1>, tensor<i64>) -> tensor<1xi1>
+// CHECK-NEXT:      %[[a6]] = stablehlo.reshape %[[a4]] : (tensor<1xi1>) -> tensor<i1>
+// CHECK-NEXT:      %[[a8]] = stablehlo.dynamic_slice %[[a24]], %[[a23]], sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
+// CHECK-NEXT:      %[[a9]] = stablehlo.reshape %[[a8]] : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:      %[[a11]] = arith.addf %[[a9]], %[[a9]] : tensor<f32>
+// CHECK-NEXT:      %[[a14]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a15]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a16]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a17]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a18]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a13]] = stablehlo.broadcast_in_dim %[[a11]], dims = [] : (tensor<f32>) -> tensor<1xf32>
+// CHECK-NEXT:      %[[a20]] = stablehlo.dynamic_slice %[[a24]], %[[a23]], sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
+// CHECK-NEXT:      %[[a21]] = stablehlo.broadcast_in_dim %[[a6]], dims = [] : (tensor<i1>) -> tensor<1xi1>
+// CHECK-NEXT:      %[[a26:.+]] = stablehlo.select %[[a21]], %[[a13]], %[[a20]] : tensor<1xi1>, tensor<1xf32>
+// CHECK-NEXT:      %[[a27:.+]] = stablehlo.dynamic_update_slice %[[a24]], %[[a26]], %[[a23]] : (tensor<10xf32>, tensor<1xf32>, tensor<i64>) -> tensor<10xf32>
+// CHECK-NEXT:      %[[a28:.+]] = stablehlo.not %[[a6]] : tensor<i1>
+// CHECK-NEXT:      %[[a29:.+]] = stablehlo.dynamic_slice %[[a27]], %[[a23]], sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
+// CHECK-NEXT:      %[[a30:.+]] = stablehlo.reshape %[[a29]] : (tensor<1xf32>) -> tensor<f32>
+// CHECK-NEXT:      %[[a31:.+]] = arith.mulf %[[a30]], %[[a30]] : tensor<f32>
+// CHECK-NEXT:      %[[a19]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a32:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a33:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a34:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a35:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a36:.+]] = stablehlo.broadcast_in_dim %[[a31]], dims = [] : (tensor<f32>) -> tensor<1xf32>
+// CHECK-NEXT:      %[[a37:.+]] = stablehlo.dynamic_slice %[[a27]], %[[a23]], sizes = [1] : (tensor<10xf32>, tensor<i64>) -> tensor<1xf32>
+// CHECK-NEXT:      %[[a38:.+]] = stablehlo.broadcast_in_dim %[[a28]], dims = [] : (tensor<i1>) -> tensor<1xi1>
+// CHECK-NEXT:      %[[a39:.+]] = stablehlo.select %[[a38]], %[[a36]], %[[a37]] : tensor<1xi1>, tensor<1xf32>
+// CHECK-NEXT:      %[[a40:.+]] = stablehlo.dynamic_update_slice %[[a27]], %[[a39]], %[[a23]] : (tensor<10xf32>, tensor<1xf32>, tensor<i64>) -> tensor<10xf32>
+// CHECK-NEXT:      %[[a41:.+]] = stablehlo.add %[[a23]], %[[a7]] : tensor<i64>
+// CHECK-NEXT:      stablehlo.return %[[a41]], %[[a40]], %[[a25]] : tensor<i64>, tensor<10xf32>, tensor<10xi1>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a2]]#1, %[[a2]]#2 : tensor<10xf32>, tensor<10xi1>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @test_nested_if_masking_raised(%[[a1]]: tensor<10xf32>, %[[a22]]: tensor<10xi1>, %[[a42:.+]]: tensor<10xi1>) -> (tensor<10xf32>, tensor<10xi1>, tensor<10xi1>) {
+// CHECK-NEXT:    %[[a2]] = stablehlo.iota dim = 0 : tensor<10xi64>
+// CHECK-NEXT:    %[[a3]] = stablehlo.constant dense<0> : tensor<10xi64>
+// CHECK-NEXT:    %[[a4]] = stablehlo.add %[[a2]], %[[a3]] : tensor<10xi64>
+// CHECK-NEXT:    %[[a5]] = stablehlo.constant dense<1> : tensor<10xi64>
+// CHECK-NEXT:    %[[a6]] = stablehlo.multiply %[[a4]], %[[a5]] : tensor<10xi64>
+// CHECK-NEXT:    %[[a7]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a10]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a8]] = stablehlo.and %[[a22]], %[[a42]] : tensor<10xi1>
+// CHECK-NEXT:    %[[a12]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a9]] = arith.addf %[[a1]], %[[a1]] : tensor<10xf32>
+// CHECK-NEXT:    %[[a14]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a15]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a16]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a17]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a18]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a19]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a11]] = stablehlo.select %[[a8]], %[[a9]], %[[a1]] : tensor<10xi1>, tensor<10xf32>
+// CHECK-NEXT:    %[[a13]] = stablehlo.dynamic_update_slice %[[a1]], %[[a11]], %[[a19]] : (tensor<10xf32>, tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
+// CHECK-NEXT:    return %[[a13]], %[[a22]], %[[a42]] : tensor<10xf32>, tensor<10xi1>, tensor<10xi1>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @test_if_masking_raised(%[[a1]]: tensor<10xf32>, %[[a22]]: tensor<10xi1>) -> (tensor<10xf32>, tensor<10xi1>) {
+// CHECK-NEXT:    %[[a2]] = stablehlo.iota dim = 0 : tensor<10xi64>
+// CHECK-NEXT:    %[[a3]] = stablehlo.constant dense<0> : tensor<10xi64>
+// CHECK-NEXT:    %[[a4]] = stablehlo.add %[[a2]], %[[a3]] : tensor<10xi64>
+// CHECK-NEXT:    %[[a5]] = stablehlo.constant dense<1> : tensor<10xi64>
+// CHECK-NEXT:    %[[a6]] = stablehlo.multiply %[[a4]], %[[a5]] : tensor<10xi64>
+// CHECK-NEXT:    %[[a7]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a10]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a8]] = arith.addf %[[a1]], %[[a1]] : tensor<10xf32>
+// CHECK-NEXT:    %[[a12]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a14]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a15]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a16]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a17]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a18]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a9]] = stablehlo.select %[[a22]], %[[a8]], %[[a1]] : tensor<10xi1>, tensor<10xf32>
+// CHECK-NEXT:    %[[a11]] = stablehlo.dynamic_update_slice %[[a1]], %[[a9]], %[[a18]] : (tensor<10xf32>, tensor<10xf32>, tensor<i64>) -> tensor<10xf32>
+// CHECK-NEXT:    return %[[a11]], %[[a22]] : tensor<10xf32>, tensor<10xi1>
+// CHECK-NEXT:  }

--- a/test/lit_tests/raising/affine_to_stablehlo_if_masking2.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_if_masking2.mlir
@@ -114,217 +114,206 @@ module @reactant_dot_gat... attributes {llvm.data_layout = "e-p6:32:32-i64:64-i1
   }
 }
 
-// CHECK:  func.func private @"##call__Z22gpu_dot_gather_kernel_16CompilerMetadataI11DynamicSize12DynamicCheckv16CartesianIndicesILi3E5TupleI5OneToI5Int64ES6_S6_EE7NDRangeILi3ES0_S0_S8_S8_EE13CuTracedArrayI7Float64Li3ELi1E9_1__4__2_ESC_ISD_Li4ELi1E12_1__4__3__2_ESC_ISD_Li2ELi1E6_4__2_ESC_I5Int32Li1ELi1E4_2__ESI_SI_7Workset#283$par0_raised"(%arg0: tensor<2x4x1xf64>, %arg1: tensor<2x3x4x1xf64>, %arg2: tensor<2x4xf64>, %arg3: tensor<2xi32>, %arg4: tensor<2xi32>, %arg5: tensor<2xi32>) -> (tensor<2x4x1xf64>, tensor<2x3x4x1xf64>, tensor<2x4xf64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) {
-// CHECK-NEXT:    %c = stablehlo.constant dense<1> : tensor<3xi64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<3xi64>
-// CHECK-NEXT:    %c_1 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %c_2 = stablehlo.constant dense<4> : tensor<i64>
-// CHECK-NEXT:    %c_3 = stablehlo.constant dense<3> : tensor<i64>
-// CHECK-NEXT:    %c_4 = stablehlo.constant dense<2> : tensor<i64>
-// CHECK-NEXT:    %c_5 = stablehlo.constant dense<-1> : tensor<i64>
-// CHECK-NEXT:    %c_6 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %c_7 = stablehlo.constant dense<12> : tensor<i64>
-// CHECK-NEXT:    %[[v0:.+]] = stablehlo.iota dim = 0 : tensor<3xi64>
-// CHECK-NEXT:    %[[v1:.+]] = stablehlo.add %[[v0]], %c_0 : tensor<3xi64>
-// CHECK-NEXT:    %[[v2:.+]] = stablehlo.multiply %[[v1]], %c : tensor<3xi64>
-// CHECK-NEXT:    %[[v3:.+]] = stablehlo.reshape %arg3 : (tensor<2xi32>) -> tensor<2xi32>
-// CHECK-NEXT:    %[[v4:.+]] = stablehlo.broadcast_in_dim %c_6, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %[[v5:.+]] = arith.addi %[[v2]], %[[v4]] : tensor<3xi64>
-// CHECK-NEXT:    %[[v6:.+]] = arith.extsi %[[v3]] : tensor<2xi32> to tensor<2xi64>
-// CHECK-NEXT:    %[[v7:.+]] = stablehlo.broadcast_in_dim %c_5, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v8:.+]] = arith.addi %[[v6]], %[[v7]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v9:.+]] = stablehlo.convert %[[v3]] : (tensor<2xi32>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v10:.+]] = stablehlo.broadcast_in_dim %c_5, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v11:.+]] = arith.addi %[[v9]], %[[v10]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v12:.+]] = stablehlo.convert %[[v3]] : (tensor<2xi32>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v13:.+]] = stablehlo.broadcast_in_dim %c_5, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v14:.+]] = arith.addi %[[v12]], %[[v13]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v15:.+]] = stablehlo.reshape %[[v11]] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v16:.+]] = "stablehlo.gather"(%arg4, %[[v15]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<2xi32>, tensor<2x1xi64>) -> tensor<2xi32>
-// CHECK-NEXT:    %[[v17:.+]] = arith.extsi %[[v16]] : tensor<2xi32> to tensor<2xi64>
-// CHECK-NEXT:    %[[v18:.+]] = stablehlo.reshape %[[v14]] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v19:.+]] = "stablehlo.gather"(%arg5, %[[v18]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<2xi32>, tensor<2x1xi64>) -> tensor<2xi32>
-// CHECK-NEXT:    %[[v20:.+]] = arith.extsi %[[v19]] : tensor<2xi32> to tensor<2xi64>
-// CHECK-NEXT:    %[[v21:.+]] = stablehlo.broadcast_in_dim %[[v5]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v22:.+]] = stablehlo.broadcast_in_dim %[[v20]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v23:.+]] = arith.cmpi sle, %[[v21]], %[[v22]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v24:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v25:.+]] = arith.muli %[[v8]], %[[v24]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v26:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v27:.+]] = arith.remui %[[v25]], %[[v26]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v28:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v29:.+]] = arith.divui %[[v25]], %[[v28]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v30:.+]] = stablehlo.reshape %[[v29]] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v31:.+]] = stablehlo.broadcast_in_dim %[[v27]], dims = [0] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v32:.+]] = stablehlo.broadcast_in_dim %[[v30]], dims = [0, 1] : (tensor<2x1xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v33:.+]] = stablehlo.concatenate %[[v32]], %[[v31]], dim = 1 : (tensor<2x1xi64>, tensor<2x1xi64>) -> tensor<2x2xi64>
-// CHECK-NEXT:    %[[v34:.+]] = "stablehlo.gather"(%arg2, %[[v33]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<2x4xf64>, tensor<2x2xi64>) -> tensor<2xf64>
-// CHECK-NEXT:    %[[v35:.+]] = stablehlo.broadcast_in_dim %c_5, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v36:.+]] = arith.addi %[[v17]], %[[v35]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v37:.+]] = stablehlo.broadcast_in_dim %c_7, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v38:.+]] = arith.muli %[[v36]], %[[v37]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v39:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %[[v40:.+]] = stablehlo.multiply %[[v2]], %[[v39]] : tensor<3xi64>
-// CHECK-NEXT:    %[[v41:.+]] = stablehlo.broadcast_in_dim %[[v40]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v42:.+]] = stablehlo.broadcast_in_dim %[[v38]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v43:.+]] = arith.addi %[[v41]], %[[v42]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v44:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v45:.+]] = arith.remui %[[v43]], %[[v44]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v46:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v47:.+]] = arith.divui %[[v43]], %[[v46]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v48:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v49:.+]] = arith.remui %[[v47]], %[[v48]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v50:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v51:.+]] = arith.divui %[[v47]], %[[v50]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v52:.+]] = stablehlo.reshape %[[v51]] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v53:.+]] = stablehlo.broadcast_in_dim %[[v49]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v54:.+]] = stablehlo.broadcast_in_dim %[[v52]], dims = [0, 1, 2] : (tensor<3x2x1xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v55:.+]] = stablehlo.concatenate %[[v54]], %[[v53]], dim = 2 : (tensor<3x2x1xi64>, tensor<3x2x1xi64>) -> tensor<3x2x2xi64>
-// CHECK-NEXT:    %[[v56:.+]] = stablehlo.broadcast_in_dim %[[v45]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v57:.+]] = stablehlo.broadcast_in_dim %[[v55]], dims = [0, 1, 2] : (tensor<3x2x2xi64>) -> tensor<3x2x2xi64>
-// CHECK-NEXT:    %[[v58:.+]] = stablehlo.concatenate %[[v57]], %[[v56]], dim = 2 : (tensor<3x2x2xi64>, tensor<3x2x1xi64>) -> tensor<3x2x3xi64>
-// CHECK-NEXT:    %[[v59:.+]] = stablehlo.broadcast_in_dim %c_1, dims = [] : (tensor<i64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v60:.+]] = stablehlo.broadcast_in_dim %[[v58]], dims = [0, 1, 2] : (tensor<3x2x3xi64>) -> tensor<3x2x3xi64>
-// CHECK-NEXT:    %[[v61:.+]] = stablehlo.concatenate %[[v60]], %[[v59]], dim = 2 : (tensor<3x2x3xi64>, tensor<3x2x1xi64>) -> tensor<3x2x4xi64>
-// CHECK-NEXT:    %[[v62:.+]] = "stablehlo.gather"(%arg1, %[[v61]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2, 3], start_index_map = [0, 1, 2, 3], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1, 1>}> : (tensor<2x3x4x1xf64>, tensor<3x2x4xi64>) -> tensor<3x2xf64>
-// CHECK-NEXT:    %[[v63:.+]] = stablehlo.broadcast_in_dim %[[v34]], dims = [0] : (tensor<2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v64:.+]] = stablehlo.broadcast_in_dim %[[v62]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v65:.+]] = arith.mulf %[[v63]], %[[v64]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
-// CHECK-NEXT:    %[[v66:.+]] = stablehlo.broadcast_in_dim %c_6, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v67:.+]] = arith.addi %[[v25]], %[[v66]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v68:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v69:.+]] = arith.remui %[[v67]], %[[v68]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v70:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v71:.+]] = arith.divui %[[v67]], %[[v70]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v72:.+]] = stablehlo.reshape %[[v71]] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v73:.+]] = stablehlo.broadcast_in_dim %[[v69]], dims = [0] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v74:.+]] = stablehlo.broadcast_in_dim %[[v72]], dims = [0, 1] : (tensor<2x1xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v75:.+]] = stablehlo.concatenate %[[v74]], %[[v73]], dim = 1 : (tensor<2x1xi64>, tensor<2x1xi64>) -> tensor<2x2xi64>
-// CHECK-NEXT:    %[[v76:.+]] = "stablehlo.gather"(%arg2, %[[v75]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<2x4xf64>, tensor<2x2xi64>) -> tensor<2xf64>
-// CHECK-NEXT:    %[[v77:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %[[v78:.+]] = stablehlo.multiply %[[v2]], %[[v77]] : tensor<3xi64>
-// CHECK-NEXT:    %[[v79:.+]] = stablehlo.broadcast_in_dim %c_6, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %[[v80:.+]] = stablehlo.add %[[v78]], %[[v79]] : tensor<3xi64>
-// CHECK-NEXT:    %[[v81:.+]] = stablehlo.broadcast_in_dim %[[v80]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v82:.+]] = stablehlo.broadcast_in_dim %[[v38]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v83:.+]] = arith.addi %[[v81]], %[[v82]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v84:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v85:.+]] = arith.remui %[[v83]], %[[v84]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v86:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v87:.+]] = arith.divui %[[v83]], %[[v86]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v88:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v89:.+]] = arith.remui %[[v87]], %[[v88]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v90:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v91:.+]] = arith.divui %[[v87]], %[[v90]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v92:.+]] = stablehlo.reshape %[[v91]] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v93:.+]] = stablehlo.broadcast_in_dim %[[v89]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v94:.+]] = stablehlo.broadcast_in_dim %[[v92]], dims = [0, 1, 2] : (tensor<3x2x1xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v95:.+]] = stablehlo.concatenate %[[v94]], %[[v93]], dim = 2 : (tensor<3x2x1xi64>, tensor<3x2x1xi64>) -> tensor<3x2x2xi64>
-// CHECK-NEXT:    %[[v96:.+]] = stablehlo.broadcast_in_dim %[[v85]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v97:.+]] = stablehlo.broadcast_in_dim %[[v95]], dims = [0, 1, 2] : (tensor<3x2x2xi64>) -> tensor<3x2x2xi64>
-// CHECK-NEXT:    %[[v98:.+]] = stablehlo.concatenate %[[v97]], %[[v96]], dim = 2 : (tensor<3x2x2xi64>, tensor<3x2x1xi64>) -> tensor<3x2x3xi64>
-// CHECK-NEXT:    %[[v99:.+]] = stablehlo.broadcast_in_dim %c_1, dims = [] : (tensor<i64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v100:.+]] = stablehlo.broadcast_in_dim %[[v98]], dims = [0, 1, 2] : (tensor<3x2x3xi64>) -> tensor<3x2x3xi64>
-// CHECK-NEXT:    %[[v101:.+]] = stablehlo.concatenate %[[v100]], %[[v99]], dim = 2 : (tensor<3x2x3xi64>, tensor<3x2x1xi64>) -> tensor<3x2x4xi64>
-// CHECK-NEXT:    %[[v102:.+]] = "stablehlo.gather"(%arg1, %[[v101]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2, 3], start_index_map = [0, 1, 2, 3], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1, 1>}> : (tensor<2x3x4x1xf64>, tensor<3x2x4xi64>) -> tensor<3x2xf64>
-// CHECK-NEXT:    %[[v103:.+]] = stablehlo.broadcast_in_dim %[[v76]], dims = [0] : (tensor<2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v104:.+]] = stablehlo.broadcast_in_dim %[[v102]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v105:.+]] = arith.mulf %[[v103]], %[[v104]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
-// CHECK-NEXT:    %[[v106:.+]] = arith.addf %[[v65]], %[[v105]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
-// CHECK-NEXT:    %[[v107:.+]] = stablehlo.broadcast_in_dim %c_4, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v108:.+]] = arith.addi %[[v25]], %[[v107]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v109:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v110:.+]] = arith.remui %[[v108]], %[[v109]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v111:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v112:.+]] = arith.divui %[[v108]], %[[v111]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v113:.+]] = stablehlo.reshape %[[v112]] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v114:.+]] = stablehlo.broadcast_in_dim %[[v110]], dims = [0] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v115:.+]] = stablehlo.broadcast_in_dim %[[v113]], dims = [0, 1] : (tensor<2x1xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v116:.+]] = stablehlo.concatenate %[[v115]], %[[v114]], dim = 1 : (tensor<2x1xi64>, tensor<2x1xi64>) -> tensor<2x2xi64>
-// CHECK-NEXT:    %[[v117:.+]] = "stablehlo.gather"(%arg2, %[[v116]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<2x4xf64>, tensor<2x2xi64>) -> tensor<2xf64>
-// CHECK-NEXT:    %[[v118:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %[[v119:.+]] = stablehlo.multiply %[[v2]], %[[v118]] : tensor<3xi64>
-// CHECK-NEXT:    %[[v120:.+]] = stablehlo.broadcast_in_dim %c_4, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %[[v121:.+]] = stablehlo.add %[[v119]], %[[v120]] : tensor<3xi64>
-// CHECK-NEXT:    %[[v122:.+]] = stablehlo.broadcast_in_dim %[[v121]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v123:.+]] = stablehlo.broadcast_in_dim %[[v38]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v124:.+]] = arith.addi %[[v122]], %[[v123]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v125:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v126:.+]] = arith.remui %[[v124]], %[[v125]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v127:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v128:.+]] = arith.divui %[[v124]], %[[v127]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v129:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v130:.+]] = arith.remui %[[v128]], %[[v129]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v131:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v132:.+]] = arith.divui %[[v128]], %[[v131]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v133:.+]] = stablehlo.reshape %[[v132]] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v134:.+]] = stablehlo.broadcast_in_dim %[[v130]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v135:.+]] = stablehlo.broadcast_in_dim %[[v133]], dims = [0, 1, 2] : (tensor<3x2x1xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v136:.+]] = stablehlo.concatenate %[[v135]], %[[v134]], dim = 2 : (tensor<3x2x1xi64>, tensor<3x2x1xi64>) -> tensor<3x2x2xi64>
-// CHECK-NEXT:    %[[v137:.+]] = stablehlo.broadcast_in_dim %[[v126]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v138:.+]] = stablehlo.broadcast_in_dim %[[v136]], dims = [0, 1, 2] : (tensor<3x2x2xi64>) -> tensor<3x2x2xi64>
-// CHECK-NEXT:    %[[v139:.+]] = stablehlo.concatenate %[[v138]], %[[v137]], dim = 2 : (tensor<3x2x2xi64>, tensor<3x2x1xi64>) -> tensor<3x2x3xi64>
-// CHECK-NEXT:    %[[v140:.+]] = stablehlo.broadcast_in_dim %c_1, dims = [] : (tensor<i64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v141:.+]] = stablehlo.broadcast_in_dim %[[v139]], dims = [0, 1, 2] : (tensor<3x2x3xi64>) -> tensor<3x2x3xi64>
-// CHECK-NEXT:    %[[v142:.+]] = stablehlo.concatenate %[[v141]], %[[v140]], dim = 2 : (tensor<3x2x3xi64>, tensor<3x2x1xi64>) -> tensor<3x2x4xi64>
-// CHECK-NEXT:    %[[v143:.+]] = "stablehlo.gather"(%arg1, %[[v142]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2, 3], start_index_map = [0, 1, 2, 3], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1, 1>}> : (tensor<2x3x4x1xf64>, tensor<3x2x4xi64>) -> tensor<3x2xf64>
-// CHECK-NEXT:    %[[v144:.+]] = stablehlo.broadcast_in_dim %[[v117]], dims = [0] : (tensor<2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v145:.+]] = stablehlo.broadcast_in_dim %[[v143]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v146:.+]] = arith.mulf %[[v144]], %[[v145]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
-// CHECK-NEXT:    %[[v147:.+]] = arith.addf %[[v106]], %[[v146]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
-// CHECK-NEXT:    %[[v148:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v149:.+]] = arith.addi %[[v25]], %[[v148]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v150:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v151:.+]] = arith.remui %[[v149]], %[[v150]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v152:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<2xi64>
-// CHECK-NEXT:    %[[v153:.+]] = arith.divui %[[v149]], %[[v152]] : tensor<2xi64>
-// CHECK-NEXT:    %[[v154:.+]] = stablehlo.reshape %[[v153]] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v155:.+]] = stablehlo.broadcast_in_dim %[[v151]], dims = [0] : (tensor<2xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v156:.+]] = stablehlo.broadcast_in_dim %[[v154]], dims = [0, 1] : (tensor<2x1xi64>) -> tensor<2x1xi64>
-// CHECK-NEXT:    %[[v157:.+]] = stablehlo.concatenate %[[v156]], %[[v155]], dim = 1 : (tensor<2x1xi64>, tensor<2x1xi64>) -> tensor<2x2xi64>
-// CHECK-NEXT:    %[[v158:.+]] = "stablehlo.gather"(%arg2, %[[v157]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<2x4xf64>, tensor<2x2xi64>) -> tensor<2xf64>
-// CHECK-NEXT:    %[[v159:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %[[v160:.+]] = stablehlo.multiply %[[v2]], %[[v159]] : tensor<3xi64>
-// CHECK-NEXT:    %[[v161:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %[[v162:.+]] = stablehlo.add %[[v160]], %[[v161]] : tensor<3xi64>
-// CHECK-NEXT:    %[[v163:.+]] = stablehlo.broadcast_in_dim %[[v162]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v164:.+]] = stablehlo.broadcast_in_dim %[[v38]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v165:.+]] = arith.addi %[[v163]], %[[v164]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v166:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v167:.+]] = arith.remui %[[v165]], %[[v166]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v168:.+]] = stablehlo.broadcast_in_dim %c_2, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v169:.+]] = arith.divui %[[v165]], %[[v168]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v170:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v171:.+]] = arith.remui %[[v169]], %[[v170]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v172:.+]] = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<3x2xi64>
-// CHECK-NEXT:    %[[v173:.+]] = arith.divui %[[v169]], %[[v172]] : tensor<3x2xi64>
-// CHECK-NEXT:    %[[v174:.+]] = stablehlo.reshape %[[v173]] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v175:.+]] = stablehlo.broadcast_in_dim %[[v171]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v176:.+]] = stablehlo.broadcast_in_dim %[[v174]], dims = [0, 1, 2] : (tensor<3x2x1xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v177:.+]] = stablehlo.concatenate %[[v176]], %[[v175]], dim = 2 : (tensor<3x2x1xi64>, tensor<3x2x1xi64>) -> tensor<3x2x2xi64>
-// CHECK-NEXT:    %[[v178:.+]] = stablehlo.broadcast_in_dim %[[v167]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v179:.+]] = stablehlo.broadcast_in_dim %[[v177]], dims = [0, 1, 2] : (tensor<3x2x2xi64>) -> tensor<3x2x2xi64>
-// CHECK-NEXT:    %[[v180:.+]] = stablehlo.concatenate %[[v179]], %[[v178]], dim = 2 : (tensor<3x2x2xi64>, tensor<3x2x1xi64>) -> tensor<3x2x3xi64>
-// CHECK-NEXT:    %[[v181:.+]] = stablehlo.broadcast_in_dim %c_1, dims = [] : (tensor<i64>) -> tensor<3x2x1xi64>
-// CHECK-NEXT:    %[[v182:.+]] = stablehlo.broadcast_in_dim %[[v180]], dims = [0, 1, 2] : (tensor<3x2x3xi64>) -> tensor<3x2x3xi64>
-// CHECK-NEXT:    %[[v183:.+]] = stablehlo.concatenate %[[v182]], %[[v181]], dim = 2 : (tensor<3x2x3xi64>, tensor<3x2x1xi64>) -> tensor<3x2x4xi64>
-// CHECK-NEXT:    %[[v184:.+]] = "stablehlo.gather"(%arg1, %[[v183]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2, 3], start_index_map = [0, 1, 2, 3], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1, 1>}> : (tensor<2x3x4x1xf64>, tensor<3x2x4xi64>) -> tensor<3x2xf64>
-// CHECK-NEXT:    %[[v185:.+]] = stablehlo.broadcast_in_dim %[[v158]], dims = [0] : (tensor<2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v186:.+]] = stablehlo.broadcast_in_dim %[[v184]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v187:.+]] = arith.mulf %[[v185]], %[[v186]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
-// CHECK-NEXT:    %[[v188:.+]] = arith.addf %[[v147]], %[[v187]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
-// CHECK-NEXT:    %[[v189:.+]] = stablehlo.slice %arg0 [0:2, 1:4, 0:1] : (tensor<2x4x1xf64>) -> tensor<2x3x1xf64>
-// CHECK-NEXT:    %[[v190:.+]] = stablehlo.reshape %[[v189]] : (tensor<2x3x1xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v191:.+]] = arith.addf %[[v190]], %[[v188]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
-// CHECK-NEXT:    %[[v192:.+]] = stablehlo.broadcast_in_dim %[[v191]], dims = [0, 1] : (tensor<2x3xf64>) -> tensor<2x3x1xf64>
-// CHECK-NEXT:    %[[v193:.+]] = stablehlo.dynamic_slice %arg0, %c_1, %c_6, %c_1, sizes = [2, 3, 1] : (tensor<2x4x1xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<2x3x1xf64>
-// CHECK-NEXT:    %[[v194:.+]] = stablehlo.reshape %[[v192]] : (tensor<2x3x1xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v195:.+]] = stablehlo.reshape %[[v193]] : (tensor<2x3x1xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %[[v196:.+]] = stablehlo.broadcast_in_dim %[[v194]], dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
-// CHECK-NEXT:    %[[v197:.+]] = stablehlo.broadcast_in_dim %[[v195]], dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
-// CHECK-NEXT:    %[[v198:.+]] = stablehlo.select %[[v23]], %[[v196]], %[[v197]] : tensor<3x2xi1>, tensor<3x2xf64>
-// CHECK-NEXT:    %[[v199:.+]] = stablehlo.broadcast_in_dim %[[v198]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3x1xf64>
-// CHECK-NEXT:    %[[v200:.+]] = stablehlo.dynamic_update_slice %arg0, %[[v199]], %c_1, %c_6, %c_1 : (tensor<2x4x1xf64>, tensor<2x3x1xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<2x4x1xf64>
-// CHECK-NEXT:    return %[[v200]], %arg1, %arg2, %arg3, %arg4, %arg5 : tensor<2x4x1xf64>, tensor<2x3x4x1xf64>, tensor<2x4xf64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>
+// CHECK:  module @reactant_dot_gat... attributes {llvm.data_layout = "e-p6:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64", mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
+// CHECK-NEXT:  llvm.module_flags [#llvm.mlir.module_flag<warning, "Dwarf Version", 2 : i32>, #llvm.mlir.module_flag<warning, "Debug Info Version", 3 : i32>, #llvm.mlir.module_flag<override, "nvvm-reflect-ftz", 0 : i32>]
+// CHECK-NEXT:  func.func @main(%[[a1:.+]]: tensor<2x4x1xf64> {enzymexla.memory_effects = [], tf.aliasing_output = 0 : i32}, %[[a2:.+]]: tensor<2x3x4x1xf64> {enzymexla.memory_effects = ["read", "write", "allocate", "free"], tf.aliasing_output = 1 : i32}, %[[a3:.+]]: tensor<2x4xf64> {enzymexla.memory_effects = ["read", "write", "allocate", "free"], tf.aliasing_output = 2 : i32}, %[[a4:.+]]: tensor<2xi32> {enzymexla.memory_effects = ["read", "write", "allocate", "free"], tf.aliasing_output = 3 : i32}, %[[a5:.+]]: tensor<2xi32> {enzymexla.memory_effects = ["read", "write", "allocate", "free"], tf.aliasing_output = 4 : i32}, %[[a6:.+]]: tensor<2xi32> {enzymexla.memory_effects = ["read", "write", "allocate", "free"], tf.aliasing_output = 5 : i32}) -> (tensor<2x4x1xf64>, tensor<2x3x4x1xf64>, tensor<2x4xf64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) attributes {enzymexla.memory_effects = ["read", "write", "allocate", "free"]} {
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<2x4x1xf64>
+// CHECK-NEXT:    %[[a8:.+]]:6 = call @"##call__Z22gpu_dot_gather_kernel_16CompilerMetadataI11DynamicSize12DynamicCheckv16CartesianIndicesILi3E5TupleI5OneToI5Int64ES6_S6_EE7NDRangeILi3ES0_S0_S8_S8_EE13CuTracedArrayI7Float64Li3ELi1E9_1__4__2_ESC_ISD_Li4ELi1E12_1__4__3__2_ESC_ISD_Li2ELi1E6_4__2_ESC_I5Int32Li1ELi1E4_2__ESI_SI_7Workset#283$par0_raised"(%[[a7]], %[[a2]], %[[a3]], %[[a4]], %[[a5]], %[[a6]]) : (tensor<2x4x1xf64>, tensor<2x3x4x1xf64>, tensor<2x4xf64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> (tensor<2x4x1xf64>, tensor<2x3x4x1xf64>, tensor<2x4xf64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>)
+// CHECK-NEXT:    return %[[a8]]#0, %[[a2]], %[[a3]], %[[a4]], %[[a5]], %[[a6]] : tensor<2x4x1xf64>, tensor<2x3x4x1xf64>, tensor<2x4xf64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>
 // CHECK-NEXT:  }
-
+// CHECK-NEXT:  func.func private @"##call__Z22gpu_dot_gather_kernel_16CompilerMetadataI11DynamicSize12DynamicCheckv16CartesianIndicesILi3E5TupleI5OneToI5Int64ES6_S6_EE7NDRangeILi3ES0_S0_S8_S8_EE13CuTracedArrayI7Float64Li3ELi1E9_1__4__2_ESC_ISD_Li4ELi1E12_1__4__3__2_ESC_ISD_Li2ELi1E6_4__2_ESC_I5Int32Li1ELi1E4_2__ESI_SI_7Workset#283$par0_raised"(%[[a1]]: tensor<2x4x1xf64>, %[[a2]]: tensor<2x3x4x1xf64>, %[[a3]]: tensor<2x4xf64>, %[[a4]]: tensor<2xi32>, %[[a5]]: tensor<2xi32>, %[[a6]]: tensor<2xi32>) -> (tensor<2x4x1xf64>, tensor<2x3x4x1xf64>, tensor<2x4xf64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) {
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.constant dense<1> : tensor<3xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.constant dense<0> : tensor<3xi64>
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.constant dense<4> : tensor<i64>
+// CHECK-NEXT:    %[[a13:.+]] = stablehlo.constant dense<3> : tensor<i64>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.constant dense<-1> : tensor<i64>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.constant dense<12> : tensor<i64>
+// CHECK-NEXT:    %[[a8]] = stablehlo.iota dim = 0 : tensor<3xi64>
+// CHECK-NEXT:    %[[a18:.+]] = stablehlo.add %[[a8]], %[[a10]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a19:.+]] = stablehlo.multiply %[[a18]], %[[a9]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a20:.+]] = stablehlo.broadcast_in_dim %[[a16]], dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %[[a21:.+]] = arith.addi %[[a19]], %[[a20]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a22:.+]] = arith.extsi %[[a4]] : tensor<2xi32> to tensor<2xi64>
+// CHECK-NEXT:    %[[a23:.+]] = stablehlo.broadcast_in_dim %[[a15]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a24:.+]] = arith.addi %[[a22]], %[[a23]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a25:.+]] = stablehlo.convert %[[a4]] : (tensor<2xi32>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a26:.+]] = stablehlo.broadcast_in_dim %[[a15]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a27:.+]] = arith.addi %[[a25]], %[[a26]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a28:.+]] = stablehlo.convert %[[a4]] : (tensor<2xi32>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a29:.+]] = stablehlo.broadcast_in_dim %[[a15]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a30:.+]] = arith.addi %[[a28]], %[[a29]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a31:.+]] = stablehlo.reshape %[[a27]] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a32:.+]] = "stablehlo.gather"(%[[a5]], %[[a31]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<2xi32>, tensor<2x1xi64>) -> tensor<2xi32>
+// CHECK-NEXT:    %[[a33:.+]] = arith.extsi %[[a32]] : tensor<2xi32> to tensor<2xi64>
+// CHECK-NEXT:    %[[a34:.+]] = stablehlo.reshape %[[a30]] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a35:.+]] = "stablehlo.gather"(%[[a6]], %[[a34]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<2xi32>, tensor<2x1xi64>) -> tensor<2xi32>
+// CHECK-NEXT:    %[[a36:.+]] = arith.extsi %[[a35]] : tensor<2xi32> to tensor<2xi64>
+// CHECK-NEXT:    %[[a37:.+]] = stablehlo.broadcast_in_dim %[[a21]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a38:.+]] = stablehlo.broadcast_in_dim %[[a36]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a39:.+]] = arith.cmpi sle, %[[a37]], %[[a38]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a40:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a41:.+]] = arith.muli %[[a24]], %[[a40]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a42:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a43:.+]] = arith.remui %[[a41]], %[[a42]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a44:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a45:.+]] = arith.divui %[[a41]], %[[a44]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a46:.+]] = stablehlo.reshape %[[a45]] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a47:.+]] = stablehlo.broadcast_in_dim %[[a43]], dims = [0] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a48:.+]] = stablehlo.concatenate %[[a46]], %[[a47]], dim = 1 : (tensor<2x1xi64>, tensor<2x1xi64>) -> tensor<2x2xi64>
+// CHECK-NEXT:    %[[a49:.+]] = "stablehlo.gather"(%[[a3]], %[[a48]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<2x4xf64>, tensor<2x2xi64>) -> tensor<2xf64>
+// CHECK-NEXT:    %[[a50:.+]] = stablehlo.broadcast_in_dim %[[a15]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a51:.+]] = arith.addi %[[a33]], %[[a50]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a52:.+]] = stablehlo.broadcast_in_dim %[[a17]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a53:.+]] = arith.muli %[[a51]], %[[a52]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a54:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %[[a55:.+]] = stablehlo.multiply %[[a19]], %[[a54]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a56:.+]] = stablehlo.broadcast_in_dim %[[a55]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a57:.+]] = stablehlo.broadcast_in_dim %[[a53]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a58:.+]] = arith.addi %[[a56]], %[[a57]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a59:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a60:.+]] = arith.remui %[[a58]], %[[a59]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a61:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a62:.+]] = arith.divui %[[a58]], %[[a61]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a63:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a64:.+]] = arith.remui %[[a62]], %[[a63]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a65:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a66:.+]] = arith.divui %[[a62]], %[[a65]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a67:.+]] = stablehlo.reshape %[[a66]] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a68:.+]] = stablehlo.broadcast_in_dim %[[a64]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a69:.+]] = stablehlo.concatenate %[[a67]], %[[a68]], dim = 2 : (tensor<3x2x1xi64>, tensor<3x2x1xi64>) -> tensor<3x2x2xi64>
+// CHECK-NEXT:    %[[a70:.+]] = stablehlo.broadcast_in_dim %[[a60]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a71:.+]] = stablehlo.concatenate %[[a69]], %[[a70]], dim = 2 : (tensor<3x2x2xi64>, tensor<3x2x1xi64>) -> tensor<3x2x3xi64>
+// CHECK-NEXT:    %[[a72:.+]] = stablehlo.broadcast_in_dim %[[a11]], dims = [] : (tensor<i64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a73:.+]] = stablehlo.concatenate %[[a71]], %[[a72]], dim = 2 : (tensor<3x2x3xi64>, tensor<3x2x1xi64>) -> tensor<3x2x4xi64>
+// CHECK-NEXT:    %[[a74:.+]] = "stablehlo.gather"(%[[a2]], %[[a73]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2, 3], start_index_map = [0, 1, 2, 3], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1, 1>}> : (tensor<2x3x4x1xf64>, tensor<3x2x4xi64>) -> tensor<3x2xf64>
+// CHECK-NEXT:    %[[a75:.+]] = stablehlo.broadcast_in_dim %[[a49]], dims = [0] : (tensor<2xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a76:.+]] = stablehlo.broadcast_in_dim %[[a74]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a77:.+]] = arith.mulf %[[a75]], %[[a76]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
+// CHECK-NEXT:    %[[a78:.+]] = stablehlo.broadcast_in_dim %[[a16]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a79:.+]] = arith.addi %[[a41]], %[[a78]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a80:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a81:.+]] = arith.remui %[[a79]], %[[a80]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a82:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a83:.+]] = arith.divui %[[a79]], %[[a82]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a84:.+]] = stablehlo.reshape %[[a83]] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a85:.+]] = stablehlo.broadcast_in_dim %[[a81]], dims = [0] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a86:.+]] = stablehlo.concatenate %[[a84]], %[[a85]], dim = 1 : (tensor<2x1xi64>, tensor<2x1xi64>) -> tensor<2x2xi64>
+// CHECK-NEXT:    %[[a87:.+]] = "stablehlo.gather"(%[[a3]], %[[a86]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<2x4xf64>, tensor<2x2xi64>) -> tensor<2xf64>
+// CHECK-NEXT:    %[[a88:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %[[a89:.+]] = stablehlo.multiply %[[a19]], %[[a88]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a90:.+]] = stablehlo.broadcast_in_dim %[[a16]], dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %[[a91:.+]] = stablehlo.add %[[a89]], %[[a90]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a92:.+]] = stablehlo.broadcast_in_dim %[[a91]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a93:.+]] = stablehlo.broadcast_in_dim %[[a53]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a94:.+]] = arith.addi %[[a92]], %[[a93]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a95:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a96:.+]] = arith.remui %[[a94]], %[[a95]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a97:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a98:.+]] = arith.divui %[[a94]], %[[a97]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a99:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a100:.+]] = arith.remui %[[a98]], %[[a99]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a101:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a102:.+]] = arith.divui %[[a98]], %[[a101]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a103:.+]] = stablehlo.reshape %[[a102]] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a104:.+]] = stablehlo.broadcast_in_dim %[[a100]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a105:.+]] = stablehlo.concatenate %[[a103]], %[[a104]], dim = 2 : (tensor<3x2x1xi64>, tensor<3x2x1xi64>) -> tensor<3x2x2xi64>
+// CHECK-NEXT:    %[[a106:.+]] = stablehlo.broadcast_in_dim %[[a96]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a107:.+]] = stablehlo.concatenate %[[a105]], %[[a106]], dim = 2 : (tensor<3x2x2xi64>, tensor<3x2x1xi64>) -> tensor<3x2x3xi64>
+// CHECK-NEXT:    %[[a108:.+]] = stablehlo.broadcast_in_dim %[[a11]], dims = [] : (tensor<i64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a109:.+]] = stablehlo.concatenate %[[a107]], %[[a108]], dim = 2 : (tensor<3x2x3xi64>, tensor<3x2x1xi64>) -> tensor<3x2x4xi64>
+// CHECK-NEXT:    %[[a110:.+]] = "stablehlo.gather"(%[[a2]], %[[a109]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2, 3], start_index_map = [0, 1, 2, 3], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1, 1>}> : (tensor<2x3x4x1xf64>, tensor<3x2x4xi64>) -> tensor<3x2xf64>
+// CHECK-NEXT:    %[[a111:.+]] = stablehlo.broadcast_in_dim %[[a87]], dims = [0] : (tensor<2xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a112:.+]] = stablehlo.broadcast_in_dim %[[a110]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a113:.+]] = arith.mulf %[[a111]], %[[a112]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
+// CHECK-NEXT:    %[[a114:.+]] = arith.addf %[[a77]], %[[a113]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
+// CHECK-NEXT:    %[[a115:.+]] = stablehlo.broadcast_in_dim %[[a14]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a116:.+]] = arith.addi %[[a41]], %[[a115]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a117:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a118:.+]] = arith.remui %[[a116]], %[[a117]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a119:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a120:.+]] = arith.divui %[[a116]], %[[a119]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a121:.+]] = stablehlo.reshape %[[a120]] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a122:.+]] = stablehlo.broadcast_in_dim %[[a118]], dims = [0] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a123:.+]] = stablehlo.concatenate %[[a121]], %[[a122]], dim = 1 : (tensor<2x1xi64>, tensor<2x1xi64>) -> tensor<2x2xi64>
+// CHECK-NEXT:    %[[a124:.+]] = "stablehlo.gather"(%[[a3]], %[[a123]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<2x4xf64>, tensor<2x2xi64>) -> tensor<2xf64>
+// CHECK-NEXT:    %[[a125:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %[[a126:.+]] = stablehlo.multiply %[[a19]], %[[a125]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a127:.+]] = stablehlo.broadcast_in_dim %[[a14]], dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %[[a128:.+]] = stablehlo.add %[[a126]], %[[a127]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a129:.+]] = stablehlo.broadcast_in_dim %[[a128]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a130:.+]] = stablehlo.broadcast_in_dim %[[a53]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a131:.+]] = arith.addi %[[a129]], %[[a130]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a132:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a133:.+]] = arith.remui %[[a131]], %[[a132]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a134:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a135:.+]] = arith.divui %[[a131]], %[[a134]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a136:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a137:.+]] = arith.remui %[[a135]], %[[a136]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a138:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a139:.+]] = arith.divui %[[a135]], %[[a138]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a140:.+]] = stablehlo.reshape %[[a139]] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a141:.+]] = stablehlo.broadcast_in_dim %[[a137]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a142:.+]] = stablehlo.concatenate %[[a140]], %[[a141]], dim = 2 : (tensor<3x2x1xi64>, tensor<3x2x1xi64>) -> tensor<3x2x2xi64>
+// CHECK-NEXT:    %[[a143:.+]] = stablehlo.broadcast_in_dim %[[a133]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a144:.+]] = stablehlo.concatenate %[[a142]], %[[a143]], dim = 2 : (tensor<3x2x2xi64>, tensor<3x2x1xi64>) -> tensor<3x2x3xi64>
+// CHECK-NEXT:    %[[a145:.+]] = stablehlo.broadcast_in_dim %[[a11]], dims = [] : (tensor<i64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a146:.+]] = stablehlo.concatenate %[[a144]], %[[a145]], dim = 2 : (tensor<3x2x3xi64>, tensor<3x2x1xi64>) -> tensor<3x2x4xi64>
+// CHECK-NEXT:    %[[a147:.+]] = "stablehlo.gather"(%[[a2]], %[[a146]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2, 3], start_index_map = [0, 1, 2, 3], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1, 1>}> : (tensor<2x3x4x1xf64>, tensor<3x2x4xi64>) -> tensor<3x2xf64>
+// CHECK-NEXT:    %[[a148:.+]] = stablehlo.broadcast_in_dim %[[a124]], dims = [0] : (tensor<2xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a149:.+]] = stablehlo.broadcast_in_dim %[[a147]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a150:.+]] = arith.mulf %[[a148]], %[[a149]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
+// CHECK-NEXT:    %[[a151:.+]] = arith.addf %[[a114]], %[[a150]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
+// CHECK-NEXT:    %[[a152:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a153:.+]] = arith.addi %[[a41]], %[[a152]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a154:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a155:.+]] = arith.remui %[[a153]], %[[a154]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a156:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<2xi64>
+// CHECK-NEXT:    %[[a157:.+]] = arith.divui %[[a153]], %[[a156]] : tensor<2xi64>
+// CHECK-NEXT:    %[[a158:.+]] = stablehlo.reshape %[[a157]] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a159:.+]] = stablehlo.broadcast_in_dim %[[a155]], dims = [0] : (tensor<2xi64>) -> tensor<2x1xi64>
+// CHECK-NEXT:    %[[a160:.+]] = stablehlo.concatenate %[[a158]], %[[a159]], dim = 1 : (tensor<2x1xi64>, tensor<2x1xi64>) -> tensor<2x2xi64>
+// CHECK-NEXT:    %[[a161:.+]] = "stablehlo.gather"(%[[a3]], %[[a160]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<2x4xf64>, tensor<2x2xi64>) -> tensor<2xf64>
+// CHECK-NEXT:    %[[a162:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %[[a163:.+]] = stablehlo.multiply %[[a19]], %[[a162]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a164:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %[[a165:.+]] = stablehlo.add %[[a163]], %[[a164]] : tensor<3xi64>
+// CHECK-NEXT:    %[[a166:.+]] = stablehlo.broadcast_in_dim %[[a165]], dims = [0] : (tensor<3xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a167:.+]] = stablehlo.broadcast_in_dim %[[a53]], dims = [1] : (tensor<2xi64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a168:.+]] = arith.addi %[[a166]], %[[a167]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a169:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a170:.+]] = arith.remui %[[a168]], %[[a169]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a171:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a172:.+]] = arith.divui %[[a168]], %[[a171]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a173:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a174:.+]] = arith.remui %[[a172]], %[[a173]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a175:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i64>) -> tensor<3x2xi64>
+// CHECK-NEXT:    %[[a176:.+]] = arith.divui %[[a172]], %[[a175]] : tensor<3x2xi64>
+// CHECK-NEXT:    %[[a177:.+]] = stablehlo.reshape %[[a176]] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a178:.+]] = stablehlo.broadcast_in_dim %[[a174]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a179:.+]] = stablehlo.concatenate %[[a177]], %[[a178]], dim = 2 : (tensor<3x2x1xi64>, tensor<3x2x1xi64>) -> tensor<3x2x2xi64>
+// CHECK-NEXT:    %[[a180:.+]] = stablehlo.broadcast_in_dim %[[a170]], dims = [0, 1] : (tensor<3x2xi64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a181:.+]] = stablehlo.concatenate %[[a179]], %[[a180]], dim = 2 : (tensor<3x2x2xi64>, tensor<3x2x1xi64>) -> tensor<3x2x3xi64>
+// CHECK-NEXT:    %[[a182:.+]] = stablehlo.broadcast_in_dim %[[a11]], dims = [] : (tensor<i64>) -> tensor<3x2x1xi64>
+// CHECK-NEXT:    %[[a183:.+]] = stablehlo.concatenate %[[a181]], %[[a182]], dim = 2 : (tensor<3x2x3xi64>, tensor<3x2x1xi64>) -> tensor<3x2x4xi64>
+// CHECK-NEXT:    %[[a184:.+]] = "stablehlo.gather"(%[[a2]], %[[a183]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1, 2, 3], start_index_map = [0, 1, 2, 3], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1, 1, 1>}> : (tensor<2x3x4x1xf64>, tensor<3x2x4xi64>) -> tensor<3x2xf64>
+// CHECK-NEXT:    %[[a185:.+]] = stablehlo.broadcast_in_dim %[[a161]], dims = [0] : (tensor<2xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a186:.+]] = stablehlo.broadcast_in_dim %[[a184]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a187:.+]] = arith.mulf %[[a185]], %[[a186]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
+// CHECK-NEXT:    %[[a188:.+]] = arith.addf %[[a151]], %[[a187]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
+// CHECK-NEXT:    %[[a189:.+]] = stablehlo.slice %[[a1]] [0:2, 1:4, 0:1] : (tensor<2x4x1xf64>) -> tensor<2x3x1xf64>
+// CHECK-NEXT:    %[[a190:.+]] = stablehlo.reshape %[[a189]] : (tensor<2x3x1xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a191:.+]] = arith.addf %[[a190]], %[[a188]] {fastmathFlags = #llvm.fastmath<none>} : tensor<2x3xf64>
+// CHECK-NEXT:    %[[a192:.+]] = stablehlo.broadcast_in_dim %[[a191]], dims = [0, 1] : (tensor<2x3xf64>) -> tensor<2x3x1xf64>
+// CHECK-NEXT:    %[[a193:.+]] = stablehlo.slice %[[a1]] [0:2, 1:4, 0:1] : (tensor<2x4x1xf64>) -> tensor<2x3x1xf64>
+// CHECK-NEXT:    %[[a194:.+]] = stablehlo.reshape %[[a192]] : (tensor<2x3x1xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a195:.+]] = stablehlo.reshape %[[a193]] : (tensor<2x3x1xf64>) -> tensor<2x3xf64>
+// CHECK-NEXT:    %[[a196:.+]] = stablehlo.broadcast_in_dim %[[a194]], dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+// CHECK-NEXT:    %[[a197:.+]] = stablehlo.broadcast_in_dim %[[a195]], dims = [1, 0] : (tensor<2x3xf64>) -> tensor<3x2xf64>
+// CHECK-NEXT:    %[[a198:.+]] = stablehlo.select %[[a39]], %[[a196]], %[[a197]] : tensor<3x2xi1>, tensor<3x2xf64>
+// CHECK-NEXT:    %[[a199:.+]] = stablehlo.broadcast_in_dim %[[a198]], dims = [1, 0] : (tensor<3x2xf64>) -> tensor<2x3x1xf64>
+// CHECK-NEXT:    %[[a200:.+]] = stablehlo.dynamic_update_slice %[[a1]], %[[a199]], %[[a11]], %[[a16]], %[[a11]] : (tensor<2x4x1xf64>, tensor<2x3x1xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<2x4x1xf64>
+// CHECK-NEXT:    return %[[a200]], %[[a2]], %[[a3]], %[[a4]], %[[a5]], %[[a6]] : tensor<2x4x1xf64>, tensor<2x3x4x1xf64>, tensor<2x4xf64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>
+// CHECK-NEXT:  }

--- a/test/lit_tests/raising/affine_to_stablehlo_scatgath.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_scatgath.mlir
@@ -56,91 +56,100 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vec
 // Define arg2 = 0 - 18000
 // Define arg3 = 0 - 120
 
-// CHECK:  func.func private @rxla$raised_0(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> (tensor<?xf32>, tensor<?xf32>) {
 
 // arg2
-// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<18000xi64>
 
 // 0
-// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<18000xi64>
 
 // arg2
-// CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<18000xi64>
 
 // 1
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<18000xi64>
 
 // arg2
-// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_0 : tensor<18000xi64>
 
 // arg3
-// CHECK-NEXT:    %3 = stablehlo.iota dim = 0 : tensor<120xi64>
 
 // 0
-// CHECK-NEXT:    %c_1 = stablehlo.constant dense<0> : tensor<120xi64>
 
 // arg3
-// CHECK-NEXT:    %4 = stablehlo.add %3, %c_1 : tensor<120xi64>
 
 // 1
-// CHECK-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<120xi64>
 
 // arg3
-// CHECK-NEXT:    %5 = stablehlo.multiply %4, %c_2 : tensor<120xi64>
 
 // 128
-// CHECK-NEXT:    %c_3 = stablehlo.constant dense<128> : tensor<i64>
 
 // 128
-// CHECK-NEXT:    %6 = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<18000xi64>
 
 // arg2 * 128
-// CHECK-NEXT:    %7 = stablehlo.multiply %2, %6 : tensor<18000xi64>
 
 // [arg3, :         ]
-// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %5, dims = [0] : (tensor<120xi64>) -> tensor<120x18000xi64>
 
 // [:   , arg2 * 128]
-// CHECK-NEXT:    %9 = stablehlo.broadcast_in_dim %7, dims = [1] : (tensor<18000xi64>) -> tensor<120x18000xi64>
 
 // arg3 + arg2 * 128 (axis is arg3, arg2)
-// CHECK-NEXT:    %10 = stablehlo.add %8, %9 : tensor<120x18000xi64>
 
 //  arg3 + arg2 * 128 (axis is (arg3, arg2)); append the index_vector_dim
-// CHECK-NEXT:    %11 = stablehlo.reshape %10 : (tensor<120x18000xi64>) -> tensor<120x18000x1xi64>
 
 // arg0[arg3 + arg2 * 128] (axis is (arg3, arg2))
-// CHECK-NEXT:    %12 = "stablehlo.gather"(%arg0, %11) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<?xf32>, tensor<120x18000x1xi64>) -> tensor<120x18000xf32>
 
 // 128
-// CHECK-NEXT:    %c_4 = stablehlo.constant dense<128> : tensor<i64>
 
 // 128
-// CHECK-NEXT:    %13 = stablehlo.broadcast_in_dim %c_4, dims = [] : (tensor<i64>) -> tensor<18000xi64>
 
 // arg2 * 128
-// CHECK-NEXT:    %14 = stablehlo.multiply %2, %13 : tensor<18000xi64>
 
 // [arg3, :]
-// CHECK-NEXT:    %15 = stablehlo.broadcast_in_dim %5, dims = [0] : (tensor<120xi64>) -> tensor<120x18000xi64>
 
 // [:   , arg2 * 128]
-// CHECK-NEXT:    %16 = stablehlo.broadcast_in_dim %14, dims = [1] : (tensor<18000xi64>) -> tensor<120x18000xi64>
 
 // arg3 + arg2 * 128 (axis is arg3, arg2)
-// CHECK-NEXT:    %17 = stablehlo.add %15, %16 : tensor<120x18000xi64>
 
 //  arg3 + arg2 * 128 (axis is (arg3, arg2)); scatter mirrors the gather
 //  reshape above (%11): append the index_vector_dim.
-// CHECK-NEXT:    %18 = stablehlo.reshape %17 : (tensor<120x18000xi64>) -> tensor<120x18000x1xi64>
 
 // arg0[arg3 + arg2 * 128] (axis is (arg3, arg2))
-// CHECK-NEXT:    %19 = stablehlo.broadcast_in_dim %12, dims = [0, 1] : (tensor<120x18000xf32>) -> tensor<120x18000xf32>
 
-// CHECK-NEXT:    %20 = "stablehlo.scatter"(%arg1, %18, %19) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
+// CHECK:  module attributes {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, llvm.module_asm = [], llvm.target_triple = "x86_64-unknown-linux-gnu"} {
+// CHECK-NEXT:  llvm.func internal unnamed_addr fastcc @_ZL4kernPfS_(%arg0: !llvm.ptr {llvm.noundef}, %arg1: !llvm.ptr {llvm.noundef}) attributes {dso_local, no_infs_fp_math = true, no_inline, no_nans_fp_math = true, no_signed_zeros_fp_math = true, no_unwind, passthrough = ["mustprogress", ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], sym_visibility = "private", target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic", uwtable_kind = #llvm.uwtableKind<async>} {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c150 = arith.constant 150 : index
+// CHECK-NEXT:    %c120 = arith.constant 120 : index
+// CHECK-NEXT:    %0 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xf32>
+// CHECK-NEXT:    %1 = "enzymexla.pointer2memref"(%arg1) : (!llvm.ptr) -> memref<?xf32>
+// CHECK-NEXT:    enzymexla.xla_wrapper @rxla$raised_0 (%0, %1) : (memref<?xf32>, memref<?xf32>) -> ()
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func private @rxla$raised_0(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> (tensor<?xf32>, tensor<?xf32>) {
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<18000xi64>
+// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<18000xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<18000xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<18000xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_0 : tensor<18000xi64>
+// CHECK-NEXT:    %3 = stablehlo.iota dim = 0 : tensor<120xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<0> : tensor<120xi64>
+// CHECK-NEXT:    %4 = stablehlo.add %3, %c_1 : tensor<120xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<120xi64>
+// CHECK-NEXT:    %5 = stablehlo.multiply %4, %c_2 : tensor<120xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<128> : tensor<i64>
+// CHECK-NEXT:    %6 = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<18000xi64>
+// CHECK-NEXT:    %7 = stablehlo.multiply %2, %6 : tensor<18000xi64>
+// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %5, dims = [0] : (tensor<120xi64>) -> tensor<120x18000xi64>
+// CHECK-NEXT:    %9 = stablehlo.broadcast_in_dim %7, dims = [1] : (tensor<18000xi64>) -> tensor<120x18000xi64>
+// CHECK-NEXT:    %10 = stablehlo.add %8, %9 : tensor<120x18000xi64>
+// CHECK-NEXT:    %11 = stablehlo.reshape %10 : (tensor<120x18000xi64>) -> tensor<120x18000x1xi64>
+// CHECK-NEXT:    %12 = "stablehlo.gather"(%arg0, %11) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<?xf32>, tensor<120x18000x1xi64>) -> tensor<120x18000xf32>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<128> : tensor<i64>
+// CHECK-NEXT:    %13 = stablehlo.broadcast_in_dim %c_4, dims = [] : (tensor<i64>) -> tensor<18000xi64>
+// CHECK-NEXT:    %14 = stablehlo.multiply %2, %13 : tensor<18000xi64>
+// CHECK-NEXT:    %15 = stablehlo.broadcast_in_dim %5, dims = [0] : (tensor<120xi64>) -> tensor<120x18000xi64>
+// CHECK-NEXT:    %16 = stablehlo.broadcast_in_dim %14, dims = [1] : (tensor<18000xi64>) -> tensor<120x18000xi64>
+// CHECK-NEXT:    %17 = stablehlo.add %15, %16 : tensor<120x18000xi64>
+// CHECK-NEXT:    %18 = stablehlo.reshape %17 : (tensor<120x18000xi64>) -> tensor<120x18000x1xi64>
+// CHECK-NEXT:    %19 = "stablehlo.scatter"(%arg1, %18, %12) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
 // CHECK-NEXT:    ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
 // CHECK-NEXT:      stablehlo.return %arg3 : tensor<f32>
 // CHECK-NEXT:    }) : (tensor<?xf32>, tensor<120x18000x1xi64>, tensor<120x18000xf32>) -> tensor<?xf32>
-// CHECK-NEXT:    return %arg0, %20 : tensor<?xf32>, tensor<?xf32>
+// CHECK-NEXT:    return %arg0, %19 : tensor<?xf32>, tensor<?xf32>
 // CHECK-NEXT:  }
-

--- a/test/lit_tests/raising/affine_to_stablehlo_tridiagonal.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_tridiagonal.mlir
@@ -676,8 +676,7 @@ module {
 }
 
 // The yielded accumulators re-align onto the carried layout as permuting
-// broadcasts before the return.
-// CHECK:      %[[ALIGN1:.+]] = stablehlo.broadcast_in_dim %3191, dims = [0, 3, 1, 2] : (tensor<2x16x16x3xf32>) -> tensor<2x16x3x16xf32>
-// CHECK-NEXT:      %[[ALIGN2:.+]] = stablehlo.broadcast_in_dim %3508, dims = [0, 3, 1, 2] : (tensor<2x16x16x3xf32>) -> tensor<2x16x3x16xf32>
-// CHECK-NEXT:      stablehlo.return %{{.+}}, %[[ALIGN1]], %[[ALIGN2]], %{{.+}}, %{{.+}}, %iterArg_491, %iterArg_492, %iterArg_493, %iterArg_494, %iterArg_495, %iterArg_496, %iterArg_497, %iterArg_498, %iterArg_499 : tensor<i64>, tensor<2x16x3x16xf32>, tensor<2x16x3x16xf32>, tensor<61x28x46xf32>, tensor<50x18x36xf32>, tensor<61xf32>, tensor<60xf32>, tensor<1x28x46xf32>, tensor<60x28x46xf32>, tensor<60x28x46xf32>, tensor<60x28x46xf32>, tensor<f32>, tensor<f32>, tensor<f32>
-// CHECK-NEXT:    }
+// broadcasts, which feed the while as its init.
+// CHECK:      %[[ALIGN1:.+]] = stablehlo.broadcast_in_dim %{{.+}}, dims = [0, 3, 1, 2] : (tensor<2x16x16x3xf32>) -> tensor<2x16x3x16xf32>
+// CHECK:      %[[ALIGN2:.+]] = stablehlo.broadcast_in_dim %{{.+}}, dims = [0, 3, 1, 2] : (tensor<2x16x16x3xf32>) -> tensor<2x16x3x16xf32>
+// CHECK:      stablehlo.while(%iterArg = %{{.+}}, %iterArg_{{.+}} = %[[ALIGN1]], %iterArg_{{.+}} = %[[ALIGN2]],

--- a/test/lit_tests/raising/atomic_add_scatter.mlir
+++ b/test/lit_tests/raising/atomic_add_scatter.mlir
@@ -17,23 +17,20 @@ module {
   }
 }
 
-// CHECK:  func.func private @atomic_add_raised(%[[buf:.+]]: tensor<8xf64>, %[[idx:.+]]: tensor<16xi32>, %[[val:.+]]: tensor<16xf64>) -> (tensor<8xf64>, tensor<16xi32>, tensor<16xf64>) {
-// CHECK-NEXT:    %[[iota:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
-// CHECK-NEXT:    %[[c0:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
-// CHECK-NEXT:    %[[lanes:.+]] = stablehlo.add %[[iota]], %[[c0]] : tensor<16xi64>
-// CHECK-NEXT:    %[[c1:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
-// CHECK-NEXT:    %{{.+}} = stablehlo.multiply %[[lanes]], %[[c1]] : tensor<16xi64>
-// CHECK-NEXT:    %[[idxr:.+]] = stablehlo.reshape %[[idx]] : (tensor<16xi32>) -> tensor<16xi32>
-// CHECK-NEXT:    %[[idx64:.+]] = stablehlo.convert %[[idxr]] : (tensor<16xi32>) -> tensor<16xi64>
-// CHECK-NEXT:    %[[valr:.+]] = stablehlo.reshape %[[val]] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:    %[[sidx:.+]] = stablehlo.reshape %[[idx64]] : (tensor<16xi64>) -> tensor<16x1xi64>
-// CHECK-NEXT:    %[[upd:.+]] = stablehlo.broadcast_in_dim %[[valr]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:    %[[scat:.+]] = "stablehlo.scatter"(%[[buf]], %[[sidx]], %[[upd]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
-// CHECK-NEXT:    ^bb0(%[[a:.+]]: tensor<f64>, %[[b:.+]]: tensor<f64>):
-// CHECK-NEXT:      %[[sum:.+]] = stablehlo.add %[[a]], %[[b]] : tensor<f64>
-// CHECK-NEXT:      stablehlo.return %[[sum]] : tensor<f64>
+// CHECK:    func.func private @atomic_add_raised(%[[a1:.+]]: tensor<8xf64>, %[[a2:.+]]: tensor<16xi32>, %[[a3:.+]]: tensor<16xf64>) -> (tensor<8xf64>, tensor<16xi32>, tensor<16xf64>) {
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.add %[[a4]], %[[a5]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.multiply %[[a6]], %[[a7]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.convert %[[a2]] : (tensor<16xi32>) -> tensor<16xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.reshape %[[a9]] : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %[[a11:.+]] = "stablehlo.scatter"(%[[a1]], %[[a10]], %[[a3]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%[[a12:.+]]: tensor<f64>, %[[a13:.+]]: tensor<f64>):
+// CHECK-NEXT:      %[[a14:.+]] = stablehlo.add %[[a12]], %[[a13]] : tensor<f64>
+// CHECK-NEXT:      stablehlo.return %[[a14]] : tensor<f64>
 // CHECK-NEXT:    }) : (tensor<8xf64>, tensor<16x1xi64>, tensor<16xf64>) -> tensor<8xf64>
-// CHECK-NEXT:    return %[[scat]], %[[idx]], %[[val]] : tensor<8xf64>, tensor<16xi32>, tensor<16xf64>
+// CHECK-NEXT:    return %[[a11]], %[[a2]], %[[a3]] : tensor<8xf64>, tensor<16xi32>, tensor<16xf64>
 // CHECK-NEXT:  }
 
 // -----
@@ -52,21 +49,18 @@ module {
   }
 }
 
-// CHECK:  func.func private @atomic_add_int_raised(%[[buf:.+]]: tensor<8xi32>, %[[idx:.+]]: tensor<16xi32>, %[[val:.+]]: tensor<16xi32>) -> (tensor<8xi32>, tensor<16xi32>, tensor<16xi32>) {
-// CHECK-NEXT:    %[[iota:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
-// CHECK-NEXT:    %[[c0:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
-// CHECK-NEXT:    %[[lanes:.+]] = stablehlo.add %[[iota]], %[[c0]] : tensor<16xi64>
-// CHECK-NEXT:    %[[c1:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
-// CHECK-NEXT:    %{{.+}} = stablehlo.multiply %[[lanes]], %[[c1]] : tensor<16xi64>
-// CHECK-NEXT:    %[[idxr:.+]] = stablehlo.reshape %[[idx]] : (tensor<16xi32>) -> tensor<16xi32>
-// CHECK-NEXT:    %[[idx64:.+]] = stablehlo.convert %[[idxr]] : (tensor<16xi32>) -> tensor<16xi64>
-// CHECK-NEXT:    %[[valr:.+]] = stablehlo.reshape %[[val]] : (tensor<16xi32>) -> tensor<16xi32>
-// CHECK-NEXT:    %[[sidx:.+]] = stablehlo.reshape %[[idx64]] : (tensor<16xi64>) -> tensor<16x1xi64>
-// CHECK-NEXT:    %[[upd:.+]] = stablehlo.broadcast_in_dim %[[valr]], dims = [0] : (tensor<16xi32>) -> tensor<16xi32>
-// CHECK-NEXT:    %[[scat:.+]] = "stablehlo.scatter"(%[[buf]], %[[sidx]], %[[upd]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
-// CHECK-NEXT:    ^bb0(%[[a:.+]]: tensor<i32>, %[[b:.+]]: tensor<i32>):
-// CHECK-NEXT:      %[[sum:.+]] = stablehlo.add %[[a]], %[[b]] : tensor<i32>
-// CHECK-NEXT:      stablehlo.return %[[sum]] : tensor<i32>
+// CHECK:    func.func private @atomic_add_int_raised(%[[a1:.+]]: tensor<8xi32>, %[[a2:.+]]: tensor<16xi32>, %[[a3:.+]]: tensor<16xi32>) -> (tensor<8xi32>, tensor<16xi32>, tensor<16xi32>) {
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.add %[[a4]], %[[a5]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.multiply %[[a6]], %[[a7]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.convert %[[a2]] : (tensor<16xi32>) -> tensor<16xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.reshape %[[a9]] : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %[[a11:.+]] = "stablehlo.scatter"(%[[a1]], %[[a10]], %[[a3]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%[[a12:.+]]: tensor<i32>, %[[a13:.+]]: tensor<i32>):
+// CHECK-NEXT:      %[[a14:.+]] = stablehlo.add %[[a12]], %[[a13]] : tensor<i32>
+// CHECK-NEXT:      stablehlo.return %[[a14]] : tensor<i32>
 // CHECK-NEXT:    }) : (tensor<8xi32>, tensor<16x1xi64>, tensor<16xi32>) -> tensor<8xi32>
-// CHECK-NEXT:    return %[[scat]], %[[idx]], %[[val]] : tensor<8xi32>, tensor<16xi32>, tensor<16xi32>
+// CHECK-NEXT:    return %[[a11]], %[[a2]], %[[a3]] : tensor<8xi32>, tensor<16xi32>, tensor<16xi32>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/atomic_add_scatter_enzyme.mlir
+++ b/test/lit_tests/raising/atomic_add_scatter_enzyme.mlir
@@ -16,21 +16,18 @@ module {
   }
 }
 
-// CHECK:  func.func private @atomic_add_raised(%[[r1:.+]]: tensor<8xf64>, %[[r2:.+]]: tensor<16xi32>, %[[r3:.+]]: tensor<16xf64>) -> (tensor<8xf64>, tensor<16xi32>, tensor<16xf64>) {
-// CHECK-NEXT:  %[[r4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
-// CHECK-NEXT:  %[[r5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
-// CHECK-NEXT:  %[[r6:.+]] = stablehlo.add %[[r4]], %[[r5]] : tensor<16xi64>
-// CHECK-NEXT:  %[[r7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
-// CHECK-NEXT:  %[[r8:.+]] = stablehlo.multiply %[[r6]], %[[r7]] : tensor<16xi64>
-// CHECK-NEXT:  %[[r9:.+]] = stablehlo.reshape %[[r2]] : (tensor<16xi32>) -> tensor<16xi32>
-// CHECK-NEXT:  %[[r10:.+]] = stablehlo.convert %[[r9]] : (tensor<16xi32>) -> tensor<16xi64>
-// CHECK-NEXT:  %[[r11:.+]] = stablehlo.reshape %[[r3]] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[r12:.+]] = stablehlo.reshape %[[r10]] : (tensor<16xi64>) -> tensor<16x1xi64>
-// CHECK-NEXT:  %[[r13:.+]] = stablehlo.broadcast_in_dim %[[r11]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[r14:.+]] = "stablehlo.scatter"(%[[r1]], %[[r12]], %[[r13]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
-// CHECK-NEXT:  ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
-// CHECK-NEXT:  %[[r15:.+]] = stablehlo.add %arg3, %arg4 : tensor<f64>
-// CHECK-NEXT:  stablehlo.return %[[r15]] : tensor<f64>
-// CHECK-NEXT:  }) : (tensor<8xf64>, tensor<16x1xi64>, tensor<16xf64>) -> tensor<8xf64>
-// CHECK-NEXT:  return %[[r14]], %[[r2]], %[[r3]] : tensor<8xf64>, tensor<16xi32>, tensor<16xf64>
+// CHECK:    func.func private @atomic_add_raised(%[[a1:.+]]: tensor<8xf64>, %[[a2:.+]]: tensor<16xi32>, %[[a3:.+]]: tensor<16xf64>) -> (tensor<8xf64>, tensor<16xi32>, tensor<16xf64>) {
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.add %[[a4]], %[[a5]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.multiply %[[a6]], %[[a7]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.convert %[[a2]] : (tensor<16xi32>) -> tensor<16xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.reshape %[[a9]] : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %[[a11:.+]] = "stablehlo.scatter"(%[[a1]], %[[a10]], %[[a3]]) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%[[a12:.+]]: tensor<f64>, %[[a13:.+]]: tensor<f64>):
+// CHECK-NEXT:      %[[a14:.+]] = stablehlo.add %[[a12]], %[[a13]] : tensor<f64>
+// CHECK-NEXT:      stablehlo.return %[[a14]] : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<8xf64>, tensor<16x1xi64>, tensor<16xf64>) -> tensor<8xf64>
+// CHECK-NEXT:    return %[[a11]], %[[a2]], %[[a3]] : tensor<8xf64>, tensor<16xi32>, tensor<16xf64>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/inline_alloca_scope.mlir
+++ b/test/lit_tests/raising/inline_alloca_scope.mlir
@@ -19,25 +19,23 @@ module {
   }
 }
 
-// CHECK:  func.func private @scoped_raised(%[[v1:.+]]: tensor<16xf64>, %[[v2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
-// CHECK-NEXT:  %[[v3:.+]] = stablehlo.constant dense<2.000000e+00> : tensor<f64>
-// CHECK-NEXT:  %[[v4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
-// CHECK-NEXT:  %[[v5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
-// CHECK-NEXT:  %[[v6:.+]] = stablehlo.add %[[v4]], %[[v5]] : tensor<16xi64>
-// CHECK-NEXT:  %[[v7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
-// CHECK-NEXT:  %[[v8:.+]] = stablehlo.multiply %[[v6]], %[[v7]] : tensor<16xi64>
-// CHECK-NEXT:  %[[v9:.+]] = stablehlo.reshape %[[v2]] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v10:.+]] = stablehlo.broadcast_in_dim %[[v3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v11:.+]] = arith.mulf %[[v9]], %[[v10]] : tensor<16xf64>
-// CHECK-NEXT:  %[[v12:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v13:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v14:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v15:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v17:.+]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:  %[[v18:.+]] = stablehlo.broadcast_in_dim %[[v11]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v19:.+]] = stablehlo.dynamic_update_slice %[[v1]], %[[v18]], %[[v17]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
-// CHECK-NEXT:  return %[[v19]], %[[v2]] : tensor<16xf64>, tensor<16xf64>
+// CHECK:    func.func private @scoped_raised(%[[a1:.+]]: tensor<16xf64>, %[[a2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.add %[[a4]], %[[a5]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.multiply %[[a6]], %[[a7]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.broadcast_in_dim %[[a3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:    %[[a10:.+]] = arith.mulf %[[a2]], %[[a9]] : tensor<16xf64>
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a13:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.dynamic_update_slice %[[a1]], %[[a10]], %[[a16]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:    return %[[a17]], %[[a2]] : tensor<16xf64>, tensor<16xf64>
 // CHECK-NEXT:  }
 
 // -----
@@ -68,26 +66,24 @@ module {
   }
 }
 
-// CHECK:  func.func private @trapped_raised(%[[v1:.+]]: tensor<16xf64>, %[[v2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
-// CHECK-NEXT:  %[[v3:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK-NEXT:  %[[v4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
-// CHECK-NEXT:  %[[v5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
-// CHECK-NEXT:  %[[v6:.+]] = stablehlo.add %[[v4]], %[[v5]] : tensor<16xi64>
-// CHECK-NEXT:  %[[v7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
-// CHECK-NEXT:  %[[v8:.+]] = stablehlo.multiply %[[v6]], %[[v7]] : tensor<16xi64>
-// CHECK-NEXT:  %[[v9:.+]] = stablehlo.reshape %[[v2]] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v10:.+]] = stablehlo.broadcast_in_dim %[[v3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v11:.+]] = arith.cmpf uge, %[[v9]], %[[v10]] : tensor<16xf64>
-// CHECK-NEXT:  %[[v12:.+]] = arith.addf %[[v9]], %[[v9]] : tensor<16xf64>
-// CHECK-NEXT:  %[[v13:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v14:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v15:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v17:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v18:.+]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:  %[[v19:.+]] = stablehlo.broadcast_in_dim %[[v12]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v20:.+]] = stablehlo.dynamic_update_slice %[[v1]], %[[v19]], %[[v18]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
-// CHECK-NEXT:  return %[[v20]], %[[v2]] : tensor<16xf64>, tensor<16xf64>
+// CHECK:    func.func private @trapped_raised(%[[a1:.+]]: tensor<16xf64>, %[[a2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.add %[[a4]], %[[a5]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.multiply %[[a6]], %[[a7]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.broadcast_in_dim %[[a3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:    %[[a10:.+]] = arith.cmpf uge, %[[a2]], %[[a9]] : tensor<16xf64>
+// CHECK-NEXT:    %[[a11:.+]] = arith.addf %[[a2]], %[[a2]] : tensor<16xf64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a13:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a18:.+]] = stablehlo.dynamic_update_slice %[[a1]], %[[a11]], %[[a17]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:    return %[[a18]], %[[a2]] : tensor<16xf64>, tensor<16xf64>
 // CHECK-NEXT:  }
 
 // -----
@@ -122,27 +118,25 @@ module {
   }
 }
 
-// CHECK:  func.func private @chained_raised(%[[v1:.+]]: tensor<16xf64>, %[[v2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
-// CHECK-NEXT:  %[[v3:.+]] = stablehlo.constant dense<1.000000e+00> : tensor<f64>
-// CHECK-NEXT:  %[[v4:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK-NEXT:  %[[v5:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
-// CHECK-NEXT:  %[[v6:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
-// CHECK-NEXT:  %[[v7:.+]] = stablehlo.add %[[v5]], %[[v6]] : tensor<16xi64>
-// CHECK-NEXT:  %[[v8:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
-// CHECK-NEXT:  %[[v9:.+]] = stablehlo.multiply %[[v7]], %[[v8]] : tensor<16xi64>
-// CHECK-NEXT:  %[[v10:.+]] = stablehlo.reshape %[[v2]] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v11:.+]] = stablehlo.broadcast_in_dim %[[v4]], dims = [] : (tensor<f64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v12:.+]] = arith.cmpf uge, %[[v10]], %[[v11]] : tensor<16xf64>
-// CHECK-NEXT:  %[[v13:.+]] = stablehlo.broadcast_in_dim %[[v3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v14:.+]] = arith.cmpf ule, %[[v10]], %[[v13]] : tensor<16xf64>
-// CHECK-NEXT:  %[[v15:.+]] = arith.mulf %[[v10]], %[[v10]] : tensor<16xf64>
-// CHECK-NEXT:  %[[v16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v17:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v18:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v19:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v20:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:  %[[v21:.+]] = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:  %[[v22:.+]] = stablehlo.broadcast_in_dim %[[v15]], dims = [0] : (tensor<16xf64>) -> tensor<16xf64>
-// CHECK-NEXT:  %[[v23:.+]] = stablehlo.dynamic_update_slice %[[v1]], %[[v22]], %[[v21]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
-// CHECK-NEXT:  return %[[v23]], %[[v2]] : tensor<16xf64>, tensor<16xf64>
+// CHECK:    func.func private @chained_raised(%[[a1:.+]]: tensor<16xf64>, %[[a2:.+]]: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.add %[[a5]], %[[a6]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.multiply %[[a7]], %[[a8]] : tensor<16xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.broadcast_in_dim %[[a4]], dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:    %[[a11:.+]] = arith.cmpf uge, %[[a2]], %[[a10]] : tensor<16xf64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.broadcast_in_dim %[[a3]], dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:    %[[a13:.+]] = arith.cmpf ule, %[[a2]], %[[a12]] : tensor<16xf64>
+// CHECK-NEXT:    %[[a14:.+]] = arith.mulf %[[a2]], %[[a2]] : tensor<16xf64>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a18:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a19:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a20:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a21:.+]] = stablehlo.dynamic_update_slice %[[a1]], %[[a14]], %[[a20]] : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:    return %[[a21]], %[[a2]] : tensor<16xf64>, tensor<16xf64>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/raise_for_of_parallel.mlir
+++ b/test/lit_tests/raising/raise_for_of_parallel.mlir
@@ -17,15 +17,34 @@ func.func @timeloop(%out: memref<100xf64, 1>, %nbuf: memref<i64, 1>) {
   return
 }
 
-// CHECK-LABEL: func.func private @timeloop_raised(
-// CHECK-SAME: %[[OUT:.+]]: tensor<100xf64>, %[[N:.+]]: tensor<i64>
-// CHECK: %[[WHILE:.+]]:3 = stablehlo.while(%[[IV:.+]] = %{{.+}}, %[[BUF:.+]] = %[[OUT]], %{{.+}} = %[[N]]) : tensor<i64>, tensor<100xf64>, tensor<i64>
-// CHECK: cond {
-// CHECK: stablehlo.compare LT, %[[IV]], %{{.+}} : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK: } do {
-// CHECK: %[[CUR:.+]] = stablehlo.reshape %[[BUF]] : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK: arith.addf %[[CUR]], %{{.+}} : tensor<100xf64>
-// CHECK: return %[[WHILE]]#1, %[[WHILE]]#2 : tensor<100xf64>, tensor<i64>
+// CHECK:    func.func private @timeloop_raised(%[[a1:.+]]: tensor<100xf64>, %[[a2:.+]]: tensor<i64>) -> (tensor<100xf64>, tensor<i64>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %[[a6:.+]]:3 = stablehlo.while(%[[a7:.+]] = %[[a4]], %[[a8:.+]] = %[[a1]], %[[a9:.+]] = %[[a2]]) : tensor<i64>, tensor<100xf64>, tensor<i64>
+// CHECK-NEXT:    cond {
+// CHECK-NEXT:      %[[a10:.+]] = stablehlo.compare LT, %[[a7]], %[[a2]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      stablehlo.return %[[a10]] : tensor<i1>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      %[[a10]] = stablehlo.iota dim = 0 : tensor<100xi64>
+// CHECK-NEXT:      %[[a11:.+]] = stablehlo.constant dense<0> : tensor<100xi64>
+// CHECK-NEXT:      %[[a12:.+]] = stablehlo.add %[[a10]], %[[a11]] : tensor<100xi64>
+// CHECK-NEXT:      %[[a13:.+]] = stablehlo.constant dense<1> : tensor<100xi64>
+// CHECK-NEXT:      %[[a14:.+]] = stablehlo.multiply %[[a12]], %[[a13]] : tensor<100xi64>
+// CHECK-NEXT:      %[[a15:.+]] = stablehlo.broadcast_in_dim %[[a3]], dims = [] : (tensor<f64>) -> tensor<100xf64>
+// CHECK-NEXT:      %[[a16:.+]] = arith.addf %[[a8]], %[[a15]] : tensor<100xf64>
+// CHECK-NEXT:      %[[a17:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a18:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a19:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a20:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a21:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a22:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a23:.+]] = stablehlo.dynamic_update_slice %[[a8]], %[[a16]], %[[a22]] : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK-NEXT:      %[[a24:.+]] = stablehlo.add %[[a7]], %[[a5]] : tensor<i64>
+// CHECK-NEXT:      stablehlo.return %[[a24]], %[[a23]], %[[a9]] : tensor<i64>, tensor<100xf64>, tensor<i64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a6]]#1, %[[a6]]#2 : tensor<100xf64>, tensor<i64>
+// CHECK-NEXT:  }
 
 // -----
 
@@ -48,9 +67,42 @@ func.func @scratchloop(%out: memref<10xf64, 1>, %nbuf: memref<i64, 1>) {
   return
 }
 
-// CHECK-LABEL: func.func private @scratchloop_raised(
-// CHECK-SAME: %[[OUT2:.+]]: tensor<10xf64>, %[[N2:.+]]: tensor<i64>
-// CHECK: %[[ZERO:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<10xf64>
-// CHECK: stablehlo.while
-// CHECK: } do {
-// CHECK: stablehlo.reverse
+// CHECK:    func.func private @scratchloop_raised(%[[a1:.+]]: tensor<10xf64>, %[[a2:.+]]: tensor<i64>) -> (tensor<10xf64>, tensor<i64>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<10xf64>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %[[a6:.+]]:4 = stablehlo.while(%[[a7:.+]] = %[[a4]], %[[a8:.+]] = %[[a1]], %[[a9:.+]] = %[[a2]], %[[a10:.+]] = %[[a3]]) : tensor<i64>, tensor<10xf64>, tensor<i64>, tensor<10xf64>
+// CHECK-NEXT:    cond {
+// CHECK-NEXT:      %[[a11:.+]] = stablehlo.compare LT, %[[a7]], %[[a2]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      stablehlo.return %[[a11]] : tensor<i1>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      %[[a11]] = stablehlo.iota dim = 0 : tensor<10xi64>
+// CHECK-NEXT:      %[[a12:.+]] = stablehlo.constant dense<0> : tensor<10xi64>
+// CHECK-NEXT:      %[[a13:.+]] = stablehlo.add %[[a11]], %[[a12]] : tensor<10xi64>
+// CHECK-NEXT:      %[[a14:.+]] = stablehlo.constant dense<1> : tensor<10xi64>
+// CHECK-NEXT:      %[[a15:.+]] = stablehlo.multiply %[[a13]], %[[a14]] : tensor<10xi64>
+// CHECK-NEXT:      %[[a16:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a17:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a18:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a19:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a20:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a21:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a22:.+]] = stablehlo.dynamic_update_slice %[[a10]], %[[a8]], %[[a21]] : (tensor<10xf64>, tensor<10xf64>, tensor<i64>) -> tensor<10xf64>
+// CHECK-NEXT:      %[[a23:.+]] = stablehlo.iota dim = 0 : tensor<10xi64>
+// CHECK-NEXT:      %[[a24:.+]] = stablehlo.constant dense<0> : tensor<10xi64>
+// CHECK-NEXT:      %[[a25:.+]] = stablehlo.add %[[a23]], %[[a24]] : tensor<10xi64>
+// CHECK-NEXT:      %[[a26:.+]] = stablehlo.constant dense<1> : tensor<10xi64>
+// CHECK-NEXT:      %[[a27:.+]] = stablehlo.multiply %[[a25]], %[[a26]] : tensor<10xi64>
+// CHECK-NEXT:      %[[a28:.+]] = stablehlo.reverse %[[a22]], dims = [0] : tensor<10xf64>
+// CHECK-NEXT:      %[[a29:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a30:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a31:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a32:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a33:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a34:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a35:.+]] = stablehlo.dynamic_update_slice %[[a8]], %[[a28]], %[[a34]] : (tensor<10xf64>, tensor<10xf64>, tensor<i64>) -> tensor<10xf64>
+// CHECK-NEXT:      %[[a36:.+]] = stablehlo.add %[[a7]], %[[a5]] : tensor<i64>
+// CHECK-NEXT:      stablehlo.return %[[a36]], %[[a35]], %[[a9]], %[[a22]] : tensor<i64>, tensor<10xf64>, tensor<i64>, tensor<10xf64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a6]]#1, %[[a6]]#2 : tensor<10xf64>, tensor<i64>
+// CHECK-NEXT:  }

--- a/test/lit_tests/raising/raise_index_cast_i1.mlir
+++ b/test/lit_tests/raising/raise_index_cast_i1.mlir
@@ -47,12 +47,10 @@ func.func @unsigned(%out: memref<4xf64, 1>) {
 // CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
 // CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
 // CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %6, dims = [0] : (tensor<4xf64>) -> tensor<4xf64>
-// CHECK-NEXT:    %8 = stablehlo.dynamic_update_slice %arg0, %7, %c_7 : (tensor<4xf64>, tensor<4xf64>, tensor<i64>) -> tensor<4xf64>
-// CHECK-NEXT:    return %8 : tensor<4xf64>
+// CHECK-NEXT:    %7 = stablehlo.dynamic_update_slice %arg0, %6, %c_7 : (tensor<4xf64>, tensor<4xf64>, tensor<i64>) -> tensor<4xf64>
+// CHECK-NEXT:    return %7 : tensor<4xf64>
 // CHECK-NEXT:  }
-
-// CHECK:    func.func private @signed_raised(%arg0: tensor<4xf64>) -> tensor<4xf64> {
+// CHECK-NEXT:  func.func private @signed_raised(%arg0: tensor<4xf64>) -> tensor<4xf64> {
 // CHECK-NEXT:    %c = stablehlo.constant dense<2> : tensor<i64>
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4xi64>
 // CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<4xi64>
@@ -70,7 +68,6 @@ func.func @unsigned(%out: memref<4xf64, 1>) {
 // CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
 // CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
 // CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %7, dims = [0] : (tensor<4xf64>) -> tensor<4xf64>
-// CHECK-NEXT:    %9 = stablehlo.dynamic_update_slice %arg0, %8, %c_7 : (tensor<4xf64>, tensor<4xf64>, tensor<i64>) -> tensor<4xf64>
-// CHECK-NEXT:    return %9 : tensor<4xf64>
+// CHECK-NEXT:    %8 = stablehlo.dynamic_update_slice %arg0, %7, %c_7 : (tensor<4xf64>, tensor<4xf64>, tensor<i64>) -> tensor<4xf64>
+// CHECK-NEXT:    return %8 : tensor<4xf64>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/raise_masked_scalar_store.mlir
+++ b/test/lit_tests/raising/raise_masked_scalar_store.mlir
@@ -28,11 +28,7 @@ func.func @scalar_masked(%out: memref<f64, 1>, %in: memref<4xf64, 1>, %flag: mem
 // CHECK-NEXT:    %4 = stablehlo.reshape %3 : (tensor<1xf64>) -> tensor<f64>
 // CHECK-NEXT:    %5 = stablehlo.reshape %arg2 : (tensor<1xi64>) -> tensor<i64>
 // CHECK-NEXT:    %6 = arith.cmpi eq, %5, %c : tensor<i64>
-// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f64>) -> tensor<f64>
-// CHECK-NEXT:    %8 = stablehlo.reshape %7 : (tensor<f64>) -> tensor<f64>
-// CHECK-NEXT:    %9 = stablehlo.reshape %arg0 : (tensor<f64>) -> tensor<f64>
-// CHECK-NEXT:    %10 = stablehlo.select %6, %8, %9 : tensor<i1>, tensor<f64>
-// CHECK-NEXT:    %11 = stablehlo.broadcast_in_dim %10, dims = [] : (tensor<f64>) -> tensor<f64>
-// CHECK-NEXT:    %12 = stablehlo.dynamic_update_slice %arg0, %11 : (tensor<f64>, tensor<f64>) -> tensor<f64>
-// CHECK-NEXT:    return %12, %arg1, %arg2 : tensor<f64>, tensor<4xf64>, tensor<1xi64>
+// CHECK-NEXT:    %7 = stablehlo.select %6, %4, %arg0 : tensor<i1>, tensor<f64>
+// CHECK-NEXT:    %8 = stablehlo.dynamic_update_slice %arg0, %7 : (tensor<f64>, tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:    return %8, %arg1, %arg2 : tensor<f64>, tensor<4xf64>, tensor<1xi64>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/raise_pad_guarded_lane_load.mlir
+++ b/test/lit_tests/raising/raise_pad_guarded_lane_load.mlir
@@ -44,70 +44,63 @@ func.func @guarded_lane_read(%out: memref<9xf64, 1>, %in: memref<6xf64, 1>) {
 // CHECK-NEXT:    %c_3 = stablehlo.constant dense<1> : tensor<6xi64>
 // CHECK-NEXT:    %5 = stablehlo.multiply %4, %c_3 : tensor<6xi64>
 // CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %6 = stablehlo.dynamic_slice %arg1, %c_4, sizes = [6] : (tensor<6xf64>, tensor<i64>) -> tensor<6xf64>
-// CHECK-NEXT:    %7 = stablehlo.reshape %6 : (tensor<6xf64>) -> tensor<6xf64>
 // CHECK-NEXT:    %c_5 = stablehlo.constant dense<3> : tensor<i64>
-// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %c_5, dims = [] : (tensor<i64>) -> tensor<6xi64>
+// CHECK-NEXT:    %6 = stablehlo.broadcast_in_dim %c_5, dims = [] : (tensor<i64>) -> tensor<6xi64>
 // CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<6xi64>
-// CHECK-NEXT:    %9 = stablehlo.compare LT, %5, %c_6 : (tensor<6xi64>, tensor<6xi64>) -> tensor<6xi1>
+// CHECK-NEXT:    %7 = stablehlo.compare LT, %5, %c_6 : (tensor<6xi64>, tensor<6xi64>) -> tensor<6xi1>
 // CHECK-NEXT:    %c_7 = stablehlo.constant dense<1> : tensor<6xi64>
-// CHECK-NEXT:    %10 = stablehlo.negate %5 : tensor<6xi64>
-// CHECK-NEXT:    %11 = stablehlo.subtract %10, %c_7 : tensor<6xi64>
-// CHECK-NEXT:    %12 = stablehlo.select %9, %11, %5 : tensor<6xi1>, tensor<6xi64>
-// CHECK-NEXT:    %13 = stablehlo.divide %12, %8 : tensor<6xi64>
-// CHECK-NEXT:    %14 = stablehlo.negate %13 : tensor<6xi64>
-// CHECK-NEXT:    %15 = stablehlo.subtract %14, %c_7 : tensor<6xi64>
-// CHECK-NEXT:    %16 = stablehlo.select %9, %15, %13 : tensor<6xi1>, tensor<6xi64>
+// CHECK-NEXT:    %8 = stablehlo.negate %5 : tensor<6xi64>
+// CHECK-NEXT:    %9 = stablehlo.subtract %8, %c_7 : tensor<6xi64>
+// CHECK-NEXT:    %10 = stablehlo.select %7, %9, %5 : tensor<6xi1>, tensor<6xi64>
+// CHECK-NEXT:    %11 = stablehlo.divide %10, %6 : tensor<6xi64>
+// CHECK-NEXT:    %12 = stablehlo.negate %11 : tensor<6xi64>
+// CHECK-NEXT:    %13 = stablehlo.subtract %12, %c_7 : tensor<6xi64>
+// CHECK-NEXT:    %14 = stablehlo.select %7, %13, %11 : tensor<6xi1>, tensor<6xi64>
 // CHECK-NEXT:    %c_8 = stablehlo.constant dense<3> : tensor<i64>
-// CHECK-NEXT:    %17 = stablehlo.broadcast_in_dim %c_8, dims = [] : (tensor<i64>) -> tensor<6xi64>
-// CHECK-NEXT:    %18 = stablehlo.remainder %5, %17 : tensor<6xi64>
+// CHECK-NEXT:    %15 = stablehlo.broadcast_in_dim %c_8, dims = [] : (tensor<i64>) -> tensor<6xi64>
+// CHECK-NEXT:    %16 = stablehlo.remainder %5, %15 : tensor<6xi64>
 // CHECK-NEXT:    %c_9 = stablehlo.constant dense<0> : tensor<6xi64>
-// CHECK-NEXT:    %19 = stablehlo.compare LT, %18, %c_9 : (tensor<6xi64>, tensor<6xi64>) -> tensor<6xi1>
-// CHECK-NEXT:    %20 = stablehlo.add %18, %17 : tensor<6xi64>
-// CHECK-NEXT:    %21 = stablehlo.select %19, %20, %18 : tensor<6xi1>, tensor<6xi64>
-// CHECK-NEXT:    %22 = stablehlo.reshape %16 : (tensor<6xi64>) -> tensor<6x1xi64>
-// CHECK-NEXT:    %23 = stablehlo.broadcast_in_dim %21, dims = [0] : (tensor<6xi64>) -> tensor<6x1xi64>
-// CHECK-NEXT:    %24 = stablehlo.broadcast_in_dim %22, dims = [0, 1] : (tensor<6x1xi64>) -> tensor<6x1xi64>
-// CHECK-NEXT:    %25 = stablehlo.concatenate %24, %23, dim = 1 : (tensor<6x1xi64>, tensor<6x1xi64>) -> tensor<6x2xi64>
-// CHECK-NEXT:    %26 = stablehlo.broadcast_in_dim %7, dims = [0] : (tensor<6xf64>) -> tensor<6xf64>
-// CHECK-NEXT:    %27 = "stablehlo.scatter"(%cst_1, %25, %26) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:    %17 = stablehlo.compare LT, %16, %c_9 : (tensor<6xi64>, tensor<6xi64>) -> tensor<6xi1>
+// CHECK-NEXT:    %18 = stablehlo.add %16, %15 : tensor<6xi64>
+// CHECK-NEXT:    %19 = stablehlo.select %17, %18, %16 : tensor<6xi1>, tensor<6xi64>
+// CHECK-NEXT:    %20 = stablehlo.reshape %14 : (tensor<6xi64>) -> tensor<6x1xi64>
+// CHECK-NEXT:    %21 = stablehlo.broadcast_in_dim %19, dims = [0] : (tensor<6xi64>) -> tensor<6x1xi64>
+// CHECK-NEXT:    %22 = stablehlo.concatenate %20, %21, dim = 1 : (tensor<6x1xi64>, tensor<6x1xi64>) -> tensor<6x2xi64>
+// CHECK-NEXT:    %23 = "stablehlo.scatter"(%cst_1, %22, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
 // CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
 // CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
 // CHECK-NEXT:    }) : (tensor<2x3xf64>, tensor<6x2xi64>, tensor<6xf64>) -> tensor<2x3xf64>
-// CHECK-NEXT:    %28 = stablehlo.iota dim = 0 : tensor<3xi64>
+// CHECK-NEXT:    %24 = stablehlo.iota dim = 0 : tensor<3xi64>
 // CHECK-NEXT:    %c_10 = stablehlo.constant dense<0> : tensor<3xi64>
-// CHECK-NEXT:    %29 = stablehlo.add %28, %c_10 : tensor<3xi64>
+// CHECK-NEXT:    %25 = stablehlo.add %24, %c_10 : tensor<3xi64>
 // CHECK-NEXT:    %c_11 = stablehlo.constant dense<1> : tensor<3xi64>
-// CHECK-NEXT:    %30 = stablehlo.multiply %29, %c_11 : tensor<3xi64>
+// CHECK-NEXT:    %26 = stablehlo.multiply %25, %c_11 : tensor<3xi64>
 // CHECK-NEXT:    %c_12 = stablehlo.constant dense<-1> : tensor<i64>
-// CHECK-NEXT:    %31 = stablehlo.broadcast_in_dim %c_12, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %32 = stablehlo.multiply %2, %31 : tensor<3xi64>
+// CHECK-NEXT:    %27 = stablehlo.broadcast_in_dim %c_12, dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %28 = stablehlo.multiply %2, %27 : tensor<3xi64>
 // CHECK-NEXT:    %c_13 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %33 = stablehlo.broadcast_in_dim %c_13, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %34 = stablehlo.add %32, %33 : tensor<3xi64>
+// CHECK-NEXT:    %29 = stablehlo.broadcast_in_dim %c_13, dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %30 = stablehlo.add %28, %29 : tensor<3xi64>
 // CHECK-NEXT:    %c_14 = stablehlo.constant dense<0> : tensor<3xi64>
-// CHECK-NEXT:    %35 = stablehlo.compare GE, %34, %c_14 : (tensor<3xi64>, tensor<3xi64>) -> tensor<3xi1>
+// CHECK-NEXT:    %31 = stablehlo.compare GE, %30, %c_14 : (tensor<3xi64>, tensor<3xi64>) -> tensor<3xi1>
 // CHECK-NEXT:    %c_15 = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-NEXT:    %c_16 = stablehlo.constant dense<0> : tensor<i64>
 // CHECK-NEXT:    %cst_17 = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK-NEXT:    %36 = stablehlo.pad %27, %cst_17, low = [0, 0], high = [1, 0], interior = [0, 0] : (tensor<2x3xf64>, tensor<f64>) -> tensor<3x3xf64>
-// CHECK-NEXT:    %37 = stablehlo.dynamic_slice %36, %c_15, %c_16, sizes = [3, 3] : (tensor<3x3xf64>, tensor<i64>, tensor<i64>) -> tensor<3x3xf64>
-// CHECK-NEXT:    %38 = stablehlo.reshape %37 : (tensor<3x3xf64>) -> tensor<3x3xf64>
-// CHECK-NEXT:    %39 = stablehlo.not %35 : tensor<3xi1>
-// CHECK-NEXT:    %40 = stablehlo.broadcast_in_dim %35, dims = [0] : (tensor<3xi1>) -> tensor<3x3xi1>
-// CHECK-NEXT:    %41 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f64>) -> tensor<3x3xf64>
-// CHECK-NEXT:    %42 = stablehlo.select %40, %38, %41 : tensor<3x3xi1>, tensor<3x3xf64>
+// CHECK-NEXT:    %32 = stablehlo.pad %23, %cst_17, low = [0, 0], high = [1, 0], interior = [0, 0] : (tensor<2x3xf64>, tensor<f64>) -> tensor<3x3xf64>
+// CHECK-NEXT:    %33 = stablehlo.not %31 : tensor<3xi1>
+// CHECK-NEXT:    %34 = stablehlo.broadcast_in_dim %31, dims = [0] : (tensor<3xi1>) -> tensor<3x3xi1>
+// CHECK-NEXT:    %35 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f64>) -> tensor<3x3xf64>
+// CHECK-NEXT:    %36 = stablehlo.select %34, %32, %35 : tensor<3x3xi1>, tensor<3x3xf64>
 // CHECK-NEXT:    %c_18 = stablehlo.constant dense<3> : tensor<i64>
-// CHECK-NEXT:    %43 = stablehlo.broadcast_in_dim %c_18, dims = [] : (tensor<i64>) -> tensor<3xi64>
-// CHECK-NEXT:    %44 = stablehlo.multiply %2, %43 : tensor<3xi64>
-// CHECK-NEXT:    %45 = stablehlo.broadcast_in_dim %44, dims = [0] : (tensor<3xi64>) -> tensor<3x3xi64>
-// CHECK-NEXT:    %46 = stablehlo.broadcast_in_dim %30, dims = [1] : (tensor<3xi64>) -> tensor<3x3xi64>
-// CHECK-NEXT:    %47 = stablehlo.add %45, %46 : tensor<3x3xi64>
-// CHECK-NEXT:    %48 = stablehlo.reshape %47 : (tensor<3x3xi64>) -> tensor<3x3x1xi64>
-// CHECK-NEXT:    %49 = stablehlo.broadcast_in_dim %42, dims = [0, 1] : (tensor<3x3xf64>) -> tensor<3x3xf64>
-// CHECK-NEXT:    %50 = "stablehlo.scatter"(%arg0, %48, %49) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
+// CHECK-NEXT:    %37 = stablehlo.broadcast_in_dim %c_18, dims = [] : (tensor<i64>) -> tensor<3xi64>
+// CHECK-NEXT:    %38 = stablehlo.multiply %2, %37 : tensor<3xi64>
+// CHECK-NEXT:    %39 = stablehlo.broadcast_in_dim %38, dims = [0] : (tensor<3xi64>) -> tensor<3x3xi64>
+// CHECK-NEXT:    %40 = stablehlo.broadcast_in_dim %26, dims = [1] : (tensor<3xi64>) -> tensor<3x3xi64>
+// CHECK-NEXT:    %41 = stablehlo.add %39, %40 : tensor<3x3xi64>
+// CHECK-NEXT:    %42 = stablehlo.reshape %41 : (tensor<3x3xi64>) -> tensor<3x3x1xi64>
+// CHECK-NEXT:    %43 = "stablehlo.scatter"(%arg0, %42, %36) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
 // CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
 // CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
 // CHECK-NEXT:    }) : (tensor<9xf64>, tensor<3x3x1xi64>, tensor<3x3xf64>) -> tensor<9xf64>
-// CHECK-NEXT:    return %50, %arg1 : tensor<9xf64>, tensor<6xf64>
+// CHECK-NEXT:    return %43, %arg1 : tensor<9xf64>, tensor<6xf64>
 // CHECK-NEXT:  }

--- a/test/lit_tests/raising/raise_scf_loops.mlir
+++ b/test/lit_tests/raising/raise_scf_loops.mlir
@@ -21,15 +21,39 @@ func.func @scfred(%out: memref<100xf64, 1>, %in: memref<?xf64, 1>, %nb: memref<i
   return
 }
 
-// CHECK-LABEL: func.func private @scfred_raised(
-// CHECK: %[[W:[0-9]+]]:5 = stablehlo.while(%[[IV:[a-zA-Z0-9_]+]] = %{{[^,]+}}, %[[ACC:[a-zA-Z0-9_]+]] = %{{[^,]+}}, %{{.+}}) : tensor<i32>, tensor<100xf64>, tensor<100xf64>, tensor<?xf64>, tensor<i32>
-// CHECK: cond {
-// CHECK: stablehlo.compare LT, %[[IV]], %{{.+}} : (tensor<i32>, tensor<i32>) -> tensor<i1>
-// CHECK: } do {
-// CHECK: "stablehlo.gather"
-// CHECK: arith.addf %[[ACC]], %{{.+}} : tensor<100xf64>
-// CHECK: stablehlo.add %[[IV]], %{{.+}} : tensor<i32>
-// CHECK: stablehlo.dynamic_update_slice %[[W]]#2, %{{.+}} : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK:    func.func private @scfred_raised(%[[a1:.+]]: tensor<100xf64>, %[[a2:.+]]: tensor<?xf64>, %[[a3:.+]]: tensor<i32>) -> (tensor<100xf64>, tensor<?xf64>, tensor<i32>) {
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<100> : tensor<i32>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.iota dim = 0 : tensor<100xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<0> : tensor<100xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.add %[[a6]], %[[a7]] : tensor<100xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.constant dense<1> : tensor<100xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.multiply %[[a8]], %[[a9]] : tensor<100xi64>
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.broadcast_in_dim %[[a4]], dims = [] : (tensor<f64>) -> tensor<100xf64>
+// CHECK-NEXT:    %[[a12:.+]]:5 = stablehlo.while(%[[a13:.+]] = %[[a5]], %[[a14:.+]] = %[[a11]], %[[a15:.+]] = %[[a1]], %[[a16:.+]] = %[[a2]], %[[a17:.+]] = %[[a3]]) : tensor<i32>, tensor<100xf64>, tensor<100xf64>, tensor<?xf64>, tensor<i32>
+// CHECK-NEXT:    cond {
+// CHECK-NEXT:      %[[a18:.+]] = stablehlo.compare LT, %[[a13]], %[[a3]] : (tensor<i32>, tensor<i32>) -> tensor<i1>
+// CHECK-NEXT:      stablehlo.return %[[a18]] : tensor<i1>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      %[[a18]] = stablehlo.convert %[[a10]] : (tensor<100xi64>) -> tensor<100xi32>
+// CHECK-NEXT:      %[[a19:.+]] = stablehlo.broadcast_in_dim %[[a13]], dims = [] : (tensor<i32>) -> tensor<100xi32>
+// CHECK-NEXT:      %[[a20:.+]] = arith.addi %[[a19]], %[[a18]] : tensor<100xi32>
+// CHECK-NEXT:      %[[a21:.+]] = stablehlo.convert %[[a20]] : (tensor<100xi32>) -> tensor<100xi64>
+// CHECK-NEXT:      %[[a22:.+]] = stablehlo.reshape %[[a21]] : (tensor<100xi64>) -> tensor<100x1xi64>
+// CHECK-NEXT:      %[[a23:.+]] = "stablehlo.gather"(%[[a16]], %[[a22]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<?xf64>, tensor<100x1xi64>) -> tensor<100xf64>
+// CHECK-NEXT:      %[[a24:.+]] = arith.addf %[[a14]], %[[a23]] : tensor<100xf64>
+// CHECK-NEXT:      %[[a25:.+]] = stablehlo.add %[[a13]], %[[a5]] : tensor<i32>
+// CHECK-NEXT:      stablehlo.return %[[a25]], %[[a24]], %[[a15]], %[[a16]], %[[a17]] : tensor<i32>, tensor<100xf64>, tensor<100xf64>, tensor<?xf64>, tensor<i32>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a26:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a27:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a28:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a29:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a30:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a31:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a32:.+]] = stablehlo.dynamic_update_slice %[[a12]]#2, %[[a12]]#1, %[[a31]] : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK-NEXT:    return %[[a32]], %[[a12]]#3, %[[a12]]#4 : tensor<100xf64>, tensor<?xf64>, tensor<i32>
+// CHECK-NEXT:  }
 
 // -----
 
@@ -64,89 +88,76 @@ func.func @pingpong(%a: memref<100xf64, 1>, %b: memref<100xf64, 1>, %ni: index) 
   return
 }
 
-// CHECK:    func.func @pingpong(%arg0: memref<100xf64, 1>, %arg1: memref<100xf64, 1>, %arg2: index) {
-// CHECK-NEXT:    %alloca = memref.alloca() : memref<i64>
-// CHECK-NEXT:    %c1 = arith.constant 1 : index
-// CHECK-NEXT:    %c100 = arith.constant 100 : index
-// CHECK-NEXT:    %memref = gpu.alloc  () : memref<i64, 1>
-// CHECK-NEXT:    %0 = arith.index_cast %arg2 : index to i64
-// CHECK-NEXT:    affine.store %0, %alloca[] : memref<i64>
-// CHECK-NEXT:    %c8 = arith.constant 8 : index
-// CHECK-NEXT:    enzymexla.memcpy  %memref, %alloca, %c8 : memref<i64, 1>, memref<i64>
-// CHECK-NEXT:    enzymexla.xla_wrapper @rxla$raised_0 (%arg0, %arg1, %memref) : (memref<100xf64, 1>, memref<100xf64, 1>, memref<i64, 1>) -> ()
-// CHECK-NEXT:    %c0 = arith.constant 0 : index
-// CHECK-NEXT:    gpu.dealloc  %memref : memref<i64, 1>
+// CHECK:    func.func @pingpong(%[[a1:.+]]: memref<100xf64, 1>, %[[a2:.+]]: memref<100xf64, 1>, %[[a3:.+]]: index) {
+// CHECK-NEXT:    %[[a4:.+]] = memref.alloca() : memref<i64>
+// CHECK-NEXT:    %[[a5:.+]] = arith.constant 1 : index
+// CHECK-NEXT:    %[[a6:.+]] = arith.constant 100 : index
+// CHECK-NEXT:    %[[a7:.+]] = gpu.alloc  () : memref<i64, 1>
+// CHECK-NEXT:    %[[a8:.+]] = arith.index_cast %[[a3]] : index to i64
+// CHECK-NEXT:    affine.store %[[a8]], %[[a4]][] : memref<i64>
+// CHECK-NEXT:    %[[a9:.+]] = arith.constant 8 : index
+// CHECK-NEXT:    enzymexla.memcpy  %[[a7]], %[[a4]], %[[a9]] : memref<i64, 1>, memref<i64>
+// CHECK-NEXT:    enzymexla.xla_wrapper @rxla$raised_0 (%[[a1]], %[[a2]], %[[a7]]) : (memref<100xf64, 1>, memref<100xf64, 1>, memref<i64, 1>) -> ()
+// CHECK-NEXT:    %[[a10:.+]] = arith.constant 0 : index
+// CHECK-NEXT:    gpu.dealloc  %[[a7]] : memref<i64, 1>
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
-// CHECK-NEXT:  func.func private @rxla$raised_0(%arg0: tensor<100xf64>, %arg1: tensor<100xf64>, %arg2: tensor<i64>) -> (tensor<100xf64>, tensor<100xf64>, tensor<i64>) {
-// CHECK-NEXT:    %0 = stablehlo.reshape %arg2 : (tensor<i64>) -> tensor<i64>
-// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %1:3 = stablehlo.while(%iterArg = %c, %iterArg_1 = %arg0, %iterArg_2 = %arg1) : tensor<i64>, tensor<100xf64>, tensor<100xf64> attributes {enzymexla.parallel}
+// CHECK-NEXT:  func.func private @rxla$raised_0(%[[a1]]: tensor<100xf64>, %[[a2]]: tensor<100xf64>, %[[a3]]: tensor<i64>) -> (tensor<100xf64>, tensor<100xf64>, tensor<i64>) {
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %[[a8]]:3 = stablehlo.while(%[[a13:.+]] = %[[a11]], %[[a14:.+]] = %[[a1]], %[[a15:.+]] = %[[a2]]) : tensor<i64>, tensor<100xf64>, tensor<100xf64> attributes {enzymexla.parallel}
 // CHECK-NEXT:    cond {
-// CHECK-NEXT:      %2 = stablehlo.compare LT, %iterArg, %0 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      stablehlo.return %2 : tensor<i1>
+// CHECK-NEXT:      %[[a16:.+]] = stablehlo.compare LT, %[[a13]], %[[a3]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      stablehlo.return %[[a16]] : tensor<i1>
 // CHECK-NEXT:    } do {
-// CHECK-NEXT:      %2 = stablehlo.iota dim = 0 : tensor<100xi64>
-// CHECK-NEXT:      %c_3 = stablehlo.constant dense<0> : tensor<100xi64>
-// CHECK-NEXT:      %3 = stablehlo.add %2, %c_3 : tensor<100xi64>
-// CHECK-NEXT:      %c_4 = stablehlo.constant dense<1> : tensor<100xi64>
-// CHECK-NEXT:      %4 = stablehlo.multiply %3, %c_4 : tensor<100xi64>
-// CHECK-NEXT:      %c_5 = stablehlo.constant dense<2> : tensor<i64>
-// CHECK-NEXT:      %5 = stablehlo.remainder %iterArg, %c_5 : tensor<i64>
-// CHECK-NEXT:      %c_6 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:      %6 = stablehlo.compare LT, %5, %c_6 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      %7 = stablehlo.add %5, %c_5 : tensor<i64>
-// CHECK-NEXT:      %8 = stablehlo.select %6, %7, %5 : tensor<i1>, tensor<i64>
-// CHECK-NEXT:      %c_7 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:      %9 = stablehlo.compare EQ, %8, %c_7 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      %10 = stablehlo.reshape %iterArg_1 : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %11 = stablehlo.not %9 : tensor<i1>
-// CHECK-NEXT:      %12 = stablehlo.reshape %iterArg_2 : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %13 = stablehlo.broadcast_in_dim %9, dims = [] : (tensor<i1>) -> tensor<100xi1>
-// CHECK-NEXT:      %14 = stablehlo.select %13, %10, %12 : tensor<100xi1>, tensor<100xf64>
-// CHECK-NEXT:      %15 = arith.mulf %14, %14 : tensor<100xf64>
-// CHECK-NEXT:      %c_8 = stablehlo.constant dense<2> : tensor<i64>
-// CHECK-NEXT:      %16 = stablehlo.remainder %iterArg, %c_8 : tensor<i64>
-// CHECK-NEXT:      %c_9 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:      %17 = stablehlo.compare LT, %16, %c_9 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      %18 = stablehlo.add %16, %c_8 : tensor<i64>
-// CHECK-NEXT:      %19 = stablehlo.select %17, %18, %16 : tensor<i1>, tensor<i64>
-// CHECK-NEXT:      %c_10 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:      %20 = stablehlo.compare EQ, %19, %c_10 : (tensor<i64>, tensor<i64>) -> tensor<i1>
-// CHECK-NEXT:      %c_11 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_12 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_13 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_14 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_15 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_16 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:      %21 = stablehlo.broadcast_in_dim %15, dims = [0] : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %22 = stablehlo.dynamic_slice %iterArg_2, %c_16, sizes = [100] : (tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
-// CHECK-NEXT:      %23 = stablehlo.reshape %21 : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %24 = stablehlo.reshape %22 : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %25 = stablehlo.broadcast_in_dim %20, dims = [] : (tensor<i1>) -> tensor<100xi1>
-// CHECK-NEXT:      %26 = stablehlo.select %25, %23, %24 : tensor<100xi1>, tensor<100xf64>
-// CHECK-NEXT:      %27 = stablehlo.broadcast_in_dim %26, dims = [0] : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %28 = stablehlo.dynamic_update_slice %iterArg_2, %27, %c_16 : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
-// CHECK-NEXT:      %29 = stablehlo.not %20 : tensor<i1>
-// CHECK-NEXT:      %c_17 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_18 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_19 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_20 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_21 = stablehlo.constant dense<0> : tensor<1xi64>
-// CHECK-NEXT:      %c_22 = stablehlo.constant dense<0> : tensor<i64>
-// CHECK-NEXT:      %30 = stablehlo.broadcast_in_dim %15, dims = [0] : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %31 = stablehlo.dynamic_slice %iterArg_1, %c_22, sizes = [100] : (tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
-// CHECK-NEXT:      %32 = stablehlo.reshape %30 : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %33 = stablehlo.reshape %31 : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %34 = stablehlo.broadcast_in_dim %29, dims = [] : (tensor<i1>) -> tensor<100xi1>
-// CHECK-NEXT:      %35 = stablehlo.select %34, %32, %33 : tensor<100xi1>, tensor<100xf64>
-// CHECK-NEXT:      %36 = stablehlo.broadcast_in_dim %35, dims = [0] : (tensor<100xf64>) -> tensor<100xf64>
-// CHECK-NEXT:      %37 = stablehlo.dynamic_update_slice %iterArg_1, %36, %c_22 : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
-// CHECK-NEXT:      %38 = stablehlo.add %iterArg, %c_0 : tensor<i64>
-// CHECK-NEXT:      stablehlo.return %38, %37, %28 : tensor<i64>, tensor<100xf64>, tensor<100xf64>
+// CHECK-NEXT:      %[[a16]] = stablehlo.iota dim = 0 : tensor<100xi64>
+// CHECK-NEXT:      %[[a17:.+]] = stablehlo.constant dense<0> : tensor<100xi64>
+// CHECK-NEXT:      %[[a18:.+]] = stablehlo.add %[[a16]], %[[a17]] : tensor<100xi64>
+// CHECK-NEXT:      %[[a19:.+]] = stablehlo.constant dense<1> : tensor<100xi64>
+// CHECK-NEXT:      %[[a20:.+]] = stablehlo.multiply %[[a18]], %[[a19]] : tensor<100xi64>
+// CHECK-NEXT:      %[[a21:.+]] = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:      %[[a22:.+]] = stablehlo.remainder %[[a13]], %[[a21]] : tensor<i64>
+// CHECK-NEXT:      %[[a23:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a24:.+]] = stablehlo.compare LT, %[[a22]], %[[a23]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      %[[a25:.+]] = stablehlo.add %[[a22]], %[[a21]] : tensor<i64>
+// CHECK-NEXT:      %[[a26:.+]] = stablehlo.select %[[a24]], %[[a25]], %[[a22]] : tensor<i1>, tensor<i64>
+// CHECK-NEXT:      %[[a27:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a28:.+]] = stablehlo.compare EQ, %[[a26]], %[[a27]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      %[[a29:.+]] = stablehlo.not %[[a28]] : tensor<i1>
+// CHECK-NEXT:      %[[a30:.+]] = stablehlo.broadcast_in_dim %[[a28]], dims = [] : (tensor<i1>) -> tensor<100xi1>
+// CHECK-NEXT:      %[[a31:.+]] = stablehlo.select %[[a30]], %[[a14]], %[[a15]] : tensor<100xi1>, tensor<100xf64>
+// CHECK-NEXT:      %[[a32:.+]] = arith.mulf %[[a31]], %[[a31]] : tensor<100xf64>
+// CHECK-NEXT:      %[[a33:.+]] = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:      %[[a34:.+]] = stablehlo.remainder %[[a13]], %[[a33]] : tensor<i64>
+// CHECK-NEXT:      %[[a35:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a36:.+]] = stablehlo.compare LT, %[[a34]], %[[a35]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      %[[a37:.+]] = stablehlo.add %[[a34]], %[[a33]] : tensor<i64>
+// CHECK-NEXT:      %[[a38:.+]] = stablehlo.select %[[a36]], %[[a37]], %[[a34]] : tensor<i1>, tensor<i64>
+// CHECK-NEXT:      %[[a39:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a40:.+]] = stablehlo.compare EQ, %[[a38]], %[[a39]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      %[[a41:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a42:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a43:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a44:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a45:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a46:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a47:.+]] = stablehlo.broadcast_in_dim %[[a40]], dims = [] : (tensor<i1>) -> tensor<100xi1>
+// CHECK-NEXT:      %[[a48:.+]] = stablehlo.select %[[a47]], %[[a32]], %[[a15]] : tensor<100xi1>, tensor<100xf64>
+// CHECK-NEXT:      %[[a49:.+]] = stablehlo.dynamic_update_slice %[[a15]], %[[a48]], %[[a46]] : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK-NEXT:      %[[a50:.+]] = stablehlo.not %[[a40]] : tensor<i1>
+// CHECK-NEXT:      %[[a51:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a52:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a53:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a54:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a55:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:      %[[a56:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:      %[[a57:.+]] = stablehlo.broadcast_in_dim %[[a50]], dims = [] : (tensor<i1>) -> tensor<100xi1>
+// CHECK-NEXT:      %[[a58:.+]] = stablehlo.select %[[a57]], %[[a32]], %[[a14]] : tensor<100xi1>, tensor<100xf64>
+// CHECK-NEXT:      %[[a59:.+]] = stablehlo.dynamic_update_slice %[[a14]], %[[a58]], %[[a56]] : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK-NEXT:      %[[a60:.+]] = stablehlo.add %[[a13]], %[[a12]] : tensor<i64>
+// CHECK-NEXT:      stablehlo.return %[[a60]], %[[a59]], %[[a49]] : tensor<i64>, tensor<100xf64>, tensor<100xf64>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    return %1#1, %1#2, %arg2 : tensor<100xf64>, tensor<100xf64>, tensor<i64>
+// CHECK-NEXT:    return %[[a8]]#1, %[[a8]]#2, %[[a3]] : tensor<100xf64>, tensor<100xf64>, tensor<i64>
 // CHECK-NEXT:  }
 
 // -----
@@ -167,12 +178,56 @@ func.func @lanefor(%out: memref<8xf64, 1>, %in: memref<?xf64, 1>) {
   return
 }
 
-// CHECK-LABEL: func.func private @lanefor_raised(
-// CHECK: stablehlo.reduce{{.*}}applies stablehlo.maximum
-// CHECK: stablehlo.while
-// CHECK: } do {
-// CHECK: %[[ACTIVE:.+]] = stablehlo.compare LT, %{{.+}}, %{{.+}} : (tensor<8xi64>, tensor<8xi64>) -> tensor<8xi1>
-// CHECK: stablehlo.select %[[ACTIVE]], %{{.+}}, %{{.+}} : tensor<8xi1>, tensor<8xf64>
+// CHECK:    func.func private @lanefor_raised(%[[a1:.+]]: tensor<8xf64>, %[[a2:.+]]: tensor<?xf64>) -> (tensor<8xf64>, tensor<?xf64>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.iota dim = 0 : tensor<8xi64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<0> : tensor<8xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.add %[[a4]], %[[a5]] : tensor<8xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<1> : tensor<8xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.multiply %[[a6]], %[[a7]] : tensor<8xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.constant dense<8> : tensor<i64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.constant dense<8> : tensor<i64>
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.constant dense<8> : tensor<i64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %[[a13:.+]] = stablehlo.broadcast_in_dim %[[a11]], dims = [] : (tensor<i64>) -> tensor<8xi64>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<8xi64>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.subtract %[[a13]], %[[a8]] : tensor<8xi64>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.constant dense<0> : tensor<8xi64>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.maximum %[[a15]], %[[a16]] : tensor<8xi64>
+// CHECK-NEXT:    %[[a18:.+]] = stablehlo.constant dense<1> : tensor<8xi64>
+// CHECK-NEXT:    %[[a19:.+]] = stablehlo.subtract %[[a14]], %[[a18]] : tensor<8xi64>
+// CHECK-NEXT:    %[[a20:.+]] = stablehlo.add %[[a17]], %[[a19]] : tensor<8xi64>
+// CHECK-NEXT:    %[[a21:.+]] = stablehlo.divide %[[a20]], %[[a14]] : tensor<8xi64>
+// CHECK-NEXT:    %[[a22:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a23:.+]] = stablehlo.reduce(%[[a21]] init: %[[a22]]) applies stablehlo.maximum across dimensions = [0] : (tensor<8xi64>, tensor<i64>) -> tensor<i64>
+// CHECK-NEXT:    %[[a24:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a25:.+]] = stablehlo.broadcast_in_dim %[[a3]], dims = [] : (tensor<f64>) -> tensor<8xf64>
+// CHECK-NEXT:    %[[a26:.+]]:4 = stablehlo.while(%[[a27:.+]] = %[[a24]], %[[a28:.+]] = %[[a25]], %[[a29:.+]] = %[[a1]], %[[a30:.+]] = %[[a2]]) : tensor<i64>, tensor<8xf64>, tensor<8xf64>, tensor<?xf64>
+// CHECK-NEXT:    cond {
+// CHECK-NEXT:      %[[a31:.+]] = stablehlo.compare LT, %[[a27]], %[[a23]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
+// CHECK-NEXT:      stablehlo.return %[[a31]] : tensor<i1>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      %[[a31]] = stablehlo.broadcast_in_dim %[[a27]], dims = [] : (tensor<i64>) -> tensor<8xi64>
+// CHECK-NEXT:      %[[a32:.+]] = stablehlo.multiply %[[a31]], %[[a14]] : tensor<8xi64>
+// CHECK-NEXT:      %[[a33:.+]] = stablehlo.add %[[a8]], %[[a32]] : tensor<8xi64>
+// CHECK-NEXT:      %[[a34:.+]] = stablehlo.compare LT, %[[a33]], %[[a13]] : (tensor<8xi64>, tensor<8xi64>) -> tensor<8xi1>
+// CHECK-NEXT:      %[[a35:.+]] = stablehlo.reshape %[[a33]] : (tensor<8xi64>) -> tensor<8x1xi64>
+// CHECK-NEXT:      %[[a36:.+]] = "stablehlo.gather"(%[[a30]], %[[a35]]) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<?xf64>, tensor<8x1xi64>) -> tensor<8xf64>
+// CHECK-NEXT:      %[[a37:.+]] = arith.addf %[[a28]], %[[a36]] : tensor<8xf64>
+// CHECK-NEXT:      %[[a38:.+]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:      %[[a39:.+]] = stablehlo.add %[[a27]], %[[a38]] : tensor<i64>
+// CHECK-NEXT:      %[[a40:.+]] = stablehlo.select %[[a34]], %[[a37]], %[[a28]] : tensor<8xi1>, tensor<8xf64>
+// CHECK-NEXT:      stablehlo.return %[[a39]], %[[a40]], %[[a29]], %[[a30]] : tensor<i64>, tensor<8xf64>, tensor<8xf64>, tensor<?xf64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a41:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a42:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a43:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a44:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a45:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a46:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a47:.+]] = stablehlo.dynamic_update_slice %[[a26]]#2, %[[a26]]#1, %[[a46]] : (tensor<8xf64>, tensor<8xf64>, tensor<i64>) -> tensor<8xf64>
+// CHECK-NEXT:    return %[[a47]], %[[a26]]#3 : tensor<8xf64>, tensor<?xf64>
+// CHECK-NEXT:  }
 
 // -----
 
@@ -198,7 +253,32 @@ func.func @dowhile_loop(%out: memref<100xf64, 1>, %nb: memref<i32, 1>) {
   return
 }
 
-// CHECK-LABEL: func.func private @dowhile_loop_raised(
-// CHECK: stablehlo.while(%[[C:[a-zA-Z0-9_]+]] = %{{[^,]+}}, %{{.+}}) : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<i32>
-// CHECK: cond {
-// CHECK: stablehlo.return %[[C]] : tensor<i1>
+// CHECK:    func.func private @dowhile_loop_raised(%[[a1:.+]]: tensor<100xf64>, %[[a2:.+]]: tensor<i32>) -> (tensor<100xf64>, tensor<i32>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<0> : tensor<i32>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.constant dense<1> : tensor<i32>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.iota dim = 0 : tensor<100xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.constant dense<0> : tensor<100xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.add %[[a5]], %[[a6]] : tensor<100xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.constant dense<1> : tensor<100xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.multiply %[[a7]], %[[a8]] : tensor<100xi64>
+// CHECK-NEXT:    %[[a10:.+]] = arith.addi %[[a3]], %[[a4]] : tensor<i32>
+// CHECK-NEXT:    %[[a11:.+]] = arith.cmpi slt, %[[a10]], %[[a2]] : tensor<i32>
+// CHECK-NEXT:    %[[a12:.+]]:4 = stablehlo.while(%[[a13:.+]] = %[[a11]], %[[a14:.+]] = %[[a10]], %[[a15:.+]] = %[[a1]], %[[a16:.+]] = %[[a2]]) : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<i32>
+// CHECK-NEXT:    cond {
+// CHECK-NEXT:      stablehlo.return %[[a13]] : tensor<i1>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      %[[a17:.+]] = arith.addi %[[a14]], %[[a4]] : tensor<i32>
+// CHECK-NEXT:      %[[a18:.+]] = arith.cmpi slt, %[[a17]], %[[a2]] : tensor<i32>
+// CHECK-NEXT:      stablehlo.return %[[a18]], %[[a17]], %[[a15]], %[[a16]] : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<i32>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a19:.+]] = arith.sitofp %[[a12]]#1 : tensor<i32> to tensor<f64>
+// CHECK-NEXT:    %[[a20:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a21:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a22:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a23:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a24:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a25:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a26:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<100xf64>
+// CHECK-NEXT:    %[[a27:.+]] = stablehlo.dynamic_update_slice %[[a12]]#2, %[[a26]], %[[a25]] : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK-NEXT:    return %[[a27]], %[[a12]]#3 : tensor<100xf64>, tensor<i32>
+// CHECK-NEXT:  }

--- a/test/lit_tests/raising/raise_scf_while.mlir
+++ b/test/lit_tests/raising/raise_scf_while.mlir
@@ -22,17 +22,35 @@ func.func @dowhile_loop(%out: memref<100xf64, 1>, %nb: memref<i32, 1>) {
   return
 }
 
-// CHECK-LABEL: func.func private @dowhile_loop_raised(
-// CHECK: %[[I0:.+]] = arith.addi %{{.+}}, %{{.+}} : tensor<i32>
-// CHECK: %[[C0:.+]] = arith.cmpi slt, %[[I0]], %{{.+}} : tensor<i32>
-// CHECK: %[[W:.+]]:4 = stablehlo.while(%[[C:[a-zA-Z0-9_]+]] = %[[C0]], %[[I:.+]] = %[[I0]], %{{.+}}) : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<i32>
-// CHECK: cond {
-// CHECK: stablehlo.return %[[C]] : tensor<i1>
-// CHECK: } do {
-// CHECK: %[[I1:.+]] = arith.addi %[[I]], %{{.+}} : tensor<i32>
-// CHECK: %[[C1:.+]] = arith.cmpi slt, %[[I1]], %{{.+}} : tensor<i32>
-// CHECK: stablehlo.return %[[C1]], %[[I1]], %{{.+}}, %{{.+}} : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<i32>
-// CHECK: arith.sitofp %[[W]]#1
+// CHECK:    func.func private @dowhile_loop_raised(%[[a1:.+]]: tensor<100xf64>, %[[a2:.+]]: tensor<i32>) -> (tensor<100xf64>, tensor<i32>) {
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<0> : tensor<i32>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.constant dense<1> : tensor<i32>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.iota dim = 0 : tensor<100xi64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.constant dense<0> : tensor<100xi64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.add %[[a5]], %[[a6]] : tensor<100xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.constant dense<1> : tensor<100xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.multiply %[[a7]], %[[a8]] : tensor<100xi64>
+// CHECK-NEXT:    %[[a10:.+]] = arith.addi %[[a3]], %[[a4]] : tensor<i32>
+// CHECK-NEXT:    %[[a11:.+]] = arith.cmpi slt, %[[a10]], %[[a2]] : tensor<i32>
+// CHECK-NEXT:    %[[a12:.+]]:4 = stablehlo.while(%[[a13:.+]] = %[[a11]], %[[a14:.+]] = %[[a10]], %[[a15:.+]] = %[[a1]], %[[a16:.+]] = %[[a2]]) : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<i32>
+// CHECK-NEXT:    cond {
+// CHECK-NEXT:      stablehlo.return %[[a13]] : tensor<i1>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      %[[a17:.+]] = arith.addi %[[a14]], %[[a4]] : tensor<i32>
+// CHECK-NEXT:      %[[a18:.+]] = arith.cmpi slt, %[[a17]], %[[a2]] : tensor<i32>
+// CHECK-NEXT:      stablehlo.return %[[a18]], %[[a17]], %[[a15]], %[[a16]] : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<i32>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a19:.+]] = arith.sitofp %[[a12]]#1 : tensor<i32> to tensor<f64>
+// CHECK-NEXT:    %[[a20:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a21:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a22:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a23:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a24:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a25:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a26:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<100xf64>
+// CHECK-NEXT:    %[[a27:.+]] = stablehlo.dynamic_update_slice %[[a12]]#2, %[[a26]], %[[a25]] : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK-NEXT:    return %[[a27]], %[[a12]]#3 : tensor<100xf64>, tensor<i32>
+// CHECK-NEXT:  }
 
 // -----
 
@@ -61,15 +79,37 @@ func.func @dowhile_store(%out: memref<100xf64, 1>, %acc: memref<f64, 1>, %nb: me
   return
 }
 
-// CHECK-LABEL: func.func private @dowhile_store_raised(
-// CHECK: %[[A0:.+]] = stablehlo.dynamic_update_slice %arg1, %{{.+}} : (tensor<f64>, tensor<f64>) -> tensor<f64>
-// CHECK: stablehlo.while(%[[C:[a-zA-Z0-9_]+]] = %{{[^,]+}}, %[[I:.+]] = %{{[^,]+}}, %{{.+}} = %arg0, %[[A:.+]] = %[[A0]], %{{.+}}) : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<f64>, tensor<i32>
-// CHECK: cond {
-// CHECK: stablehlo.return %[[C]] : tensor<i1>
-// CHECK: } do {
-// CHECK: %[[I1:.+]] = arith.addi %[[I]], %{{.+}} : tensor<i32>
-// CHECK: %[[S:.+]] = arith.addf
-// CHECK: %[[B:.+]] = stablehlo.broadcast_in_dim %[[S]]
-// CHECK: %[[A1:.+]] = stablehlo.dynamic_update_slice %[[A]], %[[B]]
-// CHECK: %[[C1:.+]] = arith.cmpi slt, %[[I1]], %{{.+}} : tensor<i32>
-// CHECK: stablehlo.return %[[C1]], %[[I1]], %{{.+}}, %[[A1]], %{{.+}} : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<f64>, tensor<i32>
+// CHECK:    func.func private @dowhile_store_raised(%[[a1:.+]]: tensor<100xf64>, %[[a2:.+]]: tensor<f64>, %[[a3:.+]]: tensor<i32>) -> (tensor<100xf64>, tensor<f64>, tensor<i32>) {
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.constant dense<0> : tensor<i32>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<1> : tensor<i32>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.iota dim = 0 : tensor<100xi64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.constant dense<0> : tensor<100xi64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.add %[[a7]], %[[a8]] : tensor<100xi64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.constant dense<1> : tensor<100xi64>
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.multiply %[[a9]], %[[a10]] : tensor<100xi64>
+// CHECK-NEXT:    %[[a12:.+]] = arith.addi %[[a4]], %[[a5]] : tensor<i32>
+// CHECK-NEXT:    %[[a13:.+]] = arith.addf %[[a2]], %[[a6]] : tensor<f64>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.dynamic_update_slice %[[a2]], %[[a13]] : (tensor<f64>, tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a15:.+]] = arith.cmpi slt, %[[a12]], %[[a3]] : tensor<i32>
+// CHECK-NEXT:    %[[a16:.+]]:5 = stablehlo.while(%[[a17:.+]] = %[[a15]], %[[a18:.+]] = %[[a12]], %[[a19:.+]] = %[[a1]], %[[a20:.+]] = %[[a14]], %[[a21:.+]] = %[[a3]]) : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<f64>, tensor<i32>
+// CHECK-NEXT:    cond {
+// CHECK-NEXT:      stablehlo.return %[[a17]] : tensor<i1>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      %[[a22:.+]] = arith.addi %[[a18]], %[[a5]] : tensor<i32>
+// CHECK-NEXT:      %[[a23:.+]] = arith.addf %[[a20]], %[[a6]] : tensor<f64>
+// CHECK-NEXT:      %[[a24:.+]] = stablehlo.dynamic_update_slice %[[a20]], %[[a23]] : (tensor<f64>, tensor<f64>) -> tensor<f64>
+// CHECK-NEXT:      %[[a25:.+]] = arith.cmpi slt, %[[a22]], %[[a3]] : tensor<i32>
+// CHECK-NEXT:      stablehlo.return %[[a25]], %[[a22]], %[[a19]], %[[a24]], %[[a21]] : tensor<i1>, tensor<i32>, tensor<100xf64>, tensor<f64>, tensor<i32>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a26:.+]] = arith.sitofp %[[a16]]#1 : tensor<i32> to tensor<f64>
+// CHECK-NEXT:    %[[a27:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a28:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a29:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a30:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a31:.+]] = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %[[a32:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a33:.+]] = stablehlo.broadcast_in_dim %[[a26]], dims = [] : (tensor<f64>) -> tensor<100xf64>
+// CHECK-NEXT:    %[[a34:.+]] = stablehlo.dynamic_update_slice %[[a16]]#2, %[[a33]], %[[a32]] : (tensor<100xf64>, tensor<100xf64>, tensor<i64>) -> tensor<100xf64>
+// CHECK-NEXT:    return %[[a34]], %[[a16]]#3, %[[a16]]#4 : tensor<100xf64>, tensor<f64>, tensor<i32>
+// CHECK-NEXT:  }

--- a/test/lit_tests/raising/raiseaffineif.mlir
+++ b/test/lit_tests/raising/raiseaffineif.mlir
@@ -92,157 +92,141 @@ module {
 }
 }
 
-// CHECK:  func.func private @"##call__Z40gpu_compute_hydrostatic_free_surface_Gc_16CompilerMetadataI10StaticSizeI13_180__85__20_E12DynamicCheckvv7NDRangeILi3ES0_I11_12__6__20_ES0_I11_16__16__1_EvvEE11OffsetArrayI7Float64Li3E13CuTracedArrayIS9_Li3ELi1E13_194__99__34_EE20ImmersedBoundaryGridIS9_8Periodic14RightConnected7Bounded28OrthogonalSphericalShellGridIS9_SE_SF_SG_28StaticVerticalDiscretizationIS8_IS9_Li1ESA_IS9_Li1ELi1E5_35__EES8_IS9_Li1ESA_IS9_Li1ELi1E5_34__EESK_SM_ES8_IS9_Li2ESA_IS9_Li2ELi1E9_194__99_EE8TripolarI5Int64SR_SR_EvE16GridFittedBottomI5FieldI6CenterSW_vvvvS8_IS9_Li3ESA_IS9_Li3ELi1E12_194__99__1_EES9_vvvE23CenterImmersedConditionEvvvEv5TupleI3ValILi3EES14_I2_eEv24CATKEVerticalDiffusivityI36VerticallyImplicitTimeDiscretization17CATKEMixingLengthIS9_ES9_v13CATKEEquationIS9_EE24DefaultBoundaryConditionI17BoundaryConditionI4FluxvEE13BuoyancyForceI16SeawaterBuoyancyIS9_25BoussinesqEquationOfStateI24TEOS10SeawaterPolynomialIS9_ES9_EvvE18NegativeZDirectionEv10NamedTupleI12__u___v___w_S13_ISC_SC_S8_IS9_Li3ESA_IS9_Li3ELi1E13_194__99__35_EEEE24SplitExplicitFreeSurfaceIS8_IS9_Li3ESA_IS9_Li3ELi1E13_194__187__1_EES1S_I8__U___V_S13_ISV_I4FaceSW_vvvvS1Z_S9_vvvESV_ISW_S20_vvvvS1Z_S9_vvvEEES1S_I12______U___V_S13_IS1Z_S21_S22_EES9_v18FixedSubstepNumberIS9_S13_IS9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_EE21ForwardBackwardSchemeES1S_I12__T___S___e_S13_ISC_SC_SC_EES1S_I141___u____c____e___Le___J____previous_compute_time___previous_velocities____tupled_tracer_diffusivities____tupled_implicit_linear_coefficients_S13_IS1U_S1U_S1U_SC_SZ_16ReactantRefValueIS9_ES1S_I8__u___v_S13_ISC_SC_EES1S_I12__T___S___e_S13_IS1U_S1U_S1U_EES1S_I12__T___S___e_S13_I9ZeroFieldISR_Li3EES2L_SC_EEEES1S_I2__S13_ES1S_I53__time___last__t___last_stage__t___iteration___stage_S13_IS9_S9_S9_SR_SR_EE11zeroforcingE#860$par244_raised"(%arg0: tensor<34x99x194xf64>, %arg1: tensor<34xf64>, %arg2: tensor<35xf64>, %arg3: tensor<34xf64>, %arg4: tensor<99x194xf64>, %arg5: tensor<99x194xf64>, %arg6: tensor<99x194xf64>, %arg7: tensor<1x99x194xf64>, %arg8: tensor<34x99x194xf64>, %arg9: tensor<35x99x194xf64>) -> (tensor<34x99x194xf64>, tensor<34xf64>, tensor<35xf64>, tensor<34xf64>, tensor<99x194xf64>, tensor<99x194xf64>, tensor<99x194xf64>, tensor<1x99x194xf64>, tensor<34x99x194xf64>, tensor<35x99x194xf64>) {
-// CHECK-NEXT:    %[[v0:.+]] = stablehlo.constant dense<7> : tensor<i64>
-// CHECK-NEXT:    %[[v1:.+]] = stablehlo.constant dense<-19> : tensor<i64>
-// CHECK-NEXT:    %[[v2:.+]] = stablehlo.constant dense<1> : tensor<20xi64>
-// CHECK-NEXT:    %[[v3:.+]] = stablehlo.constant dense<0> : tensor<20xi64>
-// CHECK-NEXT:    %[[v4:.+]] = stablehlo.constant dense<2> : tensor<i64>
-// CHECK-NEXT:    %[[v5:.+]] = stablehlo.constant dense<1> : tensor<i64>
-// CHECK-NEXT:    %[[v6:.+]] = stablehlo.constant dense<20> : tensor<i64>
-// CHECK-NEXT:    %[[v7:.+]] = stablehlo.constant dense<1.000000e+00> : tensor<f64>
-// CHECK-NEXT:    %[[v8:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-// CHECK-NEXT:    %[[v9:.+]] = stablehlo.iota dim = 0 : tensor<20xi64>
-// CHECK-NEXT:    %[[v10:.+]] = stablehlo.add %[[v9]], %[[v3]] : tensor<20xi64>
-// CHECK-NEXT:    %[[v11:.+]] = stablehlo.multiply %[[v10]], %[[v2]] : tensor<20xi64>
-// CHECK-NEXT:    %[[v12:.+]] = stablehlo.slice %arg6 [7:92, 7:187] : (tensor<99x194xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v13:.+]] = stablehlo.reshape %[[v12]] : (tensor<85x180xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v14:.+]] = stablehlo.slice %arg3 [7:27] : (tensor<34xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v15:.+]] = stablehlo.reshape %[[v14]] : (tensor<20xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v16:.+]] = stablehlo.broadcast_in_dim %[[v13]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v17:.+]] = stablehlo.broadcast_in_dim %[[v15]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v18:.+]] = arith.mulf %[[v16]], %[[v17]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v19:.+]] = stablehlo.broadcast_in_dim %[[v7]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v20:.+]] = arith.divf %[[v19]], %[[v18]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v21:.+]] = stablehlo.slice %arg5 [7:92, 8:188] : (tensor<99x194xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v22:.+]] = stablehlo.reshape %[[v21]] : (tensor<85x180xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v23:.+]] = stablehlo.broadcast_in_dim %[[v22]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v24:.+]] = stablehlo.broadcast_in_dim %[[v15]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v25:.+]] = arith.mulf %[[v23]], %[[v24]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v26:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v27:.+]] = arith.mulf %[[v25]], %[[v26]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v28:.+]] = stablehlo.slice %arg5 [7:92, 7:187] : (tensor<99x194xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v29:.+]] = stablehlo.reshape %[[v28]] : (tensor<85x180xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v30:.+]] = stablehlo.broadcast_in_dim %[[v29]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v31:.+]] = stablehlo.broadcast_in_dim %[[v15]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v32:.+]] = arith.mulf %[[v30]], %[[v31]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v33:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v34:.+]] = arith.mulf %[[v32]], %[[v33]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v35:.+]] = arith.subf %[[v27]], %[[v34]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v36:.+]] = stablehlo.slice %arg4 [8:93, 7:187] : (tensor<99x194xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v37:.+]] = stablehlo.reshape %[[v36]] : (tensor<85x180xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v38:.+]] = stablehlo.broadcast_in_dim %[[v37]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v39:.+]] = stablehlo.broadcast_in_dim %[[v15]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v40:.+]] = arith.mulf %[[v38]], %[[v39]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v41:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v42:.+]] = arith.mulf %[[v40]], %[[v41]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v43:.+]] = stablehlo.slice %arg4 [7:92, 7:187] : (tensor<99x194xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v44:.+]] = stablehlo.reshape %[[v43]] : (tensor<85x180xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v45:.+]] = stablehlo.broadcast_in_dim %[[v44]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v46:.+]] = stablehlo.broadcast_in_dim %[[v15]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v47:.+]] = arith.mulf %[[v45]], %[[v46]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v48:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v49:.+]] = arith.mulf %[[v47]], %[[v48]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v50:.+]] = arith.subf %[[v42]], %[[v49]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v51:.+]] = stablehlo.broadcast_in_dim %[[v4]], dims = [] : (tensor<i64>) -> tensor<20xi64>
-// CHECK-NEXT:    %[[v52:.+]] = arith.addi %[[v11]], %[[v51]] : tensor<20xi64>
-// CHECK-NEXT:    %[[v53:.+]] = stablehlo.slice %arg9 [8:28, 7:92, 7:187] : (tensor<35x99x194xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v54:.+]] = stablehlo.reshape %[[v53]] : (tensor<20x85x180xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v55:.+]] = arith.negf %[[v54]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v56:.+]] = stablehlo.slice %arg1 [8:28] : (tensor<34xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v57:.+]] = stablehlo.reshape %[[v56]] : (tensor<20xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v58:.+]] = stablehlo.slice %arg7 [0:1, 7:92, 7:187] : (tensor<1x99x194xf64>) -> tensor<1x85x180xf64>
-// CHECK-NEXT:    %[[v59:.+]] = stablehlo.reshape %[[v58]] : (tensor<1x85x180xf64>) -> tensor<85x180xf64>
-// CHECK-NEXT:    %[[v60:.+]] = stablehlo.broadcast_in_dim %[[v57]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v61:.+]] = stablehlo.broadcast_in_dim %[[v59]], dims = [1, 2] : (tensor<85x180xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v62:.+]] = arith.cmpf ole, %[[v60]], %[[v61]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v63:.+]] = stablehlo.broadcast_in_dim %[[v6]], dims = [] : (tensor<i64>) -> tensor<20xi64>
-// CHECK-NEXT:    %[[v64:.+]] = arith.cmpi sgt, %[[v52]], %[[v63]] : tensor<20xi64>
-// CHECK-NEXT:    %[[v65:.+]] = stablehlo.broadcast_in_dim %[[v64]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v66:.+]] = arith.ori %[[v65]], %[[v62]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v67:.+]] = stablehlo.broadcast_in_dim %[[v6]], dims = [] : (tensor<i64>) -> tensor<20xi64>
-// CHECK-NEXT:    %[[v68:.+]] = arith.cmpi sle, %[[v52]], %[[v67]] : tensor<20xi64>
-// CHECK-NEXT:    %[[v69:.+]] = stablehlo.broadcast_in_dim %[[v68]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v70:.+]] = arith.andi %[[v69]], %[[v66]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v71:.+]] = stablehlo.slice %arg1 [7:27] : (tensor<34xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v72:.+]] = stablehlo.reshape %[[v71]] : (tensor<20xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v73:.+]] = stablehlo.broadcast_in_dim %[[v72]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v74:.+]] = stablehlo.broadcast_in_dim %[[v59]], dims = [1, 2] : (tensor<85x180xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v75:.+]] = arith.cmpf ole, %[[v73]], %[[v74]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v76:.+]] = arith.ori %[[v70]], %[[v75]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v77:.+]] = stablehlo.slice %arg8 [8:28, 7:92, 7:187] : (tensor<34x99x194xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v78:.+]] = stablehlo.reshape %[[v77]] : (tensor<20x85x180xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v79:.+]] = stablehlo.slice %arg8 [7:27, 7:92, 7:187] : (tensor<34x99x194xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v80:.+]] = stablehlo.reshape %[[v79]] : (tensor<20x85x180xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v81:.+]] = arith.subf %[[v78]], %[[v80]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v82:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v83:.+]] = arith.select %[[v76]], %[[v82]], %[[v81]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v84:.+]] = stablehlo.slice %arg2 [9:29] : (tensor<35xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v85:.+]] = stablehlo.reshape %[[v84]] : (tensor<20xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v86:.+]] = stablehlo.broadcast_in_dim %[[v85]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v87:.+]] = arith.divf %[[v83]], %[[v86]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v88:.+]] = arith.mulf %[[v55]], %[[v87]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v89:.+]] = stablehlo.broadcast_in_dim %[[v1]], dims = [] : (tensor<i64>) -> tensor<20xi64>
-// CHECK-NEXT:    %[[v90:.+]] = stablehlo.add %[[v11]], %[[v89]] : tensor<20xi64>
-// CHECK-NEXT:    %[[v91:.+]] = stablehlo.compare  EQ, %[[v90]], %[[v3]] : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
-// CHECK-NEXT:    %[[v92:.+]] = stablehlo.broadcast_in_dim %[[v91]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v93:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v94:.+]] = stablehlo.select %[[v92]], %[[v88]], %[[v93]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v95:.+]] = arith.ori %[[v66]], %[[v75]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v96:.+]] = stablehlo.broadcast_in_dim %[[v68]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v97:.+]] = arith.andi %[[v96]], %[[v95]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v98:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v99:.+]] = arith.select %[[v97]], %[[v98]], %[[v94]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v100:.+]] = stablehlo.broadcast_in_dim %[[v13]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v101:.+]] = stablehlo.broadcast_in_dim %[[v99]], dims = [2, 0, 1] : (tensor<20x85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v102:.+]] = arith.mulf %[[v100]], %[[v101]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v103:.+]] = stablehlo.slice %arg9 [7:27, 7:92, 7:187] : (tensor<35x99x194xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v104:.+]] = stablehlo.reshape %[[v103]] : (tensor<20x85x180xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v105:.+]] = arith.negf %[[v104]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v106:.+]] = stablehlo.slice %arg1 [6:26] : (tensor<34xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v107:.+]] = stablehlo.reshape %[[v106]] : (tensor<20xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v108:.+]] = stablehlo.broadcast_in_dim %[[v107]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v109:.+]] = stablehlo.broadcast_in_dim %[[v59]], dims = [1, 2] : (tensor<85x180xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v110:.+]] = arith.cmpf ole, %[[v108]], %[[v109]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v111:.+]] = stablehlo.broadcast_in_dim %[[v5]], dims = [] : (tensor<i64>) -> tensor<20xi64>
-// CHECK-NEXT:    %[[v112:.+]] = arith.cmpi ult, %[[v11]], %[[v111]] : tensor<20xi64>
-// CHECK-NEXT:    %[[v113:.+]] = stablehlo.broadcast_in_dim %[[v112]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v114:.+]] = arith.ori %[[v113]], %[[v110]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v115:.+]] = stablehlo.broadcast_in_dim %[[v5]], dims = [] : (tensor<i64>) -> tensor<20xi64>
-// CHECK-NEXT:    %[[v116:.+]] = arith.cmpi uge, %[[v11]], %[[v115]] : tensor<20xi64>
-// CHECK-NEXT:    %[[v117:.+]] = stablehlo.broadcast_in_dim %[[v116]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v118:.+]] = arith.andi %[[v117]], %[[v114]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v119:.+]] = arith.ori %[[v75]], %[[v118]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v120:.+]] = stablehlo.slice %arg8 [6:26, 7:92, 7:187] : (tensor<34x99x194xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v121:.+]] = stablehlo.reshape %[[v120]] : (tensor<20x85x180xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v122:.+]] = arith.subf %[[v80]], %[[v121]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v123:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v124:.+]] = arith.select %[[v119]], %[[v123]], %[[v122]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v125:.+]] = stablehlo.slice %arg2 [8:28] : (tensor<35xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v126:.+]] = stablehlo.reshape %[[v125]] : (tensor<20xf64>) -> tensor<20xf64>
-// CHECK-NEXT:    %[[v127:.+]] = stablehlo.broadcast_in_dim %[[v126]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v128:.+]] = arith.divf %[[v124]], %[[v127]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v129:.+]] = arith.mulf %[[v105]], %[[v128]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v130:.+]] = stablehlo.compare  EQ, %[[v11]], %[[v3]] : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
-// CHECK-NEXT:    %[[v131:.+]] = stablehlo.broadcast_in_dim %[[v130]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v132:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v133:.+]] = stablehlo.select %[[v131]], %[[v129]], %[[v132]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v134:.+]] = arith.ori %[[v75]], %[[v114]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v135:.+]] = stablehlo.broadcast_in_dim %[[v116]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v136:.+]] = arith.andi %[[v135]], %[[v134]] : tensor<20x85x180xi1>
-// CHECK-NEXT:    %[[v137:.+]] = stablehlo.broadcast_in_dim %[[v8]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v138:.+]] = arith.select %[[v136]], %[[v137]], %[[v133]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v139:.+]] = stablehlo.broadcast_in_dim %[[v13]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v140:.+]] = stablehlo.broadcast_in_dim %[[v138]], dims = [2, 0, 1] : (tensor<20x85x180xf64>) -> tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v141:.+]] = arith.mulf %[[v139]], %[[v140]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v142:.+]] = arith.subf %[[v102]], %[[v141]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v143:.+]] = arith.addf %[[v35]], %[[v50]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v144:.+]] = arith.addf %[[v143]], %[[v142]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v145:.+]] = arith.mulf %[[v20]], %[[v144]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v146:.+]] = arith.negf %[[v145]] : tensor<85x180x20xf64>
-// CHECK-NEXT:    %[[v147:.+]] = stablehlo.broadcast_in_dim %[[v146]], dims = [1, 2, 0] : (tensor<85x180x20xf64>) -> tensor<20x85x180xf64>
-// CHECK-NEXT:    %[[v148:.+]] = stablehlo.dynamic_update_slice %arg0, %[[v147]], %[[v0]], %[[v0]], %[[v0]] : (tensor<34x99x194xf64>, tensor<20x85x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<34x99x194xf64>
-// CHECK-NEXT:    return %[[v148]], %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8, %arg9 : tensor<34x99x194xf64>, tensor<34xf64>, tensor<35xf64>, tensor<34xf64>, tensor<99x194xf64>, tensor<99x194xf64>, tensor<99x194xf64>, tensor<1x99x194xf64>, tensor<34x99x194xf64>, tensor<35x99x194xf64>
+// CHECK:    func.func private @"##call__Z40gpu_compute_hydrostatic_free_surface_Gc_16CompilerMetadataI10StaticSizeI13_180__85__20_E12DynamicCheckvv7NDRangeILi3ES0_I11_12__6__20_ES0_I11_16__16__1_EvvEE11OffsetArrayI7Float64Li3E13CuTracedArrayIS9_Li3ELi1E13_194__99__34_EE20ImmersedBoundaryGridIS9_8Periodic14RightConnected7Bounded28OrthogonalSphericalShellGridIS9_SE_SF_SG_28StaticVerticalDiscretizationIS8_IS9_Li1ESA_IS9_Li1ELi1E5_35__EES8_IS9_Li1ESA_IS9_Li1ELi1E5_34__EESK_SM_ES8_IS9_Li2ESA_IS9_Li2ELi1E9_194__99_EE8TripolarI5Int64SR_SR_EvE16GridFittedBottomI5FieldI6CenterSW_vvvvS8_IS9_Li3ESA_IS9_Li3ELi1E12_194__99__1_EES9_vvvE23CenterImmersedConditionEvvvEv5TupleI3ValILi3EES14_I2_eEv24CATKEVerticalDiffusivityI36VerticallyImplicitTimeDiscretization17CATKEMixingLengthIS9_ES9_v13CATKEEquationIS9_EE24DefaultBoundaryConditionI17BoundaryConditionI4FluxvEE13BuoyancyForceI16SeawaterBuoyancyIS9_25BoussinesqEquationOfStateI24TEOS10SeawaterPolynomialIS9_ES9_EvvE18NegativeZDirectionEv10NamedTupleI12__u___v___w_S13_ISC_SC_S8_IS9_Li3ESA_IS9_Li3ELi1E13_194__99__35_EEEE24SplitExplicitFreeSurfaceIS8_IS9_Li3ESA_IS9_Li3ELi1E13_194__187__1_EES1S_I8__U___V_S13_ISV_I4FaceSW_vvvvS1Z_S9_vvvESV_ISW_S20_vvvvS1Z_S9_vvvEEES1S_I12______U___V_S13_IS1Z_S21_S22_EES9_v18FixedSubstepNumberIS9_S13_IS9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_S9_EE21ForwardBackwardSchemeES1S_I12__T___S___e_S13_ISC_SC_SC_EES1S_I141___u____c____e___Le___J____previous_compute_time___previous_velocities____tupled_tracer_diffusivities____tupled_implicit_linear_coefficients_S13_IS1U_S1U_S1U_SC_SZ_16ReactantRefValueIS9_ES1S_I8__u___v_S13_ISC_SC_EES1S_I12__T___S___e_S13_IS1U_S1U_S1U_EES1S_I12__T___S___e_S13_I9ZeroFieldISR_Li3EES2L_SC_EEEES1S_I2__S13_ES1S_I53__time___last__t___last_stage__t___iteration___stage_S13_IS9_S9_S9_SR_SR_EE11zeroforcingE#860$par244_raised"(%[[a1:.+]]: tensor<34x99x194xf64>, %[[a2:.+]]: tensor<34xf64>, %[[a3:.+]]: tensor<35xf64>, %[[a4:.+]]: tensor<34xf64>, %[[a5:.+]]: tensor<99x194xf64>, %[[a6:.+]]: tensor<99x194xf64>, %[[a7:.+]]: tensor<99x194xf64>, %[[a8:.+]]: tensor<1x99x194xf64>, %[[a9:.+]]: tensor<34x99x194xf64>, %[[a10:.+]]: tensor<35x99x194xf64>) -> (tensor<34x99x194xf64>, tensor<34xf64>, tensor<35xf64>, tensor<34xf64>, tensor<99x194xf64>, tensor<99x194xf64>, tensor<99x194xf64>, tensor<1x99x194xf64>, tensor<34x99x194xf64>, tensor<35x99x194xf64>) {
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.constant dense<7> : tensor<i64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.constant dense<-19> : tensor<i64>
+// CHECK-NEXT:    %[[a13:.+]] = stablehlo.constant dense<1> : tensor<20xi64>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.constant dense<0> : tensor<20xi64>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.constant dense<2> : tensor<i64>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.constant dense<20> : tensor<i64>
+// CHECK-NEXT:    %[[a18:.+]] = stablehlo.constant dense<1.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a19:.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %[[a20:.+]] = stablehlo.iota dim = 0 : tensor<20xi64>
+// CHECK-NEXT:    %[[a21:.+]] = stablehlo.add %[[a20]], %[[a14]] : tensor<20xi64>
+// CHECK-NEXT:    %[[a22:.+]] = stablehlo.multiply %[[a21]], %[[a13]] : tensor<20xi64>
+// CHECK-NEXT:    %[[a23:.+]] = stablehlo.slice %[[a7]] [7:92, 7:187] : (tensor<99x194xf64>) -> tensor<85x180xf64>
+// CHECK-NEXT:    %[[a24:.+]] = stablehlo.slice %[[a4]] [7:27] : (tensor<34xf64>) -> tensor<20xf64>
+// CHECK-NEXT:    %[[a25:.+]] = stablehlo.broadcast_in_dim %[[a23]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a26:.+]] = stablehlo.broadcast_in_dim %[[a24]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a27:.+]] = arith.mulf %[[a25]], %[[a26]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a28:.+]] = stablehlo.broadcast_in_dim %[[a18]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a29:.+]] = arith.divf %[[a28]], %[[a27]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a30:.+]] = stablehlo.slice %[[a6]] [7:92, 8:188] : (tensor<99x194xf64>) -> tensor<85x180xf64>
+// CHECK-NEXT:    %[[a31:.+]] = stablehlo.broadcast_in_dim %[[a30]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a32:.+]] = stablehlo.broadcast_in_dim %[[a24]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a33:.+]] = arith.mulf %[[a31]], %[[a32]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a34:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a35:.+]] = arith.mulf %[[a33]], %[[a34]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a36:.+]] = stablehlo.slice %[[a6]] [7:92, 7:187] : (tensor<99x194xf64>) -> tensor<85x180xf64>
+// CHECK-NEXT:    %[[a37:.+]] = stablehlo.broadcast_in_dim %[[a36]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a38:.+]] = stablehlo.broadcast_in_dim %[[a24]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a39:.+]] = arith.mulf %[[a37]], %[[a38]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a40:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a41:.+]] = arith.mulf %[[a39]], %[[a40]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a42:.+]] = arith.subf %[[a35]], %[[a41]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a43:.+]] = stablehlo.slice %[[a5]] [8:93, 7:187] : (tensor<99x194xf64>) -> tensor<85x180xf64>
+// CHECK-NEXT:    %[[a44:.+]] = stablehlo.broadcast_in_dim %[[a43]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a45:.+]] = stablehlo.broadcast_in_dim %[[a24]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a46:.+]] = arith.mulf %[[a44]], %[[a45]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a47:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a48:.+]] = arith.mulf %[[a46]], %[[a47]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a49:.+]] = stablehlo.slice %[[a5]] [7:92, 7:187] : (tensor<99x194xf64>) -> tensor<85x180xf64>
+// CHECK-NEXT:    %[[a50:.+]] = stablehlo.broadcast_in_dim %[[a49]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a51:.+]] = stablehlo.broadcast_in_dim %[[a24]], dims = [2] : (tensor<20xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a52:.+]] = arith.mulf %[[a50]], %[[a51]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a53:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a54:.+]] = arith.mulf %[[a52]], %[[a53]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a55:.+]] = arith.subf %[[a48]], %[[a54]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a56:.+]] = stablehlo.broadcast_in_dim %[[a15]], dims = [] : (tensor<i64>) -> tensor<20xi64>
+// CHECK-NEXT:    %[[a57:.+]] = arith.addi %[[a22]], %[[a56]] : tensor<20xi64>
+// CHECK-NEXT:    %[[a58:.+]] = stablehlo.slice %[[a10]] [8:28, 7:92, 7:187] : (tensor<35x99x194xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a59:.+]] = arith.negf %[[a58]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a60:.+]] = stablehlo.slice %[[a2]] [8:28] : (tensor<34xf64>) -> tensor<20xf64>
+// CHECK-NEXT:    %[[a61:.+]] = stablehlo.slice %[[a8]] [0:1, 7:92, 7:187] : (tensor<1x99x194xf64>) -> tensor<1x85x180xf64>
+// CHECK-NEXT:    %[[a62:.+]] = stablehlo.reshape %[[a61]] : (tensor<1x85x180xf64>) -> tensor<85x180xf64>
+// CHECK-NEXT:    %[[a63:.+]] = stablehlo.broadcast_in_dim %[[a60]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a64:.+]] = stablehlo.broadcast_in_dim %[[a62]], dims = [1, 2] : (tensor<85x180xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a65:.+]] = arith.cmpf ole, %[[a63]], %[[a64]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a66:.+]] = stablehlo.broadcast_in_dim %[[a17]], dims = [] : (tensor<i64>) -> tensor<20xi64>
+// CHECK-NEXT:    %[[a67:.+]] = arith.cmpi sgt, %[[a57]], %[[a66]] : tensor<20xi64>
+// CHECK-NEXT:    %[[a68:.+]] = stablehlo.broadcast_in_dim %[[a67]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a69:.+]] = arith.ori %[[a68]], %[[a65]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a70:.+]] = stablehlo.broadcast_in_dim %[[a17]], dims = [] : (tensor<i64>) -> tensor<20xi64>
+// CHECK-NEXT:    %[[a71:.+]] = arith.cmpi sle, %[[a57]], %[[a70]] : tensor<20xi64>
+// CHECK-NEXT:    %[[a72:.+]] = stablehlo.broadcast_in_dim %[[a71]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a73:.+]] = arith.andi %[[a72]], %[[a69]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a74:.+]] = stablehlo.slice %[[a2]] [7:27] : (tensor<34xf64>) -> tensor<20xf64>
+// CHECK-NEXT:    %[[a75:.+]] = stablehlo.broadcast_in_dim %[[a74]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a76:.+]] = stablehlo.broadcast_in_dim %[[a62]], dims = [1, 2] : (tensor<85x180xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a77:.+]] = arith.cmpf ole, %[[a75]], %[[a76]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a78:.+]] = arith.ori %[[a73]], %[[a77]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a79:.+]] = stablehlo.slice %[[a9]] [8:28, 7:92, 7:187] : (tensor<34x99x194xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a80:.+]] = stablehlo.slice %[[a9]] [7:27, 7:92, 7:187] : (tensor<34x99x194xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a81:.+]] = arith.subf %[[a79]], %[[a80]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a82:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a83:.+]] = arith.select %[[a78]], %[[a82]], %[[a81]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a84:.+]] = stablehlo.slice %[[a3]] [9:29] : (tensor<35xf64>) -> tensor<20xf64>
+// CHECK-NEXT:    %[[a85:.+]] = stablehlo.broadcast_in_dim %[[a84]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a86:.+]] = arith.divf %[[a83]], %[[a85]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a87:.+]] = arith.mulf %[[a59]], %[[a86]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a88:.+]] = stablehlo.broadcast_in_dim %[[a12]], dims = [] : (tensor<i64>) -> tensor<20xi64>
+// CHECK-NEXT:    %[[a89:.+]] = stablehlo.add %[[a22]], %[[a88]] : tensor<20xi64>
+// CHECK-NEXT:    %[[a90:.+]] = stablehlo.compare EQ, %[[a89]], %[[a14]] : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+// CHECK-NEXT:    %[[a91:.+]] = stablehlo.broadcast_in_dim %[[a90]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a92:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a93:.+]] = stablehlo.select %[[a91]], %[[a87]], %[[a92]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a94:.+]] = arith.ori %[[a69]], %[[a77]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a95:.+]] = stablehlo.broadcast_in_dim %[[a71]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a96:.+]] = arith.andi %[[a95]], %[[a94]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a97:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a98:.+]] = arith.select %[[a96]], %[[a97]], %[[a93]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a99:.+]] = stablehlo.broadcast_in_dim %[[a23]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a100:.+]] = stablehlo.broadcast_in_dim %[[a98]], dims = [2, 0, 1] : (tensor<20x85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a101:.+]] = arith.mulf %[[a99]], %[[a100]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a102:.+]] = stablehlo.slice %[[a10]] [7:27, 7:92, 7:187] : (tensor<35x99x194xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a103:.+]] = arith.negf %[[a102]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a104:.+]] = stablehlo.slice %[[a2]] [6:26] : (tensor<34xf64>) -> tensor<20xf64>
+// CHECK-NEXT:    %[[a105:.+]] = stablehlo.broadcast_in_dim %[[a104]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a106:.+]] = stablehlo.broadcast_in_dim %[[a62]], dims = [1, 2] : (tensor<85x180xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a107:.+]] = arith.cmpf ole, %[[a105]], %[[a106]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a108:.+]] = stablehlo.broadcast_in_dim %[[a16]], dims = [] : (tensor<i64>) -> tensor<20xi64>
+// CHECK-NEXT:    %[[a109:.+]] = arith.cmpi ult, %[[a22]], %[[a108]] : tensor<20xi64>
+// CHECK-NEXT:    %[[a110:.+]] = stablehlo.broadcast_in_dim %[[a109]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a111:.+]] = arith.ori %[[a110]], %[[a107]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a112:.+]] = stablehlo.broadcast_in_dim %[[a16]], dims = [] : (tensor<i64>) -> tensor<20xi64>
+// CHECK-NEXT:    %[[a113:.+]] = arith.cmpi uge, %[[a22]], %[[a112]] : tensor<20xi64>
+// CHECK-NEXT:    %[[a114:.+]] = stablehlo.broadcast_in_dim %[[a113]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a115:.+]] = arith.andi %[[a114]], %[[a111]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a116:.+]] = arith.ori %[[a77]], %[[a115]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a117:.+]] = stablehlo.slice %[[a9]] [6:26, 7:92, 7:187] : (tensor<34x99x194xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a118:.+]] = arith.subf %[[a80]], %[[a117]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a119:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a120:.+]] = arith.select %[[a116]], %[[a119]], %[[a118]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a121:.+]] = stablehlo.slice %[[a3]] [8:28] : (tensor<35xf64>) -> tensor<20xf64>
+// CHECK-NEXT:    %[[a122:.+]] = stablehlo.broadcast_in_dim %[[a121]], dims = [0] : (tensor<20xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a123:.+]] = arith.divf %[[a120]], %[[a122]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a124:.+]] = arith.mulf %[[a103]], %[[a123]] {fastmathFlags = #llvm.fastmath<none>} : tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a125:.+]] = stablehlo.compare EQ, %[[a22]], %[[a14]] : (tensor<20xi64>, tensor<20xi64>) -> tensor<20xi1>
+// CHECK-NEXT:    %[[a126:.+]] = stablehlo.broadcast_in_dim %[[a125]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a127:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a128:.+]] = stablehlo.select %[[a126]], %[[a124]], %[[a127]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a129:.+]] = arith.ori %[[a77]], %[[a111]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a130:.+]] = stablehlo.broadcast_in_dim %[[a113]], dims = [0] : (tensor<20xi1>) -> tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a131:.+]] = arith.andi %[[a130]], %[[a129]] : tensor<20x85x180xi1>
+// CHECK-NEXT:    %[[a132:.+]] = stablehlo.broadcast_in_dim %[[a19]], dims = [] : (tensor<f64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a133:.+]] = arith.select %[[a131]], %[[a132]], %[[a128]] : tensor<20x85x180xi1>, tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a134:.+]] = stablehlo.broadcast_in_dim %[[a23]], dims = [0, 1] : (tensor<85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a135:.+]] = stablehlo.broadcast_in_dim %[[a133]], dims = [2, 0, 1] : (tensor<20x85x180xf64>) -> tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a136:.+]] = arith.mulf %[[a134]], %[[a135]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a137:.+]] = arith.subf %[[a101]], %[[a136]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a138:.+]] = arith.addf %[[a42]], %[[a55]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a139:.+]] = arith.addf %[[a138]], %[[a137]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a140:.+]] = arith.mulf %[[a29]], %[[a139]] {fastmathFlags = #llvm.fastmath<none>} : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a141:.+]] = arith.negf %[[a140]] : tensor<85x180x20xf64>
+// CHECK-NEXT:    %[[a142:.+]] = stablehlo.broadcast_in_dim %[[a141]], dims = [1, 2, 0] : (tensor<85x180x20xf64>) -> tensor<20x85x180xf64>
+// CHECK-NEXT:    %[[a143:.+]] = stablehlo.dynamic_update_slice %[[a1]], %[[a142]], %[[a11]], %[[a11]], %[[a11]] : (tensor<34x99x194xf64>, tensor<20x85x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<34x99x194xf64>
+// CHECK-NEXT:    return %[[a143]], %[[a2]], %[[a3]], %[[a4]], %[[a5]], %[[a6]], %[[a7]], %[[a8]], %[[a9]], %[[a10]] : tensor<34x99x194xf64>, tensor<34xf64>, tensor<35xf64>, tensor<34xf64>, tensor<99x194xf64>, tensor<99x194xf64>, tensor<99x194xf64>, tensor<1x99x194xf64>, tensor<34x99x194xf64>, tensor<35x99x194xf64>
 // CHECK-NEXT:  }
 
 // -----
@@ -256,19 +240,9 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %c-1_i64 = arith.constant -1 : i64
     affine.parallel (%arg1) = (0) to (180) {
-      // CHECK: stablehlo.slice %[[arg0:.+]] [0:1, 7:8, 7:187]
-      // CHECK: %[[argu:.+]] = stablehlo.dynamic_update_slice %[[arg0]]
       %0 = affine.load %arg0[0, 7, %arg1 + 7] : memref<1x104x194xf64, 1>
       affine.store %0, %arg0[0, 6, %arg1 + 7] : memref<1x104x194xf64, 1>
       %1:10 = affine.if #set(%arg1) -> (i64, i64, f64, f64, f64, f64, f64, f64, f64, f64) {
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 96:97, 8:188]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 89:90, 8:188]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 90:91, 8:188]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 91:92, 8:188]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 92:93, 8:188]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 93:94, 8:188]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 94:95, 8:188]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 95:96, 8:188]
         %13 = affine.load %arg0[0, 96, -%arg1 + 187] : memref<1x104x194xf64, 1>
         %14 = affine.load %arg0[0, 89, -%arg1 + 187] : memref<1x104x194xf64, 1>
         %15 = affine.load %arg0[0, 90, -%arg1 + 187] : memref<1x104x194xf64, 1>
@@ -279,14 +253,6 @@ module {
         %20 = affine.load %arg0[0, 95, -%arg1 + 187] : memref<1x104x194xf64, 1>
         affine.yield %c-1_i64, %c182_i64, %13, %14, %15, %16, %17, %18, %19, %20 : i64, i64, f64, f64, f64, f64, f64, f64, f64, f64
       } else {
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 96:97, 7:8]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 89:90, 7:8]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 90:91, 7:8]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 91:92, 7:8]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 92:93, 7:8]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 93:94, 7:8]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 94:95, 7:8]
-        // CHECK: stablehlo.slice %[[argu]] [0:1, 95:96, 7:8]
         %13 = affine.load %arg0[0, 96, 7] : memref<1x104x194xf64, 1>
         %14 = affine.load %arg0[0, 89, 7] : memref<1x104x194xf64, 1>
         %15 = affine.load %arg0[0, 90, 7] : memref<1x104x194xf64, 1>
@@ -324,3 +290,125 @@ module {
     return
   }
 }
+
+// CHECK:    func.func private @par6_raised(%[[a1:.+]]: tensor<1x104x194xf64>) -> tensor<1x104x194xf64> {
+// CHECK-NEXT:    %[[a2:.+]] = stablehlo.constant dense<96> : tensor<i64>
+// CHECK-NEXT:    %[[a3:.+]] = stablehlo.constant dense<89> : tensor<i64>
+// CHECK-NEXT:    %[[a4:.+]] = stablehlo.constant dense<103> : tensor<i64>
+// CHECK-NEXT:    %[[a5:.+]] = stablehlo.constant dense<102> : tensor<i64>
+// CHECK-NEXT:    %[[a6:.+]] = stablehlo.constant dense<101> : tensor<i64>
+// CHECK-NEXT:    %[[a7:.+]] = stablehlo.constant dense<100> : tensor<i64>
+// CHECK-NEXT:    %[[a8:.+]] = stablehlo.constant dense<99> : tensor<i64>
+// CHECK-NEXT:    %[[a9:.+]] = stablehlo.constant dense<98> : tensor<i64>
+// CHECK-NEXT:    %[[a10:.+]] = stablehlo.constant dense<97> : tensor<i64>
+// CHECK-NEXT:    %[[a11:.+]] = stablehlo.constant dense<7> : tensor<i64>
+// CHECK-NEXT:    %[[a12:.+]] = stablehlo.constant dense<6> : tensor<i64>
+// CHECK-NEXT:    %[[a13:.+]] = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %[[a14:.+]] = stablehlo.constant dense<1> : tensor<180xi64>
+// CHECK-NEXT:    %[[a15:.+]] = stablehlo.constant dense<0> : tensor<180xi64>
+// CHECK-NEXT:    %[[a16:.+]] = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %[[a17:.+]] = stablehlo.constant dense<-1> : tensor<i64>
+// CHECK-NEXT:    %[[a18:.+]] = stablehlo.iota dim = 0 : tensor<180xi64>
+// CHECK-NEXT:    %[[a19:.+]] = stablehlo.add %[[a18]], %[[a15]] : tensor<180xi64>
+// CHECK-NEXT:    %[[a20:.+]] = stablehlo.multiply %[[a19]], %[[a14]] : tensor<180xi64>
+// CHECK-NEXT:    %[[a21:.+]] = stablehlo.slice %[[a1]] [0:1, 7:8, 7:187] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a22:.+]] = stablehlo.reshape %[[a21]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a23:.+]] = stablehlo.broadcast_in_dim %[[a22]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a24:.+]] = stablehlo.dynamic_update_slice %[[a1]], %[[a23]], %[[a13]], %[[a12]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    %[[a25:.+]] = stablehlo.broadcast_in_dim %[[a17]], dims = [] : (tensor<i64>) -> tensor<180xi64>
+// CHECK-NEXT:    %[[a26:.+]] = stablehlo.add %[[a20]], %[[a25]] : tensor<180xi64>
+// CHECK-NEXT:    %[[a27:.+]] = stablehlo.compare GE, %[[a26]], %[[a15]] : (tensor<180xi64>, tensor<180xi64>) -> tensor<180xi1>
+// CHECK-NEXT:    %[[a28:.+]] = stablehlo.slice %[[a24]] [0:1, 96:97, 8:188] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a29:.+]] = stablehlo.reverse %[[a28]], dims = [2] : tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a30:.+]] = stablehlo.reshape %[[a29]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a31:.+]] = stablehlo.slice %[[a24]] [0:1, 89:90, 8:188] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a32:.+]] = stablehlo.reverse %[[a31]], dims = [2] : tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a33:.+]] = stablehlo.reshape %[[a32]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a34:.+]] = stablehlo.slice %[[a24]] [0:1, 90:91, 8:188] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a35:.+]] = stablehlo.reverse %[[a34]], dims = [2] : tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a36:.+]] = stablehlo.reshape %[[a35]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a37:.+]] = stablehlo.slice %[[a24]] [0:1, 91:92, 8:188] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a38:.+]] = stablehlo.reverse %[[a37]], dims = [2] : tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a39:.+]] = stablehlo.reshape %[[a38]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a40:.+]] = stablehlo.slice %[[a24]] [0:1, 92:93, 8:188] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a41:.+]] = stablehlo.reverse %[[a40]], dims = [2] : tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a42:.+]] = stablehlo.reshape %[[a41]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a43:.+]] = stablehlo.slice %[[a24]] [0:1, 93:94, 8:188] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a44:.+]] = stablehlo.reverse %[[a43]], dims = [2] : tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a45:.+]] = stablehlo.reshape %[[a44]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a46:.+]] = stablehlo.slice %[[a24]] [0:1, 94:95, 8:188] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a47:.+]] = stablehlo.reverse %[[a46]], dims = [2] : tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a48:.+]] = stablehlo.reshape %[[a47]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a49:.+]] = stablehlo.slice %[[a24]] [0:1, 95:96, 8:188] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a50:.+]] = stablehlo.reverse %[[a49]], dims = [2] : tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a51:.+]] = stablehlo.reshape %[[a50]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a52:.+]] = stablehlo.slice %[[a24]] [0:1, 96:97, 7:8] : (tensor<1x104x194xf64>) -> tensor<1x1x1xf64>
+// CHECK-NEXT:    %[[a53:.+]] = stablehlo.reshape %[[a52]] : (tensor<1x1x1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a54:.+]] = stablehlo.slice %[[a24]] [0:1, 89:90, 7:8] : (tensor<1x104x194xf64>) -> tensor<1x1x1xf64>
+// CHECK-NEXT:    %[[a55:.+]] = stablehlo.reshape %[[a54]] : (tensor<1x1x1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a56:.+]] = stablehlo.slice %[[a24]] [0:1, 90:91, 7:8] : (tensor<1x104x194xf64>) -> tensor<1x1x1xf64>
+// CHECK-NEXT:    %[[a57:.+]] = stablehlo.reshape %[[a56]] : (tensor<1x1x1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a58:.+]] = stablehlo.slice %[[a24]] [0:1, 91:92, 7:8] : (tensor<1x104x194xf64>) -> tensor<1x1x1xf64>
+// CHECK-NEXT:    %[[a59:.+]] = stablehlo.reshape %[[a58]] : (tensor<1x1x1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a60:.+]] = stablehlo.slice %[[a24]] [0:1, 92:93, 7:8] : (tensor<1x104x194xf64>) -> tensor<1x1x1xf64>
+// CHECK-NEXT:    %[[a61:.+]] = stablehlo.reshape %[[a60]] : (tensor<1x1x1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a62:.+]] = stablehlo.slice %[[a24]] [0:1, 93:94, 7:8] : (tensor<1x104x194xf64>) -> tensor<1x1x1xf64>
+// CHECK-NEXT:    %[[a63:.+]] = stablehlo.reshape %[[a62]] : (tensor<1x1x1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a64:.+]] = stablehlo.slice %[[a24]] [0:1, 94:95, 7:8] : (tensor<1x104x194xf64>) -> tensor<1x1x1xf64>
+// CHECK-NEXT:    %[[a65:.+]] = stablehlo.reshape %[[a64]] : (tensor<1x1x1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a66:.+]] = stablehlo.slice %[[a24]] [0:1, 95:96, 7:8] : (tensor<1x104x194xf64>) -> tensor<1x1x1xf64>
+// CHECK-NEXT:    %[[a67:.+]] = stablehlo.reshape %[[a66]] : (tensor<1x1x1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %[[a68:.+]] = stablehlo.broadcast_in_dim %[[a17]], dims = [] : (tensor<i64>) -> tensor<180xi64>
+// CHECK-NEXT:    %[[a69:.+]] = stablehlo.broadcast_in_dim %[[a16]], dims = [] : (tensor<i64>) -> tensor<180xi64>
+// CHECK-NEXT:    %[[a70:.+]] = stablehlo.select %[[a27]], %[[a68]], %[[a69]] : tensor<180xi1>, tensor<180xi64>
+// CHECK-NEXT:    %[[a71:.+]] = stablehlo.broadcast_in_dim %[[a53]], dims = [] : (tensor<f64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a72:.+]] = stablehlo.select %[[a27]], %[[a30]], %[[a71]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a73:.+]] = stablehlo.broadcast_in_dim %[[a55]], dims = [] : (tensor<f64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a74:.+]] = stablehlo.select %[[a27]], %[[a33]], %[[a73]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a75:.+]] = stablehlo.broadcast_in_dim %[[a57]], dims = [] : (tensor<f64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a76:.+]] = stablehlo.select %[[a27]], %[[a36]], %[[a75]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a77:.+]] = stablehlo.broadcast_in_dim %[[a59]], dims = [] : (tensor<f64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a78:.+]] = stablehlo.select %[[a27]], %[[a39]], %[[a77]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a79:.+]] = stablehlo.broadcast_in_dim %[[a61]], dims = [] : (tensor<f64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a80:.+]] = stablehlo.select %[[a27]], %[[a42]], %[[a79]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a81:.+]] = stablehlo.broadcast_in_dim %[[a63]], dims = [] : (tensor<f64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a82:.+]] = stablehlo.select %[[a27]], %[[a45]], %[[a81]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a83:.+]] = stablehlo.broadcast_in_dim %[[a65]], dims = [] : (tensor<f64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a84:.+]] = stablehlo.select %[[a27]], %[[a48]], %[[a83]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a85:.+]] = stablehlo.broadcast_in_dim %[[a67]], dims = [] : (tensor<f64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a86:.+]] = stablehlo.select %[[a27]], %[[a51]], %[[a85]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a87:.+]] = arith.sitofp %[[a70]] : tensor<180xi64> to tensor<180xf64>
+// CHECK-NEXT:    %[[a88:.+]] = arith.mulf %[[a87]], %[[a86]] {fastmathFlags = #llvm.fastmath<none>} : tensor<180xf64>
+// CHECK-NEXT:    %[[a89:.+]] = stablehlo.broadcast_in_dim %[[a88]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a90:.+]] = stablehlo.dynamic_update_slice %[[a24]], %[[a89]], %[[a13]], %[[a10]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    %[[a91:.+]] = arith.mulf %[[a87]], %[[a84]] {fastmathFlags = #llvm.fastmath<none>} : tensor<180xf64>
+// CHECK-NEXT:    %[[a92:.+]] = stablehlo.broadcast_in_dim %[[a91]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a93:.+]] = stablehlo.dynamic_update_slice %[[a90]], %[[a92]], %[[a13]], %[[a9]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    %[[a94:.+]] = arith.mulf %[[a87]], %[[a82]] {fastmathFlags = #llvm.fastmath<none>} : tensor<180xf64>
+// CHECK-NEXT:    %[[a95:.+]] = stablehlo.broadcast_in_dim %[[a94]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a96:.+]] = stablehlo.dynamic_update_slice %[[a93]], %[[a95]], %[[a13]], %[[a8]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    %[[a97:.+]] = arith.mulf %[[a87]], %[[a80]] {fastmathFlags = #llvm.fastmath<none>} : tensor<180xf64>
+// CHECK-NEXT:    %[[a98:.+]] = stablehlo.broadcast_in_dim %[[a97]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a99:.+]] = stablehlo.dynamic_update_slice %[[a96]], %[[a98]], %[[a13]], %[[a7]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    %[[a100:.+]] = arith.mulf %[[a87]], %[[a78]] {fastmathFlags = #llvm.fastmath<none>} : tensor<180xf64>
+// CHECK-NEXT:    %[[a101:.+]] = stablehlo.broadcast_in_dim %[[a100]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a102:.+]] = stablehlo.dynamic_update_slice %[[a99]], %[[a101]], %[[a13]], %[[a6]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    %[[a103:.+]] = arith.mulf %[[a87]], %[[a76]] {fastmathFlags = #llvm.fastmath<none>} : tensor<180xf64>
+// CHECK-NEXT:    %[[a104:.+]] = stablehlo.broadcast_in_dim %[[a103]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a105:.+]] = stablehlo.dynamic_update_slice %[[a102]], %[[a104]], %[[a13]], %[[a5]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    %[[a106:.+]] = arith.mulf %[[a87]], %[[a74]] {fastmathFlags = #llvm.fastmath<none>} : tensor<180xf64>
+// CHECK-NEXT:    %[[a107:.+]] = stablehlo.broadcast_in_dim %[[a106]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a108:.+]] = stablehlo.dynamic_update_slice %[[a105]], %[[a107]], %[[a13]], %[[a4]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    %[[a109:.+]] = arith.mulf %[[a87]], %[[a72]] {fastmathFlags = #llvm.fastmath<none>} : tensor<180xf64>
+// CHECK-NEXT:    %[[a110:.+]] = stablehlo.slice %[[a108]] [0:1, 96:97, 7:187] : (tensor<1x104x194xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a111:.+]] = stablehlo.reshape %[[a110]] : (tensor<1x1x180xf64>) -> tensor<180xf64>
+// CHECK-NEXT:    %[[a112:.+]] = stablehlo.broadcast_in_dim %[[a17]], dims = [] : (tensor<i64>) -> tensor<180xi64>
+// CHECK-NEXT:    %[[a113:.+]] = stablehlo.multiply %[[a20]], %[[a112]] : tensor<180xi64>
+// CHECK-NEXT:    %[[a114:.+]] = stablehlo.broadcast_in_dim %[[a3]], dims = [] : (tensor<i64>) -> tensor<180xi64>
+// CHECK-NEXT:    %[[a115:.+]] = stablehlo.add %[[a113]], %[[a114]] : tensor<180xi64>
+// CHECK-NEXT:    %[[a116:.+]] = stablehlo.compare GE, %[[a115]], %[[a15]] : (tensor<180xi64>, tensor<180xi64>) -> tensor<180xi1>
+// CHECK-NEXT:    %[[a117:.+]] = stablehlo.select %[[a116]], %[[a111]], %[[a109]] : tensor<180xi1>, tensor<180xf64>
+// CHECK-NEXT:    %[[a118:.+]] = stablehlo.broadcast_in_dim %[[a117]], dims = [2] : (tensor<180xf64>) -> tensor<1x1x180xf64>
+// CHECK-NEXT:    %[[a119:.+]] = stablehlo.dynamic_update_slice %[[a108]], %[[a118]], %[[a13]], %[[a2]], %[[a11]] : (tensor<1x104x194xf64>, tensor<1x1x180xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1x104x194xf64>
+// CHECK-NEXT:    return %[[a119]] : tensor<1x104x194xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
The raiser created `stablehlo.reshape`, `broadcast_in_dim`, `transpose`, `concatenate`, `slice` and `dynamic_slice` directly, so raised kernels carried identity reshapes (`tensor<i64> -> tensor<i64>`) and identity broadcasts (`dims = [0]` onto the same shape) that only enzyme-hlo-opt removed later.

Utils already has `ReshapeOpCreate` / `TransposeOpCreate` / `ConcatenateOpCreate` / `SliceOpCreate` / `DynamicSliceOpCreate`, which return the input when the op would be a no-op. This adds `BroadcastInDimOpCreate` next to them (the input when the target shape equals the input's along the identity mapping) and routes every such creation in `AffineToStableHLORaising.cpp` through the helpers: 16 reshapes, 10 broadcasts, 3 transposes, 11 concatenates, 5 slices, 2 dynamic slices.

Test goldens lose the identity ops (18 raising tests; the partial-check ones that named an identity op are now full-line goldens, keeping the `%[[aN:.+]]` named-capture style where the test used it). In the tridiagonal test the re-aligned accumulators now feed the while as its init once the identity reshapes between them are gone.

Part of #2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
