### PR TITLE
Factor transposes through select and clamp

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -957,6 +957,7 @@ static void addTransposePropagateUpPasses(std::vector<std::string> &list,
 static void addTransposePropagateDownPasses(std::vector<std::string> &list) {
   list.push_back("reorder_elementwise_and_shape_op<16>");
   list.push_back("elementwise_all_transpose_operands_simplify");
+  list.push_back("broadcasting_elementwise_all_transpose_operands_simplify");
   list.push_back("slice_transpose");
   list.push_back("dynamic_slice_transpose");
   list.push_back("einsum_transpose<1>");

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -7629,12 +7629,13 @@ struct ScatterToDynamicUpdateSlice final
   }
 };
 
-struct ElementwiseAllTransposeOperandsSimplify
+template <template <typename> class Trait>
+struct ElementwiseAllTransposeOperandsSimplifyBase
     : public CheckedOpTraitRewritePattern<
-          OpTrait::Elementwise, ElementwiseAllTransposeOperandsSimplify> {
+          Trait, ElementwiseAllTransposeOperandsSimplifyBase<Trait>> {
   using CheckedOpTraitRewritePattern<
-      OpTrait::Elementwise,
-      ElementwiseAllTransposeOperandsSimplify>::CheckedOpTraitRewritePattern;
+      Trait, ElementwiseAllTransposeOperandsSimplifyBase<Trait>>::
+      CheckedOpTraitRewritePattern;
 
   LogicalResult matchAndRewriteImpl(Operation *op,
                                     PatternRewriter &rewriter) const {
@@ -7647,6 +7648,16 @@ struct ElementwiseAllTransposeOperandsSimplify
     DenseI64ArrayAttr permutation;
     bool foundTranspose = false;
     for (auto operand : op->getOperands()) {
+      auto type = dyn_cast<RankedTensorType>(operand.getType());
+      if (!type)
+        return failure();
+      // Select predicates and clamp bounds may be scalars. They have no axes
+      // to permute and do not determine the result's shape.
+      if (type.getRank() == 0) {
+        kinds.push_back(OperandKind::Scalar);
+        operands.push_back(operand);
+        continue;
+      }
       if (matchPattern(operand, m_Constant())) {
         kinds.push_back(OperandKind::Const);
         operands.push_back(operand);
@@ -7683,6 +7694,7 @@ struct ElementwiseAllTransposeOperandsSimplify
     for (size_t i = 0; i < operands.size(); i++) {
       switch (kinds[i]) {
       case OperandKind::Transpose:
+      case OperandKind::Scalar:
         break;
       case OperandKind::Const:
         // This will be eliminated by a transpose(constant) -> constant
@@ -7694,14 +7706,13 @@ struct ElementwiseAllTransposeOperandsSimplify
       }
     }
 
-    auto operandTy = cast<RankedTensorType>(operands[0].getType());
-    SmallVector<int64_t> elemResShape(operandTy.getShape().begin(),
-                                      operandTy.getShape().end());
+    auto resultType = cast<RankedTensorType>(op->getResult(0).getType());
+    SmallVector<int64_t> elemResShape;
+    for (int64_t dim : invPerm.asArrayRef())
+      elemResShape.push_back(resultType.getDimSize(dim));
     auto newOp = Operation::create(
         op->getLoc(), op->getName(),
-        {RankedTensorType::get(
-            elemResShape,
-            cast<TensorType>(op->getResult(0).getType()).getElementType())},
+        {RankedTensorType::get(elemResShape, resultType.getElementType())},
         operands, op->getAttrs(), mlir::PropertyRef(), op->getSuccessors(), 0);
     rewriter.insert(newOp);
     auto newTransposeOp = stablehlo::TransposeOp::create(
@@ -7711,8 +7722,14 @@ struct ElementwiseAllTransposeOperandsSimplify
   }
 
 private:
-  enum class OperandKind { Transpose, Const };
+  enum class OperandKind { Transpose, Const, Scalar };
 };
+
+using ElementwiseAllTransposeOperandsSimplify =
+    ElementwiseAllTransposeOperandsSimplifyBase<OpTrait::Elementwise>;
+using BroadcastingElementwiseAllTransposeOperandsSimplify =
+    ElementwiseAllTransposeOperandsSimplifyBase<
+        mlir::hlo::OpTrait::BroadcastingElementwise>;
 
 struct TransposeElementwiseTransposeSimplify
     : public CheckedOpRewritePattern<stablehlo::TransposeOp,
@@ -37072,6 +37089,7 @@ struct EnzymeHLOOptPass
     patterns.add<GatherConstProp, ClampConstProp>(context);
 
     patterns.add<ElementwiseAllTransposeOperandsSimplify,
+                 BroadcastingElementwiseAllTransposeOperandsSimplify,
                  TransposeElementwiseTransposeSimplify,
                  AssociativeBinaryOpReordering,
                  CommonAssociativeCommutativeOpReorder>(context);

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -759,6 +759,11 @@ def ApplyElementwiseAllTransposeOperandsSimplifyPatterns : EnzymeHLOPatternOp<
   let patterns = ["ElementwiseAllTransposeOperandsSimplify"];
 }
 
+def ApplyBroadcastingElementwiseAllTransposeOperandsSimplifyPatterns : EnzymeHLOPatternOp<
+    "broadcasting_elementwise_all_transpose_operands_simplify"> {
+  let patterns = ["BroadcastingElementwiseAllTransposeOperandsSimplify"];
+}
+
 def  AssociativeCommonMulOpReorderingPatterns : EnzymeHLOPatternOp<
     "associative_common_mul_op_reordering"> {
   let patterns = ["AssociativeCommonMulOpReordering<stablehlo::AddOp>",

--- a/test/lit_tests/transpose_broadcasting_elementwise.mlir
+++ b/test/lit_tests/transpose_broadcasting_elementwise.mlir
@@ -1,0 +1,128 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt --inline --canonicalize --symbol-dce --drop-unsupported-attributes | stablehlo-translate --interpret
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=broadcasting_elementwise_all_transpose_operands_simplify" --transform-interpreter --enzyme-hlo-remove-transform | FileCheck %s --check-prefix=TRANSFORM
+
+// A select with a tensor predicate blocks ordinary elementwise transpose
+// factoring: SelectOp has BroadcastingElementwise, not Elementwise. Factor
+// its input transposes first so the shared arithmetic can stay in 2x3 layout.
+// The selected value and its square are each computed once and reused.
+// The transform-only run factors the select, leaving the multiply in 3x2
+// layout. This checks the new pattern's transform registration directly.
+// TRANSFORM-LABEL: func.func @shared_select(
+// TRANSFORM-SAME: %[[P:.*]]: tensor<2x3xi1>, %[[X:.*]]: tensor<2x3xi32>
+// TRANSFORM: %[[S:.*]] = stablehlo.select %[[P]], %[[X]], {{.*}} : tensor<2x3xi1>, tensor<2x3xi32>
+// TRANSFORM-NEXT: %[[T:.*]] = stablehlo.transpose %[[S]], dims = [1, 0]
+// TRANSFORM-NEXT: %[[M:.*]] = stablehlo.multiply %[[T]], %[[T]] : tensor<3x2xi32>
+// CHECK-LABEL: func.func @shared_select(
+// CHECK-SAME: %[[P:.*]]: tensor<2x3xi1>, %[[X:.*]]: tensor<2x3xi32>
+// CHECK-NOT: stablehlo.transpose
+// CHECK: %[[S:.*]] = stablehlo.select %[[P]], %[[X]],
+// CHECK-NOT: stablehlo.transpose
+// CHECK: %[[M:.*]] = stablehlo.multiply %[[S]], %[[S]]
+// CHECK: %[[A:.*]] = stablehlo.add
+// CHECK-NOT: stablehlo.transpose
+// CHECK: return %[[M]], %[[A]]
+func.func @shared_select(%pred: tensor<2x3xi1>, %x: tensor<2x3xi32>) -> (tensor<2x3xi32>, tensor<2x3xi32>) {
+  %zero = stablehlo.constant dense<0> : tensor<3x2xi32>
+  %p = stablehlo.transpose %pred, dims = [1, 0] : (tensor<2x3xi1>) -> tensor<3x2xi1>
+  %t = stablehlo.transpose %x, dims = [1, 0] : (tensor<2x3xi32>) -> tensor<3x2xi32>
+  %s = stablehlo.select %p, %t, %zero : tensor<3x2xi1>, tensor<3x2xi32>
+  %m = stablehlo.multiply %s, %s : tensor<3x2xi32>
+  %a = stablehlo.add %s, %m : tensor<3x2xi32>
+  %r0 = stablehlo.transpose %m, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  %r1 = stablehlo.transpose %a, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  return %r0, %r1 : tensor<2x3xi32>, tensor<2x3xi32>
+}
+
+// Scalar predicates stay scalar. The result shape must come from the select's
+// tensor result, not its first operand. The non-splat constant's elements must
+// also follow the inverse permutation.
+// A sharding attribute must not block factoring and must be preserved.
+// TRANSFORM-LABEL: func.func @scalar_select(
+// TRANSFORM-SAME: %[[P:.*]]: tensor<i1>, %[[X:.*]]: tensor<2x3xi32>
+// TRANSFORM: stablehlo.select %[[P]], %[[X]], {{.*}} {mhlo.sharding = "{replicated}"} : tensor<i1>, tensor<2x3xi32>
+// CHECK-LABEL: func.func @scalar_select(
+// CHECK-SAME: %[[P:.*]]: tensor<i1>, %[[X:.*]]: tensor<2x3xi32>
+// CHECK: stablehlo.constant dense<{{.*}}1, 3, 5{{.*}}2, 4, 6{{.*}}> : tensor<2x3xi32>
+// CHECK-NOT: stablehlo.transpose
+// CHECK: stablehlo.select %[[P]], %[[X]],
+// CHECK-NOT: stablehlo.transpose
+// CHECK: return
+func.func @scalar_select(%pred: tensor<i1>, %x: tensor<2x3xi32>) -> tensor<2x3xi32> {
+  %fallback = stablehlo.constant dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi32>
+  %t = stablehlo.transpose %x, dims = [1, 0] : (tensor<2x3xi32>) -> tensor<3x2xi32>
+  %s = stablehlo.select %pred, %t, %fallback {mhlo.sharding = "{replicated}"} : tensor<i1>, tensor<3x2xi32>
+  %r = stablehlo.transpose %s, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  return %r : tensor<2x3xi32>
+}
+
+// Clamp also has BroadcastingElementwise. Both scalar bounds must remain
+// scalars while the tensor operand and result change layout.
+// TRANSFORM-LABEL: func.func @scalar_clamp(
+// TRANSFORM-SAME: %[[LOW:.*]]: tensor<i32>, %[[X:.*]]: tensor<2x3xi32>, %[[HIGH:.*]]: tensor<i32>
+// TRANSFORM: stablehlo.clamp %[[LOW]], %[[X]], %[[HIGH]] : (tensor<i32>, tensor<2x3xi32>, tensor<i32>) -> tensor<2x3xi32>
+// CHECK-LABEL: func.func @scalar_clamp(
+// CHECK-SAME: %[[LOW:.*]]: tensor<i32>, %[[X:.*]]: tensor<2x3xi32>, %[[HIGH:.*]]: tensor<i32>
+// CHECK-NOT: stablehlo.transpose
+// CHECK: stablehlo.clamp %[[LOW]], %[[X]], %[[HIGH]] : (tensor<i32>, tensor<2x3xi32>, tensor<i32>) -> tensor<2x3xi32>
+// CHECK-NOT: stablehlo.transpose
+// CHECK: return
+func.func @scalar_clamp(%low: tensor<i32>, %x: tensor<2x3xi32>, %high: tensor<i32>) -> tensor<2x3xi32> {
+  %t = stablehlo.transpose %x, dims = [1, 0] : (tensor<2x3xi32>) -> tensor<3x2xi32>
+  %c = stablehlo.clamp %low, %t, %high : (tensor<i32>, tensor<3x2xi32>, tensor<i32>) -> tensor<3x2xi32>
+  %r = stablehlo.transpose %c, dims = [1, 0] : (tensor<3x2xi32>) -> tensor<2x3xi32>
+  return %r : tensor<2x3xi32>
+}
+
+// Exercise a non-self-inverse permutation; tensor clamp bounds are permuted
+// along with the value. The scalar upper bound still has no axes.
+// CHECK-LABEL: func.func @three_axes(
+// CHECK-NOT: stablehlo.transpose
+// CHECK: stablehlo.clamp
+// CHECK-NOT: stablehlo.transpose
+// CHECK: return
+func.func @three_axes(%low: tensor<2x3x4xi32>, %x: tensor<2x3x4xi32>, %high: tensor<i32>) -> tensor<2x3x4xi32> {
+  %l = stablehlo.transpose %low, dims = [2, 0, 1] : (tensor<2x3x4xi32>) -> tensor<4x2x3xi32>
+  %t = stablehlo.transpose %x, dims = [2, 0, 1] : (tensor<2x3x4xi32>) -> tensor<4x2x3xi32>
+  %c = stablehlo.clamp %l, %t, %high : (tensor<4x2x3xi32>, tensor<4x2x3xi32>, tensor<i32>) -> tensor<4x2x3xi32>
+  %r = stablehlo.transpose %c, dims = [1, 2, 0] : (tensor<4x2x3xi32>) -> tensor<2x3x4xi32>
+  return %r : tensor<2x3x4xi32>
+}
+
+// A common permutation is required. These square tensors have equal shapes
+// but different permutations, so their indexing cannot be factored together.
+// CHECK-LABEL: func.func @different_permutations(
+// CHECK: stablehlo.transpose {{.*}}dims = [1, 2, 0]
+// CHECK: stablehlo.transpose {{.*}}dims = [2, 0, 1]
+// CHECK: stablehlo.select
+// CHECK: return
+func.func @different_permutations(%pred: tensor<2x2x2xi1>, %x: tensor<2x2x2xi32>, %y: tensor<2x2x2xi32>) -> tensor<2x2x2xi32> {
+  %p = stablehlo.transpose %pred, dims = [1, 2, 0] : (tensor<2x2x2xi1>) -> tensor<2x2x2xi1>
+  %t = stablehlo.transpose %x, dims = [2, 0, 1] : (tensor<2x2x2xi32>) -> tensor<2x2x2xi32>
+  %u = stablehlo.transpose %y, dims = [2, 0, 1] : (tensor<2x2x2xi32>) -> tensor<2x2x2xi32>
+  %r = stablehlo.select %p, %t, %u : tensor<2x2x2xi1>, tensor<2x2x2xi32>
+  return %r : tensor<2x2x2xi32>
+}
+
+func.func @main() {
+  %x = stablehlo.constant dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi32>
+  %p = stablehlo.constant dense<[[true, false, true], [false, true, true]]> : tensor<2x3xi1>
+  %expected_square = stablehlo.constant dense<[[0, 0, 4], [0, 16, 25]]> : tensor<2x3xi32>
+  %expected_sum = stablehlo.constant dense<[[0, 0, 6], [0, 20, 30]]> : tensor<2x3xi32>
+  %shared:2 = func.call @shared_select(%p, %x) : (tensor<2x3xi1>, tensor<2x3xi32>) -> (tensor<2x3xi32>, tensor<2x3xi32>)
+  check.expect_eq %shared#0, %expected_square : tensor<2x3xi32>
+  check.expect_eq %shared#1, %expected_sum : tensor<2x3xi32>
+  %yes = stablehlo.constant dense<true> : tensor<i1>
+  %no = stablehlo.constant dense<false> : tensor<i1>
+  %fallback = stablehlo.constant dense<[[1, 3, 5], [2, 4, 6]]> : tensor<2x3xi32>
+  %chosen = func.call @scalar_select(%yes, %x) : (tensor<i1>, tensor<2x3xi32>) -> tensor<2x3xi32>
+  %other = func.call @scalar_select(%no, %x) : (tensor<i1>, tensor<2x3xi32>) -> tensor<2x3xi32>
+  check.expect_eq %chosen, %x : tensor<2x3xi32>
+  check.expect_eq %other, %fallback : tensor<2x3xi32>
+  %low = stablehlo.constant dense<1> : tensor<i32>
+  %high = stablehlo.constant dense<4> : tensor<i32>
+  %expected_clamp = stablehlo.constant dense<[[1, 1, 2], [3, 4, 4]]> : tensor<2x3xi32>
+  %clamped = func.call @scalar_clamp(%low, %x, %high) : (tensor<i32>, tensor<2x3xi32>, tensor<i32>) -> tensor<2x3xi32>
+  check.expect_eq %clamped, %expected_clamp : tensor<2x3xi32>
+  return
+}


### PR DESCRIPTION
`ElementwiseAllTransposeOperandsSimplify` skips `select` and `clamp` because StableHLO gives them the `BroadcastingElementwise` trait. This blocks transpose factoring through shared expressions; LBM retained 72 transposes after optimization.

Reuse the existing pattern for broadcasting elementwise operations. Preserve scalar predicates and clamp bounds, derive the permuted result shape from the original result, and use `Operation::create` with the rewritten operands, result type, and original attributes. The ordinary elementwise transform registration keeps its existing name. Register the broadcasting variant as `broadcasting_elementwise_all_transpose_operands_simplify` in the transform dialect and immediately after the ordinary variant in the C API downward transpose propagation list.

The new LIT test explains the before/after behavior for shared select arithmetic, scalar operands, non-splat constants, non-self-inverse permutations, and incompatible permutations, with numerical checks against independent expected values in the StableHLO interpreter.

Validation:

- 73 related transpose/select/clamp and transform LIT tests pass on this branch based on main; 74 pass on LBM staging. The regression directly applies the new named transform pattern and checks that a sharding attribute is preserved.
- Clang-format 16 passes for the changed C++ file; `git diff --check` passes.
- In the normal LBM staging pipeline, post-optimization transposes drop from 72 to 0 and reshapes from 22 to 12. LBM sources and executable are unchanged, and output is byte-identical to the validated baseline.
- A 20-timestep LBM profile still has 511 GPU kernel launches and 48 DUS operations in the optimized loop body.

The same logical change is included on `vim/lbm-staging` as `f356ef738e2782efb8f36a52137f47d1cc665bff`; the only integration difference is retaining each branch's existing transpose-cancellation registration.

Fresh LBM staging benchmark (20 timesteps on an RTX 5090; medians of three captures per configuration):

| Version | Transposes | GPU launches | Summed GPU kernel time |
|---|---:|---:|---:|
| XLA baseline | 72 | 511 | 9.398 ms |
| XLA with this change | 0 | 511 | 9.403 ms |
| CUDA reference | — | 20 | 5.756 ms |

Before/after XLA runtimes were profiled in alternating order after builds completed. The +0.06% difference is within the observed variation; this change simplifies the input IR but shows no measurable LBM speedup. GPU kernel time excludes compilation, transfers and launch gaps. All XLA outputs are byte-identical to the baseline and agree with CUDA within atol=1e-6, rtol=1e-5 (maximum absolute error 5.96e-7).

After the review fixes, the rebuilt runtime generates byte-identical optimized LBM MLIR to the benchmarked version (zero transposes). The C API was checked directly to confirm that the new pattern immediately follows the ordinary elementwise pattern when downward transpose propagation is selected.
