### PR TITLE
polygeist-mem2reg: reads of bytes nothing writes are undef

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -2228,6 +2228,10 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
 
   SmallPtrSet<Operation *, 4> AliasingStoreOperations;
 
+  SmallVector<std::pair<uint64_t, uint64_t>> writtenRanges;
+
+  bool writeUnknown = false;
+
   LLVM_DEBUG(llvm::dbgs()
              << "Begin forwarding store of " << AI << " to load\n"
              << *AI.getDefiningOp()->getParentOfType<FunctionOpInterface>()
@@ -2281,6 +2285,15 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       }
       // A load naming the slot reads it; one that may only overlap it reads
       // something this knows nothing about, which is no reason to stop.
+      // The bytes of the slot each store lands on, and whether a write may
+      // land where it cannot be told.
+      auto noteWritten = [&](std::optional<uint64_t> at,
+                             std::optional<uint64_t> size) {
+        if (at && size)
+          writtenRanges.emplace_back(*at, *at + *size);
+        else
+          writeUnknown = true;
+      };
       auto matchLoad = [&](Operation *loadOp, OffsetTree accessed) {
         uint64_t at = 0;
         Type read = loadOp->getResult(0).getType();
@@ -2344,7 +2357,12 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
         LLVM_DEBUG(llvm::dbgs() << "Matching Load: " << *loadOp << "\n");
       };
       auto matchStore = [&](Operation *storeOp, OffsetTree accessed) {
-        switch (idx.matches(tree.add(accessed, dl), dl)) {
+        OffsetTree stored = tree.add(accessed, dl);
+        Match match = idx.matches(stored, dl);
+        if (match != Match::None)
+          noteWritten(idx.containsAt(stored, dl),
+                      typeSize(stored.getBase(), dl));
+        switch (match) {
         case Match::Exact:
           LLVM_DEBUG(llvm::dbgs() << "Matching Store: " << *storeOp << "\n");
           allStoreOps.insert(storeOp);
@@ -2410,6 +2428,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
           if (!isCallNonCapturing(callOp, val, symbolTables)) {
             LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << callOp << "\n");
             AliasingStoreOperations.insert(callOp.getOperation());
+            writeUnknown = true;
             if (!callee || !getNonCapturingFunctions().count(
                                callee.getLeafReference().str()))
               captured = true;
@@ -2419,6 +2438,7 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
             // is exactly this. The slot's value is unknown after the call.
             LLVM_DEBUG(llvm::dbgs() << "Aliasing Store: " << callOp << "\n");
             AliasingStoreOperations.insert(callOp.getOperation());
+            writeUnknown = true;
           }
         }
         continue;
@@ -2432,7 +2452,10 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
                   : OffsetTree::unknown();
 
         if (transferDest(user) == val) {
-          switch (idx.matches(touched, dl)) {
+          Match match = idx.matches(touched, dl);
+          if (match != Match::None)
+            noteWritten(idx.containsAt(touched, dl), bytes);
+          switch (match) {
           case Match::Exact:
             // Writing exactly this slot writes a value that is known when what
             // it was written from is: the bytes of a fill, when they are zero,
@@ -2492,11 +2515,13 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
       captured = true;
     }
   }
-  if (SharedMemAddr)
+  if (SharedMemAddr) {
+    writeUnknown = true;
     AI.getDefiningOp()->getParentOp()->walk([&](mlir::NVVM::BarrierOp op) {
       LLVM_DEBUG(llvm::dbgs() << "Unknown, potential store: " << *op << "\n");
       AliasingStoreOperations.insert(op);
     });
+  }
 
   if (captured) {
     if (capturedAliasing.count(AI.getDefiningOp()) == 0) {
@@ -2537,6 +2562,56 @@ bool PolygeistMem2Reg::forwardStoreToLoad(
         continue;
       LLVM_DEBUG(llvm::dbgs() << "Potential Op ith Effect: " << *op << "\n");
       AliasingStoreOperations.insert(op);
+    }
+  }
+
+  // Bytes of an allocation nothing writes -- no store lands on them and no
+  // write may land where it cannot be told -- hold uninitialized memory, so a
+  // read of them is undef, as LLVM's mem2reg answers a load no store reaches.
+  // A load of the slot is such a read, and so is a field extracted from a
+  // load of it, field by field; the load goes with its last extract.
+  if (!captured && !writeUnknown &&
+      isa<memref::AllocaOp, memref::AllocOp, LLVM::AllocaOp>(
+          AI.getDefiningOp())) {
+    auto written = [&](uint64_t lo, uint64_t hi) {
+      return llvm::any_of(writtenRanges, [&](auto &range) {
+        return range.first < hi && lo < range.second;
+      });
+    };
+    auto undef = [&](Operation *read) {
+      OpBuilder builder(read);
+      Value value = LLVM::UndefOp::create(builder, read->getLoc(),
+                                          read->getResult(0).getType());
+      read->getResult(0).replaceAllUsesWith(value);
+      loadOpsToErase.push_back(read);
+      changed = true;
+    };
+    for (Operation *load :
+         SmallVector<Operation *>(loadOps.begin(), loadOps.end())) {
+      auto contained = containedLoads.find(load);
+      uint64_t at = contained == containedLoads.end() ? 0 : contained->second;
+      auto size = typeSize(load->getResult(0).getType(), dl);
+      if (!size)
+        continue;
+      if (!written(at, at + *size)) {
+        undef(load);
+        loadOps.erase(load);
+        continue;
+      }
+      if (contained != containedLoads.end())
+        continue;
+      for (Operation *user :
+           SmallVector<Operation *>(load->getResult(0).getUsers())) {
+        auto extract = dyn_cast<LLVM::ExtractValueOp>(user);
+        if (!extract || llvm::is_contained(loadOpsToErase, extract))
+          continue;
+        auto field = aggregateFieldOffset(elType, extract.getPosition(), dl);
+        if (!field)
+          continue;
+        auto fieldSize = typeSize(field->second, dl);
+        if (fieldSize && !written(field->first, field->first + *fieldSize))
+          undef(extract);
+      }
     }
   }
 
@@ -3104,6 +3179,8 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
     return std::make_pair(typeSize(tree.getBase(), dl).value_or(0), tree);
   };
   std::map<std::pair<uint64_t, OffsetTree>, unsigned> lastStored;
+  // Whether anything writes the allocation at all.
+  bool anyWrite = false;
 
   std::deque<std::pair<mlir::Value, OffsetTree>> list = {{AI, OffsetTree()}};
 
@@ -3112,6 +3189,7 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
     list.pop_front();
     for (auto *U : val.getUsers()) {
       if (auto SO = dyn_cast<memref::StoreOp>(U)) {
+        anyWrite = true;
         lastStored[slotOf(
             tree.add(accessOffsets(SO.getValue().getType(), SO.getMemRef(),
                                    SO.getIndices(), dl),
@@ -3121,6 +3199,7 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
             accessOffsets(LO.getType(), LO.getMemRef(), LO.getIndices(), dl),
             dl))]++;
       } else if (auto SO = dyn_cast<affine::AffineStoreOp>(U)) {
+        anyWrite = true;
         lastStored[slotOf(
             tree.add(accessOffsets(SO.getValue().getType(), SO.getMemRef(),
                                    SO.getAffineMapAttr().getValue(),
@@ -3133,11 +3212,14 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
                                    LO.getMapOperands(), dl),
                      dl))]++;
       } else if (auto SO = dyn_cast<LLVM::StoreOp>(U)) {
+        anyWrite = true;
         lastStored[slotOf(
             tree.add(accessOffsets(SO.getValue().getType()), dl))]++;
       } else if (auto LO = dyn_cast<LLVM::LoadOp>(U)) {
         lastStored[slotOf(tree.add(accessOffsets(LO.getType()), dl))]++;
       } else if (isa<LLVM::MemcpyOp, LLVM::MemmoveOp, LLVM::MemsetOp>(U)) {
+        if (transferDest(U) == val)
+          anyWrite = true;
         // What a transfer reads or fills is a slot like any other, and the
         // forwarding can only be asked about slots it is told of.
         if (auto bytes = transferLength(U))
@@ -3148,6 +3230,8 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
       } else if (isa<memref::CastOp, Memref2PointerOp, Pointer2MemrefOp,
                      LLVM::BitcastOp, LLVM::AddrSpaceCastOp>(U)) {
         list.emplace_back(U->getResult(0), tree);
+      } else {
+        anyWrite = true;
       }
     }
   }
@@ -3156,7 +3240,8 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
   // of a piece of a slot is an access of that slot too, since the piece can be
   // taken out of what is in it. It counts the other way round as well, since
   // an access reaching over the whole of a slot may be all that is ever said
-  // about what is in it.
+  // about what is in it. When nothing writes the allocation, one access is
+  // enough: whatever it reads is uninitialized.
   std::vector<OffsetTree> todo;
   for (auto &pair : lastStored) {
     unsigned count = pair.second;
@@ -3165,7 +3250,7 @@ std::vector<OffsetTree> getLastStored(mlir::Value AI, const DataLayout &dl) {
           (pair.first.second.containsAt(other.first.second, dl) ||
            other.first.second.containsAt(pair.first.second, dl)))
         count += other.second;
-    if (count > 1)
+    if (count > 1 || !anyWrite)
       todo.push_back(pair.first.second);
   }
   return todo;

--- a/test/lit_tests/mem2reg_transfer_partial_overlap.mlir
+++ b/test/lit_tests/mem2reg_transfer_partial_overlap.mlir
@@ -33,7 +33,8 @@ llvm.func @partial_overlap_clobber(%src: !llvm.ptr) {
 // -----
 
 // A copy that does not reach the slot leaves the cached value alone: filling
-// a[0..16) does not touch a[24..32), so the two loads still fold to one.
+// a[0..16) does not touch a[24..32), so the two loads still fold to one -- a
+// load of what the copy that filled a[24..32) read.
 
 llvm.func @use(f64)
 
@@ -44,6 +45,8 @@ llvm.func @disjoint_copy_still_forwards(%src: !llvm.ptr) {
   %a = llvm.alloca %c1 x !llvm.array<8 x f64> {alignment = 16 : i64} : (i32) -> !llvm.ptr
   %at24 = llvm.getelementptr %a[24] : (!llvm.ptr) -> !llvm.ptr, i8
   %at0 = llvm.getelementptr %a[0] : (!llvm.ptr) -> !llvm.ptr, i8
+  %c8 = llvm.mlir.constant(8 : i64) : i64
+  "llvm.intr.memcpy"(%at24, %src, %c8) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
   // CHECK: %[[V:.+]] = llvm.load
   %v1 = llvm.load %at24 : !llvm.ptr -> f64
   llvm.call @use(%v1) : (f64) -> ()

--- a/test/lit_tests/mem2reg_unstored_undef.mlir
+++ b/test/lit_tests/mem2reg_unstored_undef.mlir
@@ -1,0 +1,48 @@
+// RUN: enzymexlamlir-opt --polygeist-mem2reg %s | FileCheck %s
+
+// Bytes of an allocation nothing writes hold uninitialized memory, so a read
+// of them is undef: a load of a slot no store reaches, and a field extracted
+// from a load of a struct whose other fields were stored. The stored fields
+// forward as before, and the whole load goes with its last extract.
+
+func.func @unstored() -> i32 {
+  %alloca = memref.alloca() : memref<i32>
+  %0 = memref.load %alloca[] : memref<i32>
+  return %0 : i32
+}
+
+llvm.func @padding(%arg0: i32, %arg1: f64) -> !llvm.struct<(i32, f64, i8)> {
+  %c1 = llvm.mlir.constant(1 : i32) : i32
+  %alloca = llvm.alloca %c1 x !llvm.struct<(i32, array<4 x i8>, f64)> : (i32) -> !llvm.ptr
+  llvm.store %arg0, %alloca : i32, !llvm.ptr
+  %gep = llvm.getelementptr %alloca[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, array<4 x i8>, f64)>
+  llvm.store %arg1, %gep : f64, !llvm.ptr
+  %0 = llvm.load %alloca : !llvm.ptr -> !llvm.struct<(i32, array<4 x i8>, f64)>
+  %1 = llvm.extractvalue %0[0] : !llvm.struct<(i32, array<4 x i8>, f64)>
+  %2 = llvm.extractvalue %0[2] : !llvm.struct<(i32, array<4 x i8>, f64)>
+  %3 = llvm.extractvalue %0[1, 0] : !llvm.struct<(i32, array<4 x i8>, f64)>
+  %4 = llvm.mlir.undef : !llvm.struct<(i32, f64, i8)>
+  %5 = llvm.insertvalue %1, %4[0] : !llvm.struct<(i32, f64, i8)>
+  %6 = llvm.insertvalue %2, %5[1] : !llvm.struct<(i32, f64, i8)>
+  %7 = llvm.insertvalue %3, %6[2] : !llvm.struct<(i32, f64, i8)>
+  llvm.return %7 : !llvm.struct<(i32, f64, i8)>
+}
+
+// CHECK:    func.func @unstored() -> i32 {
+// CHECK-NEXT:    %0 = llvm.mlir.undef : i32
+// CHECK-NEXT:    return %0 : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  llvm.func @padding(%arg0: i32, %arg1: f64) -> !llvm.struct<(i32, f64, i8)> {
+// CHECK-NEXT:    %0 = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:    %1 = llvm.alloca %0 x !llvm.struct<(i32, array<4 x i8>, f64)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:    llvm.store %arg0, %1 : i32, !llvm.ptr
+// CHECK-NEXT:    %2 = llvm.getelementptr %1[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, array<4 x i8>, f64)>
+// CHECK-NEXT:    llvm.store %arg1, %2 : f64, !llvm.ptr
+// CHECK-NEXT:    %3 = llvm.load %1 : !llvm.ptr -> !llvm.struct<(i32, array<4 x i8>, f64)>
+// CHECK-NEXT:    %4 = llvm.mlir.undef : i8
+// CHECK-NEXT:    %5 = llvm.mlir.undef : !llvm.struct<(i32, f64, i8)>
+// CHECK-NEXT:    %6 = llvm.insertvalue %arg0, %5[0] : !llvm.struct<(i32, f64, i8)> 
+// CHECK-NEXT:    %7 = llvm.insertvalue %arg1, %6[1] : !llvm.struct<(i32, f64, i8)> 
+// CHECK-NEXT:    %8 = llvm.insertvalue %4, %7[2] : !llvm.struct<(i32, f64, i8)> 
+// CHECK-NEXT:    llvm.return %8 : !llvm.struct<(i32, f64, i8)>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Follows #3167. Once the host's undef stores into a closure's padding are gone, the padding bytes have no store at all, and the kernel's copy of the closure still extracts them out of a whole-struct load, which then cannot be forwarded and keeps `bilininteg_curlcurl_pa` on #2933.

Bytes of an allocation nothing writes hold uninitialized memory, so a read of them is undef, as LLVM's mem2reg answers a load no store reaches. The slot analysis now records where each store (or transfer) that matches the slot lands within it, and whether some write may land where it cannot be told (a call that may write, a shared-memory barrier). For an allocation that is not captured and without such an unknown write, a load of bytes no store lands on becomes undef, and so does a field extracted from a load of the slot when no store lands on the field's bytes; the load goes with its last extract. Slot selection, which only tried slots named by more than one access, also tries an allocation nothing writes.

Tests: a load of an allocation with no store, and a struct whose padding is extracted between two stored fields (the fields forward as before, the padding is undef). One existing test read never-written bytes to show a disjoint copy leaves a cached value alone; it now initializes them with a copy first, and its checks hold unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
