### PR TITLE
Tests: keep the unroll-budget test cheap

### DIFF
--- a/test/lit_tests/raising/affine_to_stablehlo_unroll_budget.mlir
+++ b/test/lit_tests/raising/affine_to_stablehlo_unroll_budget.mlir
@@ -1,9 +1,11 @@
-// RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false' | FileCheck %s
-// RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false unroll_budget=8' | FileCheck %s --check-prefix=TIGHT
+// RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false unroll_budget=64' | FileCheck %s
+// RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false unroll_budget=2' | FileCheck %s --check-prefix=TIGHT
 // RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false unroll_budget=-1' | FileCheck %s --check-prefix=UNBOUNDED
+// RUN: enzymexlamlir-opt %s '--raise-affine-to-stablehlo=enable_lockstep_for=false prefer_while_raising=false' | FileCheck %s --check-prefix=DEFAULT
 
 // A constant-bound loop whose (nested) unrolled size exceeds the budget
-// iterates as a while even when unrolling is preferred.
+// iterates as a while even when unrolling is preferred. The loops stay small
+// so the unbounded run is cheap; the default budget (1 << 16) unrolls both.
 
 // CHECK-LABEL: @small_raised
 // CHECK-NOT: stablehlo.while
@@ -23,11 +25,17 @@
 // UNBOUNDED-LABEL: @big_raised
 // UNBOUNDED-NOT: stablehlo.while
 
+// DEFAULT-LABEL: @small_raised
+// DEFAULT-NOT: stablehlo.while
+
+// DEFAULT-LABEL: @big_raised
+// DEFAULT-NOT: stablehlo.while
+
 module {
   func.func private @big(%arg0: memref<16xf64, 1>) {
     %cst = arith.constant 5.000000e-01 : f64
     affine.parallel (%t) = (0) to (16) {
-      affine.for %i = 0 to 100000 {
+      affine.for %i = 0 to 1000 {
         %0 = affine.load %arg0[%t] : memref<16xf64, 1>
         %1 = arith.addf %0, %cst : f64
         affine.store %1, %arg0[%t] : memref<16xf64, 1>


### PR DESCRIPTION
The unbounded RUN line of `affine_to_stablehlo_unroll_budget.mlir` unrolls a 100000-iteration loop into a 70 MB module of 100k dynamic-update-slices. In the debug CI job that takes 4-5 s on a good run and blew the 60 s test timeout on a slow runner (https://github.com/EnzymeAD/Enzyme-JAX/actions/runs/34158070359/job/101853927342).

The loop is now 1000 iterations with explicit budgets: 64 (big loop iterates, small unrolls), 2 (both iterate), -1 (both unroll), and a fourth run with the default budget (both unroll). Every run takes under 50 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
