### PR TITLE
Raising pipeline: call the callees that cannot unwind before the first inline

### DIFF
--- a/src/enzyme_ad/jax/Passes/InvokeToCall.cpp
+++ b/src/enzyme_ad/jax/Passes/InvokeToCall.cpp
@@ -1,0 +1,100 @@
+//===- InvokeToCall.cpp - Call the callees that cannot unwind -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// The LLVM dialect inliner takes only llvm.call sites. An llvm.invoke of a
+// function that cannot unwind has a dead unwind edge, so it becomes an
+// llvm.call and a branch to its normal successor; a landing pad left without
+// a predecessor goes with it. Whether a function can unwind is decided over
+// its body -- it never resumes, and every call in it reaches a function that
+// cannot unwind -- the way the pipeline treats every body it inlines, rather
+// than left to the attribute LLVM withholds from a definition another unit
+// might supersede.
+//
+//===---------------------------------------------------------------------===//
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "src/enzyme_ad/jax/Passes/Passes.h"
+
+namespace mlir {
+namespace enzyme {
+#define GEN_PASS_DEF_INVOKETOCALLPASS
+#include "src/enzyme_ad/jax/Passes/Passes.h.inc"
+} // namespace enzyme
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+struct InvokeToCallPass
+    : public enzyme::impl::InvokeToCallPassBase<InvokeToCallPass> {
+  using InvokeToCallPassBase::InvokeToCallPassBase;
+
+  void runOnOperation() override {
+    SymbolTableCollection symbols;
+    SmallVector<LLVM::LLVMFuncOp> funcs;
+    DenseSet<Operation *> noUnwind;
+    getOperation()->walk([&](LLVM::LLVMFuncOp fn) {
+      funcs.push_back(fn);
+      if (fn.getNoUnwind())
+        noUnwind.insert(fn);
+    });
+    auto calleeCannotUnwind = [&](CallOpInterface call) {
+      Operation *callee = call.resolveCallableInTable(&symbols);
+      return callee && noUnwind.contains(callee);
+    };
+    for (bool changed = true; changed;) {
+      changed = false;
+      for (LLVM::LLVMFuncOp fn : funcs) {
+        if (fn.isExternal() || noUnwind.contains(fn))
+          continue;
+        bool mayUnwind = fn.walk([&](Operation *op) {
+                             if (isa<LLVM::ResumeOp, LLVM::InlineAsmOp>(op))
+                               return WalkResult::interrupt();
+                             if (auto call = dyn_cast<CallOpInterface>(op))
+                               if (!calleeCannotUnwind(call))
+                                 return WalkResult::interrupt();
+                             return WalkResult::advance();
+                           }).wasInterrupted();
+        if (mayUnwind)
+          continue;
+        noUnwind.insert(fn);
+        fn.setNoUnwind(true);
+        changed = true;
+      }
+    }
+
+    IRRewriter rewriter(&getContext());
+    for (LLVM::LLVMFuncOp fn : funcs) {
+      SmallVector<LLVM::InvokeOp> invokes;
+      fn.walk([&](LLVM::InvokeOp invoke) {
+        if (calleeCannotUnwind(invoke))
+          invokes.push_back(invoke);
+      });
+      if (invokes.empty())
+        continue;
+      for (LLVM::InvokeOp invoke : invokes) {
+        auto callee =
+            cast<LLVM::LLVMFuncOp>(invoke.resolveCallableInTable(&symbols));
+        rewriter.setInsertionPoint(invoke);
+        auto call = LLVM::CallOp::create(rewriter, invoke.getLoc(), callee,
+                                         invoke.getCalleeOperands());
+        call.setCConv(invoke.getCConv());
+        if (auto attrs = invoke.getArgAttrsAttr())
+          call.setArgAttrsAttr(attrs);
+        if (auto attrs = invoke.getResAttrsAttr())
+          call.setResAttrsAttr(attrs);
+        rewriter.replaceAllUsesWith(invoke.getResults(), call.getResults());
+        rewriter.replaceOpWithNewOp<LLVM::BrOp>(
+            invoke, invoke.getNormalDestOperands(), invoke.getNormalDest());
+      }
+      (void)eraseUnreachableBlocks(rewriter, fn->getRegions());
+    }
+  }
+};
+} // namespace

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -368,6 +368,13 @@ def HoistAllocasPass : Pass<"hoist-allocas"> {
   ];
 }
 
+def InvokeToCallPass : Pass<"invoke-to-call"> {
+  let summary = "Call, rather than invoke, the callees that cannot unwind";
+  let dependentDialects = [
+    "LLVM::LLVMDialect",
+  ];
+}
+
 def StripDeadPersonalityPass : Pass<"strip-dead-personality"> {
   let summary = "Drop the personality of functions that have no landing pad, "
                 "so the inliner accepts them";

--- a/src/enzyme_ad/jax/raise.cpp
+++ b/src/enzyme_ad/jax/raise.cpp
@@ -117,7 +117,7 @@ extern "C" std::string runLLVMToMLIRRoundTrip(std::string input,
                                     : "canonicalize-parallel{parallel=false}";
   // clang-format off
   std::string pass_pipeline =
-      "inline{default-pipeline=canonicalize "
+      "invoke-to-call,inline{default-pipeline=canonicalize "
       "max-iterations=4},sroa-wrappers{set_private=false attributor=false},"
       "lift-tessera-annotations,parse-optimization-rules,"
       "libdevice-funcs-raise,"

--- a/test/lit_tests/invoke_to_call.mlir
+++ b/test/lit_tests/invoke_to_call.mlir
@@ -1,0 +1,84 @@
+// RUN: enzymexlamlir-opt %s --invoke-to-call | FileCheck %s
+
+// @leaf calls nothing and @through_leaf only calls it, so neither can unwind
+// and their invokes become calls; the landing pad @only_leaf no longer reaches
+// goes with it. @may_throw is a declaration and @rethrows resumes, so their
+// invokes stay.
+
+llvm.func @__gxx_personality_v0(...) -> i32
+llvm.func @may_throw()
+
+llvm.func @leaf(%arg0: !llvm.ptr) -> i32 {
+  %0 = llvm.load %arg0 : !llvm.ptr -> i32
+  llvm.return %0 : i32
+}
+
+llvm.func @through_leaf(%arg0: !llvm.ptr) -> i32 {
+  %0 = llvm.call @leaf(%arg0) : (!llvm.ptr) -> i32
+  llvm.return %0 : i32
+}
+
+llvm.func @rethrows() attributes {personality = @__gxx_personality_v0} {
+  llvm.invoke @may_throw() to ^bb1 unwind ^bb2 : () -> ()
+^bb1:
+  llvm.return
+^bb2:
+  %0 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.resume %0 : !llvm.struct<(ptr, i32)>
+}
+
+llvm.func @caller(%arg0: !llvm.ptr) -> i32 attributes {personality = @__gxx_personality_v0} {
+  %0 = llvm.invoke @through_leaf(%arg0) to ^bb1 unwind ^bb3 : (!llvm.ptr) -> i32
+^bb1:
+  llvm.invoke @rethrows() to ^bb2 unwind ^bb3 : () -> ()
+^bb2:
+  llvm.return %0 : i32
+^bb3:
+  %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.resume %1 : !llvm.struct<(ptr, i32)>
+}
+
+llvm.func @only_leaf(%arg0: !llvm.ptr) -> i32 attributes {personality = @__gxx_personality_v0} {
+  %0 = llvm.invoke @leaf(%arg0) to ^bb1 unwind ^bb2 : (!llvm.ptr) -> i32
+^bb1:
+  llvm.return %0 : i32
+^bb2:
+  %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.resume %1 : !llvm.struct<(ptr, i32)>
+}
+
+// CHECK:    llvm.func @__gxx_personality_v0(...) -> i32
+// CHECK-NEXT:  llvm.func @may_throw()
+// CHECK-NEXT:  llvm.func @leaf(%arg0: !llvm.ptr) -> i32 attributes {no_unwind} {
+// CHECK-NEXT:    %0 = llvm.load %arg0 : !llvm.ptr -> i32
+// CHECK-NEXT:    llvm.return %0 : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @through_leaf(%arg0: !llvm.ptr) -> i32 attributes {no_unwind} {
+// CHECK-NEXT:    %0 = llvm.call @leaf(%arg0) : (!llvm.ptr) -> i32
+// CHECK-NEXT:    llvm.return %0 : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @rethrows() attributes {personality = @__gxx_personality_v0} {
+// CHECK-NEXT:    llvm.invoke @may_throw() to ^bb1 unwind ^bb2 : () -> ()
+// CHECK-NEXT:  ^bb1:  // pred: ^bb0
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  ^bb2:  // pred: ^bb0
+// CHECK-NEXT:    %0 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+// CHECK-NEXT:    llvm.resume %0 : !llvm.struct<(ptr, i32)>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @caller(%arg0: !llvm.ptr) -> i32 attributes {personality = @__gxx_personality_v0} {
+// CHECK-NEXT:    %0 = llvm.call @through_leaf(%arg0) : (!llvm.ptr) -> i32
+// CHECK-NEXT:    llvm.br ^bb1
+// CHECK-NEXT:  ^bb1:  // pred: ^bb0
+// CHECK-NEXT:    llvm.invoke @rethrows() to ^bb2 unwind ^bb3 : () -> ()
+// CHECK-NEXT:  ^bb2:  // pred: ^bb1
+// CHECK-NEXT:    llvm.return %0 : i32
+// CHECK-NEXT:  ^bb3:  // pred: ^bb1
+// CHECK-NEXT:    %1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+// CHECK-NEXT:    llvm.resume %1 : !llvm.struct<(ptr, i32)>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @only_leaf(%arg0: !llvm.ptr) -> i32 attributes {personality = @__gxx_personality_v0} {
+// CHECK-NEXT:    %0 = llvm.call @leaf(%arg0) : (!llvm.ptr) -> i32
+// CHECK-NEXT:    llvm.br ^bb1
+// CHECK-NEXT:  ^bb1:  // pred: ^bb0
+// CHECK-NEXT:    llvm.return %0 : i32
+// CHECK-NEXT:  }


### PR DESCRIPTION
Companion to EnzymeAD/Reactant#98, on the MLIR side and before the first `inline`. The LLVM dialect inliner takes only `llvm.call` sites, and MFEM's forall CPU fallback invokes the `__host__ __device__` lambda's host copy per element; that `llvm.invoke` never inlines, the closure alloca escapes into it, mem2reg never forwards the field stores into the kernel's whole-struct load, and 16 TUs still need the aggregate-load splitting of #2933 after #3159/#3160.

`invoke-to-call` decides over each body whether a function can unwind (it never resumes, has no inline asm, and every call in it reaches a function that cannot unwind, to a fixpoint from the functions already marked `no_unwind`), marks those `no_unwind`, and rewrites an `llvm.invoke` of one into an `llvm.call` plus a branch to the normal successor, erasing a landing pad left without predecessors. Declarations without `no_unwind`, indirect calls and functions that resume stay may-unwind, so their invokes are untouched. Test: full goldens for a leaf, a function through a leaf, a resuming function, and a landing pad that goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
