### PR TITLE
Raising: lane-private scratch gets the batched axes as leading dimensions

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -883,6 +883,49 @@ bool isSafeToSpeculativelyExecuteAtScope(Operation *scope, Operation *op) {
   return inBounds;
 }
 
+// A buffer raised with leading lane dimensions (see the memref.alloca case)
+// is indexed by the lane induction variables before its own indices.
+static void prependLaneDims(Value memref, affine::AffineValueMap &avm,
+                            DenseMap<Value, affine::AffineValueMap> &maps) {
+  auto it = maps.find(memref);
+  if (it == maps.end())
+    return;
+  const affine::AffineValueMap &lane = it->second;
+  unsigned K = lane.getNumResults();
+  AffineMap map = avm.getAffineMap();
+  unsigned nd = map.getNumDims();
+  SmallVector<AffineExpr> exprs;
+  for (unsigned k = 0; k < K; ++k)
+    exprs.push_back(getAffineDimExpr(k, map.getContext()));
+  for (AffineExpr e : map.getResults())
+    exprs.push_back(e.shiftDims(nd, K));
+  SmallVector<Value> operands(lane.getOperands().begin(),
+                              lane.getOperands().end());
+  operands.append(avm.getOperands().begin(), avm.getOperands().begin() + nd);
+  operands.append(avm.getOperands().begin() + nd, avm.getOperands().end());
+  avm = affine::AffineValueMap(
+      AffineMap::get(nd + K, map.getNumSymbols(), exprs, map.getContext()),
+      operands);
+}
+
+// The lane induction variables' raised values, to prepend to a memref.load
+// or memref.store's indices; nullopt when one is not raised.
+static std::optional<SmallVector<Value>>
+laneIndices(Value memref, IRMapping &mapping,
+            DenseMap<Value, affine::AffineValueMap> &maps) {
+  SmallVector<Value> indices;
+  auto it = maps.find(memref);
+  if (it == maps.end())
+    return indices;
+  for (Value iv : it->second.getOperands()) {
+    Value mapped = mapping.lookupOrNull(iv);
+    if (!mapped || !maps.count(mapped))
+      return std::nullopt;
+    indices.push_back(mapped);
+  }
+  return indices;
+}
+
 static LogicalResult
 tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
                         llvm::DenseMap<Value, affine::AffineValueMap> &maps,
@@ -3088,6 +3131,7 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
 
     affine::AffineValueMap accessValueMap;
     access.getAccessMap(&accessValueMap);
+    prependLaneDims(access.memref, accessValueMap, maps);
     // See tryRaisingForOpToStableHLOUnroll
     accessValueMap.composeSimplifyAndCanonicalize();
 
@@ -3444,6 +3488,7 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
 
     affine::AffineValueMap accessValueMap;
     access.getAccessMap(&accessValueMap);
+    prependLaneDims(access.memref, accessValueMap, maps);
     // See tryRaisingForOpToStableHLOUnroll
     accessValueMap.composeSimplifyAndCanonicalize();
 
@@ -3819,8 +3864,8 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
             Value uiv = getIVForExpr(unionMap, E);
             int64_t storeDim = -1;
             if (uiv)
-              for (auto [k, SE] :
-                   llvm::enumerate(storeOp.getMap().getResults())) {
+              for (auto [k, SE] : llvm::enumerate(
+                       accessValueMap.getAffineMap().getResults())) {
                 if (SE.isSymbolicOrConstant())
                   continue;
                 if (getIVForExpr(accessValueMap,
@@ -4071,7 +4116,7 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
         for (auto [i, E] :
              llvm::enumerate(maskMap.getAffineMap().getResults())) {
           Value iv = getIVForExpr(maskMap, E);
-          if (!iv || llvm::is_contained(storeOp.getIndices(), iv))
+          if (!iv || llvm::is_contained(accessValueMap.getOperands(), iv))
             continue;
           for (auto EE : updateValueMap.getAffineMap().getResults())
             if (getIVForExpr(updateValueMap, EE) == iv)
@@ -4126,7 +4171,8 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       ShapedType updateType = cast<ShapedType>(update.getType());
       SmallVector<int64_t> updateShapeWithoutConstantDims;
 
-      for (auto [i, E] : llvm::enumerate(storeOp.getMap().getResults())) {
+      for (auto [i, E] :
+           llvm::enumerate(accessValueMap.getAffineMap().getResults())) {
         if (!E.isSymbolicOrConstant()) {
           nonConstantDims.push_back(i);
           updateShapeWithoutConstantDims.push_back(updateType.getShape()[i]);
@@ -4134,7 +4180,8 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       }
 
       affine::AffineValueMap storeValueMap(
-          storeOp.getMap().getSubMap(nonConstantDims), storeOp.getIndices());
+          accessValueMap.getAffineMap().getSubMap(nonConstantDims),
+          accessValueMap.getOperands());
 
       SmallVector<int64_t> updateShape(updateType.getShape().begin(),
                                        updateType.getShape().end());
@@ -4170,7 +4217,7 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       for (auto dim : storeValueMap.getOperands()) {
         // This dim is present in the masked update and not in the stored
         // dimensions.
-        if (!llvm::is_contained(storeOp.getIndices(), dim)) {
+        if (!llvm::is_contained(accessValueMap.getOperands(), dim)) {
           auto err = op->emitError(
                          "masked affine.store is dependent on less dimensions "
                          "than masked stored value:\n")
@@ -4204,17 +4251,19 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
         assert(!E.isSymbolicOrConstant()); // constant dims have been removed
         auto iv = getIVForExpr(storeValueMap, E);
 
-        for (auto [j, EE] : llvm::enumerate(storeOp.getMap().getResults())) {
+        for (auto [j, EE] :
+             llvm::enumerate(accessValueMap.getAffineMap().getResults())) {
           if (EE.isSymbolicOrConstant())
             continue;
 
           int ivPos = 0;
-          for (int e = storeOp.getMap().getNumDims(); ivPos < e; ++ivPos) {
+          for (int e = accessValueMap.getAffineMap().getNumDims(); ivPos < e;
+               ++ivPos) {
             if (EE.isFunctionOfDim(ivPos))
               break;
           }
 
-          auto storeIV = storeOp.getIndices()[ivPos];
+          auto storeIV = accessValueMap.getOperands()[ivPos];
 
           if (iv == storeIV) {
             assert(maskedUpdateBroadcastDims[i] == -1);
@@ -4298,7 +4347,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
   if (auto loadOp = dyn_cast<memref::LoadOp>(op)) {
     auto memref = loadOp.getMemref();
 
-    SmallVector<Value> lIndices;
+    auto lIndicesOr = laneIndices(memref, mapping, maps);
+    if (!lIndicesOr)
+      return failure();
+    SmallVector<Value> lIndices = std::move(*lIndicesOr);
     for (auto idx : loadOp.getIndices()) {
       Value mapped = mapping.lookupOrNull(idx);
       if (!mapped || !maps.count(mapped))
@@ -4328,7 +4380,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       return failure();
     Value value = rmw.getValue();
     Value memref = rmw.getMemref();
-    SmallVector<Value> sIndices;
+    auto sIndicesOr = laneIndices(memref, mapping, maps);
+    if (!sIndicesOr)
+      return failure();
+    SmallVector<Value> sIndices = std::move(*sIndicesOr);
     for (auto idx : rmw.getIndices()) {
       Value mapped = mapping.lookupOrNull(idx);
       if (!mapped || !maps.count(mapped))
@@ -4360,7 +4415,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
       return failure();
     Value value = rmw.getValue();
     Value memref = rmw.getMemref();
-    SmallVector<Value> sIndices;
+    auto sIndicesOr = laneIndices(memref, mapping, maps);
+    if (!sIndicesOr)
+      return failure();
+    SmallVector<Value> sIndices = std::move(*sIndicesOr);
     for (auto idx : rmw.getIndices()) {
       Value mapped = mapping.lookupOrNull(idx);
       if (!mapped || !maps.count(mapped))
@@ -4447,7 +4505,10 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     Value value = storeOp.getValueToStore();
     Value memref = storeOp.getMemref();
 
-    SmallVector<Value> sIndices;
+    auto sIndicesOr = laneIndices(memref, mapping, maps);
+    if (!sIndicesOr)
+      return failure();
+    SmallVector<Value> sIndices = std::move(*sIndicesOr);
     for (auto idx : storeOp.getIndices()) {
       Value mapped = mapping.lookupOrNull(idx);
       if (!mapped || !maps.count(mapped))
@@ -5034,13 +5095,37 @@ tryRaisingOpToStableHLO(Operation *op, IRMapping &mapping, OpBuilder &builder,
     if (!MT.hasStaticShape() || !isXLACompatiblePrimitive(MT.getElementType()))
       return op->emitError("cannot raise dynamic or non-primitive alloca")
              << *op;
-    auto TT = RankedTensorType::get(MT.getShape(), MT.getElementType());
+    // Under batched axes every lane owns a copy: the buffer gets one leading
+    // dimension per batched axis whose loop encloses the alloca, and its map
+    // records the axes so that each access indexes its lane's copy first.
+    // Shared memory sits between the grid and the thread parallel, so it
+    // batches over the grid alone.
+    SmallVector<int64_t> shape;
+    SmallVector<Value> laneIVs;
+    for (auto [range, iv] : llvm::zip(pc.ranges, pc.ivs)) {
+      Operation *owner = affine::getAffineParallelInductionVarOwner(iv);
+      if (!owner)
+        owner = affine::getForInductionVarOwner(iv);
+      if (!owner || !owner->isAncestor(alloca))
+        continue;
+      shape.push_back(range.getNumIters());
+      laneIVs.push_back(iv);
+    }
+    shape.append(MT.getShape().begin(), MT.getShape().end());
+    auto TT = RankedTensorType::get(shape, MT.getElementType());
     Value zero = stablehlo::ConstantOp::create(
         builder, rewriteLocation(op->getLoc(), pc.options.strip_llvm_debuginfo),
         TT,
         SplatElementsAttr::get(TT, builder.getZeroAttr(MT.getElementType())));
     mapping.map(alloca.getResult(), zero);
     maps[zero] = affine::AffineValueMap(AffineMap::get(op->getContext()), {});
+    if (!laneIVs.empty()) {
+      SmallVector<AffineExpr> exprs;
+      for (unsigned k = 0; k < laneIVs.size(); ++k)
+        exprs.push_back(getAffineDimExpr(k, op->getContext()));
+      maps[alloca.getResult()] = affine::AffineValueMap(
+          AffineMap::get(laneIVs.size(), 0, exprs, op->getContext()), laneIVs);
+    }
     return success();
   }
 

--- a/test/lit_tests/raising/raise_lane_private_scratch.mlir
+++ b/test/lit_tests/raising/raise_lane_private_scratch.mlir
@@ -1,0 +1,351 @@
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo="prefer_while_raising=false err_if_not_fully_raised=true" --split-input-file | FileCheck %s
+// RUN: enzymexlamlir-opt %s --raise-affine-to-stablehlo="prefer_while_raising=false err_if_not_fully_raised=true" --enzyme-hlo-opt --split-input-file | FileCheck %s --check-prefix=OPT
+
+// Scratch allocated inside batched axes is private to each lane: every lane
+// writes its own values at the same indices, so the buffer gains one leading
+// dimension per axis in scope and every access indexes its lane's copy first.
+// Modeled as one shared buffer all lanes would read lane 0's values.
+
+module {
+  func.func private @lane(%out: memref<64xf64, 1>, %in: memref<64xf64, 1>) {
+    %two = arith.constant 2.0 : f64
+    affine.parallel (%e) = (0) to (4) {
+      affine.parallel (%t) = (0) to (16) {
+        %loc = memref.alloca() : memref<2xf64>
+        %v = affine.load %in[%t] : memref<64xf64, 1>
+        affine.store %v, %loc[0] : memref<2xf64>
+        %v2 = arith.mulf %v, %two : f64
+        affine.store %v2, %loc[1] : memref<2xf64>
+        %a = affine.load %loc[0] : memref<2xf64>
+        %b = affine.load %loc[1] : memref<2xf64>
+        %s = arith.addf %a, %b : f64
+        affine.store %s, %out[%e * 16 + %t] : memref<64xf64, 1>
+      }
+    }
+    return
+  }
+}
+
+// CHECK:    func.func private @lane_raised(%arg0: tensor<64xf64>, %arg1: tensor<64xf64>) -> (tensor<64xf64>, tensor<64xf64>) {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4xi64>
+// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<4xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<4xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<4xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_0 : tensor<4xi64>
+// CHECK-NEXT:    %3 = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %4 = stablehlo.add %3, %c_1 : tensor<16xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %5 = stablehlo.multiply %4, %c_2 : tensor<16xi64>
+// CHECK-NEXT:    %cst_3 = stablehlo.constant dense<0.000000e+00> : tensor<4x16x2xf64>
+// CHECK-NEXT:    %6 = stablehlo.slice %arg1 [0:16] : (tensor<64xf64>) -> tensor<16xf64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_8 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_9 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_10 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_11 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_12 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_13 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_14 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_15 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_16 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_17 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_18 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_19 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_20 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_21 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %7 = stablehlo.broadcast_in_dim %6, dims = [1] : (tensor<16xf64>) -> tensor<4x16x1xf64>
+// CHECK-NEXT:    %8 = stablehlo.dynamic_update_slice %cst_3, %7, %c_9, %c_15, %c_21 : (tensor<4x16x2xf64>, tensor<4x16x1xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<4x16x2xf64>
+// CHECK-NEXT:    %9 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f64>) -> tensor<16xf64>
+// CHECK-NEXT:    %10 = arith.mulf %6, %9 : tensor<16xf64>
+// CHECK-NEXT:    %c_22 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_23 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_24 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_25 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_26 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_27 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_28 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_29 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_30 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_31 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_32 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_33 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_34 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_35 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_36 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_37 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_38 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_39 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %11 = stablehlo.broadcast_in_dim %10, dims = [1] : (tensor<16xf64>) -> tensor<4x16x1xf64>
+// CHECK-NEXT:    %12 = stablehlo.dynamic_update_slice %8, %11, %c_27, %c_33, %c_39 : (tensor<4x16x2xf64>, tensor<4x16x1xf64>, tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<4x16x2xf64>
+// CHECK-NEXT:    %13 = stablehlo.slice %12 [0:4, 0:16, 0:1] : (tensor<4x16x2xf64>) -> tensor<4x16x1xf64>
+// CHECK-NEXT:    %14 = stablehlo.reshape %13 : (tensor<4x16x1xf64>) -> tensor<4x16xf64>
+// CHECK-NEXT:    %15 = stablehlo.slice %12 [0:4, 0:16, 1:2] : (tensor<4x16x2xf64>) -> tensor<4x16x1xf64>
+// CHECK-NEXT:    %16 = stablehlo.reshape %15 : (tensor<4x16x1xf64>) -> tensor<4x16xf64>
+// CHECK-NEXT:    %17 = arith.addf %14, %16 : tensor<4x16xf64>
+// CHECK-NEXT:    %c_40 = stablehlo.constant dense<16> : tensor<i64>
+// CHECK-NEXT:    %18 = stablehlo.broadcast_in_dim %c_40, dims = [] : (tensor<i64>) -> tensor<4xi64>
+// CHECK-NEXT:    %19 = stablehlo.multiply %2, %18 : tensor<4xi64>
+// CHECK-NEXT:    %20 = stablehlo.broadcast_in_dim %19, dims = [0] : (tensor<4xi64>) -> tensor<4x16xi64>
+// CHECK-NEXT:    %21 = stablehlo.broadcast_in_dim %5, dims = [1] : (tensor<16xi64>) -> tensor<4x16xi64>
+// CHECK-NEXT:    %22 = stablehlo.add %20, %21 : tensor<4x16xi64>
+// CHECK-NEXT:    %23 = stablehlo.reshape %22 : (tensor<4x16xi64>) -> tensor<4x16x1xi64>
+// CHECK-NEXT:    %24 = "stablehlo.scatter"(%arg0, %23, %17) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
+// CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<64xf64>, tensor<4x16x1xi64>, tensor<4x16xf64>) -> tensor<64xf64>
+// CHECK-NEXT:    return %24, %arg1 : tensor<64xf64>, tensor<64xf64>
+// CHECK-NEXT:  }
+
+// OPT:  module {
+// OPT-NEXT:  func.func private @lane_raised(%arg0: tensor<64xf64>, %arg1: tensor<64xf64>) -> (tensor<64xf64>, tensor<64xf64>) {
+// OPT-NEXT:    %cst = stablehlo.constant dense<2.000000e+00> : tensor<16xf64>
+// OPT-NEXT:    %0 = stablehlo.slice %arg1 [0:16] : (tensor<64xf64>) -> tensor<16xf64>
+// OPT-NEXT:    %1 = stablehlo.broadcast_in_dim %0, dims = [1] : (tensor<16xf64>) -> tensor<4x16x1xf64>
+// OPT-NEXT:    %2 = arith.mulf %0, %cst : tensor<16xf64>
+// OPT-NEXT:    %3 = stablehlo.broadcast_in_dim %2, dims = [1] : (tensor<16xf64>) -> tensor<4x16x1xf64>
+// OPT-NEXT:    %4 = stablehlo.reshape %1 : (tensor<4x16x1xf64>) -> tensor<64xf64>
+// OPT-NEXT:    %5 = stablehlo.reshape %3 : (tensor<4x16x1xf64>) -> tensor<64xf64>
+// OPT-NEXT:    %6 = arith.addf %4, %5 : tensor<64xf64>
+// OPT-NEXT:    return %6, %arg1 : tensor<64xf64>, tensor<64xf64>
+// OPT-NEXT:  }
+
+// -----
+// The same through memref.load/store: the lane induction variables are
+// prepended to the indices.
+
+module {
+  func.func private @lane_memref(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    affine.parallel (%t) = (0) to (16) {
+      %loc = memref.alloca() : memref<2xf64>
+      %v = affine.load %in[%t] : memref<16xf64, 1>
+      memref.store %v, %loc[%c0] : memref<2xf64>
+      memref.store %v, %loc[%c1] : memref<2xf64>
+      %a = memref.load %loc[%c0] : memref<2xf64>
+      %b = memref.load %loc[%c1] : memref<2xf64>
+      %s = arith.addf %a, %b : f64
+      affine.store %s, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// CHECK:    func.func private @lane_memref_raised(%arg0: tensor<16xf64>, %arg1: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<i64>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c_1 : tensor<16xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_2 : tensor<16xi64>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<16x2xf64>
+// CHECK-NEXT:    %3 = stablehlo.reshape %2 : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %4 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %5 = stablehlo.concatenate %3, %4, dim = 1 : (tensor<16x1xi64>, tensor<16x1xi64>) -> tensor<16x2xi64>
+// CHECK-NEXT:    %6 = "stablehlo.scatter"(%cst, %5, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<16x2xf64>, tensor<16x2xi64>, tensor<16xf64>) -> tensor<16x2xf64>
+// CHECK-NEXT:    %7 = stablehlo.reshape %2 : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %c_0, dims = [] : (tensor<i64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %9 = stablehlo.concatenate %7, %8, dim = 1 : (tensor<16x1xi64>, tensor<16x1xi64>) -> tensor<16x2xi64>
+// CHECK-NEXT:    %10 = "stablehlo.scatter"(%6, %9, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<16x2xf64>, tensor<16x2xi64>, tensor<16xf64>) -> tensor<16x2xf64>
+// CHECK-NEXT:    %11 = stablehlo.reshape %2 : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %12 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %13 = stablehlo.concatenate %11, %12, dim = 1 : (tensor<16x1xi64>, tensor<16x1xi64>) -> tensor<16x2xi64>
+// CHECK-NEXT:    %14 = "stablehlo.gather"(%10, %13) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<16x2xf64>, tensor<16x2xi64>) -> tensor<16xf64>
+// CHECK-NEXT:    %15 = stablehlo.reshape %2 : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %16 = stablehlo.broadcast_in_dim %c_0, dims = [] : (tensor<i64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %17 = stablehlo.concatenate %15, %16, dim = 1 : (tensor<16x1xi64>, tensor<16x1xi64>) -> tensor<16x2xi64>
+// CHECK-NEXT:    %18 = "stablehlo.gather"(%10, %17) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<16x2xf64>, tensor<16x2xi64>) -> tensor<16xf64>
+// CHECK-NEXT:    %19 = arith.addf %14, %18 : tensor<16xf64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_8 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %20 = stablehlo.dynamic_update_slice %arg0, %19, %c_8 : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:    return %20, %arg1 : tensor<16xf64>, tensor<16xf64>
+// CHECK-NEXT:  }
+
+// OPT:  module {
+// OPT-NEXT:  func.func private @lane_memref_raised(%arg0: tensor<16xf64>, %arg1: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// OPT-NEXT:    %c = stablehlo.constant dense<{{\[\[}}0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1], [6, 1], [7, 1], [8, 1], [9, 1], [10, 1], [11, 1], [12, 1], [13, 1], [14, 1], [15, 1]]> : tensor<16x2xi64>
+// OPT-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<16x2xf64>
+// OPT-NEXT:    %c_0 = stablehlo.constant dense<{{\[\[}}0, 0], [1, 0], [2, 0], [3, 0], [4, 0], [5, 0], [6, 0], [7, 0], [8, 0], [9, 0], [10, 0], [11, 0], [12, 0], [13, 0], [14, 0], [15, 0]]> : tensor<16x2xi64>
+// OPT-NEXT:    %0 = "stablehlo.scatter"(%cst, %c_0, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// OPT-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// OPT-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// OPT-NEXT:    }) : (tensor<16x2xf64>, tensor<16x2xi64>, tensor<16xf64>) -> tensor<16x2xf64>
+// OPT-NEXT:    %1 = "stablehlo.scatter"(%0, %c, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// OPT-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// OPT-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// OPT-NEXT:    }) : (tensor<16x2xf64>, tensor<16x2xi64>, tensor<16xf64>) -> tensor<16x2xf64>
+// OPT-NEXT:    %2 = "stablehlo.gather"(%1, %c_0) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0, 1], start_index_map = [0, 1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1>}> : (tensor<16x2xf64>, tensor<16x2xi64>) -> tensor<16xf64>
+// OPT-NEXT:    %3 = arith.addf %2, %arg1 : tensor<16xf64>
+// OPT-NEXT:    return %3, %arg1 : tensor<16xf64>, tensor<16xf64>
+// OPT-NEXT:  }
+
+// -----
+// Scratch between the two parallels is one copy per outer iteration, shared
+// by the inner lanes: it gains only the outer axis, and an inner-lane
+// indexed access into it stays a plain index.
+
+module {
+  func.func private @block(%out: memref<64xf64, 1>, %in: memref<64xf64, 1>) {
+    affine.parallel (%e) = (0) to (4) {
+      %sh = memref.alloca() : memref<16xf64>
+      affine.parallel (%t) = (0) to (16) {
+        %v = affine.load %in[%e * 16 + %t] : memref<64xf64, 1>
+        affine.store %v, %sh[%t] : memref<16xf64>
+      }
+      affine.parallel (%t) = (0) to (16) {
+        %a = affine.load %sh[15 - %t] : memref<16xf64>
+        affine.store %a, %out[%e * 16 + %t] : memref<64xf64, 1>
+      }
+    }
+    return
+  }
+}
+
+// CHECK:    func.func private @block_raised(%arg0: tensor<64xf64>, %arg1: tensor<64xf64>) -> (tensor<64xf64>, tensor<64xf64>) {
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<4xi64>
+// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<4xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<4xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<4xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_0 : tensor<4xi64>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<4x16xf64>
+// CHECK-NEXT:    %3 = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %4 = stablehlo.add %3, %c_1 : tensor<16xi64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %5 = stablehlo.multiply %4, %c_2 : tensor<16xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<16> : tensor<i64>
+// CHECK-NEXT:    %6 = stablehlo.broadcast_in_dim %c_3, dims = [] : (tensor<i64>) -> tensor<4xi64>
+// CHECK-NEXT:    %7 = stablehlo.multiply %2, %6 : tensor<4xi64>
+// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %7, dims = [0] : (tensor<4xi64>) -> tensor<4x16xi64>
+// CHECK-NEXT:    %9 = stablehlo.broadcast_in_dim %5, dims = [1] : (tensor<16xi64>) -> tensor<4x16xi64>
+// CHECK-NEXT:    %10 = stablehlo.add %8, %9 : tensor<4x16xi64>
+// CHECK-NEXT:    %11 = stablehlo.reshape %10 : (tensor<4x16xi64>) -> tensor<4x16x1xi64>
+// CHECK-NEXT:    %12 = "stablehlo.gather"(%arg1, %11) <{dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1>}> : (tensor<64xf64>, tensor<4x16x1xi64>) -> tensor<4x16xf64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_8 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_9 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %c_10 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_11 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_12 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_13 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_14 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_15 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %13 = stablehlo.dynamic_update_slice %cst, %12, %c_9, %c_15 : (tensor<4x16xf64>, tensor<4x16xf64>, tensor<i64>, tensor<i64>) -> tensor<4x16xf64>
+// CHECK-NEXT:    %14 = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %c_16 = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %15 = stablehlo.add %14, %c_16 : tensor<16xi64>
+// CHECK-NEXT:    %c_17 = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %16 = stablehlo.multiply %15, %c_17 : tensor<16xi64>
+// CHECK-NEXT:    %17 = stablehlo.reverse %13, dims = [1] : tensor<4x16xf64>
+// CHECK-NEXT:    %c_18 = stablehlo.constant dense<16> : tensor<i64>
+// CHECK-NEXT:    %18 = stablehlo.broadcast_in_dim %c_18, dims = [] : (tensor<i64>) -> tensor<4xi64>
+// CHECK-NEXT:    %19 = stablehlo.multiply %2, %18 : tensor<4xi64>
+// CHECK-NEXT:    %20 = stablehlo.broadcast_in_dim %19, dims = [0] : (tensor<4xi64>) -> tensor<4x16xi64>
+// CHECK-NEXT:    %21 = stablehlo.broadcast_in_dim %16, dims = [1] : (tensor<16xi64>) -> tensor<4x16xi64>
+// CHECK-NEXT:    %22 = stablehlo.add %20, %21 : tensor<4x16xi64>
+// CHECK-NEXT:    %23 = stablehlo.reshape %22 : (tensor<4x16xi64>) -> tensor<4x16x1xi64>
+// CHECK-NEXT:    %24 = "stablehlo.scatter"(%arg0, %23, %17) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = true}> ({
+// CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<64xf64>, tensor<4x16x1xi64>, tensor<4x16xf64>) -> tensor<64xf64>
+// CHECK-NEXT:    return %24, %arg1 : tensor<64xf64>, tensor<64xf64>
+// CHECK-NEXT:  }
+
+// OPT:  module {
+// OPT-NEXT:  func.func private @block_raised(%arg0: tensor<64xf64>, %arg1: tensor<64xf64>) -> (tensor<64xf64>, tensor<64xf64>) {
+// OPT-NEXT:    %0 = stablehlo.reshape %arg1 : (tensor<64xf64>) -> tensor<4x16xf64>
+// OPT-NEXT:    %1 = stablehlo.reverse %0, dims = [1] : tensor<4x16xf64>
+// OPT-NEXT:    %2 = stablehlo.reshape %1 : (tensor<4x16xf64>) -> tensor<64xf64>
+// OPT-NEXT:    return %2, %arg1 : tensor<64xf64>, tensor<64xf64>
+// OPT-NEXT:  }
+
+// -----
+// An atomic add into lane-private scratch accumulates per lane: the lane
+// induction variable joins the scatter indices.
+
+module {
+  func.func private @lane_atomic(%out: memref<16xf64, 1>, %in: memref<16xf64, 1>) {
+    %c0 = arith.constant 0 : index
+    affine.parallel (%t) = (0) to (16) {
+      %loc = memref.alloca() : memref<1xf64>
+      %v = affine.load %in[%t] : memref<16xf64, 1>
+      %r0 = memref.atomic_rmw addf %v, %loc[%c0] : (f64, memref<1xf64>) -> f64
+      %r1 = memref.atomic_rmw addf %v, %loc[%c0] : (f64, memref<1xf64>) -> f64
+      %a = affine.load %loc[0] : memref<1xf64>
+      affine.store %a, %out[%t] : memref<16xf64, 1>
+    }
+    return
+  }
+}
+
+// CHECK:    func.func private @lane_atomic_raised(%arg0: tensor<16xf64>, %arg1: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<16xi64>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<16xi64>
+// CHECK-NEXT:    %1 = stablehlo.add %0, %c_0 : tensor<16xi64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<16xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_1 : tensor<16xi64>
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<16x1xf64>
+// CHECK-NEXT:    %3 = stablehlo.reshape %2 : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %4 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %5 = stablehlo.concatenate %3, %4, dim = 1 : (tensor<16x1xi64>, tensor<16x1xi64>) -> tensor<16x2xi64>
+// CHECK-NEXT:    %6 = "stablehlo.scatter"(%cst, %5, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// CHECK-NEXT:      %13 = stablehlo.add %arg2, %arg3 : tensor<f64>
+// CHECK-NEXT:      stablehlo.return %13 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<16x1xf64>, tensor<16x2xi64>, tensor<16xf64>) -> tensor<16x1xf64>
+// CHECK-NEXT:    %7 = stablehlo.reshape %2 : (tensor<16xi64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %8 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i64>) -> tensor<16x1xi64>
+// CHECK-NEXT:    %9 = stablehlo.concatenate %7, %8, dim = 1 : (tensor<16x1xi64>, tensor<16x1xi64>) -> tensor<16x2xi64>
+// CHECK-NEXT:    %10 = "stablehlo.scatter"(%6, %9, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = false}> ({
+// CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// CHECK-NEXT:      %13 = stablehlo.add %arg2, %arg3 : tensor<f64>
+// CHECK-NEXT:      stablehlo.return %13 : tensor<f64>
+// CHECK-NEXT:    }) : (tensor<16x1xf64>, tensor<16x2xi64>, tensor<16xf64>) -> tensor<16x1xf64>
+// CHECK-NEXT:    %11 = stablehlo.reshape %10 : (tensor<16x1xf64>) -> tensor<16xf64>
+// CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_3 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_4 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_5 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_6 = stablehlo.constant dense<0> : tensor<1xi64>
+// CHECK-NEXT:    %c_7 = stablehlo.constant dense<0> : tensor<i64>
+// CHECK-NEXT:    %12 = stablehlo.dynamic_update_slice %arg0, %11, %c_7 : (tensor<16xf64>, tensor<16xf64>, tensor<i64>) -> tensor<16xf64>
+// CHECK-NEXT:    return %12, %arg1 : tensor<16xf64>, tensor<16xf64>
+// CHECK-NEXT:  }
+
+// OPT:  module {
+// OPT-NEXT:  func.func private @lane_atomic_raised(%arg0: tensor<16xf64>, %arg1: tensor<16xf64>) -> (tensor<16xf64>, tensor<16xf64>) {
+// OPT-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<16x1xf64>
+// OPT-NEXT:    %c = stablehlo.constant dense<{{\[\[}}0, 0], [1, 0], [2, 0], [3, 0], [4, 0], [5, 0], [6, 0], [7, 0], [8, 0], [9, 0], [10, 0], [11, 0], [12, 0], [13, 0], [14, 0], [15, 0]]> : tensor<16x2xi64>
+// OPT-NEXT:    %0 = "stablehlo.scatter"(%cst, %c, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// OPT-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// OPT-NEXT:      stablehlo.return %arg3 : tensor<f64>
+// OPT-NEXT:    }) : (tensor<16x1xf64>, tensor<16x2xi64>, tensor<16xf64>) -> tensor<16x1xf64>
+// OPT-NEXT:    %1 = "stablehlo.scatter"(%0, %c, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// OPT-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
+// OPT-NEXT:      %3 = stablehlo.add %arg2, %arg3 : tensor<f64>
+// OPT-NEXT:      stablehlo.return %3 : tensor<f64>
+// OPT-NEXT:    }) : (tensor<16x1xf64>, tensor<16x2xi64>, tensor<16xf64>) -> tensor<16x1xf64>
+// OPT-NEXT:    %2 = stablehlo.reshape %1 : (tensor<16x1xf64>) -> tensor<16xf64>
+// OPT-NEXT:    return %2, %arg1 : tensor<16xf64>, tensor<16xf64>
+// OPT-NEXT:  }

--- a/test/lit_tests/raising/raise_masked_store_overhang.mlir
+++ b/test/lit_tests/raising/raise_masked_store_overhang.mlir
@@ -10,8 +10,8 @@
 // reads the padded buffer, and the pad rows slice away afterwards.
 #set = affine_set<(d0) : (-d0 + 1 >= 0)>
 func.func @guarded_lane_store(%out: memref<18xf64, 1>, %in: memref<9xf64, 1>) {
+  %alloca = memref.alloca() : memref<2x3xf64>
   affine.parallel (%i) = (0) to (3) {
-    %alloca = memref.alloca() : memref<2x3xf64>
     affine.if #set(%i) {
       affine.for %b = 0 to 3 {
         %v = affine.load %in[%i * 3 + %b] : memref<9xf64, 1>
@@ -30,12 +30,12 @@ func.func @guarded_lane_store(%out: memref<18xf64, 1>, %in: memref<9xf64, 1>) {
 }
 
 // CHECK:    func.func private @guarded_lane_store_raised(%arg0: tensor<18xf64>, %arg1: tensor<9xf64>) -> (tensor<18xf64>, tensor<9xf64>) {
+// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<2x3xf64>
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<3xi64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<3xi64>
 // CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<3xi64>
 // CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<3xi64>
 // CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_0 : tensor<3xi64>
-// CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<2x3xf64>
 // CHECK-NEXT:    %c_1 = stablehlo.constant dense<-1> : tensor<i64>
 // CHECK-NEXT:    %3 = stablehlo.broadcast_in_dim %c_1, dims = [] : (tensor<i64>) -> tensor<3xi64>
 // CHECK-NEXT:    %4 = stablehlo.multiply %2, %3 : tensor<3xi64>

--- a/test/lit_tests/raising/raise_pad_guarded_lane_load.mlir
+++ b/test/lit_tests/raising/raise_pad_guarded_lane_load.mlir
@@ -10,8 +10,8 @@
 #set = affine_set<(d0) : (-d0 + 1 >= 0)>
 func.func @guarded_lane_read(%out: memref<9xf64, 1>, %in: memref<6xf64, 1>) {
   %cst = arith.constant 0.000000e+00 : f64
+  %alloca = memref.alloca() : memref<2x3xf64>
   affine.parallel (%i) = (0) to (3) {
-    %alloca = memref.alloca() : memref<2x3xf64>
     affine.for %a = 0 to 6 {
       %v = affine.load %in[%a] : memref<6xf64, 1>
       affine.store %v, %alloca[%a floordiv 3, %a mod 3] : memref<2x3xf64>
@@ -32,12 +32,12 @@ func.func @guarded_lane_read(%out: memref<9xf64, 1>, %in: memref<6xf64, 1>) {
 
 // CHECK:    func.func private @guarded_lane_read_raised(%arg0: tensor<9xf64>, %arg1: tensor<6xf64>) -> (tensor<9xf64>, tensor<6xf64>) {
 // CHECK-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+// CHECK-NEXT:    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<2x3xf64>
 // CHECK-NEXT:    %0 = stablehlo.iota dim = 0 : tensor<3xi64>
 // CHECK-NEXT:    %c = stablehlo.constant dense<0> : tensor<3xi64>
 // CHECK-NEXT:    %1 = stablehlo.add %0, %c : tensor<3xi64>
-// CHECK-NEXT:    %c_0 = stablehlo.constant dense<1> : tensor<3xi64>
-// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_0 : tensor<3xi64>
-// CHECK-NEXT:    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<2x3xf64>
+// CHECK-NEXT:    %c_1 = stablehlo.constant dense<1> : tensor<3xi64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %1, %c_1 : tensor<3xi64>
 // CHECK-NEXT:    %3 = stablehlo.iota dim = 0 : tensor<6xi64>
 // CHECK-NEXT:    %c_2 = stablehlo.constant dense<0> : tensor<6xi64>
 // CHECK-NEXT:    %4 = stablehlo.add %3, %c_2 : tensor<6xi64>
@@ -66,7 +66,7 @@ func.func @guarded_lane_read(%out: memref<9xf64, 1>, %in: memref<6xf64, 1>) {
 // CHECK-NEXT:    %20 = stablehlo.reshape %14 : (tensor<6xi64>) -> tensor<6x1xi64>
 // CHECK-NEXT:    %21 = stablehlo.broadcast_in_dim %19, dims = [0] : (tensor<6xi64>) -> tensor<6x1xi64>
 // CHECK-NEXT:    %22 = stablehlo.concatenate %20, %21, dim = 1 : (tensor<6x1xi64>, tensor<6x1xi64>) -> tensor<6x2xi64>
-// CHECK-NEXT:    %23 = "stablehlo.scatter"(%cst_1, %22, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
+// CHECK-NEXT:    %23 = "stablehlo.scatter"(%cst_0, %22, %arg1) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = true}> ({
 // CHECK-NEXT:    ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
 // CHECK-NEXT:      stablehlo.return %arg3 : tensor<f64>
 // CHECK-NEXT:    }) : (tensor<2x3xf64>, tensor<6x2xi64>, tensor<6xf64>) -> tensor<2x3xf64>


### PR DESCRIPTION
Replaces #2996. Scratch allocated inside batched axes is one buffer per lane, but the raising modeled it as a single tensor: a store whose indices do not involve the lane axes looked uniform, so every lane read lane 0's values (NormalTraceJump's per-thread `grad[3]` accumulators; 8-assertion miscompile in the MFEM GPU suite without a fix).

Rather than rewriting the alloca before raising, the buffer is shaped at the point it is raised: one leading dimension per batched axis whose loop encloses the alloca (parallel axes and lockstep `affine.for`s alike, from `ParallelContext::ivs`), with the axes recorded in the alloca's value map. Every affine or memref load, store and atomic add then prepends the lane induction variables to its indices (`prependLaneDims` / `laneIndices`), so the existing slice, gather, scatter and masked-update machinery sees an ordinary access into a `[lanes..., n]` buffer. Any other kind of user never raised, so there is no gating on the alloca's users.

Shared memory sits between the grid parallel and the thread parallel, so it batches over the grid alone: scratch between two parallels gets only the outer axes and stays shared by the inner lanes. `raise_masked_store_overhang.mlir` and `raise_pad_guarded_lane_load.mlir` model such buffers, so their allocas move above the lane parallel (their goldens only reorder the zero constant).

The masked dynamic-update-slice store path re-read the store op's own map and indices; it now works from the extended access map, which the bounded-parallel test (a masked axis under a size-1 grid axis) exercises.

Test: `raise_lane_private_scratch.mlir`, four cases (per-lane scratch, the same through memref.load/store, per-block scratch shared by inner lanes, atomic adds into per-lane scratch) with full goldens for the raised and the `--enzyme-hlo-opt` output; the optimizer folds each to the expected slice or reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
