### PR TITLE
EnzymeHLOOpt: a masked pick reduce over a pad with a guaranteed-true lane is a slice

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -569,6 +569,7 @@ static void addBaseTransformPasses(std::vector<std::string> &list,
   list.push_back("multiply_negated_operands_simplify");
   list.push_back("factor_scalars_in_dot_general");
   list.push_back("reduce_mul_to_dot_general");
+  list.push_back("one_hot_masked_reduce");
   list.push_back("dot_general_broadcast_in_dim");
   list.push_back("dot_general_broadcast_in_dim_sort_dims");
   list.push_back("dus_dynamic_slice_simplify");

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8087,6 +8087,129 @@ struct ReduceOrAnd
   }
 };
 
+// An index along `dims` at which a pad-shaped mask is true for every
+// position outside `dims`, if one is guaranteed: either the padding value
+// is true and every reduced dim is padded (a padded index), or the operand
+// is all true (its first index) and the other dims are unpadded or padded
+// with true. Pads with negative or interior padding are left alone.
+static std::optional<SmallVector<int64_t>>
+padTrueIndexAlongDims(Value mask, ArrayRef<int64_t> dims) {
+  auto pad = mask.getDefiningOp<stablehlo::PadOp>();
+  if (!pad || dims.empty())
+    return std::nullopt;
+  auto maskTy = cast<RankedTensorType>(mask.getType());
+  if (!maskTy.hasStaticShape() || !maskTy.getElementType().isInteger(1))
+    return std::nullopt;
+  auto opTy = cast<RankedTensorType>(pad.getOperand().getType());
+  for (int64_t d = 0; d < maskTy.getRank(); ++d)
+    if (pad.getInteriorPadding()[d] != 0 || pad.getEdgePaddingLow()[d] < 0 ||
+        pad.getEdgePaddingHigh()[d] < 0)
+      return std::nullopt;
+  bool padTrue = matchPattern(pad.getPaddingValue(), m_One());
+  SmallVector<int64_t> idx;
+  // A padded index along every reduced dim: true whatever the operand.
+  if (padTrue) {
+    bool ok = true;
+    for (int64_t d : dims) {
+      if (pad.getEdgePaddingLow()[d] > 0)
+        idx.push_back(0);
+      else if (pad.getEdgePaddingHigh()[d] > 0)
+        idx.push_back(opTy.getDimSize(d));
+      else
+        ok = false;
+    }
+    if (ok)
+      return idx;
+    idx.clear();
+  }
+  // The operand's first index along every reduced dim: true if the operand
+  // is all true and the other dims never read the (false) padding.
+  if (!matchPattern(pad.getOperand(), m_One()))
+    return std::nullopt;
+  for (int64_t d = 0; d < maskTy.getRank(); ++d) {
+    if (llvm::is_contained(dims, d)) {
+      if (opTy.getDimSize(d) < 1)
+        return std::nullopt;
+      idx.push_back(pad.getEdgePaddingLow()[d]);
+    } else if (!padTrue && (pad.getEdgePaddingLow()[d] != 0 ||
+                            pad.getEdgePaddingHigh()[d] != 0)) {
+      return std::nullopt;
+    }
+  }
+  return idx;
+}
+
+// The raiser picks one lane's value out of a reduced axis with a
+// (value, mask) reduce whose body is select(mask, new, acc) / or(mask, acc);
+// which of several live lanes wins is unspecified (the reduction order is).
+// When the mask is a pad with an index that is guaranteed true, the pick is
+// the slice at that index and the reduced mask is true.
+struct OneHotMaskedReduce
+    : public CheckedOpRewritePattern<stablehlo::ReduceOp, OneHotMaskedReduce> {
+  using CheckedOpRewritePattern<stablehlo::ReduceOp,
+                                OneHotMaskedReduce>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ReduceOp op,
+                                    PatternRewriter &rewriter) const {
+    if (op.getInputs().size() != 2 || op.getInitValues().size() != 2)
+      return failure();
+    Block &body = op.getBody().front();
+    if (body.getNumArguments() != 4)
+      return failure();
+    auto ret = dyn_cast<stablehlo::ReturnOp>(body.getTerminator());
+    if (!ret || ret.getNumOperands() != 2)
+      return failure();
+    // Block args: (acc value, acc mask, new value, new mask) in either
+    // role; the select must be keyed on one mask arg and pick that side's
+    // value, and the or must join the two mask args.
+    Value accV = body.getArgument(0), accM = body.getArgument(1),
+          newV = body.getArgument(2), newM = body.getArgument(3);
+    auto sel = ret.getOperand(0).getDefiningOp<stablehlo::SelectOp>();
+    auto orOp = ret.getOperand(1).getDefiningOp<stablehlo::OrOp>();
+    if (!sel || !orOp)
+      return failure();
+    if (!((orOp.getLhs() == accM && orOp.getRhs() == newM) ||
+          (orOp.getLhs() == newM && orOp.getRhs() == accM)))
+      return failure();
+    bool keyedOnNew = sel.getPred() == newM && sel.getOnTrue() == newV &&
+                      sel.getOnFalse() == accV;
+    bool keyedOnAcc = sel.getPred() == accM && sel.getOnTrue() == accV &&
+                      sel.getOnFalse() == newV;
+    if (!keyedOnNew && !keyedOnAcc)
+      return failure();
+    if (!matchPattern(op.getInitValues()[1], m_Zero()))
+      return failure();
+
+    SmallVector<int64_t> dims(op.getDimensions().begin(),
+                              op.getDimensions().end());
+    auto idx = padTrueIndexAlongDims(op.getInputs()[1], dims);
+    if (!idx)
+      return failure();
+
+    Value values = op.getInputs()[0];
+    auto valTy = cast<RankedTensorType>(values.getType());
+    if (!valTy.hasStaticShape())
+      return failure();
+    SmallVector<int64_t> starts(valTy.getRank(), 0), limits(valTy.getShape()),
+        strides(valTy.getRank(), 1);
+    for (auto [i, d] : llvm::enumerate(dims)) {
+      starts[d] = (*idx)[i];
+      limits[d] = (*idx)[i] + 1;
+    }
+    auto outTy = cast<RankedTensorType>(op.getResult(0).getType());
+    Value picked = stablehlo::SliceOpCreate(rewriter, op.getLoc(), values,
+                                            starts, limits, strides);
+    picked = stablehlo::ReshapeOpCreate(rewriter, op.getLoc(), picked,
+                                        outTy.getShape());
+    auto maskOutTy = cast<RankedTensorType>(op.getResult(1).getType());
+    Value anyTrue =
+        stablehlo::ConstantOp::create(rewriter, op.getLoc(), maskOutTy,
+                                      DenseElementsAttr::get(maskOutTy, true));
+    rewriter.replaceOp(op, {picked, anyTrue});
+    return success();
+  }
+};
+
 struct AndSimplify
     : public CheckedOpRewritePattern<stablehlo::AndOp, AndSimplify> {
   using CheckedOpRewritePattern<stablehlo::AndOp,
@@ -36883,10 +37006,10 @@ struct EnzymeHLOOptPass
     patterns.add<BitcastConvertCancellation>(context);
 
     patterns.add<
-        AddSimplify, SubSimplify, AndSimplify, ReduceOrAnd, MaxSimplify,
-        MinSimplify, OrSimplify, XorSimplify, MulSimplify, DivSimplify,
-        RemSimplify, PowSimplify, NoopSlice, NoopReverse, SliceReverse,
-        SliceSlice, DynamicSliceDynamicSlice, DynamicSliceSlice,
+        AddSimplify, SubSimplify, AndSimplify, OneHotMaskedReduce, ReduceOrAnd,
+        MaxSimplify, MinSimplify, OrSimplify, XorSimplify, MulSimplify,
+        DivSimplify, RemSimplify, PowSimplify, NoopSlice, NoopReverse,
+        SliceReverse, SliceSlice, DynamicSliceDynamicSlice, DynamicSliceSlice,
         SliceDynamicSlice, LogSimplify, ShiftRightLogicalSimplify,
         NegativePadToSlice, SliceSimplify, ConvertSimplify, TransposeSimplify,
         DotGeneralSimplify, DotGeneralReshape, DiagonalTensorDotGeneralRewrite,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -61,6 +61,10 @@ def ApplyAndSimplifyPatterns : EnzymeHLOPatternOp<
     "and_simplify"> {
   let patterns = ["AndSimplify"];
 }
+def ApplyOneHotMaskedReducePatterns : EnzymeHLOPatternOp<
+    "one_hot_masked_reduce"> {
+  let patterns = ["OneHotMaskedReduce"];
+}
 def ApplyReduceOrAndPatterns : EnzymeHLOPatternOp<
     "reduce_or_and"> {
   let patterns = ["ReduceOrAnd"];

--- a/test/lit_tests/one_hot_masked_reduce.mlir
+++ b/test/lit_tests/one_hot_masked_reduce.mlir
@@ -1,0 +1,150 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt --split-input-file | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=one_hot_masked_reduce" --transform-interpreter --enzyme-hlo-remove-transform --split-input-file | FileCheck %s --check-prefix=TD
+// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=one_hot_masked_reduce" --transform-interpreter --enzyme-hlo-remove-transform --split-input-file %s | FileCheck %s --check-prefix=TD
+
+// The raiser's lane-0 pick at scale: a (value, mask) reduce over the lane
+// axis whose mask is a pad of an all-true row, i.e. one-hot at lane 0. The
+// pick is the lane-0 slice of the values, folded through the transpose.
+func.func @lane0_large(%arg1: tensor<1048576xf64>) -> tensor<4096xf64> {
+  %c = stablehlo.constant dense<true> : tensor<1x4096xi1>
+  %c_0 = stablehlo.constant dense<false> : tensor<i1>
+  %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+  %0 = stablehlo.reshape %arg1 : (tensor<1048576xf64>) -> tensor<4096x256xf64>
+  %1 = stablehlo.pad %c, %c_0, low = [0, 0], high = [255, 0], interior = [0, 0] : (tensor<1x4096xi1>, tensor<i1>) -> tensor<256x4096xi1>
+  %2 = stablehlo.transpose %0, dims = [1, 0] : (tensor<4096x256xf64>) -> tensor<256x4096xf64>
+  %3:2 = stablehlo.reduce(%2 init: %cst), (%1 init: %c_0) across dimensions = [0] : (tensor<256x4096xf64>, tensor<256x4096xi1>, tensor<f64>, tensor<i1>) -> (tensor<4096xf64>, tensor<4096xi1>)
+   reducer(%arg2: tensor<f64>, %arg4: tensor<f64>) (%arg3: tensor<i1>, %arg5: tensor<i1>)  {
+    %4 = stablehlo.select %arg3, %arg2, %arg4 : tensor<i1>, tensor<f64>
+    %5 = stablehlo.or %arg3, %arg5 : tensor<i1>
+    stablehlo.return %4, %5 : tensor<f64>, tensor<i1>
+  }
+  return %3#0 : tensor<4096xf64>
+}
+
+// CHECK:    func.func @lane0_large(%arg0: tensor<1048576xf64>) -> tensor<4096xf64> {
+// CHECK-NEXT:    %0 = stablehlo.reshape %arg0 : (tensor<1048576xf64>) -> tensor<4096x256xf64>
+// CHECK-NEXT:    %1 = stablehlo.slice %0 [0:4096, 0:1] : (tensor<4096x256xf64>) -> tensor<4096x1xf64>
+// CHECK-NEXT:    %2 = stablehlo.reshape %1 : (tensor<4096x1xf64>) -> tensor<4096xf64>
+// CHECK-NEXT:    return %2 : tensor<4096xf64>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @lane0_large(%arg0: tensor<1048576xf64>) -> tensor<4096xf64> {
+// TD-NEXT:    %0 = stablehlo.reshape %arg0 : (tensor<1048576xf64>) -> tensor<4096x256xf64>
+// TD-NEXT:    %1 = stablehlo.transpose %0, dims = [1, 0] : (tensor<4096x256xf64>) -> tensor<256x4096xf64>
+// TD-NEXT:    %2 = stablehlo.slice %1 [0:1, 0:4096] : (tensor<256x4096xf64>) -> tensor<1x4096xf64>
+// TD-NEXT:    %3 = stablehlo.reshape %2 : (tensor<1x4096xf64>) -> tensor<4096xf64>
+// TD-NEXT:    return %3 : tensor<4096xf64>
+// TD-NEXT:  }
+
+// -----
+
+// A lane other than 0 (pad low = 3), and the mask result feeding a select.
+func.func @lane3(%v: tensor<8x16xf64>, %a: tensor<16xf64>, %b: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+  %c = stablehlo.constant dense<true> : tensor<1x16xi1>
+  %f = stablehlo.constant dense<false> : tensor<i1>
+  %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+  %m = stablehlo.pad %c, %f, low = [3, 0], high = [4, 0], interior = [0, 0] : (tensor<1x16xi1>, tensor<i1>) -> tensor<8x16xi1>
+  %r:2 = stablehlo.reduce(%v init: %cst), (%m init: %f) across dimensions = [0] : (tensor<8x16xf64>, tensor<8x16xi1>, tensor<f64>, tensor<i1>) -> (tensor<16xf64>, tensor<16xi1>)
+   reducer(%arg2: tensor<f64>, %arg4: tensor<f64>) (%arg3: tensor<i1>, %arg5: tensor<i1>)  {
+    %4 = stablehlo.select %arg3, %arg2, %arg4 : tensor<i1>, tensor<f64>
+    %5 = stablehlo.or %arg3, %arg5 : tensor<i1>
+    stablehlo.return %4, %5 : tensor<f64>, tensor<i1>
+  }
+  %s = stablehlo.select %r#1, %a, %b : tensor<16xi1>, tensor<16xf64>
+  return %r#0, %s : tensor<16xf64>, tensor<16xf64>
+}
+
+// CHECK:    func.func @lane3(%arg0: tensor<8x16xf64>, %arg1: tensor<16xf64>, %arg2: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [3:4, 0:16] : (tensor<8x16xf64>) -> tensor<1x16xf64>
+// CHECK-NEXT:    %1 = stablehlo.reshape %0 : (tensor<1x16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:    return %1, %arg1 : tensor<16xf64>, tensor<16xf64>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @lane3(%arg0: tensor<8x16xf64>, %arg1: tensor<16xf64>, %arg2: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<16xi1>
+// TD-NEXT:    %0 = stablehlo.slice %arg0 [3:4, 0:16] : (tensor<8x16xf64>) -> tensor<1x16xf64>
+// TD-NEXT:    %1 = stablehlo.reshape %0 : (tensor<1x16xf64>) -> tensor<16xf64>
+// TD-NEXT:    %2 = stablehlo.select %c, %arg1, %arg2 : tensor<16xi1>, tensor<16xf64>
+// TD-NEXT:    return %1, %2 : tensor<16xf64>, tensor<16xf64>
+// TD-NEXT:  }
+
+// -----
+
+// Padding with true: whatever the operand mask holds, lane 0 is padded true,
+// so the pick is lane 0 and the reduced mask is true.
+func.func @padtrue(%v: tensor<8x16xf64>, %m0: tensor<5x16xi1>) -> (tensor<16xf64>, tensor<16xi1>) {
+  %t = stablehlo.constant dense<true> : tensor<i1>
+  %f = stablehlo.constant dense<false> : tensor<i1>
+  %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+  %m = stablehlo.pad %m0, %t, low = [2, 0], high = [1, 0], interior = [0, 0] : (tensor<5x16xi1>, tensor<i1>) -> tensor<8x16xi1>
+  %r:2 = stablehlo.reduce(%v init: %cst), (%m init: %f) across dimensions = [0] : (tensor<8x16xf64>, tensor<8x16xi1>, tensor<f64>, tensor<i1>) -> (tensor<16xf64>, tensor<16xi1>)
+   reducer(%arg2: tensor<f64>, %arg4: tensor<f64>) (%arg3: tensor<i1>, %arg5: tensor<i1>)  {
+    %4 = stablehlo.select %arg3, %arg2, %arg4 : tensor<i1>, tensor<f64>
+    %5 = stablehlo.or %arg3, %arg5 : tensor<i1>
+    stablehlo.return %4, %5 : tensor<f64>, tensor<i1>
+  }
+  return %r#0, %r#1 : tensor<16xf64>, tensor<16xi1>
+}
+
+// CHECK:    func.func @padtrue(%arg0: tensor<8x16xf64>, %arg1: tensor<5x16xi1>) -> (tensor<16xf64>, tensor<16xi1>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<true> : tensor<16xi1>
+// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [0:1, 0:16] : (tensor<8x16xf64>) -> tensor<1x16xf64>
+// CHECK-NEXT:    %1 = stablehlo.reshape %0 : (tensor<1x16xf64>) -> tensor<16xf64>
+// CHECK-NEXT:    return %1, %c : tensor<16xf64>, tensor<16xi1>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @padtrue(%arg0: tensor<8x16xf64>, %arg1: tensor<5x16xi1>) -> (tensor<16xf64>, tensor<16xi1>) {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<16xi1>
+// TD-NEXT:    %0 = stablehlo.slice %arg0 [0:1, 0:16] : (tensor<8x16xf64>) -> tensor<1x16xf64>
+// TD-NEXT:    %1 = stablehlo.reshape %0 : (tensor<1x16xf64>) -> tensor<16xf64>
+// TD-NEXT:    return %1, %c : tensor<16xf64>, tensor<16xi1>
+// TD-NEXT:  }
+
+// -----
+
+// An all-true operand padded with false along a kept axis: the padded
+// columns see no true lane, so the pick stays.
+func.func @falsecols(%v: tensor<8x16xf64>) -> tensor<16xf64> {
+  %c = stablehlo.constant dense<true> : tensor<1x12xi1>
+  %f = stablehlo.constant dense<false> : tensor<i1>
+  %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+  %m = stablehlo.pad %c, %f, low = [3, 2], high = [4, 2], interior = [0, 0] : (tensor<1x12xi1>, tensor<i1>) -> tensor<8x16xi1>
+  %r:2 = stablehlo.reduce(%v init: %cst), (%m init: %f) across dimensions = [0] : (tensor<8x16xf64>, tensor<8x16xi1>, tensor<f64>, tensor<i1>) -> (tensor<16xf64>, tensor<16xi1>)
+   reducer(%arg2: tensor<f64>, %arg4: tensor<f64>) (%arg3: tensor<i1>, %arg5: tensor<i1>)  {
+    %4 = stablehlo.select %arg3, %arg2, %arg4 : tensor<i1>, tensor<f64>
+    %5 = stablehlo.or %arg3, %arg5 : tensor<i1>
+    stablehlo.return %4, %5 : tensor<f64>, tensor<i1>
+  }
+  return %r#0 : tensor<16xf64>
+}
+
+// CHECK:    func.func @falsecols(%arg0: tensor<8x16xf64>) -> tensor<16xf64> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<false> : tensor<i1>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<"0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010101010101010101010101000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"> : tensor<8x16xi1>
+// CHECK-NEXT:    %0:2 = stablehlo.reduce(%arg0 init: %cst), (%c_0 init: %c) across dimensions = [0] : (tensor<8x16xf64>, tensor<8x16xi1>, tensor<f64>, tensor<i1>) -> (tensor<16xf64>, tensor<16xi1>)
+// CHECK-NEXT:     reducer(%arg1: tensor<f64>, %arg3: tensor<f64>) (%arg2: tensor<i1>, %arg4: tensor<i1>)  {
+// CHECK-NEXT:      %1 = stablehlo.select %arg2, %arg1, %arg3 : tensor<i1>, tensor<f64>
+// CHECK-NEXT:      %2 = stablehlo.or %arg2, %arg4 : tensor<i1>
+// CHECK-NEXT:      stablehlo.return %1, %2 : tensor<f64>, tensor<i1>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %0#0 : tensor<16xf64>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @falsecols(%arg0: tensor<8x16xf64>) -> tensor<16xf64> {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<1x12xi1>
+// TD-NEXT:    %c_0 = stablehlo.constant dense<false> : tensor<i1>
+// TD-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// TD-NEXT:    %0 = stablehlo.pad %c, %c_0, low = [3, 2], high = [4, 2], interior = [0, 0] : (tensor<1x12xi1>, tensor<i1>) -> tensor<8x16xi1>
+// TD-NEXT:    %1:2 = stablehlo.reduce(%arg0 init: %cst), (%0 init: %c_0) across dimensions = [0] : (tensor<8x16xf64>, tensor<8x16xi1>, tensor<f64>, tensor<i1>) -> (tensor<16xf64>, tensor<16xi1>)
+// TD-NEXT:     reducer(%arg1: tensor<f64>, %arg3: tensor<f64>) (%arg2: tensor<i1>, %arg4: tensor<i1>)  {
+// TD-NEXT:      %2 = stablehlo.select %arg2, %arg1, %arg3 : tensor<i1>, tensor<f64>
+// TD-NEXT:      %3 = stablehlo.or %arg2, %arg4 : tensor<i1>
+// TD-NEXT:      stablehlo.return %2, %3 : tensor<f64>, tensor<i1>
+// TD-NEXT:    }
+// TD-NEXT:    return %1#0 : tensor<16xf64>
+// TD-NEXT:  }

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -355,6 +355,7 @@ select_op_canon<16>(1024);
 add_simplify<16>;
 sub_simplify<16>;
 and_simplify<16>;
+one_hot_masked_reduce;
 max_simplify<16>;
 min_simplify<16>;
 or_simplify<16>;


### PR DESCRIPTION
Follow-up to #2960's large case. The raiser picks one lane's value out of a reduced axis (a `tid == 0` broadcast store) with a `(value, mask)` `stablehlo.reduce` whose body is `select(mask, new, acc)` / `or(mask, acc)`. After #3137 the pure mask reduce folds, but the value pick stayed a full reduction: at 4096 × 256 it reduced a padded `256x4096xi1` mask against a transposed copy of the input.

Which of several live lanes such a pick returns is unspecified (it is the reduction order), so any lane guaranteed live may be returned. `OneHotMaskedReduce`: when the mask operand is a `stablehlo.pad` with a lane that is guaranteed true for every kept position, the pick is the slice at that lane (reshaped to the result shape) and the reduced mask is `true`. A lane is guaranteed true either because the padding value is true and every reduced dim is padded (a padded index), or because the operand is all true and the kept dims are unpadded or padded with true (the operand's first index). Negative or interior padding is left alone. The slice then folds through the transpose with the existing patterns, so the large case becomes

```
%0 = stablehlo.reshape %arg0 : (tensor<1048576xf64>) -> tensor<4096x256xf64>
%1 = stablehlo.slice %0 [0:4096, 0:1] : (tensor<4096x256xf64>) -> tensor<4096x1xf64>
%2 = stablehlo.reshape %1 : (tensor<4096x1xf64>) -> tensor<4096xf64>
```

Per DEVDOCS: registered as the `one_hot_masked_reduce` transform op, added to the pass list in `EnzymeXLA.cpp` and to `test/test_utils.py`. Test: the exact optimized form of #2960's `lane0_large`, a lane-3 pad with the mask result feeding a select, a true-padded mask over an arbitrary operand, and an all-true operand false-padded along the kept axis that must not fold; a second RUN line drives the pattern alone through the transform interpreter (`TD:` goldens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
