### PR TITLE
affine-cfg: raise scf.parallel reductions to affine.parallel

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineCFG.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineCFG.cpp
@@ -3230,6 +3230,42 @@ struct ForOpRaising : public OpRewritePattern<scf::ForOp> {
   }
 };
 
+// The reduction kind whose combining op `op` is (the inverse of
+// arith::getReductionOp), where affine.parallel admits that kind on op's
+// type: its signed and unsigned min/max want an integer of that signedness.
+static std::optional<AtomicRMWKind> reductionKind(Operation *op) {
+  auto intType = dyn_cast<IntegerType>(op->getResult(0).getType());
+  bool isSigned = intType && intType.isSigned();
+  bool isUnsigned = intType && intType.isUnsigned();
+  auto ifType = [](bool ok,
+                   AtomicRMWKind kind) -> std::optional<AtomicRMWKind> {
+    if (ok)
+      return kind;
+    return std::nullopt;
+  };
+  return TypeSwitch<Operation *, std::optional<AtomicRMWKind>>(op)
+      .Case<AddFOp>([](auto) { return AtomicRMWKind::addf; })
+      .Case<AddIOp>([](auto) { return AtomicRMWKind::addi; })
+      .Case<MulFOp>([](auto) { return AtomicRMWKind::mulf; })
+      .Case<MulIOp>([](auto) { return AtomicRMWKind::muli; })
+      .Case<MaximumFOp>([](auto) { return AtomicRMWKind::maximumf; })
+      .Case<MinimumFOp>([](auto) { return AtomicRMWKind::minimumf; })
+      .Case<MaxNumFOp>([](auto) { return AtomicRMWKind::maxnumf; })
+      .Case<MinNumFOp>([](auto) { return AtomicRMWKind::minnumf; })
+      .Case<MaxSIOp>(
+          [&](auto) { return ifType(isSigned, AtomicRMWKind::maxs); })
+      .Case<MinSIOp>(
+          [&](auto) { return ifType(isSigned, AtomicRMWKind::mins); })
+      .Case<MaxUIOp>(
+          [&](auto) { return ifType(isUnsigned, AtomicRMWKind::maxu); })
+      .Case<MinUIOp>(
+          [&](auto) { return ifType(isUnsigned, AtomicRMWKind::minu); })
+      .Case<OrIOp>([](auto) { return AtomicRMWKind::ori; })
+      .Case<AndIOp>([](auto) { return AtomicRMWKind::andi; })
+      .Case<XOrIOp>([](auto) { return AtomicRMWKind::xori; })
+      .Default([](auto) { return std::nullopt; });
+}
+
 struct ParallelOpRaising : public OpRewritePattern<scf::ParallelOp> {
   using OpRewritePattern<scf::ParallelOp>::OpRewritePattern;
 
@@ -3261,9 +3297,25 @@ struct ParallelOpRaising : public OpRewritePattern<scf::ParallelOp> {
                                 PatternRewriter &rewriter) const final {
     OpBuilder builder(loop);
 
-    if (loop.getResults().size())
-      return rewriter.notifyMatchFailure(
-          loop, "not dependent on a conditional result");
+    // Each reduction combines the two block arguments with one arith op, the
+    // way lower-affine writes an affine.parallel reduction.
+    auto reduceOp = cast<scf::ReduceOp>(loop.getBody()->getTerminator());
+    SmallVector<AtomicRMWKind> reductions;
+    for (Region &region : reduceOp.getReductions()) {
+      Block &body = region.front();
+      if (!llvm::hasSingleElement(body.without_terminator()))
+        return failure();
+      Operation &combine = body.front();
+      if (combine.getNumOperands() != 2 ||
+          combine.getOperand(0) != body.getArgument(0) ||
+          combine.getOperand(1) != body.getArgument(1) ||
+          body.getTerminator()->getOperand(0) != combine.getResult(0))
+        return failure();
+      std::optional<AtomicRMWKind> kind = reductionKind(&combine);
+      if (!kind)
+        return failure();
+      reductions.push_back(*kind);
+    }
 
     auto scope = getLocalAffineScope(loop);
     for (auto idx : loop.getLowerBound()) {
@@ -3282,7 +3334,6 @@ struct ParallelOpRaising : public OpRewritePattern<scf::ParallelOp> {
       else
         return failure();
 
-    ArrayRef<AtomicRMWKind> reductions;
     SmallVector<AffineMap> bounds;
     for (size_t i = 0; i < loop.getLowerBound().size(); i++)
       bounds.push_back(AffineMap::get(
@@ -3319,7 +3370,22 @@ struct ParallelOpRaising : public OpRewritePattern<scf::ParallelOp> {
                                   mergedYieldOp.getOperands());
     rewriter.eraseOp(mergedYieldOp);
 
-    rewriter.replaceOp(loop, affineLoop.getResults());
+    // affine.parallel reduces from the kind's identity; any other initial
+    // value folds in after the loop.
+    rewriter.setInsertionPointAfter(affineLoop);
+    SmallVector<Value> results;
+    for (auto [kind, init, result] :
+         llvm::zip(reductions, loop.getInitVals(), affineLoop.getResults())) {
+      Attribute cst;
+      if (matchPattern(init, m_Constant(&cst)) &&
+          cst == arith::getIdentityValueAttr(kind, result.getType(), rewriter,
+                                             loop.getLoc()))
+        results.push_back(result);
+      else
+        results.push_back(
+            arith::getReductionOp(kind, rewriter, loop.getLoc(), init, result));
+    }
+    rewriter.replaceOp(loop, results);
 
     return success();
   }

--- a/test/lit_tests/affinecfg_parallel_reductions.mlir
+++ b/test/lit_tests/affinecfg_parallel_reductions.mlir
@@ -1,0 +1,47 @@
+// RUN: enzymexlamlir-opt %s --lower-affine --affine-cfg | FileCheck %s
+
+// lower-affine writes an affine.parallel reduction as an scf.parallel that
+// starts from the kind's identity and combines with one arith op in its
+// scf.reduce; affine-cfg reads that back. A loop seeded with another value
+// folds it in after the loop.
+
+func.func @roundtrip(%arg0: memref<?xf64>) -> (f64, i32) {
+  %0:2 = affine.parallel (%i) = (0) to (8) reduce ("addf", "muli") -> (f64, i32) {
+    %v = affine.load %arg0[%i] : memref<?xf64>
+    %c = arith.fptosi %v : f64 to i32
+    affine.yield %v, %c : f64, i32
+  }
+  return %0#0, %0#1 : f64, i32
+}
+
+func.func @seeded(%arg0: memref<?xf64>, %init: f64) -> f64 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %0 = scf.parallel (%i) = (%c0) to (%c8) step (%c1) init (%init) -> f64 {
+    %v = memref.load %arg0[%i] : memref<?xf64>
+    scf.reduce(%v : f64) {
+    ^bb0(%a: f64, %b: f64):
+      %s = arith.mulf %a, %b : f64
+      scf.reduce.return %s : f64
+    }
+  }
+  return %0 : f64
+}
+
+// CHECK:    func.func @roundtrip(%arg0: memref<?xf64>) -> (f64, i32) {
+// CHECK-NEXT:    %0:2 = affine.parallel (%arg1) = (0) to (8) reduce ("addf", "muli") -> (f64, i32) {
+// CHECK-NEXT:      %1 = affine.load %arg0[%arg1] : memref<?xf64>
+// CHECK-NEXT:      %2 = arith.fptosi %1 : f64 to i32
+// CHECK-NEXT:      affine.yield %1, %2 : f64, i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %0#0, %0#1 : f64, i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @seeded(%arg0: memref<?xf64>, %arg1: f64) -> f64 {
+// CHECK-NEXT:    %0 = affine.parallel (%arg2) = (0) to (8) reduce ("mulf") -> (f64) {
+// CHECK-NEXT:      %2 = affine.load %arg0[%arg2] : memref<?xf64>
+// CHECK-NEXT:      affine.yield %2 : f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %1 = arith.mulf %arg1, %0 : f64
+// CHECK-NEXT:    return %1 : f64
+// CHECK-NEXT:  }


### PR DESCRIPTION
The second loss in #3160's lower-affine round trip: `lower-affine` writes an `affine.parallel` reduction as an `scf.parallel` seeded with the kind's identity whose `scf.reduce` combines with one arith op, and `ParallelOpRaising` refused any `scf.parallel` with results, so the loop stayed `scf.parallel` and its kernel failed to raise. Five MFEM TUs regressed this way (EA convection and diffusion, DG diffusion, quadrature interpolator, TMOP diag3), all on `affine.parallel ... reduce ("addf", ...)` loops.

`ParallelOpRaising` now reads each `scf.reduce` region as its reduction kind (the inverse of `arith::getReductionOp`) and builds the `affine.parallel` with those reductions. An `affine.parallel` reduces from the identity, so a loop seeded with the identity constant maps straight across, and any other seed is folded in after the loop with the same op.

Test: an `affine.parallel` with two reductions through `--lower-affine --affine-cfg`, and an `scf.parallel` seeded with a function argument, full goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
