### PR TITLE
canonicalize-parallel: unpack a dim3-replicated launch dimension

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -784,6 +784,54 @@ struct FlattenAggregateAlloca : public OpRewritePattern<memref::AllocaOp> {
 
 // A store of undef or poison leaves the memory holding any value, and what
 // it held before is one of those, so the store does nothing.
+// dim3 packing replicates a launch dimension into both halves of an i64 as
+// x * 0x100000001; the low half comes back through a trunc and the high half
+// through a shift. Truncation distributes over multiplication, so the low
+// half of x * c is trunc(x) when c is 1 modulo the truncated width.
+struct TruncOfMulByOneModWidth : public OpRewritePattern<arith::TruncIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::TruncIOp trunc,
+                                PatternRewriter &rewriter) const override {
+    auto type = dyn_cast<IntegerType>(trunc.getType());
+    auto mul = trunc.getIn().getDefiningOp<arith::MulIOp>();
+    APInt c;
+    if (!type || !mul || !matchPattern(mul.getRhs(), m_ConstantInt(&c)) ||
+        !c.trunc(type.getWidth()).isOne())
+      return failure();
+    rewriter.replaceOpWithNewOp<arith::TruncIOp>(trunc, type, mul.getLhs());
+    return success();
+  }
+};
+
+// The high half: x * (2^k + 1) = (x << k) + x, and the two terms do not
+// overlap when x is zero-extended from at most k bits and the sum fits, so
+// shifting the product right by k gives x back.
+struct ShiftOfMulByShiftPlusOne : public OpRewritePattern<arith::ShRUIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::ShRUIOp shift,
+                                PatternRewriter &rewriter) const override {
+    auto type = dyn_cast<IntegerType>(shift.getType());
+    auto mul = shift.getLhs().getDefiningOp<arith::MulIOp>();
+    APInt c, k;
+    if (!type || !mul || !matchPattern(mul.getRhs(), m_ConstantInt(&c)) ||
+        !matchPattern(shift.getRhs(), m_ConstantInt(&k)))
+      return failure();
+    auto ext = mul.getLhs().getDefiningOp<arith::ExtUIOp>();
+    auto inType =
+        ext ? dyn_cast<IntegerType>(ext.getIn().getType()) : IntegerType();
+    if (!inType || k.uge(type.getWidth()))
+      return failure();
+    unsigned by = k.getZExtValue();
+    if (inType.getWidth() > by || by + inType.getWidth() > type.getWidth() ||
+        c != APInt(type.getWidth(), 1).shl(by) + 1)
+      return failure();
+    rewriter.replaceOpWithNewOp<arith::ExtUIOp>(shift, type, ext.getIn());
+    return success();
+  }
+};
+
 struct StoreOfUndef
     : public OpInterfaceRewritePattern<enzyme::StoreLikeInterface> {
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
@@ -835,7 +883,8 @@ struct CanonicalizeParallelPass
         SinkThroughSelectOfConstants<arith::AddIOp>,
         SinkThroughSelectOfConstants<arith::MulIOp>, SelectOfNullPointer,
         IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>,
-        FlattenAggregateAlloca, StoreOfUndef>(ctx);
+        FlattenAggregateAlloca, StoreOfUndef, TruncOfMulByOneModWidth,
+        ShiftOfMulByShiftPlusOne>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_dim3_unpack.mlir
+++ b/test/lit_tests/canonicalize_parallel_dim3_unpack.mlir
@@ -1,0 +1,53 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel{parallel=false})" | FileCheck %s
+
+// A launch dimension packed into both halves of an i64 (x * 0x100000001) and
+// read back: the low half through a trunc, the high half through a shift.
+func.func @halves(%q: i32) -> (i32, i32) {
+  %c = arith.constant 4294967297 : i64
+  %c32 = arith.constant 32 : i64
+  %e = arith.extui %q : i32 to i64
+  %m = arith.muli %e, %c overflow<nuw> : i64
+  %lo = arith.trunci %m : i64 to i32
+  %hi64 = arith.shrui %m, %c32 : i64
+  %hi = arith.trunci %hi64 : i64 to i32
+  return %lo, %hi : i32, i32
+}
+
+// The low half of a product is only the value when the constant is 1 modulo
+// 2^32; 0x100000002 doubles it.
+func.func @low_bits_not_one(%q: i32) -> i32 {
+  %c = arith.constant 4294967298 : i64
+  %e = arith.extui %q : i32 to i64
+  %m = arith.muli %e, %c : i64
+  %lo = arith.trunci %m : i64 to i32
+  return %lo : i32
+}
+
+// A value wider than the shift overlaps its own shifted copy.
+func.func @wide_input(%q: i40) -> i64 {
+  %c = arith.constant 4294967297 : i64
+  %c32 = arith.constant 32 : i64
+  %e = arith.extui %q : i40 to i64
+  %m = arith.muli %e, %c : i64
+  %hi = arith.shrui %m, %c32 : i64
+  return %hi : i64
+}
+
+// CHECK:    func.func @halves(%arg0: i32) -> (i32, i32) {
+// CHECK-NEXT:    return %arg0, %arg0 : i32, i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @low_bits_not_one(%arg0: i32) -> i32 {
+// CHECK-NEXT:    %c4294967298_i64 = arith.constant 4294967298 : i64
+// CHECK-NEXT:    %0 = arith.extui %arg0 : i32 to i64
+// CHECK-NEXT:    %1 = arith.muli %0, %c4294967298_i64 : i64
+// CHECK-NEXT:    %2 = arith.trunci %1 : i64 to i32
+// CHECK-NEXT:    return %2 : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @wide_input(%arg0: i40) -> i64 {
+// CHECK-NEXT:    %c4294967297_i64 = arith.constant 4294967297 : i64
+// CHECK-NEXT:    %c32_i64 = arith.constant 32 : i64
+// CHECK-NEXT:    %0 = arith.extui %arg0 : i40 to i64
+// CHECK-NEXT:    %1 = arith.muli %0, %c4294967297_i64 : i64
+// CHECK-NEXT:    %2 = arith.shrui %1, %c32_i64 : i64
+// CHECK-NEXT:    return %2 : i64
+// CHECK-NEXT:  }


### PR DESCRIPTION
CUDA's dim3 packing replicates a launch dimension into both halves of an i64 as `x * 0x100000001`, and the halves are read back with a trunc (low) and a shift by 32 (high). The raiser then sees each block dimension of MFEM's `forall_2D(NF, Q1D, Q1D)` launches through that arithmetic instead of as the `Q1D` load itself, and every consumer that wants to know the dims are the same value has to peel it off again (the extent derivation in #2991 and #3134 both carry a matcher for it).

Two canonicalize-parallel patterns undo the packing at the source:

- `trunc(x * c)` is `trunc(x)` when `c` is 1 modulo the truncated width, since truncation distributes over multiplication; with `x` the zero-extension of the dim, MLIR's own `trunc(ext)` fold then yields the dim.
- `(x * (2^k + 1)) >> k` is `x` when `x` is zero-extended from at most `k` bits and the sum fits: `x * (2^k + 1) = (x << k) + x` with the two terms disjoint.

`canonicalize_parallel_dim3_unpack.mlir`: both halves of a packed i32 come back as the value; a constant whose low bits are 2 and an input wider than the shift are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
