### PR TITLE
EnzymeHLOOpt: an or/and reduce over a pad guaranteed to hold the absorbing value folds

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -383,6 +383,7 @@ static void addBaseTransformPasses(std::vector<std::string> &list,
   list.push_back("add_simplify<16>");
   list.push_back("sub_simplify<16>");
   list.push_back("and_simplify<16>");
+  list.push_back("reduce_or_and_pad");
   list.push_back("max_simplify<16>");
   list.push_back("min_simplify<16>");
   list.push_back("or_simplify<16>");

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -8087,6 +8087,79 @@ struct ReduceOrAnd
   }
 };
 
+// Whether a pad-shaped mask is guaranteed to hold `v` at some index along
+// `dims` for every position outside `dims`: either the padding value is v
+// and every reduced dim is padded, or the operand is a splat of v and the
+// other dims are unpadded or padded with v. Negative and interior padding
+// are left alone.
+static bool padHoldsAlongDims(stablehlo::PadOp pad, ArrayRef<int64_t> dims,
+                              bool v) {
+  auto maskTy = cast<RankedTensorType>(pad.getType());
+  if (!maskTy.hasStaticShape() || dims.empty())
+    return false;
+  for (int64_t d = 0; d < maskTy.getRank(); ++d)
+    if (pad.getInteriorPadding()[d] != 0 || pad.getEdgePaddingLow()[d] < 0 ||
+        pad.getEdgePaddingHigh()[d] < 0)
+      return false;
+  auto is = [&](Value x) {
+    return v ? matchPattern(x, m_One()) : matchPattern(x, m_Zero());
+  };
+  bool padIsV = is(pad.getPaddingValue());
+  if (padIsV && llvm::all_of(dims, [&](int64_t d) {
+        return pad.getEdgePaddingLow()[d] > 0 ||
+               pad.getEdgePaddingHigh()[d] > 0;
+      }))
+    return true;
+  if (!is(pad.getOperand()))
+    return false;
+  auto opTy = cast<RankedTensorType>(pad.getOperand().getType());
+  for (int64_t d = 0; d < maskTy.getRank(); ++d) {
+    if (llvm::is_contained(dims, d)) {
+      if (opTy.getDimSize(d) < 1)
+        return false;
+    } else if (!padIsV && (pad.getEdgePaddingLow()[d] != 0 ||
+                           pad.getEdgePaddingHigh()[d] != 0)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// An or-reduce over a pad that is guaranteed true somewhere along the
+// reduced axes is true (and an and-reduce over one guaranteed false is
+// false) at any size: the raiser's lane guard (`tid == 0`, a pad of an
+// all-true row once its compare folds) or-reduced over the lanes.
+struct ReduceOrAndPad
+    : public CheckedOpRewritePattern<stablehlo::ReduceOp, ReduceOrAndPad> {
+  using CheckedOpRewritePattern<stablehlo::ReduceOp,
+                                ReduceOrAndPad>::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ReduceOp op,
+                                    PatternRewriter &rewriter) const {
+    if (op.getInputs().size() != 1 || op.getInitValues().size() != 1)
+      return failure();
+    auto kind = stablehlo::CheckCommonReduceOp(op).kind;
+    bool isOr = kind == stablehlo::ReduceOpKind::Or;
+    if (!isOr && kind != stablehlo::ReduceOpKind::And)
+      return failure();
+    auto pad = op.getInputs()[0].getDefiningOp<stablehlo::PadOp>();
+    if (!pad ||
+        !cast<RankedTensorType>(pad.getType()).getElementType().isInteger(1))
+      return failure();
+    SmallVector<int64_t> dims(op.getDimensions().begin(),
+                              op.getDimensions().end());
+    // or absorbs a true, and absorbs a false, whatever the init.
+    if (!padHoldsAlongDims(pad, dims, isOr))
+      return failure();
+    auto outTy = cast<RankedTensorType>(op.getResult(0).getType());
+    if (!outTy.hasStaticShape())
+      return failure();
+    rewriter.replaceOpWithNewOp<stablehlo::ConstantOp>(
+        op, outTy, DenseElementsAttr::get(outTy, isOr));
+    return success();
+  }
+};
+
 struct AndSimplify
     : public CheckedOpRewritePattern<stablehlo::AndOp, AndSimplify> {
   using CheckedOpRewritePattern<stablehlo::AndOp,
@@ -36883,10 +36956,10 @@ struct EnzymeHLOOptPass
     patterns.add<BitcastConvertCancellation>(context);
 
     patterns.add<
-        AddSimplify, SubSimplify, AndSimplify, ReduceOrAnd, MaxSimplify,
-        MinSimplify, OrSimplify, XorSimplify, MulSimplify, DivSimplify,
-        RemSimplify, PowSimplify, NoopSlice, NoopReverse, SliceReverse,
-        SliceSlice, DynamicSliceDynamicSlice, DynamicSliceSlice,
+        AddSimplify, SubSimplify, AndSimplify, ReduceOrAndPad, ReduceOrAnd,
+        MaxSimplify, MinSimplify, OrSimplify, XorSimplify, MulSimplify,
+        DivSimplify, RemSimplify, PowSimplify, NoopSlice, NoopReverse,
+        SliceReverse, SliceSlice, DynamicSliceDynamicSlice, DynamicSliceSlice,
         SliceDynamicSlice, LogSimplify, ShiftRightLogicalSimplify,
         NegativePadToSlice, SliceSimplify, ConvertSimplify, TransposeSimplify,
         DotGeneralSimplify, DotGeneralReshape, DiagonalTensorDotGeneralRewrite,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -61,6 +61,10 @@ def ApplyAndSimplifyPatterns : EnzymeHLOPatternOp<
     "and_simplify"> {
   let patterns = ["AndSimplify"];
 }
+def ApplyReduceOrAndPadPatterns : EnzymeHLOPatternOp<
+    "reduce_or_and_pad"> {
+  let patterns = ["ReduceOrAndPad"];
+}
 def ApplyReduceOrAndPatterns : EnzymeHLOPatternOp<
     "reduce_or_and"> {
   let patterns = ["ReduceOrAnd"];

--- a/test/lit_tests/reduce_or_and_pad.mlir
+++ b/test/lit_tests/reduce_or_and_pad.mlir
@@ -1,0 +1,86 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt --split-input-file | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=reduce_or_and_pad" --transform-interpreter --enzyme-hlo-remove-transform --split-input-file | FileCheck %s --check-prefix=TD
+// RUN: enzymexlamlir-opt --enzyme-hlo-generate-td="patterns=reduce_or_and_pad" --transform-interpreter --enzyme-hlo-remove-transform --split-input-file %s | FileCheck %s --check-prefix=TD
+
+// The raiser's lane guard at scale: an all-true row padded with false over
+// 256 lanes, or-reduced over the lanes. Too large to constant-fold, it is
+// still true everywhere: the operand row is true and the columns are
+// unpadded.
+func.func @lane0_large(%a: tensor<4096xf64>, %b: tensor<4096xf64>) -> tensor<4096xf64> {
+  %c = stablehlo.constant dense<true> : tensor<1x4096xi1>
+  %f = stablehlo.constant dense<false> : tensor<i1>
+  %m = stablehlo.pad %c, %f, low = [0, 0], high = [255, 0], interior = [0, 0] : (tensor<1x4096xi1>, tensor<i1>) -> tensor<256x4096xi1>
+  %r = stablehlo.reduce(%m init: %f) applies stablehlo.or across dimensions = [0] : (tensor<256x4096xi1>, tensor<i1>) -> tensor<4096xi1>
+  %s = stablehlo.select %r, %a, %b : tensor<4096xi1>, tensor<4096xf64>
+  return %s : tensor<4096xf64>
+}
+
+// CHECK:    func.func @lane0_large(%arg0: tensor<4096xf64>, %arg1: tensor<4096xf64>) -> tensor<4096xf64> {
+// CHECK-NEXT:    return %arg0 : tensor<4096xf64>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @lane0_large(%arg0: tensor<4096xf64>, %arg1: tensor<4096xf64>) -> tensor<4096xf64> {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<4096xi1>
+// TD-NEXT:    %0 = stablehlo.select %c, %arg0, %arg1 : tensor<4096xi1>, tensor<4096xf64>
+// TD-NEXT:    return %0 : tensor<4096xf64>
+// TD-NEXT:  }
+
+// -----
+
+// Padding with true along the reduced axis makes the or true whatever the
+// operand holds; an and over a pad with false padding is false likewise.
+func.func @padvalue(%m0: tensor<5x4096xi1>, %m1: tensor<5x4096xi1>) -> (tensor<4096xi1>, tensor<4096xi1>) {
+  %t = stablehlo.constant dense<true> : tensor<i1>
+  %f = stablehlo.constant dense<false> : tensor<i1>
+  %mo = stablehlo.pad %m0, %t, low = [2, 0], high = [249, 0], interior = [0, 0] : (tensor<5x4096xi1>, tensor<i1>) -> tensor<256x4096xi1>
+  %r0 = stablehlo.reduce(%mo init: %f) applies stablehlo.or across dimensions = [0] : (tensor<256x4096xi1>, tensor<i1>) -> tensor<4096xi1>
+  %ma = stablehlo.pad %m1, %f, low = [0, 0], high = [251, 0], interior = [0, 0] : (tensor<5x4096xi1>, tensor<i1>) -> tensor<256x4096xi1>
+  %r1 = stablehlo.reduce(%ma init: %t) applies stablehlo.and across dimensions = [0] : (tensor<256x4096xi1>, tensor<i1>) -> tensor<4096xi1>
+  return %r0, %r1 : tensor<4096xi1>, tensor<4096xi1>
+}
+
+// CHECK:    func.func @padvalue(%arg0: tensor<5x4096xi1>, %arg1: tensor<5x4096xi1>) -> (tensor<4096xi1>, tensor<4096xi1>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<true> : tensor<4096xi1>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<false> : tensor<4096xi1>
+// CHECK-NEXT:    return %c, %c_0 : tensor<4096xi1>, tensor<4096xi1>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @padvalue(%arg0: tensor<5x4096xi1>, %arg1: tensor<5x4096xi1>) -> (tensor<4096xi1>, tensor<4096xi1>) {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<4096xi1>
+// TD-NEXT:    %c_0 = stablehlo.constant dense<false> : tensor<4096xi1>
+// TD-NEXT:    return %c, %c_0 : tensor<4096xi1>, tensor<4096xi1>
+// TD-NEXT:  }
+
+// -----
+
+// An all-true operand padded with false along a kept axis: the padded
+// columns hold no true, so the or stays.
+func.func @falsecols(%a: tensor<4096xf64>, %b: tensor<4096xf64>) -> tensor<4096xf64> {
+  %c = stablehlo.constant dense<true> : tensor<1x4000xi1>
+  %f = stablehlo.constant dense<false> : tensor<i1>
+  %m = stablehlo.pad %c, %f, low = [0, 48], high = [255, 48], interior = [0, 0] : (tensor<1x4000xi1>, tensor<i1>) -> tensor<256x4096xi1>
+  %r = stablehlo.reduce(%m init: %f) applies stablehlo.or across dimensions = [0] : (tensor<256x4096xi1>, tensor<i1>) -> tensor<4096xi1>
+  %s = stablehlo.select %r, %a, %b : tensor<4096xi1>, tensor<4096xf64>
+  return %s : tensor<4096xf64>
+}
+
+// CHECK:    func.func @falsecols(%arg0: tensor<4096xf64>, %arg1: tensor<4096xf64>) -> tensor<4096xf64> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<true> : tensor<1x4000xi1>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<false> : tensor<i1>
+// CHECK-NEXT:    %0 = stablehlo.pad %c, %c_0, low = [0, 48], high = [255, 48], interior = [0, 0] : (tensor<1x4000xi1>, tensor<i1>) -> tensor<256x4096xi1>
+// CHECK-NEXT:    %1 = stablehlo.reduce(%0 init: %c_0) applies stablehlo.or across dimensions = [0] : (tensor<256x4096xi1>, tensor<i1>) -> tensor<4096xi1>
+// CHECK-NEXT:    %2 = stablehlo.select %1, %arg0, %arg1 : tensor<4096xi1>, tensor<4096xf64>
+// CHECK-NEXT:    return %2 : tensor<4096xf64>
+// CHECK-NEXT:  }
+
+// TD:  module {
+// TD-NEXT:  func.func @falsecols(%arg0: tensor<4096xf64>, %arg1: tensor<4096xf64>) -> tensor<4096xf64> {
+// TD-NEXT:    %c = stablehlo.constant dense<true> : tensor<1x4000xi1>
+// TD-NEXT:    %c_0 = stablehlo.constant dense<false> : tensor<i1>
+// TD-NEXT:    %0 = stablehlo.pad %c, %c_0, low = [0, 48], high = [255, 48], interior = [0, 0] : (tensor<1x4000xi1>, tensor<i1>) -> tensor<256x4096xi1>
+// TD-NEXT:    %1 = stablehlo.reduce(%0 init: %c_0) applies stablehlo.or across dimensions = [0] : (tensor<256x4096xi1>, tensor<i1>) -> tensor<4096xi1>
+// TD-NEXT:    %2 = stablehlo.select %1, %arg0, %arg1 : tensor<4096xi1>, tensor<4096xf64>
+// TD-NEXT:    return %2 : tensor<4096xf64>
+// TD-NEXT:  }

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -355,6 +355,7 @@ select_op_canon<16>(1024);
 add_simplify<16>;
 sub_simplify<16>;
 and_simplify<16>;
+reduce_or_and_pad;
 max_simplify<16>;
 min_simplify<16>;
 or_simplify<16>;


### PR DESCRIPTION
#2960 or-reduces a store's lane mask over the axes the store does not index. The mask is the raiser's `tid == 0` guard, which becomes a `stablehlo.pad` of an all-true row once its compare folds; at 256 lanes × 4096 elements the padded `256x4096xi1` mask is too large to constant-fold, so #3137's fold never sees a constant and the reduce (and the select behind it) stayed in the kernel.

`ReduceOrAndPad`: an or-reduce over a pad that is guaranteed true somewhere along the reduced axes folds to true, and an and-reduce over one guaranteed false folds to false, at any size. Guaranteed means either the padding value is the absorbing value and every reduced dim is padded, or the operand is a splat of it and the kept dims are unpadded or padded with it (a false-padded kept column would hold no true). Negative and interior padding are left alone.

Per DEVDOCS: registered as the `reduce_or_and_pad` transform op, added to the pass list in `EnzymeXLA.cpp` after `and_simplify`, and to `test/test_utils.py`.

Test: the #2960 lane guard at scale feeding a select (folds to the selected operand), a true-padded or and a false-padded and over arbitrary operands, and an all-true operand false-padded along the kept axis that must not fold; a second RUN line drives the pattern alone through the transform interpreter (`TD:` goldens). #2960's `@lane0_large` case shows the fold in the raised kernel once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
