### PR TITLE
fix build error in Utils.cpp

### DIFF
--- a/src/enzyme_ad/jax/Utils.cpp
+++ b/src/enzyme_ad/jax/Utils.cpp
@@ -4307,7 +4307,7 @@ mlir::enzyme::homogeneousLeaves(Type type, const DataLayout &dataLayout,
   if (!isa<LLVM::LLVMArrayType, LLVM::LLVMStructType>(type) || !walk(type) ||
       paths.empty() ||
       dataLayout.getTypeSize(type) !=
-          paths.size() * dataLayout.getTypeSize(leaf))
+          (int64_t)paths.size() * dataLayout.getTypeSize(leaf))
     return std::nullopt;
   return leaf;
 }


### PR DESCRIPTION
```
src/enzyme_ad/jax/Utils.cpp:4310:24: error: use of overloaded operator '*' is ambiguous (with operand types 'size_t' (aka 'unsigned long') and 'llvm::TypeSize')
 4310 |           paths.size() * dataLayout.getTypeSize(leaf))
      |           ~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
