### PR TITLE
Drop stores of undef in canonicalize-parallel and polygeist-mem2reg

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -17,12 +17,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "Enzyme/MLIR/Dialect/Ops.h"
+#include "Enzyme/MLIR/Interfaces/AutoDiffOpInterface.h"
 #include "mlir/Analysis/DataLayoutAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/Threading.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -748,6 +750,22 @@ struct FlattenAggregateAlloca : public OpRewritePattern<memref::AllocaOp> {
   }
 };
 
+// A store of undef or poison leaves the memory holding any value, and what
+// it held before is one of those, so the store does nothing.
+struct StoreOfUndef
+    : public OpInterfaceRewritePattern<enzyme::StoreLikeInterface> {
+  using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(enzyme::StoreLikeInterface store,
+                                PatternRewriter &rewriter) const override {
+    Operation *value = store.getStoredValue().getDefiningOp();
+    if (!isa_and_nonnull<LLVM::UndefOp, LLVM::PoisonOp, ub::PoisonOp>(value))
+      return failure();
+    rewriter.eraseOp(store);
+    return success();
+  }
+};
+
 struct CanonicalizeParallelPass
     : public enzyme::impl::CanonicalizeParallelPassBase<
           CanonicalizeParallelPass> {
@@ -785,7 +803,7 @@ struct CanonicalizeParallelPass
         SinkThroughSelectOfConstants<arith::AddIOp>,
         SinkThroughSelectOfConstants<arith::MulIOp>, SelectOfNullPointer,
         IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>,
-        FlattenAggregateAlloca>(ctx);
+        FlattenAggregateAlloca, StoreOfUndef>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
@@ -3488,6 +3489,19 @@ void PolygeistMem2Reg::runOnOperation() {
     // An allocation reached only through a branch between buffers is not yet
     // promotable; splitting the accesses first gives it accesses of its own.
     changed |= splitBufferBranchAccesses(f);
+
+    // A store of undef or poison leaves the slot holding any value, and what
+    // it held before is one; kept, it only stands between a load and the
+    // store that defined the value.
+    SmallVector<Operation *> undefStores;
+    f->walk([&](enzyme::StoreLikeInterface store) {
+      if (isa_and_nonnull<LLVM::UndefOp, LLVM::PoisonOp, ub::PoisonOp>(
+              store.getStoredValue().getDefiningOp()))
+        undefStores.push_back(store);
+    });
+    for (Operation *op : undefStores)
+      op->erase();
+    changed |= !undefStores.empty();
 
     // Walk all load's and perform store to load forwarding.
     SmallVector<mlir::Value, 4> toPromote;

--- a/test/lit_tests/canonicalize_parallel_store_undef.mlir
+++ b/test/lit_tests/canonicalize_parallel_store_undef.mlir
@@ -1,0 +1,24 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel | FileCheck %s
+
+// A store of undef or poison does nothing: the memory may hold any value
+// afterwards, and what it held before is one. Stores of defined values stay.
+
+func.func @padding(%arg0: !llvm.ptr, %arg1: memref<?xi32>, %arg2: i32) {
+  %undef = llvm.mlir.undef : i32
+  %poison = ub.poison : i32
+  %0 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+  affine.store %undef, %0[3] : memref<?xi32>
+  affine.store %arg2, %0[4] : memref<?xi32>
+  %c0 = arith.constant 0 : index
+  memref.store %poison, %arg1[%c0] : memref<?xi32>
+  memref.store %arg2, %arg1[%c0] : memref<?xi32>
+  return
+}
+
+// CHECK:    func.func @padding(%arg0: !llvm.ptr, %arg1: memref<?xi32>, %arg2: i32) {
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %0 = "enzymexla.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
+// CHECK-NEXT:    affine.store %arg2, %0[4] : memref<?xi32>
+// CHECK-NEXT:    memref.store %arg2, %arg1[%c0] : memref<?xi32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }

--- a/test/lit_tests/mem2reg_store_undef.mlir
+++ b/test/lit_tests/mem2reg_store_undef.mlir
@@ -1,0 +1,18 @@
+// RUN: enzymexlamlir-opt --polygeist-mem2reg %s | FileCheck %s
+
+// A store of undef leaves the slot holding any value, and what it held
+// before is one: the load forwards the store before it, not the undef.
+
+func.func @after(%arg0: i32) -> i32 {
+  %alloca = memref.alloca() : memref<i32>
+  %undef = llvm.mlir.undef : i32
+  memref.store %arg0, %alloca[] : memref<i32>
+  memref.store %undef, %alloca[] : memref<i32>
+  %0 = memref.load %alloca[] : memref<i32>
+  return %0 : i32
+}
+
+// CHECK:    func.func @after(%arg0: i32) -> i32 {
+// CHECK-NEXT:    %0 = llvm.mlir.undef : i32
+// CHECK-NEXT:    return %arg0 : i32
+// CHECK-NEXT:  }


### PR DESCRIPTION
A store of undef or poison leaves the memory holding any value, and what it held before is one, so the store does nothing. Kept, it stands between a load and the store that defined the value. This is the last thing keeping `bilininteg_curlcurl_pa` on #2933 once Reactant#98 is in: the host writes `llvm.mlir.undef` into every padding slot of a kernel closure, the kernel's copy of that closure moves the padding along as `array<4 x i8>` members through a whole-struct load, and that load cannot be assembled from an `i32` undef per padding word.

Both passes find them through Enzyme's `StoreLikeInterface` (`getStoredValue`), which the core dialect registrations attach to `memref.store`, `affine.store` and `llvm.store`: `canonicalize-parallel` drops such stores as a canonicalization, and `polygeist-mem2reg` drops them at the start of each round, before deciding what a slot holds. Tests: the canonicalization keeps the stores of defined values next to the dropped ones; mem2reg forwards the store before an undef store rather than the undef.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
