### PR TITLE
Raising pipeline: lower affine around the second inline

### DIFF
--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -190,9 +190,9 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
     // the primal that carries the user's marker -- and any left behind
     // fail translation to LLVM IR.
     "lower-llvm-ext,"
-    "strip-dead-personality,"
+    "strip-dead-personality,lower-affine,"
     "inline{default-pipeline=canonicalize max-iterations=4},"
-    "discard-unreferenced-linkonce,"
+    "discard-unreferenced-linkonce,affine-cfg,"
     "polygeist-mem2reg," + canonicalize + ",symbol-dce,"
     // canonicalize-parallel here folds away memref.subview ops before gpu-kernel-outlining
     "" + canonicalize + ",cse";

--- a/test/lit_tests/inline_host_functor_nested.mlir
+++ b/test/lit_tests/inline_host_functor_nested.mlir
@@ -1,0 +1,46 @@
+// RUN: enzymexlamlir-opt %s --strip-dead-personality --lower-affine --inline --discard-unreferenced-linkonce --affine-cfg --polygeist-mem2reg --canonicalize | FileCheck %s
+
+// The affine dialect only lets its ops inline into an affine scope or an
+// affine loop or conditional, so a callee that starts with an affine load
+// cannot inline into a call site under an scf.if. Lowering affine before the
+// inliner and raising it again afterwards makes the call site irrelevant.
+
+llvm.func @__gxx_personality_v0(...) -> i32
+llvm.func @use(i32, !llvm.ptr)
+
+llvm.func linkonce_odr @run(%this: !llvm.ptr) attributes {personality = @__gxx_personality_v0} {
+  %view = "enzymexla.pointer2memref"(%this) : (!llvm.ptr) -> memref<?x!llvm.struct<(ptr, i32)>>
+  %functor = affine.load %view[0] : memref<?x!llvm.struct<(ptr, i32)>>
+  %p = llvm.extractvalue %functor[0] : !llvm.struct<(ptr, i32)>
+  %n = llvm.extractvalue %functor[1] : !llvm.struct<(ptr, i32)>
+  llvm.call @use(%n, %p) : (i32, !llvm.ptr) -> ()
+  llvm.return
+}
+
+llvm.func @caller(%buf: !llvm.ptr, %n: i32, %c: i1) {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %functor = llvm.alloca %c1 x !llvm.struct<(ptr, i32)> : (i32) -> !llvm.ptr
+  %ptrs = "enzymexla.pointer2memref"(%functor) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+  affine.store %buf, %ptrs[0] : memref<?x!llvm.ptr>
+  %ints = "enzymexla.pointer2memref"(%functor) : (!llvm.ptr) -> memref<?xi32>
+  affine.store %n, %ints[2] : memref<?xi32>
+  scf.if %c {
+    llvm.call @run(%functor) : (!llvm.ptr) -> ()
+  }
+  llvm.return
+}
+
+// CHECK:    llvm.func @__gxx_personality_v0(...) -> i32
+// CHECK-NEXT:  llvm.func @use(i32, !llvm.ptr)
+// CHECK-NEXT:  llvm.func @caller(%arg0: !llvm.ptr, %arg1: i32, %arg2: i1) {
+// CHECK-NEXT:    %0 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:    %1 = llvm.alloca %0 x !llvm.struct<(ptr, i32)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:    %2 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+// CHECK-NEXT:    affine.store %arg0, %2[0] : memref<?x!llvm.ptr>
+// CHECK-NEXT:    %3 = "enzymexla.pointer2memref"(%1) : (!llvm.ptr) -> memref<?xi32>
+// CHECK-NEXT:    affine.store %arg1, %3[2] : memref<?xi32>
+// CHECK-NEXT:    scf.if %arg2 {
+// CHECK-NEXT:      llvm.call @use(%arg1, %arg0) : (i32, !llvm.ptr) -> ()
+// CHECK-NEXT:    }
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }


### PR DESCRIPTION
Follow-up to #3159. Its two passes reached only `fem/derefmat_op.cpp` of the 18 TUs that need #2933: in `fem/pderefmat_op.cpp` the functor methods are called under `scf.if`/`scf.for`, and `AffineInlinerInterface::isLegalToInline(op, region)` only admits an affine op into a region whose parent is an affine scope or an affine loop/conditional, so a callee that starts with the aggregate `affine.load` stays out of line there.

Lowering affine before the second inline removes the affine ops from the callees, and `affine-cfg` right after `discard-unreferenced-linkonce` raises them back before mem2reg. On the pderefmat dump every `Run` folds into its callers, the parallels come back as `affine.parallel`, and mem2reg forwards all the fields.

Test: `inline_host_functor_nested.mlir`, the functor call under an `scf.if`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
