### PR TITLE
EnzymeHLOOpt: an or/and reduction of a constant mask folds

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -772,6 +772,7 @@ static void addConstPropPasses(std::vector<std::string> &list,
   list.push_back("log_plus_one_const_prop<1>");
   list.push_back("is_finite_const_prop");
   list.push_back("not_const_prop");
+  list.push_back("reduce_or_and");
   list.push_back("neg_const_prop");
   list.push_back("sqrt_const_prop");
   list.push_back("rsqrt_const_prop");

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8019,6 +8019,74 @@ struct NoNanSelfSubSimplify
   }
 };
 
+// An or/and reduction of a constant mask is a constant: the raiser's
+// lane masks (a one-hot `tid == 0` guard or-reduced over the lanes) fold
+// to the scalar they always were.
+struct ReduceOrAnd
+    : public CheckedOpRewritePattern<stablehlo::ReduceOp, ReduceOrAnd> {
+  using CheckedOpRewritePattern<stablehlo::ReduceOp,
+                                ReduceOrAnd>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ReduceOp op,
+                                    PatternRewriter &rewriter) const {
+    if (op.getInputs().size() != 1 || op.getInitValues().size() != 1)
+      return failure();
+    auto kind = stablehlo::CheckCommonReduceOp(op).kind;
+    bool isOr = kind == stablehlo::ReduceOpKind::Or;
+    if (!isOr && kind != stablehlo::ReduceOpKind::And)
+      return failure();
+    DenseElementsAttr input, init;
+    if (!matchPattern(op.getInputs()[0], m_Constant(&input)) ||
+        !matchPattern(op.getInitValues()[0], m_Constant(&init)))
+      return failure();
+    auto inTy = cast<RankedTensorType>(input.getType());
+    auto outTy = cast<RankedTensorType>(op.getResult(0).getType());
+    if (!inTy.getElementType().isInteger(1) || !inTy.hasStaticShape() ||
+        !outTy.hasStaticShape())
+      return failure();
+    bool initV = init.getSplatValue<bool>();
+    auto acc = [&](bool a, bool b) { return isOr ? (a || b) : (a && b); };
+
+    DenseElementsAttr result;
+    if (input.isSplat()) {
+      // Every reduced element is the same: the result is a splat too, at
+      // any size.
+      bool v = inTy.getNumElements() > 0
+                   ? acc(initV, input.getSplatValue<bool>())
+                   : initV;
+      result = DenseElementsAttr::get(outTy, v);
+    } else {
+      // Which input dims survive, in order, and the output strides.
+      llvm::SmallDenseSet<int64_t> reduced(op.getDimensions().begin(),
+                                           op.getDimensions().end());
+      SmallVector<int64_t> kept;
+      for (int64_t d = 0; d < inTy.getRank(); ++d)
+        if (!reduced.contains(d))
+          kept.push_back(d);
+      SmallVector<int64_t> outStride(kept.size(), 1);
+      for (int64_t i = (int64_t)kept.size() - 2; i >= 0; --i)
+        outStride[i] = outStride[i + 1] * inTy.getDimSize(kept[i + 1]);
+
+      SmallVector<bool> values(outTy.getNumElements(), initV);
+      SmallVector<int64_t> idx(inTy.getRank(), 0);
+      for (bool v : input.getValues<bool>()) {
+        int64_t o = 0;
+        for (auto [i, d] : llvm::enumerate(kept))
+          o += idx[d] * outStride[i];
+        values[o] = acc(values[o], v);
+        for (int64_t d = inTy.getRank() - 1; d >= 0; --d) {
+          if (++idx[d] < inTy.getDimSize(d))
+            break;
+          idx[d] = 0;
+        }
+      }
+      result = DenseElementsAttr::get(outTy, values);
+    }
+    rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(op, outTy, result);
+    return success();
+  }
+};
+
 struct AndSimplify
     : public CheckedOpRewritePattern<stablehlo::AndOp, AndSimplify> {
   using CheckedOpRewritePattern<stablehlo::AndOp,
@@ -13440,8 +13508,7 @@ struct DUSSliceSimplify final
         });
 
     LLVM_DEBUG(
-        for (auto [idx, operandSize, updateSize]
-             : llvm::zip_equal(
+        for (auto [idx, operandSize, updateSize] : llvm::zip_equal(
                  newDusIndices,
                  cast<RankedTensorType>(preSliceOperand.getType()).getShape(),
                  cast<RankedTensorType>(preSliceUpdate.getType()).getShape())) {
@@ -36816,13 +36883,13 @@ struct EnzymeHLOOptPass
     patterns.add<BitcastConvertCancellation>(context);
 
     patterns.add<
-        AddSimplify, SubSimplify, AndSimplify, MaxSimplify, MinSimplify,
-        OrSimplify, XorSimplify, MulSimplify, DivSimplify, RemSimplify,
-        PowSimplify, NoopSlice, NoopReverse, SliceReverse, SliceSlice,
-        DynamicSliceDynamicSlice, DynamicSliceSlice, SliceDynamicSlice,
-        LogSimplify, ShiftRightLogicalSimplify, NegativePadToSlice,
-        SliceSimplify, ConvertSimplify, TransposeSimplify, DotGeneralSimplify,
-        DotGeneralReshape, DiagonalTensorDotGeneralRewrite,
+        AddSimplify, SubSimplify, AndSimplify, ReduceOrAnd, MaxSimplify,
+        MinSimplify, OrSimplify, XorSimplify, MulSimplify, DivSimplify,
+        RemSimplify, PowSimplify, NoopSlice, NoopReverse, SliceReverse,
+        SliceSlice, DynamicSliceDynamicSlice, DynamicSliceSlice,
+        SliceDynamicSlice, LogSimplify, ShiftRightLogicalSimplify,
+        NegativePadToSlice, SliceSimplify, ConvertSimplify, TransposeSimplify,
+        DotGeneralSimplify, DotGeneralReshape, DiagonalTensorDotGeneralRewrite,
         DynamicSliceToStatic, DynamicUpdateSliceElim, ReduceToReshape,
         BroadcastToReshape, ReshapeEmptyBroadcast, ReshapeBroadcast,
         BroadcastReshape, ConstPropThroughBarrier, ReplaceNegAddWithSubtract,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -61,6 +61,10 @@ def ApplyAndSimplifyPatterns : EnzymeHLOPatternOp<
     "and_simplify"> {
   let patterns = ["AndSimplify"];
 }
+def ApplyReduceOrAndPatterns : EnzymeHLOPatternOp<
+    "reduce_or_and"> {
+  let patterns = ["ReduceOrAnd"];
+}
 def ApplyMaxSimplifyPatterns : EnzymeHLOPatternOp<
     "max_simplify"> {
   let patterns = ["MaxSimplify"];

--- a/test/lit_tests/reduce_or_and.mlir
+++ b/test/lit_tests/reduce_or_and.mlir
@@ -1,0 +1,111 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt --split-input-file | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=reduce_or_and" --transform-interpreter --enzyme-hlo-remove-transform --split-input-file | FileCheck %s --check-prefix=TD
+// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=reduce_or_and" --transform-interpreter --enzyme-hlo-remove-transform --split-input-file %s | FileCheck %s --check-prefix=TD
+
+// A one-hot lane mask or-reduced over the lanes is true; and-reduced it is
+// false.
+func.func @onehot(%a: tensor<16xf64>, %b: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+  %init = stablehlo.constant dense<false> : tensor<i1>
+  %top = stablehlo.constant dense<true> : tensor<i1>
+  %mask = stablehlo.constant dense<[true, false, false, false]> : tensor<4xi1>
+  %any = stablehlo.reduce(%mask init: %init) applies stablehlo.or across dimensions = [0] : (tensor<4xi1>, tensor<i1>) -> tensor<i1>
+  %all = stablehlo.reduce(%mask init: %top) applies stablehlo.and across dimensions = [0] : (tensor<4xi1>, tensor<i1>) -> tensor<i1>
+  %r0 = stablehlo.select %any, %a, %b : tensor<i1>, tensor<16xf64>
+  %r1 = stablehlo.select %all, %a, %b : tensor<i1>, tensor<16xf64>
+  return %r0, %r1 : tensor<16xf64>, tensor<16xf64>
+}
+
+
+
+// CHECK:    func.func @onehot(%arg0: tensor<16xf64>, %arg1: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:    return %arg0, %arg1 : tensor<16xf64>, tensor<16xf64>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @onehot(%arg0: tensor<16xf64>, %arg1: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<i1>
+// TD-NEXT:    %c_0 = stablehlo.constant dense<false> : tensor<i1>
+// TD-NEXT:    %0 = stablehlo.select %c, %arg0, %arg1 : tensor<i1>, tensor<16xf64>
+// TD-NEXT:    %1 = stablehlo.select %c_0, %arg0, %arg1 : tensor<i1>, tensor<16xf64>
+// TD-NEXT:    return %0, %1 : tensor<16xf64>, tensor<16xf64>
+// TD-NEXT:  }
+
+// -----
+
+// Reducing one axis of a 2-D mask keeps the other: rows [true,false] and
+// [false,false] or-reduce over the columns to [true, false].
+func.func @rows() -> tensor<2xi1> {
+  %init = stablehlo.constant dense<false> : tensor<i1>
+  %mask = stablehlo.constant dense<[[true, false, false], [false, false, false]]> : tensor<2x3xi1>
+  %r = stablehlo.reduce(%mask init: %init) applies stablehlo.or across dimensions = [1] : (tensor<2x3xi1>, tensor<i1>) -> tensor<2xi1>
+  return %r : tensor<2xi1>
+}
+
+
+
+// CHECK:    func.func @rows() -> tensor<2xi1> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<[true, false]> : tensor<2xi1>
+// CHECK-NEXT:    return %c : tensor<2xi1>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @rows() -> tensor<2xi1> {
+// TD-NEXT:    %c = stablehlo.constant dense<[true, false]> : tensor<2xi1>
+// TD-NEXT:    return %c : tensor<2xi1>
+// TD-NEXT:  }
+
+// -----
+
+// A splat mask folds through the init: all-false or-reduced with a true
+// init is true; and-reduced with a true init it is false.
+func.func @splat() -> (tensor<i1>, tensor<i1>) {
+  %top = stablehlo.constant dense<true> : tensor<i1>
+  %mask = stablehlo.constant dense<false> : tensor<32xi1>
+  %r0 = stablehlo.reduce(%mask init: %top) applies stablehlo.or across dimensions = [0] : (tensor<32xi1>, tensor<i1>) -> tensor<i1>
+  %r1 = stablehlo.reduce(%mask init: %top) applies stablehlo.and across dimensions = [0] : (tensor<32xi1>, tensor<i1>) -> tensor<i1>
+  return %r0, %r1 : tensor<i1>, tensor<i1>
+}
+
+
+
+// CHECK:    func.func @splat() -> (tensor<i1>, tensor<i1>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<true> : tensor<i1>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<false> : tensor<i1>
+// CHECK-NEXT:    return %c, %c_0 : tensor<i1>, tensor<i1>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @splat() -> (tensor<i1>, tensor<i1>) {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<i1>
+// TD-NEXT:    %c_0 = stablehlo.constant dense<false> : tensor<i1>
+// TD-NEXT:    return %c, %c_0 : tensor<i1>, tensor<i1>
+// TD-NEXT:  }
+
+// -----
+
+// A splat mask folds to a splat without materializing its elements, so
+// its size does not matter.
+func.func @hugesplat() -> (tensor<i1>, tensor<4096xi1>) {
+  %f = stablehlo.constant dense<false> : tensor<i1>
+  %mask = stablehlo.constant dense<true> : tensor<1073741824xi1>
+  %r0 = stablehlo.reduce(%mask init: %f) applies stablehlo.or across dimensions = [0] : (tensor<1073741824xi1>, tensor<i1>) -> tensor<i1>
+  %t = stablehlo.constant dense<true> : tensor<i1>
+  %mask2 = stablehlo.constant dense<true> : tensor<4096x1048576xi1>
+  %r1 = stablehlo.reduce(%mask2 init: %t) applies stablehlo.and across dimensions = [1] : (tensor<4096x1048576xi1>, tensor<i1>) -> tensor<4096xi1>
+  return %r0, %r1 : tensor<i1>, tensor<4096xi1>
+}
+
+
+
+// CHECK:    func.func @hugesplat() -> (tensor<i1>, tensor<4096xi1>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<true> : tensor<i1>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<true> : tensor<4096xi1>
+// CHECK-NEXT:    return %c, %c_0 : tensor<i1>, tensor<4096xi1>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @hugesplat() -> (tensor<i1>, tensor<4096xi1>) {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<i1>
+// TD-NEXT:    %c_0 = stablehlo.constant dense<true> : tensor<4096xi1>
+// TD-NEXT:    return %c, %c_0 : tensor<i1>, tensor<4096xi1>
+// TD-NEXT:  }

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -384,6 +384,7 @@ slice_elementwise<1>;
 slice_pad<1>;
 dot_reshape_dot<1>;
 concat_const_prop<1>(1024);
+reduce_or_and;
 concat_fuse<1>;
 pad_reshape_pad<1>;
 pad_pad<1>;


### PR DESCRIPTION
#2960 or-reduces a store's lane mask over the axes the store does not index; after the iota compare folds, that mask is a constant one-hot (`dense<[true, false, false, ...]>`) and enzyme-hlo-opt left the `stablehlo.reduce ... applies stablehlo.or` over it in place (visible in #2960's `--enzyme-hlo-opt` goldens).

`ReduceOrAnd`: an or/and reduce whose operand and init are constants folds to the reduced constant, over any subset of axes; a splat mask folds to a splat of the result type without materializing its elements, so its size does not matter. The select behind the mask then folds with it.

Per DEVDOCS: registered as the `reduce_or_and` transform op (`TransformOps.td`), added to `addConstPropPasses` in `EnzymeXLA.cpp` next to `not_const_prop`, and to the pattern list in `test/test_utils.py`.

Test: the one-hot case from #2960, a 2-D reduction keeping one axis, splat masks through a true init, and 2^30- and 4096×2^20-element splats; a second RUN line drives the pattern alone through `--enzyme-hlo-generate-td="patterns=reduce_or_and" --transform-interpreter` (`TD:` goldens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
