### PR TITLE
discard-unreferenced-linkonce: keep weak definitions

### DIFF
--- a/src/enzyme_ad/jax/Passes/DiscardUnreferencedLinkonce.cpp
+++ b/src/enzyme_ad/jax/Passes/DiscardUnreferencedLinkonce.cpp
@@ -6,10 +6,12 @@
 //
 //===---------------------------------------------------------------------===//
 //
-// symbol-dce keeps every symbol that is not private, so a linkonce or weak
+// symbol-dce keeps every symbol that is not private, so a linkonce
 // definition the inliner has folded into all its callers survives it. Each
 // translation unit that uses such a function defines its own copy, so an
-// unreferenced definition is discardable, as in LLVM's GlobalDCE.
+// unreferenced definition is discardable, as in LLVM's GlobalDCE. A weak
+// definition is not: an explicit template instantiation is weak_odr and the
+// only definition its `extern template` users will find.
 //
 //===---------------------------------------------------------------------===//
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -29,8 +31,6 @@ static bool isDiscardableLinkage(LLVM::Linkage linkage) {
   switch (linkage) {
   case LLVM::Linkage::Linkonce:
   case LLVM::Linkage::LinkonceODR:
-  case LLVM::Linkage::Weak:
-  case LLVM::Linkage::WeakODR:
     return true;
   default:
     return false;

--- a/src/enzyme_ad/jax/Passes/Passes.td
+++ b/src/enzyme_ad/jax/Passes/Passes.td
@@ -378,8 +378,7 @@ def StripDeadPersonalityPass : Pass<"strip-dead-personality"> {
 
 def DiscardUnreferencedLinkoncePass
     : Pass<"discard-unreferenced-linkonce"> {
-  let summary = "Erase linkonce and weak function definitions nothing "
-                "references";
+  let summary = "Erase linkonce function definitions nothing references";
   let dependentDialects = [
     "LLVM::LLVMDialect",
   ];

--- a/test/lit_tests/discard_unreferenced_linkonce.mlir
+++ b/test/lit_tests/discard_unreferenced_linkonce.mlir
@@ -1,7 +1,9 @@
 // RUN: enzymexlamlir-opt %s --discard-unreferenced-linkonce | FileCheck %s
 
-// Unreferenced linkonce and weak definitions go; a comdat selector is not a
-// reference, and external definitions and declarations stay.
+// Unreferenced linkonce definitions go; a comdat selector is not a
+// reference. A weak definition stays: an explicit template instantiation is
+// weak_odr and the only definition its `extern template` users have. So do
+// external definitions and declarations.
 
 llvm.comdat @__llvm_global_comdat {
   llvm.comdat_selector @dead_odr any
@@ -12,7 +14,7 @@ llvm.func linkonce_odr @dead_odr() comdat(@__llvm_global_comdat::@dead_odr) {
   llvm.return
 }
 
-llvm.func weak @dead_weak() {
+llvm.func weak_odr @instantiation() {
   llvm.return
 }
 
@@ -35,6 +37,9 @@ llvm.func @main() {
 // CHECK:    llvm.comdat @__llvm_global_comdat {
 // CHECK-NEXT:    llvm.comdat_selector @dead_odr any
 // CHECK-NEXT:    llvm.comdat_selector @live_odr any
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func weak_odr @instantiation() {
+// CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
 // CHECK-NEXT:  llvm.func linkonce_odr @live_odr() comdat(@__llvm_global_comdat::@live_odr) {
 // CHECK-NEXT:    llvm.return


### PR DESCRIPTION
#3159's `discard-unreferenced-linkonce` also erased weak and weak_odr definitions nothing in the module references. An explicit template instantiation is weak_odr and is the only definition its `extern template` users will find, so those were lost: on MFEM, `Array<double>::Abs` and `Array<int>::Max` disappeared from the raised `general/array.cpp` (330 KB to 42 KB) and the four `fem/qinterp/grad_*` objects, which are nothing but explicit instantiations of kernel specializations, shrank to under a kilobyte. Every TU still compiled; the test binary's link is where it showed, as undefined references.

Only a linkonce definition is guaranteed a copy in every unit that uses it, so the pass now erases only those. The test's dead weak function becomes a weak_odr instantiation that must stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
