### PR TITLE
Cancel partial inverse transposes across elementwise operations

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7734,37 +7734,85 @@ using BroadcastingElementwiseAllTransposeOperandsSimplify =
 struct TransposeElementwiseTransposeSimplify
     : public CheckedOpRewritePattern<stablehlo::TransposeOp,
                                      TransposeElementwiseTransposeSimplify> {
-  using CheckedOpRewritePattern<
-      stablehlo::TransposeOp,
-      TransposeElementwiseTransposeSimplify>::CheckedOpRewritePattern;
+  bool allowPartial;
+
+  TransposeElementwiseTransposeSimplify(MLIRContext *context,
+                                        PatternBenefit benefit = 1,
+                                        bool allowPartial = true)
+      : CheckedOpRewritePattern(context, benefit), allowPartial(allowPartial) {}
 
   LogicalResult matchAndRewriteImpl(stablehlo::TransposeOp op,
                                     PatternRewriter &rewriter) const {
     auto elem = op.getOperand().getDefiningOp();
-    if (!elem)
+    if (!elem ||
+        (!stablehlo::hasTraitElementwise(elem) &&
+         !isa<stablehlo::SelectOp>(elem)) ||
+        elem->getNumResults() != 1 || elem->getNumRegions() != 0)
       return failure();
-    if (!stablehlo::hasTraitElementwise(elem))
-      return failure();
-
-    SmallVector<Value> newOperands;
 
     auto invPerm = rewriter.getDenseI64ArrayAttr(
         getInversePermutation(op.getPermutation()));
-
-    for (auto operand : elem->getOperands()) {
-      auto innerTransposeOp = operand.getDefiningOp<stablehlo::TransposeOp>();
-      if (!innerTransposeOp)
+    bool singleUse = elem->hasOneUse();
+    bool cancelsTranspose = false;
+    bool allOperandsCancel = true;
+    unsigned addedTransposes = 0;
+    unsigned removedTransposes = 1;
+    SmallPtrSet<Operation *, 4> removableInputs;
+    for (Value operand : elem->getOperands()) {
+      auto type = dyn_cast<RankedTensorType>(operand.getType());
+      if (!type)
         return failure();
-      if (innerTransposeOp.getPermutationAttr() != invPerm)
+      // Select also permits a scalar predicate. It has no axes to permute.
+      if (type.getRank() == 0) {
+        allOperandsCancel = false;
+        continue;
+      }
+      if (type.getRank() != op.getType().getRank())
         return failure();
-      newOperands.push_back(innerTransposeOp.getOperand());
+      auto inner = operand.getDefiningOp<stablehlo::TransposeOp>();
+      if (inner && inner.getPermutationAttr() == invPerm) {
+        cancelsTranspose = true;
+        if (singleUse &&
+            llvm::all_of(inner->getUsers(),
+                         [&](Operation *user) { return user == elem; }) &&
+            removableInputs.insert(inner).second)
+          ++removedTransposes;
+        continue;
+      }
+      allOperandsCancel = false;
+      SplatElementsAttr splat;
+      if (!matchPattern(operand, m_Constant(&splat)))
+        ++addedTransposes;
     }
 
-    auto newElem = Operation::create(elem->getLoc(), elem->getName(),
-                                     {op->getResult(0).getType()}, newOperands,
-                                     elem->getAttrs(), mlir::PropertyRef(),
-                                     elem->getSuccessors(), 0);
-    rewriter.insert(newElem);
+    // T(select(T^-1(p), x, T^-1(y))) becomes select(p, T(x), y).
+    // Partial cancellation must strictly reduce transposes, without duplicating
+    // shared arithmetic. Neutral layout changes can cycle with transpose
+    // factoring and CSE. Shared input transposes only count as removed when all
+    // of their users disappear.
+    if ((!allowPartial && !allOperandsCancel) || !cancelsTranspose ||
+        (!allOperandsCancel && !singleUse) ||
+        (addedTransposes && addedTransposes >= removedTransposes))
+      return failure();
+
+    SmallVector<Value> newOperands;
+    for (Value operand : elem->getOperands()) {
+      if (cast<RankedTensorType>(operand.getType()).getRank() == 0) {
+        newOperands.push_back(operand);
+        continue;
+      }
+      auto inner = operand.getDefiningOp<stablehlo::TransposeOp>();
+      if (inner && inner.getPermutationAttr() == invPerm) {
+        newOperands.push_back(inner.getOperand());
+      } else {
+        newOperands.push_back(stablehlo::TransposeOp::create(
+            rewriter, op.getLoc(), operand, op.getPermutation()));
+      }
+    }
+
+    Operation *newElem = rewriter.clone(*elem);
+    newElem->setOperands(newOperands);
+    newElem->getResult(0).setType(op.getType());
     rewriter.replaceOp(op, newElem);
     return success();
   }
@@ -37090,9 +37138,10 @@ struct EnzymeHLOOptPass
 
     patterns.add<ElementwiseAllTransposeOperandsSimplify,
                  BroadcastingElementwiseAllTransposeOperandsSimplify,
-                 TransposeElementwiseTransposeSimplify,
                  AssociativeBinaryOpReordering,
                  CommonAssociativeCommutativeOpReorder>(context);
+    patterns.add<TransposeElementwiseTransposeSimplify>(
+        context, PatternBenefit(1), /*allowPartial=*/false);
 
     patterns.add<BinopPadToConcat<stablehlo::AddOp>,
                  BinopPadToConcat<stablehlo::MulOp>, ConcatPad,
@@ -37479,6 +37528,20 @@ struct EnzymeHLOOptPass
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
                                      config))) {
       signalPassFailure();
+      return;
+    }
+
+    // Partial transpose cancellation moves layouts across shared expression
+    // boundaries. Run it after transpose factoring and CSE have converged, so
+    // those patterns cannot recreate the intermediate transposes it removes.
+    RewritePatternSet transposeCleanup(context);
+    transposeCleanup.add<TransposeElementwiseTransposeSimplify>(context);
+    if (passses & 2048)
+      transposeCleanup.add<TransposeTranspose>(context);
+    if (failed(applyPatternsGreedily(getOperation(),
+                                     std::move(transposeCleanup), config))) {
+      signalPassFailure();
+      return;
     }
   }
 };

--- a/test/lit_tests/transpose_elementwise_partial.mlir
+++ b/test/lit_tests/transpose_elementwise_partial.mlir
@@ -1,0 +1,100 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt --inline --canonicalize --symbol-dce | stablehlo-translate --interpret
+
+// Cancel the inverse transposes on the predicate and false value, moving the
+// output transpose onto the one remaining operand. Three transposes become one.
+// CHECK-LABEL: func.func @select_partial(
+// CHECK-SAME: %[[P:.*]]: tensor<2x3xi1>, %[[X:.*]]: tensor<3x2xi32>, %[[Y:.*]]: tensor<2x3xi32>
+// CHECK: %[[TX:.*]] = stablehlo.transpose %[[X]], dims = [1, 0]
+// CHECK-NOT: stablehlo.transpose
+// CHECK: %[[R:.*]] = stablehlo.select %[[P]], %[[TX]], %[[Y]]
+// CHECK: return %[[R]]
+func.func @select_partial(%p: tensor<2x3xi1>, %x: tensor<3x2xi32>, %y: tensor<2x3xi32>) -> tensor<2x3xi32> {
+  %tp = stablehlo.transpose %p, dims = [1, 0] : (tensor<2x3xi1>) -> tensor<3x2xi1>
+  %ty = stablehlo.transpose %y, dims = [1, 0] : (tensor<2x3xi32>) -> tensor<3x2xi32>
+  %s = stablehlo.select %tp, %x, %ty : tensor<3x2xi1>, tensor<3x2xi32>
+  %r = stablehlo.transpose %s, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  return %r : tensor<2x3xi32>
+}
+
+// Scalar predicates have no axes to transpose.
+// CHECK-LABEL: func.func @select_scalar(
+// CHECK-SAME: %[[P:.*]]: tensor<i1>, %[[X:.*]]: tensor<3x2xi32>, %[[Y:.*]]: tensor<2x3xi32>
+// CHECK: %[[TX:.*]] = stablehlo.transpose %[[X]], dims = [1, 0]
+// CHECK-NOT: stablehlo.transpose
+// CHECK: stablehlo.select %[[P]], %[[TX]], %[[Y]]
+func.func @select_scalar(%p: tensor<i1>, %x: tensor<3x2xi32>, %y: tensor<2x3xi32>) -> tensor<2x3xi32> {
+  %ty = stablehlo.transpose %y, dims = [1, 0] : (tensor<2x3xi32>) -> tensor<3x2xi32>
+  %s = stablehlo.select %p, %x, %ty : tensor<i1>, tensor<3x2xi32>
+  %r = stablehlo.transpose %s, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  return %r : tensor<2x3xi32>
+}
+
+// Do not duplicate arithmetic that is also consumed in its original layout.
+// CHECK-LABEL: func.func @shared_arithmetic(
+// CHECK: %[[T:.*]] = stablehlo.transpose
+// CHECK: %[[S:.*]] = stablehlo.subtract %[[T]],
+// CHECK: %[[R:.*]] = stablehlo.transpose %[[S]]
+// CHECK: return %[[R]], %[[S]]
+func.func @shared_arithmetic(%x: tensor<2x3xi32>, %y: tensor<3x2xi32>) -> (tensor<2x3xi32>, tensor<3x2xi32>) {
+  %tx = stablehlo.transpose %x, dims = [1, 0] : (tensor<2x3xi32>) -> tensor<3x2xi32>
+  %s = stablehlo.subtract %tx, %y : tensor<3x2xi32>
+  %r = stablehlo.transpose %s, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  return %r, %s : tensor<2x3xi32>, tensor<3x2xi32>
+}
+
+// The inner transpose remains live through the second result. Moving the
+// outer transpose would create two new transposes while removing only one.
+// CHECK-LABEL: func.func @unprofitable_select(
+// CHECK: %[[T:.*]] = stablehlo.transpose
+// CHECK: %[[S:.*]] = stablehlo.select
+// CHECK: %[[R:.*]] = stablehlo.transpose %[[S]]
+// CHECK: return %[[R]], %[[T]]
+func.func @unprofitable_select(%p: tensor<3x2xi1>, %x: tensor<2x3xi32>, %y: tensor<3x2xi32>) -> (tensor<2x3xi32>, tensor<3x2xi32>) {
+  %tx = stablehlo.transpose %x, dims = [1, 0] : (tensor<2x3xi32>) -> tensor<3x2xi32>
+  %s = stablehlo.select %p, %tx, %y : tensor<3x2xi1>, tensor<3x2xi32>
+  %r = stablehlo.transpose %s, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  return %r, %tx : tensor<2x3xi32>, tensor<3x2xi32>
+}
+
+// A shared inverse transpose cannot be removed. Keep a neutral rewrite from
+// moving the output transpose back and forth between shared expressions.
+// CHECK-LABEL: func.func @shared_inverse_operand(
+// CHECK: %[[T:.*]] = stablehlo.transpose
+// CHECK: %[[S:.*]] = stablehlo.subtract %[[T]],
+// CHECK: %[[R:.*]] = stablehlo.transpose %[[S]]
+// CHECK: return %[[R]], %[[T]]
+func.func @shared_inverse_operand(%x: tensor<2x3xi32>, %y: tensor<3x2xi32>) -> (tensor<2x3xi32>, tensor<3x2xi32>) {
+  %tx = stablehlo.transpose %x, dims = [1, 0] : (tensor<2x3xi32>) -> tensor<3x2xi32>
+  %s = stablehlo.subtract %tx, %y : tensor<3x2xi32>
+  %r = stablehlo.transpose %s, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  return %r, %tx : tensor<2x3xi32>, tensor<3x2xi32>
+}
+
+// An inverse permutation need not equal the forward permutation.
+// CHECK-LABEL: func.func @three_axes(
+// CHECK-NOT: stablehlo.transpose
+// CHECK: stablehlo.subtract
+// CHECK-NOT: stablehlo.transpose
+// CHECK: return
+func.func @three_axes(%x: tensor<2x3x4xi32>, %y: tensor<2x3x4xi32>) -> tensor<2x3x4xi32> {
+  %tx = stablehlo.transpose %x, dims = [2, 0, 1] : (tensor<2x3x4xi32>) -> tensor<4x2x3xi32>
+  %ty = stablehlo.transpose %y, dims = [2, 0, 1] : (tensor<2x3x4xi32>) -> tensor<4x2x3xi32>
+  %s = stablehlo.subtract %tx, %ty : tensor<4x2x3xi32>
+  %r = stablehlo.transpose %s, dims = [1, 2, 0] : (tensor<4x2x3xi32>) -> tensor<2x3x4xi32>
+  return %r : tensor<2x3x4xi32>
+}
+
+func.func @main() {
+  %p = stablehlo.constant dense<[[true, false, true], [false, true, false]]> : tensor<2x3xi1>
+  %x = stablehlo.constant dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi32>
+  %y = stablehlo.constant dense<[[10, 20, 30], [40, 50, 60]]> : tensor<2x3xi32>
+  %expected = stablehlo.constant dense<[[1, 20, 5], [40, 4, 60]]> : tensor<2x3xi32>
+  %r = func.call @select_partial(%p, %x, %y) : (tensor<2x3xi1>, tensor<3x2xi32>, tensor<2x3xi32>) -> tensor<2x3xi32>
+  check.expect_eq %r, %expected : tensor<2x3xi32>
+  %yes = stablehlo.constant dense<true> : tensor<i1>
+  %transposed = stablehlo.constant dense<[[1, 3, 5], [2, 4, 6]]> : tensor<2x3xi32>
+  %s = func.call @select_scalar(%yes, %x, %y) : (tensor<i1>, tensor<3x2xi32>, tensor<2x3xi32>) -> tensor<2x3xi32>
+  check.expect_eq %s, %transposed : tensor<2x3xi32>
+  return
+}


### PR DESCRIPTION
`TransposeElementwiseTransposeSimplify` currently requires every operand to be an inverse transpose, leaving patterns such as `T(select(T^-1(p), x, T^-1(y)))` unchanged. Extend it to produce `select(p, T(x), y)`, reducing three transposes to one, including when the select predicate is scalar.

For partial cancellation, require a single-use elementwise result and a strict decrease in transpose count, accounting for shared inputs. Preserve operation properties when rebuilding the elementwise op. Run the partial form in a final cleanup inside EnzymeHLOOpt: including it in the main factoring/CSE rewrite set caused cycling on the full LBM input. Existing full cancellation remains in the main rewrite set.

Add explanatory FileCheck and StableHLO interpreter coverage for partial cancellation, scalar predicates, non-self-inverse permutations, shared arithmetic, and unprofitable rewrites. Validation: all 29 related transpose LIT targets pass on this independent branch based on current main. The combined staging build also passed all 44 related transpose/comparison/AND tests and optimized the full LBM pre-pass input in approximately 0.11 seconds.

The same change is on `vim/lbm-staging`. In the existing all-DUS LBM pipeline, this and the masked-comparison change in #3147 reduced StableHLO transposes from 130 to 72 and i8-to-i32 conversions from two to zero. The unchanged 20-timestep benchmark still launched 511 kernels; median summed GPU kernel time was 9.258 ms versus 8.707 ms before these two changes (three captures on an RTX 5090, excluding compilation and transfers). XLA had already removed explicit transpose/reshape HLO operations in the baseline, and output remained byte-identical. These combined measurements do not establish an isolated performance benefit for this PR.

CI note at submission: the formatting check reports a pre-existing line-wrap difference in the DUSDUS `LLVM_DEBUG` block on main (`fd510e64`). Running clang-format 16 on main and this branch gives the identical diff.
