### PR TITLE
canonicalize-parallel: unpack a disjoint-or packed launch dimension

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -832,6 +832,101 @@ struct ShiftOfMulByShiftPlusOne : public OpRewritePattern<arith::ShRUIOp> {
   }
 };
 
+// dim3 packing with two distinct dims arrives as a disjoint or, x | (y << 32)
+// or (y << 32) | c, and each half is read back with a trunc or a shift. The
+// folds below take the packing apart: a truncation drops a side shifted past
+// its width (TruncOrConst above drops a constant side the same way), a shift
+// by k of an or with a side shifted in by k without loss yields that side,
+// and a value zero-extended from at most k bits shifted right by k is zero.
+static bool zeroExtendedWithin(Value v, unsigned bits) {
+  auto ext = v.getDefiningOp<arith::ExtUIOp>();
+  auto in = ext ? dyn_cast<IntegerType>(ext.getIn().getType()) : IntegerType();
+  return in && in.getWidth() <= bits;
+}
+
+// The value `v` is `z << by` with no set bit shifted out, so that shifting
+// back right by `by` recovers `z`: either the shift says so (nuw) or `z` is
+// zero-extended from bits that fit under the shift.
+static Value shiftedInBy(Value v, unsigned by) {
+  auto shl = v.getDefiningOp<arith::ShLIOp>();
+  APInt k;
+  if (!shl || !matchPattern(shl.getRhs(), m_ConstantInt(&k)) || k != by)
+    return nullptr;
+  unsigned width = cast<IntegerType>(shl.getType()).getWidth();
+  if (bitEnumContainsAll(shl.getOverflowFlags(),
+                         arith::IntegerOverflowFlags::nuw) ||
+      zeroExtendedWithin(shl.getLhs(), width - by))
+    return shl.getLhs();
+  return nullptr;
+}
+
+struct TruncOfOrWithShiftedOut : public OpRewritePattern<arith::TruncIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::TruncIOp trunc,
+                                PatternRewriter &rewriter) const override {
+    auto type = dyn_cast<IntegerType>(trunc.getType());
+    auto orOp = trunc.getIn().getDefiningOp<arith::OrIOp>();
+    if (!type || !orOp)
+      return failure();
+    for (Value side : {orOp.getLhs(), orOp.getRhs()}) {
+      auto shl = side.getDefiningOp<arith::ShLIOp>();
+      APInt k;
+      if (!shl || !matchPattern(shl.getRhs(), m_ConstantInt(&k)) ||
+          k.ult(type.getWidth()))
+        continue;
+      Value other = side == orOp.getLhs() ? orOp.getRhs() : orOp.getLhs();
+      rewriter.modifyOpInPlace(trunc,
+                               [&] { trunc.getInMutable().assign(other); });
+      return success();
+    }
+    return failure();
+  }
+};
+
+struct ShiftOfOrWithShiftedIn : public OpRewritePattern<arith::ShRUIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::ShRUIOp shift,
+                                PatternRewriter &rewriter) const override {
+    auto type = dyn_cast<IntegerType>(shift.getType());
+    auto orOp = shift.getLhs().getDefiningOp<arith::OrIOp>();
+    APInt k;
+    if (!type || !orOp || !matchPattern(shift.getRhs(), m_ConstantInt(&k)) ||
+        k.uge(type.getWidth()))
+      return failure();
+    unsigned by = k.getZExtValue();
+    for (Value side : {orOp.getLhs(), orOp.getRhs()}) {
+      Value other = side == orOp.getLhs() ? orOp.getRhs() : orOp.getLhs();
+      Value in = shiftedInBy(side, by);
+      if (!in)
+        continue;
+      Value rest = arith::ShRUIOp::create(rewriter, shift.getLoc(), other,
+                                          shift.getRhs());
+      rewriter.replaceOpWithNewOp<arith::OrIOp>(shift, in, rest);
+      return success();
+    }
+    return failure();
+  }
+};
+
+struct ShiftOfNarrowZeroExtended : public OpRewritePattern<arith::ShRUIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::ShRUIOp shift,
+                                PatternRewriter &rewriter) const override {
+    auto type = dyn_cast<IntegerType>(shift.getType());
+    APInt k;
+    if (!type || !matchPattern(shift.getRhs(), m_ConstantInt(&k)) ||
+        k.uge(type.getWidth()) ||
+        !zeroExtendedWithin(shift.getLhs(), k.getZExtValue()))
+      return failure();
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+        shift, rewriter.getIntegerAttr(type, 0));
+    return success();
+  }
+};
+
 struct StoreOfUndef
     : public OpInterfaceRewritePattern<enzyme::StoreLikeInterface> {
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
@@ -884,7 +979,8 @@ struct CanonicalizeParallelPass
         SinkThroughSelectOfConstants<arith::MulIOp>, SelectOfNullPointer,
         IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>,
         FlattenAggregateAlloca, StoreOfUndef, TruncOfMulByOneModWidth,
-        ShiftOfMulByShiftPlusOne>(ctx);
+        ShiftOfMulByShiftPlusOne, TruncOfOrWithShiftedOut,
+        ShiftOfOrWithShiftedIn, ShiftOfNarrowZeroExtended>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_dim3_unpack_or.mlir
+++ b/test/lit_tests/canonicalize_parallel_dim3_unpack_or.mlir
@@ -1,0 +1,68 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel{parallel=false})" | FileCheck %s
+
+// Two launch dimensions packed as a disjoint or, (y << 32) | 2: the low half
+// is the constant, the high half is y.
+func.func @constant_low(%y: i32) -> (i32, i32) {
+  %c2 = arith.constant 2 : i64
+  %c32 = arith.constant 32 : i64
+  %e = arith.extui %y : i32 to i64
+  %s = arith.shli %e, %c32 overflow<nuw> : i64
+  %p = arith.ori %s, %c2 {isDisjoint} : i64
+  %lo = arith.trunci %p : i64 to i32
+  %hi64 = arith.shrui %p, %c32 : i64
+  %hi = arith.trunci %hi64 : i64 to i32
+  return %lo, %hi : i32, i32
+}
+
+// The same dimension in both halves, (y << 32) | y.
+func.func @replicated(%y: i32) -> (i32, i32) {
+  %c32 = arith.constant 32 : i64
+  %e = arith.extui %y : i32 to i64
+  %s = arith.shli %e, %c32 overflow<nuw> : i64
+  %p = arith.ori %s, %e {isDisjoint} : i64
+  %lo = arith.trunci %p : i64 to i32
+  %hi64 = arith.shrui %p, %c32 : i64
+  %hi = arith.trunci %hi64 : i64 to i32
+  return %lo, %hi : i32, i32
+}
+
+// A shifted-in side wider than its half overlaps the other: left alone.
+func.func @wide_high(%y: i40, %x: i32) -> i64 {
+  %c32 = arith.constant 32 : i64
+  %e = arith.extui %y : i40 to i64
+  %s = arith.shli %e, %c32 : i64
+  %f = arith.extui %x : i32 to i64
+  %p = arith.ori %s, %f : i64
+  %hi = arith.shrui %p, %c32 : i64
+  return %hi : i64
+}
+
+// A shift that promises no lost bits (nuw) is proof enough on its own.
+func.func @nuw_high(%y: i64, %x: i32) -> i64 {
+  %c32 = arith.constant 32 : i64
+  %s = arith.shli %y, %c32 overflow<nuw> : i64
+  %f = arith.extui %x : i32 to i64
+  %p = arith.ori %s, %f : i64
+  %hi = arith.shrui %p, %c32 : i64
+  return %hi : i64
+}
+
+// CHECK:    func.func @constant_low(%arg0: i32) -> (i32, i32) {
+// CHECK-NEXT:    %c2_i32 = arith.constant 2 : i32
+// CHECK-NEXT:    return %c2_i32, %arg0 : i32, i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @replicated(%arg0: i32) -> (i32, i32) {
+// CHECK-NEXT:    return %arg0, %arg0 : i32, i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @wide_high(%arg0: i40, %arg1: i32) -> i64 {
+// CHECK-NEXT:    %c32_i64 = arith.constant 32 : i64
+// CHECK-NEXT:    %0 = arith.extui %arg0 : i40 to i64
+// CHECK-NEXT:    %1 = arith.shli %0, %c32_i64 : i64
+// CHECK-NEXT:    %2 = arith.extui %arg1 : i32 to i64
+// CHECK-NEXT:    %3 = arith.ori %1, %2 : i64
+// CHECK-NEXT:    %4 = arith.shrui %3, %c32_i64 : i64
+// CHECK-NEXT:    return %4 : i64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @nuw_high(%arg0: i64, %arg1: i32) -> i64 {
+// CHECK-NEXT:    return %arg0 : i64
+// CHECK-NEXT:  }


### PR DESCRIPTION
Follow-up to #3178 for the other dim3 packing: two distinct block dimensions arrive as a disjoint or, `(y << 32) | x` or `(y << 32) | c`, and MFEM's `forall_2D(nf, 2, q)` and `forall_2D(nf, q2d, 2)` launches (normal_deriv_restriction) read the halves back with a trunc and a shift by 32. Three bit-algebra folds take that apart, alongside the existing `TruncOrConst` (which drops a constant side whose low bits are zero):

- a truncation drops an or side shifted left past the truncated width: `trunc((y << 32) | x)` is `trunc(x)`;
- a shift by `k` of an or whose one side is `z << k` that lost no bits (the shift is `nuw`, or `z` is zero-extended from at most `width - k` bits) is `z | (other >> k)`;
- a value zero-extended from at most `k` bits shifted right by `k` is zero.

Together `((y << 32) | 2) >> 32` folds to `y` and `trunc((y << 32) | y)` to `y`. `canonicalize_parallel_dim3_unpack_or.mlir` covers the constant low half, the replicated dim, and a shifted-in side too wide for its half (left alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
