### PR TITLE
raise: add an exportMLIROnly option returning the raised MLIR

### DIFF
--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -296,6 +296,13 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
     return "";
   }
 
+  if (options->exportMLIROnly) {
+    std::string res;
+    llvm::raw_string_ostream ss(res);
+    mod->print(ss, flags);
+    return res;
+  }
+
   if (getenv("DEBUG_REACTANT")) {
     llvm::errs() << " final mlir mod: ";
     mod->print(llvm::errs(), flags);

--- a/src/enzyme_ad/jax/raise.h
+++ b/src/enzyme_ad/jax/raise.h
@@ -50,6 +50,7 @@ struct MLIRRoundTripOptions {
   // Mode for the GPU serializer's late sink: 0 disables it, 1 sinks only
   // within the defining loop, 2 also rematerializes into deeper loops.
   int lateSink;
+  bool exportMLIROnly;
 };
 
 extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,


### PR DESCRIPTION
Replaces the first version of this PR, which gated the same behaviour on an
`EXPORT_REACTANT_MLIR_ONLY` environment variable and called `exit(0)`. Updated
per review: the switch is a `MLIRRoundTripOptions` field, the function returns
the string rather than exiting, and the explanatory comments are gone.

`runLLVMToMLIRRoundTrip` always translates the module back to LLVM IR after the
pass pipeline. Callers that drive it through `OVERRIDE_PASS_PIPELINE` may end
their pipeline at a high-level dialect (affine/scf/omp), and
`translateModuleToLLVMIR` then fails on the ops that are still there, so there
is no way to get the raised MLIR back out.

With `exportMLIROnly` set, the module's textual MLIR is returned once the
pipeline has run and the module has verified.

### Matching Reactant change

EnzymeAD/Reactant#94 is the other half: it adds the field to the duplicated
`MLIRRoundTripOptions`, adds `-reactant-export-mlir-only` to set it, and guards
the `parseIR` that consumes the result, since the return value is MLIR rather
than bitcode in that mode.

It has to land *after* this one, not before as I said in the previous version of
this description. `ReactantStatic` compiles with `-DREACTANT_USE_LINKED_RAISE=1`
against `@enzyme_ad//:RaiseLib`, so it sees this `raise.h` rather than the
duplicated struct, and `.exportMLIROnly` there is a compile error until
`ENZYMEXLA_COMMIT` is bumped past this PR.

The duplicated struct is only reached on the `dlsym` path of a CMake build. The
field is appended last, so between the two merges such a build reads a byte past
the caller's struct. Say the word if you would rather I close that window by
landing #94 with the pin bump in it.

No test: the option's effect is the return value's format, which the lit suite
does not currently observe. Glad to add one if you have a pattern for it.
