### PR TITLE
enzyme-hlo-opt: erase the producer a sunk slice leaves dead

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -3125,6 +3125,8 @@ struct SliceBroadcast final
 
     rewriter.replaceOpWithNewOp<stablehlo::BroadcastInDimOp>(
         op, op.getType(), tobcast, bcast.getBroadcastDimensions());
+    if (innerSlice)
+      rewriter.eraseOp(bcast);
     return success();
   }
 };
@@ -3154,6 +3156,7 @@ struct SliceTransposeBase final
     auto sliceOp = sliceTransposeHelper(transpose, rewriter, op);
     rewriter.replaceOpWithNewOp<stablehlo::TransposeOp>(
         op, sliceOp, transpose.getPermutation());
+    rewriter.eraseOp(transpose);
     return success();
   }
 };
@@ -3706,6 +3709,7 @@ struct SliceElementwise final
           elem->getLoc(), elem->getName().getIdentifier(), ValueRange(ops),
           TypeRange(op->getResult(0).getType()), elem->getAttrs(), {}, {});
       rewriter.replaceOp(op, nex);
+      rewriter.eraseOp(elem);
       return success();
     }
 
@@ -3791,6 +3795,7 @@ struct SliceElementwise final
       rewriter.replaceOpWithNewOp<stablehlo::SliceOp>(sl, nex->getResult(0),
                                                       sstarts, sstops, sints);
     }
+    rewriter.eraseOp(elem);
     return success();
   }
 };
@@ -12987,6 +12992,8 @@ struct SliceReshapeTranspose final
         rewriter, transpose.getLoc(), newslice, transpose.getPermutation());
     rewriter.replaceOpWithNewOp<stablehlo::ReshapeOp>(op, op.getType(),
                                                       newtransp);
+    rewriter.eraseOp(reshape);
+    rewriter.eraseOp(transpose);
     return success();
   }
 };
@@ -23365,9 +23372,8 @@ struct SliceSelect
         rewriter, sliceOp.getLoc(), slicedPred, slicedOnTrue, slicedOnFalse);
 
     rewriter.replaceOp(sliceOp, newSelectOp.getResult());
-
+    rewriter.eraseOp(selOp);
     return success();
-    ;
   }
 };
 

--- a/test/lit_tests/diffrules/stablehlo/fno.mlir
+++ b/test/lit_tests/diffrules/stablehlo/fno.mlir
@@ -48,7 +48,7 @@ module @reactant_enzyme_... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_
 // CHECK-NEXT:     %12 = stablehlo.slice %11 [0:16, 0:5, 0:16] {enzymexla.complex_is_purely_real = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<16x5x513xcomplex<f32>>) -> tensor<16x5x16xcomplex<f32>>
 // CHECK-NEXT:     %13 = chlo.conj %12 {enzymexla.complex_is_purely_real = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<16x5x16xcomplex<f32>> -> tensor<16x5x16xcomplex<f32>>
 // CHECK-NEXT:     %14 = stablehlo.broadcast_in_dim %cst, dims = [2] : (tensor<16xcomplex<f32>>) -> tensor<16x5x16xcomplex<f32>>
-// CHECK-NEXT:     %15 = stablehlo.multiply %13, %14 : tensor<16x5x16xcomplex<f32>>
+// CHECK-NEXT:     %15 = stablehlo.multiply %13, %14 {enzymexla.complex_is_purely_real = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<16x5x16xcomplex<f32>>
 // CHECK-NEXT:     %16 = stablehlo.dot_general %15, %5, batching_dims = [2] x [2], contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] {enzymexla.complex_is_purely_real = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<16x5x16xcomplex<f32>>, tensor<4x5x16xcomplex<f32>>) -> tensor<16x16x4xcomplex<f32>>
 // CHECK-NEXT:     %17 = chlo.conj %16 {enzymexla.complex_is_purely_real = [#enzymexla<guaranteed NOTGUARANTEED>]} : tensor<16x16x4xcomplex<f32>> -> tensor<16x16x4xcomplex<f32>>
 // CHECK-NEXT:     %18 = stablehlo.transpose %17, dims = [0, 2, 1] {enzymexla.complex_is_purely_real = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<16x16x4xcomplex<f32>>) -> tensor<16x4x16xcomplex<f32>>

--- a/test/lit_tests/slice_elementwise_chain.mlir
+++ b/test/lit_tests/slice_elementwise_chain.mlir
@@ -1,0 +1,24 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt="max_iterations=2" | FileCheck %s
+
+// A slice sinks through the whole elementwise chain within one iteration of
+// the driver, so two iterations (the second finding nothing to do) suffice.
+func.func @chain(%x: tensor<8x8xf64>, %y: tensor<8x8xf64>, %z: tensor<8x8xf64>, %w: tensor<8x8xf64>) -> tensor<2x8xf64> {
+  %0 = stablehlo.multiply %x, %y : tensor<8x8xf64>
+  %1 = stablehlo.add %0, %z : tensor<8x8xf64>
+  %2 = stablehlo.subtract %1, %w : tensor<8x8xf64>
+  %3 = stablehlo.negate %2 : tensor<8x8xf64>
+  %4 = stablehlo.slice %3 [3:5, 0:8] : (tensor<8x8xf64>) -> tensor<2x8xf64>
+  return %4 : tensor<2x8xf64>
+}
+
+// CHECK:    func.func @chain(%arg0: tensor<8x8xf64>, %arg1: tensor<8x8xf64>, %arg2: tensor<8x8xf64>, %arg3: tensor<8x8xf64>) -> tensor<2x8xf64> {
+// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [3:5, 0:8] : (tensor<8x8xf64>) -> tensor<2x8xf64>
+// CHECK-NEXT:    %1 = stablehlo.slice %arg1 [3:5, 0:8] : (tensor<8x8xf64>) -> tensor<2x8xf64>
+// CHECK-NEXT:    %2 = stablehlo.multiply %0, %1 : tensor<2x8xf64>
+// CHECK-NEXT:    %3 = stablehlo.slice %arg2 [3:5, 0:8] : (tensor<8x8xf64>) -> tensor<2x8xf64>
+// CHECK-NEXT:    %4 = stablehlo.add %2, %3 : tensor<2x8xf64>
+// CHECK-NEXT:    %5 = stablehlo.slice %arg3 [3:5, 0:8] : (tensor<8x8xf64>) -> tensor<2x8xf64>
+// CHECK-NEXT:    %6 = stablehlo.subtract %4, %5 : tensor<2x8xf64>
+// CHECK-NEXT:    %7 = stablehlo.negate %6 : tensor<2x8xf64>
+// CHECK-NEXT:    return %7 : tensor<2x8xf64>
+// CHECK-NEXT:  }


### PR DESCRIPTION
`enzyme-hlo-opt` fails silently (no diagnostic, the pass just signals failure) when the greedy driver reaches its iteration cap, and `nonlininteg_vecconvection_pa` started hitting the cap once #3174 gave the raiser cleaner affine accesses: one of its kernels is a chain of thirty unrolled 8x8 matrix products, each written as slice/broadcast/multiply/add over the previous one, and it needed about 110 iterations.

The patterns that sink a slice through an elementwise op, a transpose, a broadcast, a reshape-of-transpose, or a select fire only when the producer has a single user, and after rewriting they leave that producer dead for the driver to erase later. The slices of the producer's operands that the rewrite just created are matched before that erasure happens, see a producer that still counts the dead op among its users, fail, and are only retried on the driver's next walk. A slice therefore sinks one level per iteration. Erasing the dead producer in the pattern lets the slice sink through the whole chain in one iteration: the kernel now converges in 16 iterations instead of about 110.

`slice_elementwise_chain.mlir` runs the pass with `max_iterations=2` on a four-deep chain, which fails before this change. `diffrules/stablehlo/fno.mlir` picks up one more `complex_is_purely_real` annotation on an op the analysis now visits in a different order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
