### PR TITLE
Raising pipeline: inline kernel functor methods and discard their dead copies

### DIFF
--- a/src/enzyme_ad/jax/Passes/DiscardUnreferencedLinkonce.cpp
+++ b/src/enzyme_ad/jax/Passes/DiscardUnreferencedLinkonce.cpp
@@ -1,0 +1,66 @@
+//===- DiscardUnreferencedLinkonce.cpp - GlobalDCE for linkonce functions -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// symbol-dce keeps every symbol that is not private, so a linkonce or weak
+// definition the inliner has folded into all its callers survives it. Each
+// translation unit that uses such a function defines its own copy, so an
+// unreferenced definition is discardable, as in LLVM's GlobalDCE.
+//
+//===---------------------------------------------------------------------===//
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_DISCARDUNREFERENCEDLINKONCEPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+static bool isDiscardableLinkage(LLVM::Linkage linkage) {
+  switch (linkage) {
+  case LLVM::Linkage::Linkonce:
+  case LLVM::Linkage::LinkonceODR:
+  case LLVM::Linkage::Weak:
+  case LLVM::Linkage::WeakODR:
+    return true;
+  default:
+    return false;
+  }
+}
+
+struct DiscardUnreferencedLinkoncePass
+    : public enzyme::impl::DiscardUnreferencedLinkoncePassBase<
+          DiscardUnreferencedLinkoncePass> {
+  using DiscardUnreferencedLinkoncePassBase::
+      DiscardUnreferencedLinkoncePassBase;
+
+  void runOnOperation() override {
+    Operation *root = getOperation();
+    // Erasing one definition can leave another unreferenced.
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      SmallVector<LLVM::LLVMFuncOp> dead;
+      root->walk([&](LLVM::LLVMFuncOp fn) {
+        if (fn.isExternal() || !isDiscardableLinkage(fn.getLinkage()))
+          return;
+        if (SymbolTable::symbolKnownUseEmpty(fn, root))
+          dead.push_back(fn);
+      });
+      for (auto fn : dead) {
+        fn.erase();
+        changed = true;
+      }
+    }
+  }
+};
+} // namespace

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -368,6 +368,23 @@ def HoistAllocasPass : Pass<"hoist-allocas"> {
   ];
 }
 
+def StripDeadPersonalityPass : Pass<"strip-dead-personality"> {
+  let summary = "Drop the personality of functions that have no landing pad, "
+                "so the inliner accepts them";
+  let dependentDialects = [
+    "LLVM::LLVMDialect",
+  ];
+}
+
+def DiscardUnreferencedLinkoncePass
+    : Pass<"discard-unreferenced-linkonce"> {
+  let summary = "Erase linkonce and weak function definitions nothing "
+                "references";
+  let dependentDialects = [
+    "LLVM::LLVMDialect",
+  ];
+}
+
 def RestorePreserveNVVMPass : Pass<"restore-preserve-nvvm"> {
   let summary = "Undo PreserveNVVM(Begin)'s linkage and inlining fixups once "
                 "the raising has consumed the calls they protected";

--- a/src/enzyme_ad/jax/Passes/StripDeadPersonality.cpp
+++ b/src/enzyme_ad/jax/Passes/StripDeadPersonality.cpp
@@ -1,0 +1,46 @@
+//===- StripDeadPersonality.cpp - Drop personalities without landing pads -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// The LLVM dialect inliner refuses a callee with a personality. A personality
+// is consulted only through landing pads, so a function without one has no
+// use for it: a throwing callee unwinds through the function as through any
+// function that never had a personality, and with no landing pad to unwind
+// to, every call in it is a plain call. Dropping the attribute lets such
+// functions inline.
+//
+//===---------------------------------------------------------------------===//
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_STRIPDEADPERSONALITYPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+struct StripDeadPersonalityPass
+    : public enzyme::impl::StripDeadPersonalityPassBase<
+          StripDeadPersonalityPass> {
+  using StripDeadPersonalityPassBase::StripDeadPersonalityPassBase;
+
+  void runOnOperation() override {
+    getOperation()->walk([&](LLVM::LLVMFuncOp fn) {
+      if (!fn.getPersonality())
+        return;
+      bool hasLandingPad = false;
+      fn.walk([&](LLVM::LandingpadOp) { hasLandingPad = true; });
+      if (!hasLandingPad)
+        fn->removeAttr(fn.getPersonalityAttrName());
+    });
+  }
+};
+} // namespace

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -190,7 +190,9 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
     // the primal that carries the user's marker -- and any left behind
     // fail translation to LLVM IR.
     "lower-llvm-ext,"
+    "strip-dead-personality,"
     "inline{default-pipeline=canonicalize max-iterations=4},"
+    "discard-unreferenced-linkonce,"
     "polygeist-mem2reg," + canonicalize + ",symbol-dce,"
     // canonicalize-parallel here folds away memref.subview ops before gpu-kernel-outlining
     "" + canonicalize + ",cse";

--- a/test/lit_tests/discard_unreferenced_linkonce.mlir
+++ b/test/lit_tests/discard_unreferenced_linkonce.mlir
@@ -1,0 +1,50 @@
+// RUN: enzymexlamlir-opt %s --discard-unreferenced-linkonce | FileCheck %s
+
+// Unreferenced linkonce and weak definitions go; a comdat selector is not a
+// reference, and external definitions and declarations stay.
+
+llvm.comdat @__llvm_global_comdat {
+  llvm.comdat_selector @dead_odr any
+  llvm.comdat_selector @live_odr any
+}
+
+llvm.func linkonce_odr @dead_odr() comdat(@__llvm_global_comdat::@dead_odr) {
+  llvm.return
+}
+
+llvm.func weak @dead_weak() {
+  llvm.return
+}
+
+llvm.func linkonce_odr @live_odr() comdat(@__llvm_global_comdat::@live_odr) {
+  llvm.return
+}
+
+llvm.func @decl()
+
+llvm.func @external_unreferenced() {
+  llvm.return
+}
+
+llvm.func @main() {
+  llvm.call @live_odr() : () -> ()
+  llvm.call @decl() : () -> ()
+  llvm.return
+}
+
+// CHECK:    llvm.comdat @__llvm_global_comdat {
+// CHECK-NEXT:    llvm.comdat_selector @dead_odr any
+// CHECK-NEXT:    llvm.comdat_selector @live_odr any
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func linkonce_odr @live_odr() comdat(@__llvm_global_comdat::@live_odr) {
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @decl()
+// CHECK-NEXT:  llvm.func @external_unreferenced() {
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @main() {
+// CHECK-NEXT:    llvm.call @live_odr() : () -> ()
+// CHECK-NEXT:    llvm.call @decl() : () -> ()
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }

--- a/test/lit_tests/inline_host_functor.mlir
+++ b/test/lit_tests/inline_host_functor.mlir
@@ -1,0 +1,41 @@
+// RUN: enzymexlamlir-opt %s --strip-dead-personality --inline --discard-unreferenced-linkonce --polygeist-mem2reg --canonicalize | FileCheck %s
+
+// A method that loads its whole capture from `this` and takes it apart with
+// extractvalue, called by the function that stored the fields one by one:
+// inlined and its dead definition discarded, mem2reg forwards every field.
+
+llvm.func @__gxx_personality_v0(...) -> i32
+llvm.func @use(i32, !llvm.ptr)
+
+llvm.func linkonce_odr @run(%this: !llvm.ptr) attributes {personality = @__gxx_personality_v0} {
+  %view = "enzymexla.pointer2memref"(%this) : (!llvm.ptr) -> memref<?x!llvm.struct<(ptr, i32)>>
+  %functor = affine.load %view[0] : memref<?x!llvm.struct<(ptr, i32)>>
+  %p = llvm.extractvalue %functor[0] : !llvm.struct<(ptr, i32)>
+  %n = llvm.extractvalue %functor[1] : !llvm.struct<(ptr, i32)>
+  llvm.call @use(%n, %p) : (i32, !llvm.ptr) -> ()
+  llvm.return
+}
+
+llvm.func @caller(%buf: !llvm.ptr, %n: i32) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %functor = llvm.alloca %c1 x !llvm.struct<(ptr, i32)> : (i32) -> !llvm.ptr
+  %ptrs = "enzymexla.pointer2memref"(%functor) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+  affine.store %buf, %ptrs[0] : memref<?x!llvm.ptr>
+  %ints = "enzymexla.pointer2memref"(%functor) : (!llvm.ptr) -> memref<?xi32>
+  affine.store %n, %ints[2] : memref<?xi32>
+  llvm.call @run(%functor) : (!llvm.ptr) -> ()
+  llvm.return
+}
+
+// CHECK:    llvm.func @__gxx_personality_v0(...) -> i32
+// CHECK-NEXT:  llvm.func @use(i32, !llvm.ptr)
+// CHECK-NEXT:  llvm.func @caller(%arg0: !llvm.ptr, %arg1: i32) {
+// CHECK-NEXT:    %0 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:    %1 = llvm.alloca %0 x !llvm.struct<(ptr, i32)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %2 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+// CHECK-NEXT:    affine.store %arg0, %2[0] : memref<?x!llvm.ptr>
+// CHECK-NEXT:    %3 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?xi32>
+// CHECK-NEXT:    affine.store %arg1, %3[2] : memref<?xi32>
+// CHECK-NEXT:    llvm.call @use(%arg1, %arg0) : (i32, !llvm.ptr) -> ()
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }

--- a/test/lit_tests/strip_dead_personality.mlir
+++ b/test/lit_tests/strip_dead_personality.mlir
@@ -1,0 +1,35 @@
+// RUN: enzymexlamlir-opt %s --strip-dead-personality | FileCheck %s
+
+// A personality is consulted only through landing pads.
+
+llvm.func @__gxx_personality_v0(...) -> i32
+llvm.func @maythrow()
+
+llvm.func @no_landing_pad() attributes {personality = @__gxx_personality_v0} {
+  llvm.call @maythrow() : () -> ()
+  llvm.return
+}
+
+llvm.func @catches() attributes {personality = @__gxx_personality_v0} {
+  llvm.invoke @maythrow() to ^ok unwind ^lp : () -> ()
+^ok:
+  llvm.return
+^lp:
+  %0 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.resume %0 : !llvm.struct<(ptr, i32)>
+}
+
+// CHECK:    llvm.func @__gxx_personality_v0(...) -> i32
+// CHECK-NEXT:  llvm.func @maythrow()
+// CHECK-NEXT:  llvm.func @no_landing_pad() {
+// CHECK-NEXT:    llvm.call @maythrow() : () -> ()
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @catches() attributes {personality = @__gxx_personality_v0} {
+// CHECK-NEXT:    llvm.invoke @maythrow() to ^bb1 unwind ^bb2 : () -> ()
+// CHECK-NEXT:  ^bb1:  // pred: ^bb0
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  ^bb2:  // pred: ^bb0
+// CHECK-NEXT:    %0 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+// CHECK-NEXT:    llvm.resume %0 : !llvm.struct<(ptr, i32)>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Why #2933's shape exists, and a pipeline-side way through it.

MFEM's `CuWrapND` takes the lambda capture by reference. The functor's method (`DerefineMatrixOpMultFunctor<…>::Run(int)` in `fem/derefmat_op.cpp`) copies the capture out of `this` as one aggregate load taken apart by `extractvalue`, while its caller stored the fields one by one into the functor alloca (12 typed-view stores, no escapes). mem2reg forwards those fields as soon as the load and the stores meet in one function; on the pre-raise dump of that TU, after the pipeline's own `inline` and `polygeist-mem2reg`, no `extractvalue` remains in the caller. Two things kept them apart:

- The method still carries the `personality` the front end gave it after its invokes were lowered, and the LLVM dialect inliner refuses any callee with a personality (`InlinerInterfaceImpl.cpp`, "TODO: Handle exceptions"). A function without a landing pad has no use for one: unwinding passes straight through it either way. `strip-dead-personality` drops it.
- Once inlined, the `linkonce_odr` definition stays behind (symbol-dce keeps anything not private), and its own copy of the aggregate load still fails the raising. Every translation unit that uses such a function defines its own copy, so an unreferenced one is discardable, as LLVM's GlobalDCE does. `discard-unreferenced-linkonce` erases linkonce/weak definitions with no symbol uses (comdat selectors are not uses), to a fixpoint.

Both run around the pipeline's second `inline`. On the `derefmat_op.cpp` dump, with these two steps and no #2933, all four kernels raise.

Tests: `strip_dead_personality.mlir` (a landing-pad function keeps its personality), `discard_unreferenced_linkonce.mlir` (referenced, external and declared functions stay), `inline_host_functor.mlir` (the by-reference functor shape end to end: the call ends up with the stored SSA values and no aggregate load).

Validation on the 18 TUs that currently need #2933, and on the full suite, is running; I'll post the numbers here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
