### PR TITLE
EnzymeHLOOpt: format the DUSSliceSimplify debug check

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -13586,16 +13586,19 @@ struct DUSSliceSimplify final
               rewriter, loc, itype, cast<ElementsAttr>(makeAttr(itype, start)));
         });
 
-    LLVM_DEBUG(
-        for (auto [idx, operandSize, updateSize] : llvm::zip_equal(
-                 newDusIndices,
-                 cast<RankedTensorType>(preSliceOperand.getType()).getShape(),
-                 cast<RankedTensorType>(preSliceUpdate.getType()).getShape())) {
-          APInt start;
-          assert(matchPattern(idx, m_ConstantInt(&start)));
-          int64_t vali = start.getSExtValue();
-          assert(operandSize >= vali + updateSize);
-        });
+    LLVM_DEBUG({
+      auto operandShape =
+          cast<RankedTensorType>(preSliceOperand.getType()).getShape();
+      auto updateShape =
+          cast<RankedTensorType>(preSliceUpdate.getType()).getShape();
+      for (auto [idx, operandSize, updateSize] :
+           llvm::zip_equal(newDusIndices, operandShape, updateShape)) {
+        APInt start;
+        assert(matchPattern(idx, m_ConstantInt(&start)));
+        int64_t vali = start.getSExtValue();
+        assert(operandSize >= vali + updateSize);
+      }
+    });
 
     auto newDus = stablehlo::DynamicUpdateSliceOp::create(
         rewriter, loc, preSliceOperand, preSliceUpdate, newDusIndices);


### PR DESCRIPTION
CI's clang-format wants the range-for inside this `LLVM_DEBUG` broken differently from the local formatter, so main fails the Format check since #3136 (e.g. https://github.com/EnzymeAD/Enzyme-JAX/actions/runs/34172682365/job/101895892480 on #3124). Bind the two shapes first so the range line is short and both versions agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD