### PR TITLE
Hoist loop-carried reshapes out of StableHLO while loops

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -883,6 +883,8 @@ static void addReshapePropagateUpPasses(std::vector<std::string> &list,
                                         bool aggressive) {
   list.push_back("reshape_concat");
   list.push_back("reshape_dus");
+  list.push_back("reshape_while");
+  list.push_back("reshape_bitcast_convert");
   list.push_back("dot_reshape_pad<1>");
   list.push_back("pad_dot_general<1>(0)");
   // FIXME: see https://github.com/EnzymeAD/Enzyme-JAX/issues/1445

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -16877,6 +16877,147 @@ private:
   }
 };
 
+// Cancel reshape(bitcast_convert(reshape(x))) when the outer shape is exactly
+// the bitcast shape of x. In particular, a narrowing bitcast must retain its
+// extra innermost dimension, which groups the pieces of each source element.
+struct ReshapeBitcastConvert final
+    : CheckedOpRewritePattern<stablehlo::ReshapeOp, ReshapeBitcastConvert> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  // The intermediate bitcast may have a dynamic shape even when the source
+  // and final result statically determine the complete element grouping.
+  bool supportsDynamicShapes() const { return true; }
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ReshapeOp op,
+                                    PatternRewriter &rewriter) const {
+    auto bitcast = op.getOperand().getDefiningOp<stablehlo::BitcastConvertOp>();
+    if (!bitcast || !bitcast->hasOneUse())
+      return failure();
+    auto reshape = bitcast.getOperand().getDefiningOp<stablehlo::ReshapeOp>();
+    if (!reshape)
+      return failure();
+    auto inputType = cast<RankedTensorType>(reshape.getOperand().getType());
+    auto resultType = cast<RankedTensorType>(op.getType());
+    if (!inputType.hasStaticShape() || !resultType.hasStaticShape() ||
+        !isa<IntegerType, FloatType>(inputType.getElementType()) ||
+        !isa<IntegerType, FloatType>(resultType.getElementType()))
+      return failure();
+
+    unsigned inputBits = inputType.getElementTypeBitWidth();
+    unsigned resultBits = resultType.getElementTypeBitWidth();
+    SmallVector<int64_t> shape(inputType.getShape());
+    if (inputBits > resultBits) {
+      if (inputBits % resultBits)
+        return failure();
+      shape.push_back(inputBits / resultBits);
+    } else if (inputBits < resultBits) {
+      if (resultBits % inputBits || shape.empty() ||
+          shape.back() != resultBits / inputBits)
+        return failure();
+      shape.pop_back();
+    }
+    if (ArrayRef<int64_t>(shape) != resultType.getShape())
+      return failure();
+
+    auto updated = rewriter.replaceOpWithNewOp<stablehlo::BitcastConvertOp>(
+        op, resultType, reshape.getOperand());
+    updated->setAttrs(bitcast->getAttrs());
+    return success();
+  }
+};
+
+// Carry the shape used by the body when every use of the carried argument is
+// a reshape or bitcast_convert. Inverse views adapt those uses and preserve
+// the public result types, including when the body executes zero times.
+struct ReshapeWhile final
+    : CheckedOpRewritePattern<stablehlo::WhileOp, ReshapeWhile> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::WhileOp op,
+                                    PatternRewriter &rewriter) const {
+    auto &body = op.getBody().front();
+    auto yield = cast<stablehlo::ReturnOp>(body.getTerminator());
+    struct Candidate {
+      unsigned index;
+      RankedTensorType oldType, newType;
+      SmallVector<stablehlo::ReshapeOp> inputViews;
+    };
+    SmallVector<Candidate> candidates;
+    SmallVector<Value> yields(yield.getOperands());
+    for (auto [i, value] : llvm::enumerate(yield.getOperands())) {
+      auto reshape = value.getDefiningOp<stablehlo::ReshapeOp>();
+      if (!reshape)
+        continue;
+      auto oldType = cast<RankedTensorType>(value.getType());
+      auto newType = cast<RankedTensorType>(reshape.getOperand().getType());
+      if (oldType == newType || !oldType.hasStaticShape() ||
+          !newType.hasStaticShape() ||
+          oldType.getElementType() != newType.getElementType())
+        continue;
+      // One matching reshape is not enough: other consumers would still need
+      // the old shape inside the loop. Check both regions, allowing bitcast
+      // users even when there is no direct reshape of the argument.
+      auto onlyViews = [](BlockArgument arg) {
+        return llvm::all_of(arg.getUsers(), [](Operation *user) {
+          return isa<stablehlo::ReshapeOp, stablehlo::BitcastConvertOp>(user);
+        });
+      };
+      if (!onlyViews(body.getArgument(i)) ||
+          !onlyViews(op.getCond().front().getArgument(i)))
+        continue;
+      Candidate candidate{static_cast<unsigned>(i), oldType, newType, {}};
+      for (Operation *user : body.getArgument(i).getUsers())
+        if (auto view = dyn_cast<stablehlo::ReshapeOp>(user))
+          if (view.getType() == newType)
+            candidate.inputViews.push_back(view);
+      candidates.push_back(std::move(candidate));
+      yields[i] = reshape.getOperand();
+    }
+    if (candidates.empty())
+      return failure();
+
+    SmallVector<Value> inputs(op.getOperands());
+    SmallVector<Type> types(op.getResultTypes());
+    for (auto &candidate : candidates) {
+      inputs[candidate.index] = stablehlo::ReshapeOp::create(
+          rewriter, op.getLoc(), candidate.newType, inputs[candidate.index]);
+      types[candidate.index] = candidate.newType;
+    }
+    auto updated = stablehlo::WhileOp::create(rewriter, op.getLoc(), types,
+                                              inputs, op->getAttrs());
+    rewriter.inlineRegionBefore(op.getCond(), updated.getCond(),
+                                updated.getCond().end());
+    rewriter.inlineRegionBefore(op.getBody(), updated.getBody(),
+                                updated.getBody().end());
+    // Change the yield before replacing input views: a yielded value may be
+    // one of those views, including a view of a different loop argument.
+    rewriter.modifyOpInPlace(yield, [&] { yield->setOperands(yields); });
+    for (auto &candidate : candidates) {
+      for (Region *region : {&updated.getCond(), &updated.getBody()}) {
+        OpBuilder::InsertionGuard guard(rewriter);
+        auto arg = region->front().getArgument(candidate.index);
+        rewriter.modifyOpInPlace(updated,
+                                 [&] { arg.setType(candidate.newType); });
+        rewriter.setInsertionPointToStart(&region->front());
+        auto view = stablehlo::ReshapeOp::create(rewriter, op.getLoc(),
+                                                 candidate.oldType, arg);
+        rewriter.replaceAllUsesExcept(arg, view, view);
+      }
+      for (auto view : candidate.inputViews)
+        rewriter.replaceOp(
+            view, updated.getBody().front().getArgument(candidate.index));
+    }
+
+    SmallVector<Value> results(updated.getResults());
+    rewriter.setInsertionPointAfter(updated);
+    for (auto &candidate : candidates)
+      results[candidate.index] = stablehlo::ReshapeOp::create(
+          rewriter, op.getLoc(), candidate.oldType, results[candidate.index]);
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
+
 struct TransposeWhile
     : public CheckedOpRewritePattern<stablehlo::WhileOp, TransposeWhile> {
   using CheckedOpRewritePattern::CheckedOpRewritePattern;
@@ -37302,6 +37443,8 @@ struct EnzymeHLOOptPass
 
     // clang-format off
     patterns.add<
+        ReshapeWhile,
+        ReshapeBitcastConvert,
         WhileRepeatedInductionReduction,
         WhileOpInductionReplacement,
         WhilePadInductionReduction,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1891,6 +1891,14 @@ def WhileOpInductionReplacementPatterns : EnzymeHLOPatternOp<
   let patterns = ["WhileOpInductionReplacement"];
 }
 
+def ReshapeWhilePatterns : EnzymeHLOPatternOp<"reshape_while"> {
+  let patterns = ["ReshapeWhile"];
+}
+
+def ReshapeBitcastConvertPatterns : EnzymeHLOPatternOp<"reshape_bitcast_convert"> {
+  let patterns = ["ReshapeBitcastConvert"];
+}
+
 def TransposeWhilePatterns : EnzymeHLOPatternOp<
   "transpose_while"
 > {

--- a/test/lit_tests/reshape_bitcast_convert.mlir
+++ b/test/lit_tests/reshape_bitcast_convert.mlir
@@ -1,0 +1,67 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=reshape_bitcast_convert" --transform-interpreter --enzyme-hlo-remove-transform | FileCheck %s
+
+// The bitcast adds a trailing dimension of four bytes per f32. Folding the
+// two surrounding reshapes retains that dimension and the bitcast attributes.
+// CHECK-LABEL: func.func @narrow(
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.bitcast_convert {{.*}} {mhlo.sharding = "{replicated}"} : (tensor<2x3xf32>) -> tensor<2x3x4xi8>
+// CHECK-NOT: stablehlo.reshape
+// CHECK: return
+func.func @narrow(%x: tensor<2x3xf32>) -> tensor<2x3x4xi8> {
+  %flat = stablehlo.reshape %x : (tensor<2x3xf32>) -> tensor<6xf32>
+  %bytes = stablehlo.bitcast_convert %flat {mhlo.sharding = "{replicated}"} : (tensor<6xf32>) -> tensor<?x4xi8>
+  %r = stablehlo.reshape %bytes : (tensor<?x4xi8>) -> tensor<2x3x4xi8>
+  return %r : tensor<2x3x4xi8>
+}
+
+// Widening removes the same innermost group. Same-width bitcasts preserve
+// the entire shape. Neither case needs intermediate flat views.
+// CHECK-LABEL: func.func @widen(
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.bitcast_convert {{.*}} : (tensor<2x3x4xi8>) -> tensor<2x3xf32>
+// CHECK-NOT: stablehlo.reshape
+// CHECK: return
+func.func @widen(%x: tensor<2x3x4xi8>) -> tensor<2x3xf32> {
+  %flat = stablehlo.reshape %x : (tensor<2x3x4xi8>) -> tensor<6x4xi8>
+  %words = stablehlo.bitcast_convert %flat : (tensor<6x4xi8>) -> tensor<6xf32>
+  %r = stablehlo.reshape %words : (tensor<6xf32>) -> tensor<2x3xf32>
+  return %r : tensor<2x3xf32>
+}
+
+// CHECK-LABEL: func.func @same_width(
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.bitcast_convert {{.*}} : (tensor<2x3xf32>) -> tensor<2x3xi32>
+// CHECK-NOT: stablehlo.reshape
+// CHECK: return
+func.func @same_width(%x: tensor<2x3xf32>) -> tensor<2x3xi32> {
+  %flat = stablehlo.reshape %x : (tensor<2x3xf32>) -> tensor<6xf32>
+  %words = stablehlo.bitcast_convert %flat : (tensor<6xf32>) -> tensor<6xi32>
+  %r = stablehlo.reshape %words : (tensor<6xi32>) -> tensor<2x3xi32>
+  return %r : tensor<2x3xi32>
+}
+
+// A 3x8 result mixes the four-byte groups with other dimensions. A direct
+// bitcast of a 2x3 f32 tensor cannot have this shape, so keep both reshapes.
+// CHECK-LABEL: func.func @different_grouping(
+// CHECK: stablehlo.reshape
+// CHECK: stablehlo.bitcast_convert
+// CHECK: stablehlo.reshape {{.*}} -> tensor<3x8xi8>
+func.func @different_grouping(%x: tensor<2x3xf32>) -> tensor<3x8xi8> {
+  %flat = stablehlo.reshape %x : (tensor<2x3xf32>) -> tensor<6xf32>
+  %bytes = stablehlo.bitcast_convert %flat : (tensor<6xf32>) -> tensor<6x4xi8>
+  %r = stablehlo.reshape %bytes : (tensor<6x4xi8>) -> tensor<3x8xi8>
+  return %r : tensor<3x8xi8>
+}
+
+// Do not duplicate a bitcast with another live user.
+// CHECK-LABEL: func.func @shared_bitcast(
+// CHECK: stablehlo.reshape
+// CHECK: stablehlo.bitcast_convert
+// CHECK: stablehlo.reshape
+// CHECK: return
+func.func @shared_bitcast(%x: tensor<2x3xf32>) -> (tensor<2x3x4xi8>, tensor<6x4xi8>) {
+  %flat = stablehlo.reshape %x : (tensor<2x3xf32>) -> tensor<6xf32>
+  %bytes = stablehlo.bitcast_convert %flat : (tensor<6xf32>) -> tensor<6x4xi8>
+  %r = stablehlo.reshape %bytes : (tensor<6x4xi8>) -> tensor<2x3x4xi8>
+  return %r, %bytes : tensor<2x3x4xi8>, tensor<6x4xi8>
+}

--- a/test/lit_tests/reshape_while.mlir
+++ b/test/lit_tests/reshape_while.mlir
@@ -1,0 +1,221 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=reshape_while;reshape_bitcast_convert" --transform-interpreter --enzyme-hlo-remove-transform | FileCheck %s
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-generate-td="patterns=reshape_while;reshape_bitcast_convert" --transform-interpreter --enzyme-hlo-remove-transform --inline --canonicalize --symbol-dce --drop-unsupported-attributes | stablehlo-translate --interpret
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt --inline --canonicalize --symbol-dce --drop-unsupported-attributes | stablehlo-translate --interpret
+
+// Both buffers enter and leave the function flat, but the body uses 2x3
+// tensors. Carry those shapes through the loop. The byte view of x must also
+// use the new shape while keeping the four bytes of each i32 together.
+// Numerically, each iteration computes x' = 2*x + 1 and y' = y + x.
+// CHECK-LABEL: func.func @buffers(
+// CHECK: stablehlo.reshape {{.*}} : (tensor<6xi32>) -> tensor<2x3xi32>
+// CHECK: stablehlo.reshape {{.*}} : (tensor<6xi32>) -> tensor<2x3xi32>
+// CHECK: stablehlo.while({{.*}}) : tensor<i32>, tensor<2x3xi32>, tensor<2x3xi32>
+// CHECK: } do {
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.bitcast_convert {{.*}} : (tensor<2x3xi32>) -> tensor<2x3x4xi8>
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.return {{.*}} : tensor<i32>, tensor<2x3xi32>, tensor<2x3xi32>
+// CHECK: }
+// CHECK: stablehlo.reshape {{.*}} : (tensor<2x3xi32>) -> tensor<6xi32>
+// CHECK: stablehlo.reshape {{.*}} : (tensor<2x3xi32>) -> tensor<6xi32>
+func.func @buffers(%n: tensor<i32>, %x: tensor<6xi32>, %y: tensor<6xi32>) -> (tensor<6xi32>, tensor<6xi32>) {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %ones = stablehlo.constant dense<1> : tensor<2x3xi32>
+  %r:3 = stablehlo.while(%i = %zero, %a = %x, %b = %y) : tensor<i32>, tensor<6xi32>, tensor<6xi32>
+  cond {
+    %c = stablehlo.compare LT, %i, %n, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %c : tensor<i1>
+  } do {
+    %av = stablehlo.reshape %a : (tensor<6xi32>) -> tensor<2x3xi32>
+    %bv = stablehlo.reshape %b : (tensor<6xi32>) -> tensor<2x3xi32>
+    // Full optimization may introduce non-view users and leave this loop flat.
+    // Keep its byte view static for interpretation; only_bitcast tests a
+    // dynamic intermediate when the argument has exclusively bitcast users.
+    %bytes = stablehlo.bitcast_convert %a : (tensor<6xi32>) -> tensor<6x4xi8>
+    %byte_view = stablehlo.reshape %bytes : (tensor<6x4xi8>) -> tensor<2x3x4xi8>
+    %roundtrip = stablehlo.bitcast_convert %byte_view : (tensor<2x3x4xi8>) -> tensor<2x3xi32>
+    %twice = stablehlo.add %av, %roundtrip : tensor<2x3xi32>
+    %next_a = stablehlo.add %twice, %ones : tensor<2x3xi32>
+    %next_b = stablehlo.add %bv, %av : tensor<2x3xi32>
+    %af = stablehlo.reshape %next_a : (tensor<2x3xi32>) -> tensor<6xi32>
+    %bf = stablehlo.reshape %next_b : (tensor<2x3xi32>) -> tensor<6xi32>
+    %next_i = stablehlo.add %i, %one : tensor<i32>
+    stablehlo.return %next_i, %af, %bf : tensor<i32>, tensor<6xi32>, tensor<6xi32>
+  }
+  return %r#1, %r#2 : tensor<6xi32>, tensor<6xi32>
+}
+
+// A matching body reshape is insufficient: the condition also consumes the
+// original argument directly with a slice. Keep this carried type unchanged.
+// CHECK-LABEL: func.func @condition_use(
+// CHECK: stablehlo.while({{.*}}) : tensor<i32>, tensor<6xi32>
+// CHECK: cond {
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.slice {{.*}} : (tensor<6xi32>) -> tensor<1xi32>
+// CHECK: } do {
+// CHECK: stablehlo.reshape {{.*}} : (tensor<6xi32>) -> tensor<2x3xi32>
+// CHECK: stablehlo.return {{.*}} : tensor<i32>, tensor<6xi32>
+func.func @condition_use(%n: tensor<i32>, %x: tensor<6xi32>) -> tensor<6xi32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %limit = stablehlo.constant dense<100> : tensor<i32>
+  %ones = stablehlo.constant dense<1> : tensor<2x3xi32>
+  %r:2 = stablehlo.while(%i = %zero, %a = %x) : tensor<i32>, tensor<6xi32>
+  cond {
+    %first = stablehlo.slice %a [0:1] : (tensor<6xi32>) -> tensor<1xi32>
+    %value = stablehlo.reshape %first : (tensor<1xi32>) -> tensor<i32>
+    %c0 = stablehlo.compare LT, %i, %n, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    %c1 = stablehlo.compare LT, %value, %limit, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    %c = stablehlo.and %c0, %c1 : tensor<i1>
+    stablehlo.return %c : tensor<i1>
+  } do {
+    %av = stablehlo.reshape %a : (tensor<6xi32>) -> tensor<2x3xi32>
+    %next = stablehlo.add %av, %ones : tensor<2x3xi32>
+    %flat = stablehlo.reshape %next : (tensor<2x3xi32>) -> tensor<6xi32>
+    %next_i = stablehlo.add %i, %one : tensor<i32>
+    stablehlo.return %next_i, %flat : tensor<i32>, tensor<6xi32>
+  }
+  return %r#1 : tensor<6xi32>
+}
+
+// A matching reshape in the body must not hide an additional arithmetic user
+// of the original argument. This computes x' = 3*x and keeps the flat type.
+// CHECK-LABEL: func.func @mixed_body_use(
+// CHECK: stablehlo.while({{.*}}) : tensor<i32>, tensor<6xi32>
+// CHECK: } do {
+// CHECK: stablehlo.add {{.*}} : tensor<6xi32>
+// CHECK: stablehlo.return {{.*}} : tensor<i32>, tensor<6xi32>
+func.func @mixed_body_use(%n: tensor<i32>, %x: tensor<6xi32>) -> tensor<6xi32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %r:2 = stablehlo.while(%i = %zero, %a = %x) : tensor<i32>, tensor<6xi32>
+  cond {
+    %c = stablehlo.compare LT, %i, %n, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %c : tensor<i1>
+  } do {
+    %av = stablehlo.reshape %a : (tensor<6xi32>) -> tensor<2x3xi32>
+    %twice = stablehlo.add %a, %a : tensor<6xi32>
+    %twice_view = stablehlo.reshape %twice : (tensor<6xi32>) -> tensor<2x3xi32>
+    %next = stablehlo.add %av, %twice_view : tensor<2x3xi32>
+    %flat = stablehlo.reshape %next : (tensor<2x3xi32>) -> tensor<6xi32>
+    %next_i = stablehlo.add %i, %one : tensor<i32>
+    stablehlo.return %next_i, %flat : tensor<i32>, tensor<6xi32>
+  }
+  return %r#1 : tensor<6xi32>
+}
+
+// All users are bitcast converts, with no direct reshape of the argument.
+// This must still hoist: the byte view can use the new carried shape directly.
+// CHECK-LABEL: func.func @only_bitcast(
+// CHECK: stablehlo.while({{.*}}) : tensor<i32>, tensor<2x3xi32>
+// CHECK: } do {
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.bitcast_convert {{.*}} : (tensor<2x3xi32>) -> tensor<2x3x4xi8>
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.return {{.*}} : tensor<i32>, tensor<2x3xi32>
+func.func @only_bitcast(%n: tensor<i32>, %x: tensor<6xi32>) -> tensor<6xi32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %ones = stablehlo.constant dense<1> : tensor<2x3xi32>
+  %r:2 = stablehlo.while(%i = %zero, %a = %x) : tensor<i32>, tensor<6xi32>
+  cond {
+    %c = stablehlo.compare LT, %i, %n, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %c : tensor<i1>
+  } do {
+    %bytes = stablehlo.bitcast_convert %a : (tensor<6xi32>) -> tensor<?x4xi8>
+    %byte_view = stablehlo.reshape %bytes : (tensor<?x4xi8>) -> tensor<2x3x4xi8>
+    %value = stablehlo.bitcast_convert %byte_view : (tensor<2x3x4xi8>) -> tensor<2x3xi32>
+    %next = stablehlo.add %value, %ones : tensor<2x3xi32>
+    %flat = stablehlo.reshape %next : (tensor<2x3xi32>) -> tensor<6xi32>
+    %next_i = stablehlo.add %i, %one : tensor<i32>
+    stablehlo.return %next_i, %flat : tensor<i32>, tensor<6xi32>
+  }
+  return %r#1 : tensor<6xi32>
+}
+
+// Each yielded value is an input view of the other argument. Updating both
+// arguments together must preserve this exchange and must terminate rewriting.
+// CHECK-LABEL: func.func @swap(
+// CHECK: stablehlo.while({{.*}}) : tensor<i32>, tensor<2x3xi32>, tensor<2x3xi32>
+// CHECK: } do {
+// CHECK-NOT: stablehlo.reshape
+// CHECK: stablehlo.return {{.*}} : tensor<i32>, tensor<2x3xi32>, tensor<2x3xi32>
+func.func @swap(%n: tensor<i32>, %x: tensor<6xi32>, %y: tensor<6xi32>) -> (tensor<6xi32>, tensor<6xi32>) {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %r:3 = stablehlo.while(%i = %zero, %a = %x, %b = %y) : tensor<i32>, tensor<6xi32>, tensor<6xi32>
+  cond {
+    %c = stablehlo.compare LT, %i, %n, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %c : tensor<i1>
+  } do {
+    %av = stablehlo.reshape %a : (tensor<6xi32>) -> tensor<2x3xi32>
+    %bv = stablehlo.reshape %b : (tensor<6xi32>) -> tensor<2x3xi32>
+    %af = stablehlo.reshape %bv : (tensor<2x3xi32>) -> tensor<6xi32>
+    %bf = stablehlo.reshape %av : (tensor<2x3xi32>) -> tensor<6xi32>
+    %next_i = stablehlo.add %i, %one : tensor<i32>
+    stablehlo.return %next_i, %af, %bf : tensor<i32>, tensor<6xi32>, tensor<6xi32>
+  }
+  return %r#1, %r#2 : tensor<6xi32>, tensor<6xi32>
+}
+
+// An unused input has no incompatible consumers. Its yielded reshape can
+// still move out of the loop, preserving the input when there are zero trips.
+// CHECK-LABEL: func.func @unused_input(
+// CHECK: stablehlo.while({{.*}}) : tensor<i32>, tensor<2x3xi32>
+func.func @unused_input(%n: tensor<i32>, %x: tensor<6xi32>) -> tensor<6xi32> {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %r:2 = stablehlo.while(%i = %zero, %a = %x) : tensor<i32>, tensor<6xi32>
+  cond {
+    %c = stablehlo.compare LT, %i, %n, SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    stablehlo.return %c : tensor<i1>
+  } do {
+    %data = stablehlo.broadcast_in_dim %i, dims = [] : (tensor<i32>) -> tensor<2x3xi32>
+    %flat = stablehlo.reshape %data : (tensor<2x3xi32>) -> tensor<6xi32>
+    %next_i = stablehlo.add %i, %one : tensor<i32>
+    stablehlo.return %next_i, %flat : tensor<i32>, tensor<6xi32>
+  }
+  return %r#1 : tensor<6xi32>
+}
+
+func.func @main() {
+  %zero = stablehlo.constant dense<0> : tensor<i32>
+  %one = stablehlo.constant dense<1> : tensor<i32>
+  %three = stablehlo.constant dense<3> : tensor<i32>
+  %x = stablehlo.constant dense<[1, 2, 3, 4, 5, 6]> : tensor<6xi32>
+  %y = stablehlo.constant dense<0> : tensor<6xi32>
+  %x1 = stablehlo.constant dense<[3, 5, 7, 9, 11, 13]> : tensor<6xi32>
+  %x3 = stablehlo.constant dense<[15, 23, 31, 39, 47, 55]> : tensor<6xi32>
+  %y3 = stablehlo.constant dense<[11, 18, 25, 32, 39, 46]> : tensor<6xi32>
+  %c3 = stablehlo.constant dense<[4, 5, 6, 7, 8, 9]> : tensor<6xi32>
+  %m3 = stablehlo.constant dense<[27, 54, 81, 108, 135, 162]> : tensor<6xi32>
+  %u3 = stablehlo.constant dense<2> : tensor<6xi32>
+  %r0:2 = func.call @buffers(%zero, %x, %y) : (tensor<i32>, tensor<6xi32>, tensor<6xi32>) -> (tensor<6xi32>, tensor<6xi32>)
+  %r1:2 = func.call @buffers(%one, %x, %y) : (tensor<i32>, tensor<6xi32>, tensor<6xi32>) -> (tensor<6xi32>, tensor<6xi32>)
+  %r3:2 = func.call @buffers(%three, %x, %y) : (tensor<i32>, tensor<6xi32>, tensor<6xi32>) -> (tensor<6xi32>, tensor<6xi32>)
+  check.expect_eq %r0#0, %x : tensor<6xi32>
+  check.expect_eq %r0#1, %y : tensor<6xi32>
+  check.expect_eq %r1#0, %x1 : tensor<6xi32>
+  check.expect_eq %r1#1, %x : tensor<6xi32>
+  check.expect_eq %r3#0, %x3 : tensor<6xi32>
+  check.expect_eq %r3#1, %y3 : tensor<6xi32>
+  %c0 = func.call @condition_use(%zero, %x) : (tensor<i32>, tensor<6xi32>) -> tensor<6xi32>
+  %c = func.call @condition_use(%three, %x) : (tensor<i32>, tensor<6xi32>) -> tensor<6xi32>
+  check.expect_eq %c0, %x : tensor<6xi32>
+  check.expect_eq %c, %c3 : tensor<6xi32>
+  %m = func.call @mixed_body_use(%three, %x) : (tensor<i32>, tensor<6xi32>) -> tensor<6xi32>
+  check.expect_eq %m, %m3 : tensor<6xi32>
+  %b0 = func.call @only_bitcast(%zero, %x) : (tensor<i32>, tensor<6xi32>) -> tensor<6xi32>
+  %b = func.call @only_bitcast(%three, %x) : (tensor<i32>, tensor<6xi32>) -> tensor<6xi32>
+  check.expect_eq %b0, %x : tensor<6xi32>
+  check.expect_eq %b, %c3 : tensor<6xi32>
+  %u0 = func.call @unused_input(%zero, %x) : (tensor<i32>, tensor<6xi32>) -> tensor<6xi32>
+  %u = func.call @unused_input(%three, %x) : (tensor<i32>, tensor<6xi32>) -> tensor<6xi32>
+  check.expect_eq %u0, %x : tensor<6xi32>
+  check.expect_eq %u, %u3 : tensor<6xi32>
+  %s:2 = func.call @swap(%three, %x, %y) : (tensor<i32>, tensor<6xi32>, tensor<6xi32>) -> (tensor<6xi32>, tensor<6xi32>)
+  check.expect_eq %s#0, %y : tensor<6xi32>
+  check.expect_eq %s#1, %x : tensor<6xi32>
+  return
+}


### PR DESCRIPTION
Loops that reshape a carried buffer on entry and flatten it again at the yield now carry the body shape directly. For example, LBM can carry `tensor<379200x128xf32>` instead of `tensor<48537600xf32>`. Every use of the carried argument in both the body and condition regions must be a reshape or bitcast-convert; having one matching reshape is insufficient. Arguments used only by bitcast-convert are eligible too. Input/output reshapes retain the original boundary types and zero-iteration behavior.

Add `ReshapeWhile` and a companion `ReshapeBitcastConvert` pattern that cancels `reshape(bitcast_convert(reshape(x)))` when the direct bitcast preserves the element grouping. This handles LBM's dynamic intermediate byte-view type while retaining the trailing byte dimension. Both patterns are registered in the default EnzymeHLOOpt pass, the transform dialect, and the C API reshape pipeline.

Validation: 93 related reshape, while, bitcast, and transform LIT tests pass. New tests check the resulting IR and interpret zero, one, and multiple iterations, two buffers, buffer swaps, bitcast-only and unused arguments, and rejection of mixed arithmetic users or a direct slice user in the condition. Bitcast cases cover narrowing, widening, equal widths, mismatched grouping, and shared results.

LBM validation on the development staging branch: both buffers carry `tensor<379200x128xf32>` through the while; only the two flag-slice reshapes remain inside the body. The runtime result matches the staging optimizer output. Source files were unchanged, and the before/after output is byte-identical (6,480,000 floats; max absolute difference from native CUDA: 5.96e-7).

On an RTX 5090, 20 timesteps over three alternating captures remain at 511 launches. Median summed GPU kernel time is 9.246 ms before versus 9.249 ms after (CUDA reference: 20 launches, 5.798 ms). Both optimized HLO bodies still contain 51 fusions; this change removes views but does not produce a measurable speedup on this case. GPU timings exclude compilation, transfers, and launch gaps.

The all-uses guard produces byte-identical LBM MLIR to the version measured above.
