### PR TITLE
Pin julia version to 1.12.6 for Reactant integration

### DIFF
--- a/.github/workflows/reactant-integration.yml
+++ b/.github/workflows/reactant-integration.yml
@@ -44,7 +44,7 @@ jobs:
     secrets: inherit
     with:
       enzymejax_commit: ${{ inputs.enzymejax_commit || github.sha }}
-      julia_version: '1.12'
+      julia_version: '1.12.6'
       os: ${{ matrix.os }}
       localjll: true
       runtime: "ifrt"


### PR DESCRIPTION
CI has been red in Reactant for the 1.12.7 bump due to a change in LinearAlgebra relying on invoke (that Reactant does not seem to handle correctly). Anyway, this pins the Julia version to 1.12.6 to see if gets green again while the bug is fixed in Reactant proper.

