### PR TITLE
affine-cfg: hoist in-region pure symbols before cloning their users

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -341,8 +341,6 @@ bool isNonTopLevelPureSymbol(Value value) {
     if (!matchPattern(defOp, m_Constant(&operandCst)) &&
         !affine::isValidSymbol(value, region))
       return false;
-    if (defOp->getNumOperands() != 0)
-      return false;
     if (defOp->getParentRegion() == region)
       return false;
     return true;

--- a/test/lit_tests/affinecfg_pure_symbol_in_conditional.mlir
+++ b/test/lit_tests/affinecfg_pure_symbol_in_conditional.mlir
@@ -1,0 +1,36 @@
+// RUN: enzymexlamlir-opt %s --affine-cfg | FileCheck %s
+
+// `-1 - %n` is a valid affine symbol wherever it is defined (a pure function
+// of symbols), so the normalizer used to leave it inside the scf.if; the
+// select, no symbol with its i1 condition, was then cloned next to it, inside
+// the conditional, where it is no symbol either. Both hoist above the
+// conditional now.
+
+llvm.func @use(!llvm.ptr)
+
+llvm.func @f(%arg0: !llvm.ptr, %n: i64, %c: i1) {
+  %c-1 = arith.constant -1 : index
+  %5 = arith.index_cast %n : i64 to index
+  scf.if %c {
+    %32 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+    %34 = arith.subi %c-1, %5 : index
+    %35 = arith.select %c, %34, %5 : index
+    %40 = memref.load %32[%35] : memref<?x!llvm.ptr>
+    llvm.call @use(%40) : (!llvm.ptr) -> ()
+  }
+  llvm.return
+}
+
+// CHECK:    llvm.func @use(!llvm.ptr)
+// CHECK-NEXT:  llvm.func @f(%arg0: !llvm.ptr, %arg1: i64, %arg2: i1) {
+// CHECK-NEXT:    %c-1 = arith.constant -1 : index
+// CHECK-NEXT:    %0 = arith.index_cast %arg1 : i64 to index
+// CHECK-NEXT:    %1 = arith.subi %c-1, %0 : index
+// CHECK-NEXT:    %2 = arith.select %arg2, %1, %0 : index
+// CHECK-NEXT:    scf.if %arg2 {
+// CHECK-NEXT:      %3 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?x!llvm.ptr>
+// CHECK-NEXT:      %4 = affine.load %3[symbol(%2)] : memref<?x!llvm.ptr>
+// CHECK-NEXT:      llvm.call @use(%4) : (!llvm.ptr) -> ()
+// CHECK-NEXT:    }
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }


### PR DESCRIPTION
Follow-up to #3160, which lowers affine around the second inline: on 16 MFEM TUs that compiled before it, `affine-cfg` then crashed in `MoveLoadToAffine` (a segfault in optimized builds, `llvm_unreachable("busted")` in checked ones). Minimal reproducer, the signed-floordiv idiom `lower-affine` emits, as a load index under an `scf.if`:

```mlir
llvm.func @f(%arg0: !llvm.ptr, %n: i64, %c: i1) {
  %c-1 = arith.constant -1 : index
  %5 = arith.index_cast %n : i64 to index
  scf.if %c {
    %32 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?x!llvm.ptr>
    %34 = arith.subi %c-1, %5 : index
    %35 = arith.select %c, %34, %5 : index
    %40 = memref.load %32[%35] : memref<?x!llvm.ptr>
    llvm.call @use(%40) : (!llvm.ptr) -> ()
  }
  llvm.return
}
```

`affine::isValidSymbol` accepts a pure function of symbols wherever it is defined, so `AffineApplyNormalizer`'s `fix` returned `%34` as a symbol without hoisting it out of the conditional. The `select` is no symbol (its condition is `i1`), so it was cloned, but at the insertion point its operands dictate, next to `%34` inside the conditional, where the clone is no symbol either. `isNonTopLevelPureSymbol` exists to make `fix` clone such in-region symbols out first, but it only admitted zero-operand ops; dropping that condition is the whole fix (`isPure` already covers speculatability). The subtraction and the select now hoist above the `scf.if` and the load becomes `affine.load %3[symbol(%2)]`. Test: the reproducer, full goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
