### PR TITLE
canonicalize-parallel: sink through a whole tree of branches over constants

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -192,6 +192,44 @@ struct Pointer2MemrefOfAddrSpaceCast
   }
 };
 
+/// Whether a value is a constant, or a result of an if of flavour IfT with an
+/// else region whose arms yield such values again: a choice between
+/// constants, however many ways.
+template <typename IfT> static bool isBranchedChoiceOfConstants(Value value) {
+  SmallVector<Value> worklist{value};
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    Attribute cst;
+    if (matchPattern(current, m_Constant(&cst)))
+      continue;
+    auto result = dyn_cast<OpResult>(current);
+    if (!result || !isa<IfT>(result.getOwner()) ||
+        result.getOwner()->getRegion(1).empty())
+      return false;
+    for (Region &arm : result.getOwner()->getRegions())
+      worklist.push_back(
+          arm.front().getTerminator()->getOperand(result.getResultNumber()));
+  }
+  return true;
+}
+
+/// Whether a value is a constant, or a select on an i1 between such values.
+static bool isSelectedChoiceOfConstants(Value value) {
+  SmallVector<Value> worklist{value};
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    Attribute cst;
+    if (matchPattern(current, m_Constant(&cst)))
+      continue;
+    auto sel = current.getDefiningOp<arith::SelectOp>();
+    if (!sel || !sel.getCondition().getType().isInteger(1))
+      return false;
+    worklist.push_back(sel.getTrueValue());
+    worklist.push_back(sel.getFalseValue());
+  }
+  return true;
+}
+
 /// Builds an if of the same flavour and condition with new result types.
 static scf::IfOp createLikeIf(PatternRewriter &rewriter, scf::IfOp ifOp,
                               TypeRange types) {
@@ -217,9 +255,12 @@ static void createLikeYield(PatternRewriter &rewriter, Location loc,
 
 /// An op over what a branch chose between constants is the branch choosing
 /// between the op's own results: the op rides into the arms, where it meets a
-/// constant and folds. What a branch chose then reaches its user as the
-/// branch's own result rather than at the far end of some arithmetic, which
-/// is how an index reaches an access for split-branched-accesses.
+/// constant and folds, and the branch grows a result for it. What the branch
+/// chose then reaches the op's users as the branch's own result rather than
+/// at the far end of some arithmetic, which is how an index reaches an access
+/// for split-branched-accesses. An arm may choose again through a further
+/// branch: the op's copy in that arm is such an op over a branch itself, and
+/// sinks in turn. The branch's other users keep its results as they were.
 template <typename OpT, typename IfT>
 struct SinkThroughIfOfConstants : public OpRewritePattern<OpT> {
   using OpRewritePattern<OpT>::OpRewritePattern;
@@ -238,44 +279,64 @@ struct SinkThroughIfOfConstants : public OpRewritePattern<OpT> {
         return failure();
       branched = res;
     }
-    // A second user would keep the branch alive and pay for it twice.
-    if (!branched || !branched.hasOneUse())
+    if (!branched)
       return failure();
-
     auto ifOp = cast<IfT>(branched.getOwner());
     if (ifOp->getRegion(1).empty())
       return failure();
     // The regions of both flavours of if are the arms, in order.
     unsigned resultNo = branched.getResultNumber();
-    Value arms[2];
-    for (unsigned arm = 0; arm < 2; ++arm) {
-      arms[arm] =
-          ifOp->getRegion(arm).front().getTerminator()->getOperand(resultNo);
-      Attribute cst;
-      if (!matchPattern(arms[arm], m_Constant(&cst)))
+    for (unsigned arm = 0; arm < 2; ++arm)
+      if (!isBranchedChoiceOfConstants<IfT>(
+              ifOp->getRegion(arm).front().getTerminator()->getOperand(
+                  resultNo)))
         return failure();
-    }
 
-    // Built where the op stands, so what the branch is taken over -- in hand
-    // before the branch -- is in hand here too.
-    auto newIf = createLikeIf(rewriter, ifOp, op->getResultTypes());
+    // The branch grown by the op's results: the arms move over, and each
+    // yields the op over what it chose. The constants the op reads come
+    // along, since the arm may stand before their definitions. A result the
+    // op was the only user of goes at the same time.
+    bool consumed = branched.hasOneUse();
+    SmallVector<Type> types;
+    for (auto [index, type] : llvm::enumerate(ifOp->getResultTypes()))
+      if (!consumed || index != resultNo)
+        types.push_back(type);
+    llvm::append_range(types, op->getResultTypes());
+    rewriter.setInsertionPoint(ifOp);
+    auto grown = createLikeIf(rewriter, ifOp, types);
     for (unsigned arm = 0; arm < 2; ++arm) {
-      rewriter.setInsertionPointToStart(&newIf->getRegion(arm).front());
-      Operation *chosen = rewriter.clone(*arms[arm].getDefiningOp());
+      Block *block = &grown->getRegion(arm).front();
+      rewriter.mergeBlocks(&ifOp->getRegion(arm).front(), block);
+      Operation *yield = block->getTerminator();
+      rewriter.setInsertionPoint(yield);
       IRMapping map;
-      map.map(branched, chosen->getResult(0));
+      map.map(branched, yield->getOperand(resultNo));
+      for (Value operand : op->getOperands())
+        if (operand != branched)
+          map.map(operand,
+                  rewriter.clone(*operand.getDefiningOp())->getResult(0));
       Operation *cloned = rewriter.clone(*op.getOperation(), map);
-      createLikeYield(rewriter, op.getLoc(), newIf, cloned->getResults());
+      rewriter.modifyOpInPlace(yield, [&] {
+        if (consumed)
+          yield->eraseOperand(resultNo);
+        yield->insertOperands(yield->getNumOperands(), cloned->getResults());
+      });
     }
-    rewriter.replaceOp(op, newIf->getResults());
+    unsigned numKept = ifOp->getNumResults() - consumed;
+    rewriter.replaceOp(op, grown->getResults().drop_front(numKept));
+    unsigned kept = 0;
+    for (auto [index, result] : llvm::enumerate(ifOp->getResults()))
+      if (!consumed || index != resultNo)
+        rewriter.replaceAllUsesWith(result, grown->getResult(kept++));
+    rewriter.eraseOp(ifOp);
     return success();
   }
 };
 
 /// The select counterpart: an op over a select between constants is the
-/// select between the op over each arm, where it meets a constant and folds.
-/// A select costs nothing to keep, so a second user of it is no reason to
-/// leave the op where it is.
+/// select between the op over each arm, where it meets a constant and folds,
+/// or a further select, into which it sinks in turn. A select costs nothing
+/// to keep, so a second user of it is no reason to leave the op where it is.
 template <typename OpT>
 struct SinkThroughSelectOfConstants : public OpRewritePattern<OpT> {
   using OpRewritePattern<OpT>::OpRewritePattern;
@@ -294,13 +355,11 @@ struct SinkThroughSelectOfConstants : public OpRewritePattern<OpT> {
     }
     if (!sel || !sel.getCondition().getType().isInteger(1))
       return failure();
-    Value arms[2] = {sel.getTrueValue(), sel.getFalseValue()};
-    for (Value arm : arms) {
-      Attribute cst;
-      if (!matchPattern(arm, m_Constant(&cst)))
-        return failure();
-    }
+    if (!isSelectedChoiceOfConstants(sel.getTrueValue()) ||
+        !isSelectedChoiceOfConstants(sel.getFalseValue()))
+      return failure();
 
+    Value arms[2] = {sel.getTrueValue(), sel.getFalseValue()};
     Value chosen[2];
     for (unsigned arm = 0; arm < 2; ++arm) {
       IRMapping map;

--- a/test/lit_tests/canonicalize_parallel_if_constants.mlir
+++ b/test/lit_tests/canonicalize_parallel_if_constants.mlir
@@ -5,6 +5,8 @@
 // result: a byte offset cast and scaled arrives as the element slot itself.
 
 #set = affine_set<()[s0] : (s0 >= 1)>
+#set0 = affine_set<(d0) : (d0 == 0)>
+#set1 = affine_set<(d0) : (d0 - 1 == 0)>
 module {
 
   func.func @cast_and_divide(%s: index) -> index {
@@ -46,13 +48,39 @@ module {
     return %i : index
   }
 
-  // a second user of the branch's result: sinking would ask the branch twice
+  // a second user of the branch's result keeps it: the branch grows a result
   func.func @two_uses(%s: index) -> (index, i64) {
     %c152 = arith.constant 152 : i64
     %c164 = arith.constant 164 : i64
     %off = affine.if #set()[%s] -> i64 { affine.yield %c164 : i64 } else { affine.yield %c152 : i64 }
     %i = arith.index_cast %off : i64 to index
     return %i, %off : index, i64
+  }
+
+  // an arm that chooses between constants itself: the cast rides into the
+  // outer branch, and from its arm into the inner one, and folds at every
+  // leaf; a three-way choice by a direction is two nested affine branches
+  func.func @nested_choice(%d: index) -> index {
+    %c4 = arith.constant 4 : index
+    %c152 = arith.constant 152 : i64
+    %c164 = arith.constant 164 : i64
+    %inner = affine.if #set1(%d) -> i64 { affine.yield %c164 : i64 } else { affine.yield %c152 : i64 }
+    %off = affine.if #set0(%d) -> i64 { affine.yield %c164 : i64 } else { affine.yield %inner : i64 }
+    %i = arith.index_cast %off : i64 to index
+    %j = arith.divsi %i, %c4 : index
+    return %j : index
+  }
+
+  // a select whose arm is a branch between constants is neither a tree of
+  // branches nor one of selects: the cast stays
+  func.func @select_over_branch(%c: i1, %s: index) -> index {
+    %c152 = arith.constant 152 : i64
+    %c164 = arith.constant 164 : i64
+    %c96 = arith.constant 96 : i64
+    %inner = affine.if #set()[%s] -> i64 { affine.yield %c164 : i64 } else { affine.yield %c152 : i64 }
+    %off = arith.select %c, %c96, %inner : i64
+    %i = arith.index_cast %off : i64 to index
+    return %i : index
   }
 
   // an arm that does not choose a constant has nothing to fold against
@@ -64,65 +92,93 @@ module {
   }
 }
 
-// CHECK:  func.func @cast_and_divide(%[[v1:.+]]: index) -> index {
-// CHECK-NEXT:  %[[v2:.+]] = arith.constant 38 : index
-// CHECK-NEXT:  %[[v3:.+]] = arith.constant 41 : index
-// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> index {
-// CHECK-NEXT:  affine.yield %[[v3]] : index
-// CHECK-NEXT:  } else {
-// CHECK-NEXT:  affine.yield %[[v2]] : index
+// CHECK:  #set = affine_set<()[s0] : (s0 - 1 >= 0)>
+// CHECK-NEXT:#set1 = affine_set<()[s0] : (s0 - 1 == 0)>
+// CHECK-NEXT:#set2 = affine_set<()[s0] : (s0 == 0)>
+// CHECK-NEXT:module {
+// CHECK-NEXT:  func.func @cast_and_divide(%[[a1:.+]]: index) -> index {
+// CHECK-NEXT:    %[[a2:.+]] = arith.constant 38 : index
+// CHECK-NEXT:    %[[a3:.+]] = arith.constant 41 : index
+// CHECK-NEXT:    %[[a4:.+]] = affine.if #set()[%[[a1]]] -> index {
+// CHECK-NEXT:      affine.yield %[[a3]] : index
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a2]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a4]] : index
 // CHECK-NEXT:  }
-// CHECK-NEXT:  return %[[v4]] : index
+// CHECK-NEXT:  func.func @divide_unsigned(%[[a1]]: index) -> i64 {
+// CHECK-NEXT:    %[[a5:.+]] = arith.constant 6 : i64
+// CHECK-NEXT:    %[[a6:.+]] = arith.constant 8 : i64
+// CHECK-NEXT:    %[[a4]] = affine.if #set()[%[[a1]]] -> i64 {
+// CHECK-NEXT:      affine.yield %[[a6]] : i64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a5]] : i64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a4]] : i64
 // CHECK-NEXT:  }
-
-// CHECK:  func.func @divide_unsigned(%[[v1:.+]]: index) -> i64 {
-// CHECK-NEXT:  %[[v2:.+]] = arith.constant 6 : i64
-// CHECK-NEXT:  %[[v3:.+]] = arith.constant 8 : i64
-// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> i64 {
-// CHECK-NEXT:  affine.yield %[[v3]] : i64
-// CHECK-NEXT:  } else {
-// CHECK-NEXT:  affine.yield %[[v2]] : i64
+// CHECK-NEXT:  func.func @divide_by_branched(%[[a1]]: index) -> i64 {
+// CHECK-NEXT:    %[[a7:.+]] = arith.constant 48 : i64
+// CHECK-NEXT:    %[[a8:.+]] = arith.constant 24 : i64
+// CHECK-NEXT:    %[[a4]] = affine.if #set()[%[[a1]]] -> i64 {
+// CHECK-NEXT:      affine.yield %[[a8]] : i64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a7]] : i64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a4]] : i64
 // CHECK-NEXT:  }
-// CHECK-NEXT:  return %[[v4]] : i64
+// CHECK-NEXT:  func.func @scf_branch(%[[a1]]: i1) -> index {
+// CHECK-NEXT:    %[[a9:.+]] = arith.constant 152 : index
+// CHECK-NEXT:    %[[a10:.+]] = arith.constant 164 : index
+// CHECK-NEXT:    %[[a4]] = arith.select %[[a1]], %[[a10]], %[[a9]] : index
+// CHECK-NEXT:    return %[[a4]] : index
 // CHECK-NEXT:  }
-
-// CHECK:  func.func @divide_by_branched(%[[v1:.+]]: index) -> i64 {
-// CHECK-NEXT:  %[[v2:.+]] = arith.constant 48 : i64
-// CHECK-NEXT:  %[[v3:.+]] = arith.constant 24 : i64
-// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> i64 {
-// CHECK-NEXT:  affine.yield %[[v3]] : i64
-// CHECK-NEXT:  } else {
-// CHECK-NEXT:  affine.yield %[[v2]] : i64
+// CHECK-NEXT:  func.func @two_uses(%[[a1]]: index) -> (index, i64) {
+// CHECK-NEXT:    %[[a9]] = arith.constant 152 : index
+// CHECK-NEXT:    %[[a10]] = arith.constant 164 : index
+// CHECK-NEXT:    %[[a11:.+]] = arith.constant 152 : i64
+// CHECK-NEXT:    %[[a12:.+]] = arith.constant 164 : i64
+// CHECK-NEXT:    %[[a4]]:2 = affine.if #set()[%[[a1]]] -> (i64, index) {
+// CHECK-NEXT:      affine.yield %[[a12]], %[[a10]] : i64, index
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a11]], %[[a9]] : i64, index
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a4]]#1, %[[a4]]#0 : index, i64
 // CHECK-NEXT:  }
-// CHECK-NEXT:  return %[[v4]] : i64
+// CHECK-NEXT:  func.func @nested_choice(%[[a1]]: index) -> index {
+// CHECK-NEXT:    %[[a2]] = arith.constant 38 : index
+// CHECK-NEXT:    %[[a3]] = arith.constant 41 : index
+// CHECK-NEXT:    %[[a4]] = affine.if #set1()[%[[a1]]] -> index {
+// CHECK-NEXT:      affine.yield %[[a3]] : index
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a2]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a13:.+]] = affine.if #set2()[%[[a1]]] -> index {
+// CHECK-NEXT:      affine.yield %[[a3]] : index
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a4]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a13]] : index
 // CHECK-NEXT:  }
-
-// CHECK:  func.func @scf_branch(%[[v1:.+]]: i1) -> index {
-// CHECK-NEXT:  %[[v2:.+]] = arith.constant 152 : index
-// CHECK-NEXT:  %[[v3:.+]] = arith.constant 164 : index
-// CHECK-NEXT:  %[[v4:.+]] = arith.select %[[v1]], %[[v3]], %[[v2]] : index
-// CHECK-NEXT:  return %[[v4]] : index
+// CHECK-NEXT:  func.func @select_over_branch(%[[a1]]: i1, %[[a14:.+]]: index) -> index {
+// CHECK-NEXT:    %[[a11]] = arith.constant 152 : i64
+// CHECK-NEXT:    %[[a12]] = arith.constant 164 : i64
+// CHECK-NEXT:    %[[a15:.+]] = arith.constant 96 : i64
+// CHECK-NEXT:    %[[a4]] = affine.if #set()[%[[a14]]] -> i64 {
+// CHECK-NEXT:      affine.yield %[[a12]] : i64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a11]] : i64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a13]] = arith.select %[[a1]], %[[a15]], %[[a4]] : i64
+// CHECK-NEXT:    %[[a16:.+]] = arith.index_cast %[[a13]] : i64 to index
+// CHECK-NEXT:    return %[[a16]] : index
 // CHECK-NEXT:  }
-
-// CHECK:  func.func @two_uses(%[[v1:.+]]: index) -> (index, i64) {
-// CHECK-NEXT:  %[[v2:.+]] = arith.constant 152 : i64
-// CHECK-NEXT:  %[[v3:.+]] = arith.constant 164 : i64
-// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> i64 {
-// CHECK-NEXT:  affine.yield %[[v3]] : i64
-// CHECK-NEXT:  } else {
-// CHECK-NEXT:  affine.yield %[[v2]] : i64
-// CHECK-NEXT:  }
-// CHECK-NEXT:  %[[v5:.+]] = arith.index_cast %[[v4]] : i64 to index
-// CHECK-NEXT:  return %[[v5]], %[[v4]] : index, i64
-// CHECK-NEXT:  }
-
-// CHECK:  func.func @dynamic_arm(%[[v1:.+]]: index, %[[v2:.+]]: i64) -> index {
-// CHECK-NEXT:  %[[v3:.+]] = arith.constant 164 : i64
-// CHECK-NEXT:  %[[v4:.+]] = affine.if #set()[%[[v1]]] -> i64 {
-// CHECK-NEXT:  affine.yield %[[v3]] : i64
-// CHECK-NEXT:  } else {
-// CHECK-NEXT:  affine.yield %[[v2]] : i64
-// CHECK-NEXT:  }
-// CHECK-NEXT:  %[[v5:.+]] = arith.index_cast %[[v4]] : i64 to index
-// CHECK-NEXT:  return %[[v5]] : index
+// CHECK-NEXT:  func.func @dynamic_arm(%[[a1]]: index, %[[a14]]: i64) -> index {
+// CHECK-NEXT:    %[[a12]] = arith.constant 164 : i64
+// CHECK-NEXT:    %[[a4]] = affine.if #set()[%[[a1]]] -> i64 {
+// CHECK-NEXT:      affine.yield %[[a12]] : i64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a14]] : i64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a13]] = arith.index_cast %[[a4]] : i64 to index
+// CHECK-NEXT:    return %[[a13]] : index
 // CHECK-NEXT:  }


### PR DESCRIPTION
`canonicalize-parallel` sinks an index cast or a division into an if (or a select) whose arms are constants, so the op folds in each arm and what the branch chose reaches its user as the branch's own result. It required every arm to be a constant, and wrapped the op in a new if of the same condition. MFEM's curlcurl kernel picks one of three DeviceTensor dimensions by the direction, which arrives as two nested affine ifs:

```mlir
%113 = affine.if #set12(%arg14) -> i64 { affine.yield %c164_i64 } else { affine.yield %c152_i64 }
%114:8 = affine.if #set13(%arg14) -> (i64, ...) { ... yield %c164_i64, ... } else { ... yield %113, ... }
%131 = arith.index_cast %114#0 : i64 to index
%132 = arith.divsi %131, %c4 : index
%133 = memref.load %79[%132] : memref<?xi32>      // the kernel's copy of its closure
```

The else arm is not a constant, so nothing sank and the closure read kept a dynamic index that mem2reg cannot resolve, which is what keeps that copy, and the pointer select stored into it, alive (#3026's remaining job).

The op now sinks into the if that produced its operand, growing that if by the op's results, with the arms moved over and each yielding the op over what it chose (a result the op was the only user of is dropped at the same time). A copy that lands beside an inner if is again an op over a branch and sinks on the next application, with no bookkeeping of its own; arms may therefore be constants or further such ifs. A second user of the branch no longer blocks the sink, since the branch is evaluated once and merely grows. The select flavour likewise admits arms that select again. Test: the nested case above (cast and division fold to 41 and 38 at the leaves, both ifs kept in place), a select over a branch (neither kind, stays), and the two-user case now sinking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NFhod9UD
