### PR TITLE
Fix assertion in invoke-to-call

### DIFF
--- a/src/enzyme_ad/jax/Passes/InvokeToCall.cpp
+++ b/src/enzyme_ad/jax/Passes/InvokeToCall.cpp
@@ -90,8 +90,10 @@ struct InvokeToCallPass
         if (auto attrs = invoke.getResAttrsAttr())
           call.setResAttrsAttr(attrs);
         rewriter.replaceAllUsesWith(invoke.getResults(), call.getResults());
-        rewriter.replaceOpWithNewOp<LLVM::BrOp>(
-            invoke, invoke.getNormalDestOperands(), invoke.getNormalDest());
+        LLVM::BrOp::create(rewriter, invoke->getLoc(),
+                           invoke.getNormalDestOperands(),
+                           invoke.getNormalDest());
+        rewriter.eraseOp(invoke);
       }
       (void)eraseUnreachableBlocks(rewriter, fn->getRegions());
     }


### PR DESCRIPTION
The replaceOpWithNewOp asserts that the two ops have the same number of results, but br will have no results and the result is already forwarded from the replacing call.
