### PR TITLE
llvm-to-affine-access: deduce the memref extent of a constant-sized alloca

### DIFF
--- a/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
+++ b/src/enzyme_ad/jax/Passes/LLVMToAffineAccess.cpp
@@ -887,6 +887,47 @@ struct LoadSelect : public OpRewritePattern<affine::AffineLoadOp> {
 
 } // namespace
 
+// The memref `convertToMemref` builds has an i8 element type, so its extent is
+// a count of bytes, not of the allocated element type.
+static inline SmallVector<int64_t> getMemrefShapeForAddress(Value addressArg) {
+  auto defOp = addressArg.getDefiningOp();
+  if (!defOp) {
+    return {ShapedType::kDynamic};
+  }
+
+  // A constant-sized alloca gives the memref a static extent.
+  if (auto allocaOp = dyn_cast<LLVM::AllocaOp>(defOp)) {
+    auto sizeVal = getConstant(allocaOp.getArraySize());
+    if (!sizeVal || *sizeVal < 0) {
+      return {ShapedType::kDynamic};
+    }
+    auto elSize =
+        DataLayout::closest(allocaOp).getTypeSize(allocaOp.getElemType());
+    return {static_cast<int64_t>(elSize) * (*sizeVal)};
+  }
+
+  // Anything else (VLA, function argument, global): extent unknown.
+  return {ShapedType::kDynamic};
+}
+
+// Reinterpreting a byte-extent memref as one of `elSize`-byte elements scales
+// the extent down. A dynamic extent stays dynamic, and so does one that does
+// not divide evenly -- rounding down would put the trailing partial element out
+// of bounds.
+static inline SmallVector<int64_t> retypedShape(ArrayRef<int64_t> shape,
+                                                llvm::TypeSize elSize) {
+  SmallVector<int64_t> res(shape);
+  if (res.size() != 1 || ShapedType::isDynamic(res[0]))
+    return res;
+  uint64_t bytes = static_cast<uint64_t>(elSize);
+  if (bytes == 0 || res[0] % static_cast<int64_t>(bytes) != 0) {
+    res[0] = ShapedType::kDynamic;
+    return res;
+  }
+  res[0] /= static_cast<int64_t>(bytes);
+  return res;
+}
+
 static MemRefVal convertToMemref(PtrVal addr) {
   OpBuilder builder(addr.getContext());
   setInsertionPointAfterValue(builder, addr);
@@ -896,13 +937,13 @@ static MemRefVal convertToMemref(PtrVal addr) {
   else
     addrSpace = IntegerAttr::get(IntegerType::get(addr.getContext(), 64),
                                  addr.getType().getAddressSpace());
-  // TODO we can actually plug in the size of the memref here if `addr` is
-  // defined by an llvm.alloca
+
+  auto shape = getMemrefShapeForAddress(addr);
 
   auto ptr2memref = enzymexla::Pointer2MemrefOp::create(
       builder, addr.getLoc(),
-      MemRefType::get({ShapedType::kDynamic}, builder.getI8Type(),
-                      MemRefLayoutAttrInterface{}, Attribute(addrSpace)),
+      MemRefType::get(shape, builder.getI8Type(), MemRefLayoutAttrInterface{},
+                      Attribute(addrSpace)),
       addr);
   return cast<MemRefVal>(ptr2memref.getResult());
 }
@@ -2148,13 +2189,14 @@ convertLLVMToAffineAccess(Operation *op,
             memref = enzymexla::Memref2PointerOp::create(
                 rewriter, load.getLoc(),
                 LLVM::LLVMPointerType::get(ty.getContext()), memref);
-          memref = enzymexla::Pointer2MemrefOp::create(
-                       rewriter, load.getLoc(),
-                       MemRefType::get(memrefTy.getShape(), ty,
-                                       MemRefLayoutAttrInterface{},
-                                       memrefTy.getMemorySpace()),
-                       memref)
-                       .getResult();
+          memref =
+              enzymexla::Pointer2MemrefOp::create(
+                  rewriter, load.getLoc(),
+                  MemRefType::get(retypedShape(memrefTy.getShape(), tySize), ty,
+                                  MemRefLayoutAttrInterface{},
+                                  memrefTy.getMemorySpace()),
+                  memref)
+                  .getResult();
         }
 
         auto mao = aab.getMap();
@@ -2235,13 +2277,14 @@ convertLLVMToAffineAccess(Operation *op,
             memref = enzymexla::Memref2PointerOp::create(
                 rewriter, store.getLoc(),
                 LLVM::LLVMPointerType::get(ty.getContext()), memref);
-          memref = enzymexla::Pointer2MemrefOp::create(
-                       rewriter, store.getLoc(),
-                       MemRefType::get(memrefTy.getShape(), ty,
-                                       MemRefLayoutAttrInterface{},
-                                       memrefTy.getMemorySpace()),
-                       memref)
-                       .getResult();
+          memref =
+              enzymexla::Pointer2MemrefOp::create(
+                  rewriter, store.getLoc(),
+                  MemRefType::get(retypedShape(memrefTy.getShape(), tySize), ty,
+                                  MemRefLayoutAttrInterface{},
+                                  memrefTy.getMemorySpace()),
+                  memref)
+                  .getResult();
         }
         auto mao = aab.getMap();
         if (mao.map.getResult(0).isMultipleOf(tySize) ||
@@ -2355,13 +2398,14 @@ convertLLVMToAffineAccess(Operation *op,
             memref = enzymexla::Memref2PointerOp::create(
                 rewriter, rmw.getLoc(),
                 LLVM::LLVMPointerType::get(ty.getContext()), memref);
-          memref = enzymexla::Pointer2MemrefOp::create(
-                       rewriter, rmw.getLoc(),
-                       MemRefType::get(memrefTy.getShape(), ty,
-                                       MemRefLayoutAttrInterface{},
-                                       memrefTy.getMemorySpace()),
-                       memref)
-                       .getResult();
+          memref =
+              enzymexla::Pointer2MemrefOp::create(
+                  rewriter, rmw.getLoc(),
+                  MemRefType::get(retypedShape(memrefTy.getShape(), tySize), ty,
+                                  MemRefLayoutAttrInterface{},
+                                  memrefTy.getMemorySpace()),
+                  memref)
+                  .getResult();
         }
 
         auto mao = aab.getMap();

--- a/test/lit_tests/raising/llvm_to_affine_alloca_size.mlir
+++ b/test/lit_tests/raising/llvm_to_affine_alloca_size.mlir
@@ -1,0 +1,83 @@
+// RUN: enzymexlamlir-opt --llvm-to-affine-access %s | FileCheck %s
+
+// A constant-sized llvm.alloca gives the raised memref a static extent instead
+// of the `?` it used to always get. The extent counts bytes, because the memref
+// convertToMemref builds is i8-typed; a later reinterpretation to a wider
+// element type scales it down. Everything else stays dynamic.
+
+module {
+  llvm.func @sink(!llvm.ptr)
+
+  llvm.func @constant_alloca() {
+    %c4 = llvm.mlir.constant(4 : i32) : i32
+    %c0 = llvm.mlir.constant(0 : i32) : i32
+    %c2 = llvm.mlir.constant(2 : i32) : i32
+    %a = llvm.alloca %c4 x i32 : (i32) -> !llvm.ptr
+    %p = llvm.getelementptr %a[%c2] : (!llvm.ptr, i32) -> !llvm.ptr, i32
+    llvm.store %c0, %p : i32, !llvm.ptr
+    llvm.call @sink(%a) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+
+  llvm.func @byte_alloca() {
+    %c4 = llvm.mlir.constant(4 : i32) : i32
+    %c8 = llvm.mlir.constant(8 : i32) : i32
+    %z = llvm.mlir.constant(0 : i8) : i8
+    %a = llvm.alloca %c4 x i32 : (i32) -> !llvm.ptr
+    %p = llvm.getelementptr %a[%c8] : (!llvm.ptr, i32) -> !llvm.ptr, i8
+    llvm.store %z, %p : i8, !llvm.ptr
+    llvm.call @sink(%a) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+
+  llvm.func @uneven_alloca() {
+    %c3 = llvm.mlir.constant(3 : i32) : i32
+    %c0 = llvm.mlir.constant(0 : i32) : i32
+    %a = llvm.alloca %c3 x i8 : (i32) -> !llvm.ptr
+    llvm.store %c0, %a : i32, !llvm.ptr
+    llvm.call @sink(%a) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+
+  llvm.func @variable_alloca(%n: i32) {
+    %c0 = llvm.mlir.constant(0 : i32) : i32
+    %c2 = llvm.mlir.constant(2 : i32) : i32
+    %a = llvm.alloca %n x i32 : (i32) -> !llvm.ptr
+    %p = llvm.getelementptr %a[%c2] : (!llvm.ptr, i32) -> !llvm.ptr, i32
+    llvm.store %c0, %p : i32, !llvm.ptr
+    llvm.call @sink(%a) : (!llvm.ptr) -> ()
+    llvm.return
+  }
+
+  llvm.func @from_argument(%arg: !llvm.ptr) {
+    %c0 = llvm.mlir.constant(0 : i32) : i32
+    %c2 = llvm.mlir.constant(2 : i32) : i32
+    %p = llvm.getelementptr %arg[%c2] : (!llvm.ptr, i32) -> !llvm.ptr, i32
+    llvm.store %c0, %p : i32, !llvm.ptr
+    llvm.return
+  }
+}
+
+// 4 x i32 is 16 bytes, reinterpreted for the i32 store as 4 elements.
+// CHECK-LABEL: llvm.func @constant_alloca()
+// CHECK:         "enzymexla.pointer2memref"(%{{.*}}) : (!llvm.ptr) -> memref<4xi32>
+// CHECK:         affine.store %{{.*}}, %{{.*}}[2] {{.*}} : memref<4xi32>
+
+// The same alloca accessed bytewise keeps the byte extent, so the store at byte
+// 8 stays in bounds.
+// CHECK-LABEL: llvm.func @byte_alloca()
+// CHECK:         "enzymexla.pointer2memref"(%{{.*}}) : (!llvm.ptr) -> memref<16xi8>
+// CHECK:         affine.store %{{.*}}, %{{.*}}[8] {{.*}} : memref<16xi8>
+
+// 3 bytes is not a whole number of i32s, so the reinterpretation goes dynamic
+// rather than rounding down.
+// CHECK-LABEL: llvm.func @uneven_alloca()
+// CHECK:         "enzymexla.pointer2memref"(%{{.*}}) : (!llvm.ptr) -> memref<?xi32>
+
+// A VLA has no constant extent, so the memref stays dynamic.
+// CHECK-LABEL: llvm.func @variable_alloca(
+// CHECK:         "enzymexla.pointer2memref"(%{{.*}}) : (!llvm.ptr) -> memref<?xi32>
+
+// Neither does an incoming pointer.
+// CHECK-LABEL: llvm.func @from_argument(
+// CHECK:         "enzymexla.pointer2memref"(%{{.*}}) : (!llvm.ptr) -> memref<?xi32>


### PR DESCRIPTION
`convertToMemref` always built a dynamically-shaped memref, with a TODO noting
that the extent is actually known when the pointer comes from an `llvm.alloca`:

```cpp
// TODO we can actually plug in the size of the memref here if `addr` is
// defined by an llvm.alloca
```

This deduces it. A constant-sized alloca now yields a static extent; a VLA, a
function argument and a global keep the dynamic shape.

### The extent is in bytes

The memref `convertToMemref` builds is `i8`-typed, so its extent counts bytes,
not elements of the allocated type — `alloca %c4 x i32` is `memref<16xi8>`, not
`memref<4xi8>`. `convertLLVMAllocaToMemrefAlloca` earlier in the file already
scales by `dataLayout.getTypeSize(alloc.getElemType())` for the same reason.

That matters because of the three sites which reinterpret this memref as a
wider element type (the `LLVM::LoadOp`, `StoreOp` and `AtomicRMWOp` arms of
`convertLLVMToAffineAccess`). They passed `memrefTy.getShape()` through
verbatim while swapping the element type, which was harmless while every shape
was dynamic — `?` reinterprets to `?` — but silently carries a byte count over
as an element count once a shape is static. So this PR scales the extent there
too, and falls back to a dynamic extent when the byte count is not a whole
number of elements rather than rounding down and putting the trailing partial
element out of bounds.

Without that second half, the raiser emits out-of-bounds affine accesses. On a
`4 x i32` alloca reached bytewise, deducing an element count gives:

```mlir
%3 = "enzymexla.pointer2memref"(%2) : (!llvm.ptr) -> memref<4xi8>
affine.store %1, %3[8] {ordering = 0 : i64} : memref<4xi8>
```

— index 8 into a 4-element memref, for an object that is really 16 bytes wide.
A `3 x i8` alloca reached as `i32` comes out as `memref<3xi32>`, claiming 12
bytes of storage that do not exist.

### Testing

`test/lit_tests/raising/llvm_to_affine_alloca_size.mlir` covers the four shapes
the deduction can produce: a `4 x i32` alloca reaching an `i32` access as
`memref<4xi32>`, the same alloca reached bytewise as `memref<16xi8>`, a
`3 x i8` alloca reached as `i32` falling back to dynamic, and the VLA and
function-argument cases that stay dynamic.

The rest of `test/lit_tests/raising` is unchanged, as are the 92 tests across
the suite that mention `llvm-to-affine-access` or `pointer2memref`. No existing
test exercised a static extent here, since the pass could not produce one
before.

### Notes for review

- **The `retypedShape` change reaches past the alloca case.** It sits on the
  shared load/store/atomicrmw reinterpretation path, so in principle it affects
  any static-shaped byte memref reaching those arms — not just the ones this PR
  starts producing. In practice nothing else produces a static shape there
  today: `convertToMemref` was the only source, and it was unconditionally
  dynamic, so the new branch is inert for every input that does not go through
  the alloca deduction. That is also why the change is invisible to the
  existing suite.
- **Happy to split it out** if you would rather review it separately — the
  scaling fix stands on its own as a preparatory commit (a no-op against
  today's IR, correct for whatever first introduces a static extent), with the
  alloca deduction layered on top. I kept them together because the deduction
  is what makes the bug reachable, and separating them lands a commit whose
  motivation is not visible in its own diff.
- **Non-divisible extents go dynamic rather than rounding.** A `3 x i8` alloca
  reached as `i32` could arguably be `memref<0xi32>`, but a floor would put the
  trailing partial element out of bounds at every access after the first, so
  the conservative shape seemed better than a precise-but-wrong one. Easy to
  change if you disagree.
