### PR TITLE
polygeist-mem2reg: split accesses indexed by a tree of choices between constants

### DIFF
--- a/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
+++ b/src/enzyme_ad/jax/Passes/PolygeistMem2Reg.cpp
@@ -3451,22 +3451,79 @@ static bool splitBufferBranchAccesses(Operation *f) {
 }
 
 // A select between two constants, so that each arm names a place of its own.
-static arith::SelectOp selectOfConstants(Value v) {
-  auto sel = v.getDefiningOp<arith::SelectOp>();
-  Attribute cst;
-  if (!sel || !sel.getCondition().getType().isInteger(1) ||
-      !matchPattern(sel.getTrueValue(), m_Constant(&cst)) ||
-      !matchPattern(sel.getFalseValue(), m_Constant(&cst)))
-    return nullptr;
-  return sel;
+// A choice between constants: a constant, a select on an i1 between such
+// choices, or a result of an if with an else region whose arms yield such
+// choices.
+static bool isChoiceOfConstants(Value value) {
+  SmallVector<Value> worklist{value};
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    Attribute cst;
+    if (matchPattern(current, m_Constant(&cst)))
+      continue;
+    if (auto sel = current.getDefiningOp<arith::SelectOp>()) {
+      if (!sel.getCondition().getType().isInteger(1))
+        return false;
+      worklist.push_back(sel.getTrueValue());
+      worklist.push_back(sel.getFalseValue());
+      continue;
+    }
+    auto result = dyn_cast<OpResult>(current);
+    if (!result || !isa<scf::IfOp, affine::AffineIfOp>(result.getOwner()) ||
+        result.getOwner()->getRegion(1).empty())
+      return false;
+    for (Region &arm : result.getOwner()->getRegions())
+      worklist.push_back(
+          arm.front().getTerminator()->getOperand(result.getResultNumber()));
+  }
+  return true;
 }
 
-// An access indexed by a select between constants lands in one of two slots
-// the forwarding could match, yet names neither. When every user of the
-// allocation is an access at a constant index or at such a select, each
-// select-indexed access becomes a branch on the select's condition around an
-// access at each constant, and the forwarding then sees only constant
-// indices. Nested selects are split one index at a time, on successive
+// The branch making the same choice as `choice`, with `types` as results.
+static Operation *createBranchLike(OpBuilder &b, Location loc, Value choice,
+                                   TypeRange types) {
+  if (auto sel = choice.getDefiningOp<arith::SelectOp>())
+    return scf::IfOp::create(b, loc, types, sel.getCondition(),
+                             /*withElseRegion=*/true);
+  Operation *owner = cast<OpResult>(choice).getOwner();
+  if (auto ifOp = dyn_cast<scf::IfOp>(owner))
+    return scf::IfOp::create(b, loc, types, ifOp.getCondition(),
+                             /*withElseRegion=*/true);
+  auto ifOp = cast<affine::AffineIfOp>(owner);
+  return affine::AffineIfOp::create(b, loc, types, ifOp.getIntegerSet(),
+                                    ifOp.getOperands(),
+                                    /*withElseRegion=*/true);
+}
+
+// What `choice` chooses in arm `arm` of the branch it is.
+static Value armOf(Value choice, unsigned arm) {
+  if (auto sel = choice.getDefiningOp<arith::SelectOp>())
+    return arm == 0 ? sel.getTrueValue() : sel.getFalseValue();
+  auto result = cast<OpResult>(choice);
+  return result.getOwner()->getRegion(arm).front().getTerminator()->getOperand(
+      result.getResultNumber());
+}
+
+// Yields `values` from the arm `block` of `branch`, after what the arm holds.
+static void yieldFrom(OpBuilder &b, Location loc, Operation *branch,
+                      Block *block, ValueRange values) {
+  if (!block->empty() && block->back().hasTrait<OpTrait::IsTerminator>()) {
+    assert(values.empty());
+    return;
+  }
+  b.setInsertionPointToEnd(block);
+  if (isa<affine::AffineIfOp>(branch))
+    affine::AffineYieldOp::create(b, loc, values);
+  else
+    scf::YieldOp::create(b, loc, values);
+}
+
+// An access indexed by a choice between constants lands in one of the slots
+// the forwarding could match, yet names none. When every user of the
+// allocation is an access at a constant index or at such a choice, each
+// choice-indexed access becomes the branches of the choice around an access
+// at each constant, and the forwarding then sees only constant indices.
+// Several choice-indexed operands are split one at a time, on successive
 // rounds.
 static bool splitSelectIndexedAccesses(Value AI) {
   auto constantIndices = [](ValueRange indices) {
@@ -3512,7 +3569,7 @@ static bool splitSelectIndexedAccesses(Value AI) {
         Attribute cst;
         if (matchPattern(idx, m_Constant(&cst)))
           continue;
-        if (!selectOfConstants(idx))
+        if (!isChoiceOfConstants(idx))
           return false;
         split = true;
       }
@@ -3523,27 +3580,46 @@ static bool splitSelectIndexedAccesses(Value AI) {
 
   for (Operation *op : toSplit) {
     OpOperand *chosen = nullptr;
-    for (OpOperand &operand : op->getOpOperands())
-      if (selectOfConstants(operand.get())) {
+    for (OpOperand &operand : op->getOpOperands()) {
+      Attribute cst;
+      if (!matchPattern(operand.get(), m_Constant(&cst)) &&
+          isChoiceOfConstants(operand.get())) {
         chosen = &operand;
         break;
       }
-    auto sel = cast<arith::SelectOp>(chosen->get().getDefiningOp());
-    OpBuilder b(op);
-    auto ifOp = scf::IfOp::create(b, op->getLoc(), op->getResultTypes(),
-                                  sel.getCondition(), /*withElseRegion=*/true);
-    Value arms[2] = {sel.getTrueValue(), sel.getFalseValue()};
-    for (unsigned arm = 0; arm < 2; ++arm) {
-      Block *block = &ifOp->getRegion(arm).front();
-      b.setInsertionPointToStart(block);
-      Operation *cloned = b.clone(*op);
-      cloned->setOperand(chosen->getOperandNumber(), arms[arm]);
-      if (op->getNumResults()) {
-        b.setInsertionPointToEnd(block);
-        scf::YieldOp::create(b, op->getLoc(), cloned->getResults());
-      }
     }
-    op->replaceAllUsesWith(ifOp.getResults());
+    Location loc = op->getLoc();
+    OpBuilder b(op);
+    Operation *root =
+        createBranchLike(b, loc, chosen->get(), op->getResultTypes());
+    // Each arm holds the access at the constant its choice chooses there, or
+    // the branch of a further choice.
+    struct Arm {
+      Operation *branch;
+      unsigned arm;
+      Value choice;
+    };
+    SmallVector<Arm> worklist{{root, 0, chosen->get()},
+                              {root, 1, chosen->get()}};
+    while (!worklist.empty()) {
+      Arm item = worklist.pop_back_val();
+      Block *block = &item.branch->getRegion(item.arm).front();
+      Value picked = armOf(item.choice, item.arm);
+      b.setInsertionPointToStart(block);
+      Attribute cst;
+      if (matchPattern(picked, m_Constant(&cst))) {
+        Operation *cloned = b.clone(*op);
+        cloned->setOperand(chosen->getOperandNumber(), picked);
+        yieldFrom(b, loc, item.branch, block, cloned->getResults());
+        continue;
+      }
+      Operation *nested =
+          createBranchLike(b, loc, picked, op->getResultTypes());
+      yieldFrom(b, loc, item.branch, block, nested->getResults());
+      worklist.push_back({nested, 0, picked});
+      worklist.push_back({nested, 1, picked});
+    }
+    op->replaceAllUsesWith(root->getResults());
     op->erase();
   }
   return !toSplit.empty();

--- a/test/lit_tests/mem2reg_choice_indexed.mlir
+++ b/test/lit_tests/mem2reg_choice_indexed.mlir
@@ -1,0 +1,90 @@
+// RUN: enzymexlamlir-opt --polygeist-mem2reg %s | FileCheck %s
+
+// A read at a slot a branch picks between constants lands in one of the
+// stored slots yet names none; it splits into the same branches around a
+// read at each constant, and every leaf forwards. A three-way choice by a
+// direction arrives as two nested affine branches, the shape of a kernel
+// reading one of a closure's tensor dimensions.
+
+#set0 = affine_set<(d0) : (d0 == 0)>
+#set1 = affine_set<(d0) : (d0 - 1 == 0)>
+
+func.func @nested(%d: index, %a: i32, %b: i32, %c: i32) -> i32 {
+  %alloca = memref.alloca() : memref<8xi32>
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c5 = arith.constant 5 : index
+  memref.store %a, %alloca[%c1] : memref<8xi32>
+  memref.store %b, %alloca[%c2] : memref<8xi32>
+  memref.store %c, %alloca[%c5] : memref<8xi32>
+  %inner = affine.if #set1(%d) -> index { affine.yield %c2 : index } else { affine.yield %c5 : index }
+  %slot = affine.if #set0(%d) -> index { affine.yield %c1 : index } else { affine.yield %inner : index }
+  %v = memref.load %alloca[%slot] : memref<8xi32>
+  return %v : i32
+}
+
+func.func @select_over_branch(%d: index, %p: i1, %a: i32, %b: i32, %c: i32) -> i32 {
+  %alloca = memref.alloca() : memref<8xi32>
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c5 = arith.constant 5 : index
+  memref.store %a, %alloca[%c1] : memref<8xi32>
+  memref.store %b, %alloca[%c2] : memref<8xi32>
+  memref.store %c, %alloca[%c5] : memref<8xi32>
+  %inner = affine.if #set1(%d) -> index { affine.yield %c2 : index } else { affine.yield %c5 : index }
+  %slot = arith.select %p, %c1, %inner : index
+  %v = memref.load %alloca[%slot] : memref<8xi32>
+  return %v : i32
+}
+
+// CHECK:  #set = affine_set<(d0) : (d0 - 1 == 0)>
+// CHECK-NEXT:#set1 = affine_set<(d0) : (d0 == 0)>
+// CHECK-NEXT:module {
+// CHECK-NEXT:  func.func @nested(%[[a1:.+]]: index, %[[a2:.+]]: i32, %[[a3:.+]]: i32, %[[a4:.+]]: i32) -> i32 {
+// CHECK-NEXT:    %[[a5:.+]] = arith.constant 1 : index
+// CHECK-NEXT:    %[[a6:.+]] = arith.constant 2 : index
+// CHECK-NEXT:    %[[a7:.+]] = arith.constant 5 : index
+// CHECK-NEXT:    %[[a8:.+]] = affine.if #set(%[[a1]]) -> index {
+// CHECK-NEXT:      affine.yield %[[a6]] : index
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a7]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a9:.+]] = affine.if #set1(%[[a1]]) -> index {
+// CHECK-NEXT:      affine.yield %[[a5]] : index
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a8]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a10:.+]] = affine.if #set1(%[[a1]]) -> i32 {
+// CHECK-NEXT:      affine.yield %[[a2]] : i32
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      %[[a11:.+]] = affine.if #set(%[[a1]]) -> i32 {
+// CHECK-NEXT:        affine.yield %[[a3]] : i32
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        affine.yield %[[a4]] : i32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      affine.yield %[[a11]] : i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a10]] : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @select_over_branch(%[[a1]]: index, %[[a2]]: i1, %[[a3]]: i32, %[[a4]]: i32, %[[a12:.+]]: i32) -> i32 {
+// CHECK-NEXT:    %[[a5]] = arith.constant 1 : index
+// CHECK-NEXT:    %[[a6]] = arith.constant 2 : index
+// CHECK-NEXT:    %[[a7]] = arith.constant 5 : index
+// CHECK-NEXT:    %[[a8]] = affine.if #set(%[[a1]]) -> index {
+// CHECK-NEXT:      affine.yield %[[a6]] : index
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      affine.yield %[[a7]] : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[a9]] = arith.select %[[a2]], %[[a5]], %[[a8]] : index
+// CHECK-NEXT:    %[[a10]] = scf.if %[[a2]] -> (i32) {
+// CHECK-NEXT:      scf.yield %[[a3]] : i32
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      %[[a11]] = affine.if #set(%[[a1]]) -> i32 {
+// CHECK-NEXT:        affine.yield %[[a4]] : i32
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        affine.yield %[[a12]] : i32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      scf.yield %[[a11]] : i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[a10]] : i32
+// CHECK-NEXT:  }


### PR DESCRIPTION
Companion to #3169, on the mem2reg side. `splitSelectIndexedAccesses` split an access indexed by an `arith.select` between two constants into a branch around an access at each constant, so the forwarding sees only constant indices. A slot picked by nested ifs of constants got no such treatment: MFEM's curlcurl kernel reads one of three DeviceTensor dimensions of its closure by the direction, which arrives as two nested `affine.if`s of byte offsets. The dynamic read kept the kernel's copy of the closure alive, and with it the store of the `size > 0 ? Read() : null` pointer select into it, which the raiser then had to raise and could not; that is what still needed #3026.

The split now covers a whole tree of choices, of selects and of ifs of either flavour, rebuilt as nested like-branches at the access with a constant-index access at each leaf, through a worklist rather than recursion. Test: a read at a two-level affine choice between three stored slots, and one at a select over such a branch; both forward completely and the allocation goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
