### PR TITLE
Recognize affine iotas through reshapes

### DIFF
--- a/src/enzyme_ad/jax/Utils.cpp
+++ b/src/enzyme_ad/jax/Utils.cpp
@@ -30,6 +30,7 @@
 
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 
 #include "shardy/dialect/sdy/ir/utils.h"
 #include "stablehlo/dialect/ChloOps.h"
@@ -1853,12 +1854,11 @@ std::optional<IotaLikeTensor> detectIotaLikeTensor(mlir::Value tensor) {
 
     // navigate to the next op. If any unsupported intermediate op is found,
     // then return std::nullopt
-    // TODO: we might want to support insert_dims / drop_dims as well
     auto nextOp =
         llvm::TypeSwitch<Operation *, Operation *>(currentOp)
-            .Case<stablehlo::TransposeOp>([&](auto transposeOp) {
+            .Case<stablehlo::TransposeOp, stablehlo::ReshapeOp>([&](auto op) {
               chain.push_back({currentOp, nullptr, nullptr});
-              return transposeOp.getOperand().getDefiningOp();
+              return op.getOperand().getDefiningOp();
             })
             .Case<stablehlo::BroadcastInDimOp>(
                 [&](auto broadcastOp) -> Operation * {
@@ -1980,6 +1980,44 @@ std::optional<IotaLikeTensor> detectIotaLikeTensor(mlir::Value tensor) {
                 }
               }
               return true;
+            })
+            .Case<stablehlo::ReshapeOp>([&](auto reshapeOp) {
+              auto inputType = reshapeOp.getOperand().getType();
+              auto outputType = reshapeOp.getType();
+              if (!inputType.hasStaticShape() || !outputType.hasStaticShape() ||
+                  result.dimension < 0 ||
+                  result.dimension >= inputType.getRank())
+                return false;
+
+              auto inputShape = inputType.getShape();
+              auto outputShape = outputType.getShape();
+              if (llvm::is_contained(inputShape, 0) ||
+                  llvm::is_contained(outputShape, 0))
+                return false;
+
+              // At a linear position p, the iota coordinate is
+              // (p / stride) % extent. Reshaping preserves it when both the
+              // extent and the product of trailing dimensions stay the same.
+              // Other dimensions may be regrouped, including inserting or
+              // removing unit dimensions, but the varying axis cannot split
+              // or merge with another axis.
+              int64_t inputStride = 1;
+              for (int64_t size : inputShape.drop_front(result.dimension + 1))
+                if (llvm::MulOverflow(inputStride, size, inputStride))
+                  return false;
+
+              int64_t outputStride = 1;
+              for (int64_t dim = outputType.getRank() - 1; dim >= 0; --dim) {
+                if (outputShape[dim] == inputShape[result.dimension] &&
+                    outputStride == inputStride) {
+                  result.dimension = dim;
+                  return true;
+                }
+                if (llvm::MulOverflow(outputStride, outputShape[dim],
+                                      outputStride))
+                  return false;
+              }
+              return false;
             })
             .Case<stablehlo::BroadcastInDimOp>([&](auto broadcastOp) {
               auto broadcastDims = broadcastOp.getBroadcastDimensions();

--- a/test/lit_tests/gather_reshape_iota.mlir
+++ b/test/lit_tests/gather_reshape_iota.mlir
@@ -1,0 +1,101 @@
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{max_constant_expansion=1})" %s | FileCheck %s
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{max_constant_expansion=1})" %s | stablehlo-translate --interpret --allow-unregistered-dialect
+// RUN: stablehlo-translate --interpret --allow-unregistered-dialect %s
+
+// Inserting unit dimensions moves the varying axis from 0 to 1. Each row
+// gathers one value, repeated three times: [[1, 1, 1], [3, 3, 3]].
+// The add after the reshape keeps it inside the index expression.
+func.func @insert_unit_dims(%input: tensor<8xi64>) -> tensor<1x2x3xi64> {
+  %two = stablehlo.constant dense<2> : tensor<2x3xi64>
+  %one = stablehlo.constant dense<1> : tensor<1x2x1x3xi64>
+  %i = stablehlo.iota dim = 0 : tensor<2x3xi64>
+  %scaled = stablehlo.multiply %i, %two : tensor<2x3xi64>
+  %view = stablehlo.reshape %scaled : (tensor<2x3xi64>) -> tensor<1x2x1x3xi64>
+  %indices = stablehlo.add %view, %one : tensor<1x2x1x3xi64>
+  %gather = "stablehlo.gather"(%input, %indices) <{
+    dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>,
+    indices_are_sorted = false, slice_sizes = array<i64: 1>
+  }> : (tensor<8xi64>, tensor<1x2x1x3xi64>) -> tensor<1x2x3xi64>
+  return %gather : tensor<1x2x3xi64>
+}
+// CHECK-LABEL: @insert_unit_dims
+// CHECK-NEXT: %[[SLICE:.*]] = stablehlo.slice %arg0 [1:5:2] : (tensor<8xi64>) -> tensor<2xi64>
+// CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %[[SLICE]], dims = [1] : (tensor<2xi64>) -> tensor<1x2x3xi64>
+// CHECK-NEXT: return %[[BROADCAST]]
+
+// The non-varying 3x4 dimensions can merge into 12. The varying axis still
+// has extent 2 and stride 12, so rows gather 1 and 3 respectively.
+func.func @regroup_nonvarying_dims(%input: tensor<8xi64>) -> tensor<2x12xi64> {
+  %two = stablehlo.constant dense<2> : tensor<2x3x4xi64>
+  %one = stablehlo.constant dense<1> : tensor<2x12x1xi64>
+  %i = stablehlo.iota dim = 0 : tensor<2x3x4xi64>
+  %scaled = stablehlo.multiply %i, %two : tensor<2x3x4xi64>
+  %view = stablehlo.reshape %scaled : (tensor<2x3x4xi64>) -> tensor<2x12x1xi64>
+  %indices = stablehlo.add %view, %one : tensor<2x12x1xi64>
+  %gather = "stablehlo.gather"(%input, %indices) <{
+    dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>,
+    indices_are_sorted = false, slice_sizes = array<i64: 1>
+  }> : (tensor<8xi64>, tensor<2x12x1xi64>) -> tensor<2x12xi64>
+  return %gather : tensor<2x12xi64>
+}
+// CHECK-LABEL: @regroup_nonvarying_dims
+// CHECK-NEXT: %[[SLICE:.*]] = stablehlo.slice %arg0 [1:5:2] : (tensor<8xi64>) -> tensor<2xi64>
+// CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %[[SLICE]], dims = [0] : (tensor<2xi64>) -> tensor<2x12xi64>
+// CHECK-NEXT: return %[[BROADCAST]]
+
+// Equal extents are insufficient: input dimension 1 has stride 3, while
+// output dimensions 1 and 2 have strides 2 and 1. Neither is the same iota.
+// The result is [[[1,1],[1,3]], [[3,3],[1,1]], [[1,3],[3,3]]].
+func.func @changed_stride(%input: tensor<8xi64>) -> tensor<3x2x2xi64> {
+  %two = stablehlo.constant dense<2> : tensor<2x2x3xi64>
+  %one = stablehlo.constant dense<1> : tensor<3x2x2x1xi64>
+  %i = stablehlo.iota dim = 1 : tensor<2x2x3xi64>
+  %scaled = stablehlo.multiply %i, %two : tensor<2x2x3xi64>
+  %view = stablehlo.reshape %scaled : (tensor<2x2x3xi64>) -> tensor<3x2x2x1xi64>
+  %indices = stablehlo.add %view, %one : tensor<3x2x2x1xi64>
+  %gather = "stablehlo.gather"(%input, %indices) <{
+    dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 3>,
+    indices_are_sorted = false, slice_sizes = array<i64: 1>
+  }> : (tensor<8xi64>, tensor<3x2x2x1xi64>) -> tensor<3x2x2xi64>
+  return %gather : tensor<3x2x2xi64>
+}
+// CHECK-LABEL: @changed_stride
+// CHECK: %[[GATHER:.*]] = "stablehlo.gather"
+// CHECK-NEXT: return %[[GATHER]]
+
+// Splitting the varying axis 6 into 2x3 produces two varying dimensions,
+// which cannot be represented by a single IotaLikeTensor.
+func.func @split_varying_dim(%input: tensor<16xi64>) -> tensor<2x3xi64> {
+  %two = stablehlo.constant dense<2> : tensor<6xi64>
+  %one = stablehlo.constant dense<1> : tensor<2x3x1xi64>
+  %i = stablehlo.iota dim = 0 : tensor<6xi64>
+  %scaled = stablehlo.multiply %i, %two : tensor<6xi64>
+  %view = stablehlo.reshape %scaled : (tensor<6xi64>) -> tensor<2x3x1xi64>
+  %indices = stablehlo.add %view, %one : tensor<2x3x1xi64>
+  %gather = "stablehlo.gather"(%input, %indices) <{
+    dimension_numbers = #stablehlo.gather<collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>,
+    indices_are_sorted = false, slice_sizes = array<i64: 1>
+  }> : (tensor<16xi64>, tensor<2x3x1xi64>) -> tensor<2x3xi64>
+  return %gather : tensor<2x3xi64>
+}
+// CHECK-LABEL: @split_varying_dim
+// CHECK: %[[GATHER:.*]] = "stablehlo.gather"
+// CHECK-NEXT: return %[[GATHER]]
+
+func.func @main() {
+  %input = stablehlo.iota dim = 0 : tensor<8xi64>
+  %insert = func.call @insert_unit_dims(%input) : (tensor<8xi64>) -> tensor<1x2x3xi64>
+  %insert_expected = stablehlo.constant dense<[[[1, 1, 1], [3, 3, 3]]]> : tensor<1x2x3xi64>
+  "check.expect_eq"(%insert, %insert_expected) : (tensor<1x2x3xi64>, tensor<1x2x3xi64>) -> ()
+  %regroup = func.call @regroup_nonvarying_dims(%input) : (tensor<8xi64>) -> tensor<2x12xi64>
+  %regroup_expected = stablehlo.constant dense<[[1,1,1,1,1,1,1,1,1,1,1,1], [3,3,3,3,3,3,3,3,3,3,3,3]]> : tensor<2x12xi64>
+  "check.expect_eq"(%regroup, %regroup_expected) : (tensor<2x12xi64>, tensor<2x12xi64>) -> ()
+  %changed = func.call @changed_stride(%input) : (tensor<8xi64>) -> tensor<3x2x2xi64>
+  %changed_expected = stablehlo.constant dense<[[[1,1],[1,3]], [[3,3],[1,1]], [[1,3],[3,3]]]> : tensor<3x2x2xi64>
+  "check.expect_eq"(%changed, %changed_expected) : (tensor<3x2x2xi64>, tensor<3x2x2xi64>) -> ()
+  %input16 = stablehlo.iota dim = 0 : tensor<16xi64>
+  %split = func.call @split_varying_dim(%input16) : (tensor<16xi64>) -> tensor<2x3xi64>
+  %split_expected = stablehlo.constant dense<[[1,3,5], [7,9,11]]> : tensor<2x3xi64>
+  "check.expect_eq"(%split, %split_expected) : (tensor<2x3xi64>, tensor<2x3xi64>) -> ()
+  return
+}

--- a/test/lit_tests/lbm_gather_scatter_opts.mlir
+++ b/test/lit_tests/lbm_gather_scatter_opts.mlir
@@ -1,4 +1,5 @@
 // RUN: enzymexlamlir-opt --enzyme-hlo-opt %s | FileCheck %s
+// RUN: enzymexlamlir-opt --pass-pipeline="builtin.module(enzyme-hlo-opt{max_constant_expansion=1})" %s | FileCheck %s
 
 // ------------------------------------------------------------------------
 // Case 1: float gather whose second affine iota is hidden under
@@ -50,8 +51,9 @@ module {
   // indices[i, j] = 16 + 4*i + 32*j
   //
   // This models the LBM flag load after the f32 buffer is bitcast to bytes.
-  // Currently the gather remains because detectIotaLikeTensor does not look
-  // through the reshape.
+  // Keep a run with constant expansion disabled: folding this small index
+  // tensor would hide a failure to recognize the reshaped scaled iota in the
+  // full-size benchmark.
   // ------------------------------------------------------------------------
   func.func @gather_reshaped_scaled_iota(
       %bytes: tensor<256xi8>) -> tensor<2x3xi8> {


### PR DESCRIPTION
Gather/scatter grid analysis missed affine indices such as `reshape(multiply(iota, stride))`. In LBM, this left the two byte/flag gathers in place and prevented the existing transpose optimizations from finishing.

Teach `detectIotaLikeTensor` to traverse static reshapes when the varying dimension retains both its extent and its row-major stride. It remaps the dimension and reuses the existing gather-to-slice / scatter-to-DUS rewrites. Reshapes that split/merge the varying axis or change its stride are rejected.

The existing small LBM test folded its indices to constants, hiding this failure. Add a run with constant expansion disabled, plus symbolic and interpreter tests for axis remapping, regrouping non-varying dimensions, and rejected reshapes.

Validation:

- Five focused Bazel LIT targets passed on staging. A further direct LIT run against the freshly built optimizer covered 73 iota/gather/scatter/while cases: 72 passed and one existing expected failure.
- Original and optimized new cases checked with the StableHLO interpreter.
- Rebuilt reactant-clang and ReactantExtra, then ran unchanged LBM through the raising pipeline on an RTX 5090. Post-EnzymeHLOOpt: 2 gathers / 126 transposes → 0 / 0.
- Three alternating profiles of 20 timesteps: 551 → 511 execution kernel launches; median summed GPU kernel time 10.793 → 9.251 ms (14.3% lower), excluding XLA autotuning. All 6,480,000 float32 output values pass the CUDA comparison and are byte-identical to the baseline.

The same patch is included in `vim/lbm-staging`.
