### PR TITLE
canonicalize-parallel: shift an or with a constant side, hoist a shared clamp

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -927,6 +927,66 @@ struct ShiftOfNarrowZeroExtended : public OpRewritePattern<arith::ShRUIOp> {
   }
 };
 
+// A logical right shift distributes over an or with a constant side, so the
+// halves of a packed value with a constant half come apart: (x | C) >> k is
+// (x >> k) | (C >> k), and the narrow half shifts away entirely.
+struct ShiftOfOrWithConstant : public OpRewritePattern<arith::ShRUIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::ShRUIOp shift,
+                                PatternRewriter &rewriter) const override {
+    auto type = dyn_cast<IntegerType>(shift.getType());
+    auto orOp = shift.getLhs().getDefiningOp<arith::OrIOp>();
+    APInt c, k;
+    if (!type || !orOp || !matchPattern(shift.getRhs(), m_ConstantInt(&k)) ||
+        k.uge(type.getWidth()))
+      return failure();
+    Value other;
+    if (matchPattern(orOp.getRhs(), m_ConstantInt(&c)))
+      other = orOp.getLhs();
+    else if (matchPattern(orOp.getLhs(), m_ConstantInt(&c)))
+      other = orOp.getRhs();
+    else
+      return failure();
+    Value shifted =
+        arith::ShRUIOp::create(rewriter, shift.getLoc(), other, shift.getRhs());
+    Value constant = arith::ConstantOp::create(
+        rewriter, shift.getLoc(), rewriter.getIntegerAttr(type, c.lshr(k)));
+    rewriter.replaceOpWithNewOp<arith::OrIOp>(shift, shifted, constant);
+    return success();
+  }
+};
+
+// max(min(a, c), min(b, c)) is min(max(a, b), c), and dually for min of
+// maxes: the shared clamp moves outside, where a bound on the value is the
+// clamp's whether or not a and b are bounded.
+template <typename OuterT, typename InnerT>
+struct OuterOfInnersBySharedOperand : public OpRewritePattern<OuterT> {
+  using OpRewritePattern<OuterT>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OuterT outer,
+                                PatternRewriter &rewriter) const override {
+    auto lhs = outer.getLhs().template getDefiningOp<InnerT>();
+    auto rhs = outer.getRhs().template getDefiningOp<InnerT>();
+    if (!lhs || !rhs)
+      return failure();
+    for (Value shared : {lhs.getLhs(), lhs.getRhs()}) {
+      Value a = shared == lhs.getLhs() ? lhs.getRhs() : lhs.getLhs();
+      Value b;
+      if (shared == rhs.getLhs())
+        b = rhs.getRhs();
+      else if (shared == rhs.getRhs())
+        b = rhs.getLhs();
+      else
+        continue;
+      Value inner = OuterT::create(rewriter, outer.getLoc(), a, b);
+      rewriter.replaceOpWithNewOp<InnerT>(outer, inner, shared);
+      return success();
+    }
+    return failure();
+  }
+};
+
 struct StoreOfUndef
     : public OpInterfaceRewritePattern<enzyme::StoreLikeInterface> {
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
@@ -980,7 +1040,12 @@ struct CanonicalizeParallelPass
         IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>,
         FlattenAggregateAlloca, StoreOfUndef, TruncOfMulByOneModWidth,
         ShiftOfMulByShiftPlusOne, TruncOfOrWithShiftedOut,
-        ShiftOfOrWithShiftedIn, ShiftOfNarrowZeroExtended>(ctx);
+        ShiftOfOrWithShiftedIn, ShiftOfNarrowZeroExtended,
+        ShiftOfOrWithConstant,
+        OuterOfInnersBySharedOperand<arith::MaxSIOp, arith::MinSIOp>,
+        OuterOfInnersBySharedOperand<arith::MinSIOp, arith::MaxSIOp>,
+        OuterOfInnersBySharedOperand<arith::MaxUIOp, arith::MinUIOp>,
+        OuterOfInnersBySharedOperand<arith::MinUIOp, arith::MaxUIOp>>(ctx);
     FrozenRewritePatternSet patterns(std::move(owningPatterns));
 
     GreedyRewriteConfig config;

--- a/test/lit_tests/canonicalize_parallel_launch_folds.mlir
+++ b/test/lit_tests/canonicalize_parallel_launch_folds.mlir
@@ -1,0 +1,78 @@
+// RUN: enzymexlamlir-opt %s --pass-pipeline="builtin.module(canonicalize-parallel{parallel=false})" | FileCheck %s
+
+// A grid dimension packed with a constant high half, (zext(n) | (5 << 32)),
+// read back by the shift: the constant.
+func.func @grid_high_half(%n: i32) -> i64 {
+  %c = arith.constant 21474836480 : i64
+  %c32 = arith.constant 32 : i64
+  %e = arith.extui %n : i32 to i64
+  %p = arith.ori %e, %c : i64
+  %hi = arith.shrui %p, %c32 : i64
+  return %hi : i64
+}
+
+// A block dimension max(min(a, 14), min(b, 14)): the clamp moves outside.
+func.func @max_of_mins(%a: i32, %b: i32) -> i32 {
+  %c14 = arith.constant 14 : i32
+  %x = arith.minsi %a, %c14 : i32
+  %y = arith.minsi %b, %c14 : i32
+  %m = arith.maxsi %x, %y : i32
+  return %m : i32
+}
+
+// The dual, and the unsigned form.
+func.func @min_of_maxs(%a: i32, %b: i32) -> i32 {
+  %c1 = arith.constant 1 : i32
+  %x = arith.maxui %a, %c1 : i32
+  %y = arith.maxui %b, %c1 : i32
+  %m = arith.minui %x, %y : i32
+  return %m : i32
+}
+
+// Different clamps do not combine.
+func.func @different_clamps(%a: i32, %b: i32) -> i32 {
+  %c14 = arith.constant 14 : i32
+  %c9 = arith.constant 9 : i32
+  %x = arith.minsi %a, %c14 : i32
+  %y = arith.minsi %b, %c9 : i32
+  %m = arith.maxsi %x, %y : i32
+  return %m : i32
+}
+
+// The clamp need not be a constant, only shared, in either operand position.
+func.func @shared_value(%a: i32, %b: i32, %c: i32) -> i32 {
+  %x = arith.minsi %c, %a : i32
+  %y = arith.minsi %b, %c : i32
+  %m = arith.maxsi %x, %y : i32
+  return %m : i32
+}
+
+// CHECK:    func.func @grid_high_half(%arg0: i32) -> i64 {
+// CHECK-NEXT:    %c5_i64 = arith.constant 5 : i64
+// CHECK-NEXT:    return %c5_i64 : i64
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @max_of_mins(%arg0: i32, %arg1: i32) -> i32 {
+// CHECK-NEXT:    %c14_i32 = arith.constant 14 : i32
+// CHECK-NEXT:    %0 = arith.maxsi %arg0, %arg1 : i32
+// CHECK-NEXT:    %1 = arith.minsi %0, %c14_i32 : i32
+// CHECK-NEXT:    return %1 : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @min_of_maxs(%arg0: i32, %arg1: i32) -> i32 {
+// CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:    %0 = arith.minui %arg0, %arg1 : i32
+// CHECK-NEXT:    %1 = arith.maxui %0, %c1_i32 : i32
+// CHECK-NEXT:    return %1 : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @different_clamps(%arg0: i32, %arg1: i32) -> i32 {
+// CHECK-NEXT:    %c14_i32 = arith.constant 14 : i32
+// CHECK-NEXT:    %c9_i32 = arith.constant 9 : i32
+// CHECK-NEXT:    %0 = arith.minsi %arg0, %c14_i32 : i32
+// CHECK-NEXT:    %1 = arith.minsi %arg1, %c9_i32 : i32
+// CHECK-NEXT:    %2 = arith.maxsi %0, %1 : i32
+// CHECK-NEXT:    return %2 : i32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @shared_value(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+// CHECK-NEXT:    %0 = arith.maxsi %arg0, %arg1 : i32
+// CHECK-NEXT:    %1 = arith.minsi %0, %arg2 : i32
+// CHECK-NEXT:    return %1 : i32
+// CHECK-NEXT:  }


### PR DESCRIPTION
Two more folds for what MFEM's launches feed the raiser, found by tallying the op chains of every launch operand across the runtime-dispatch TUs; #3180's narrow-zext shift fold finishes the first one:

- `(x | C) >> k` is `(x >> k) | (C >> k)`: a logical shift distributes over an or with a constant side. The grid dimension packed as `zext(n) | (5 << 32)` and read back by the shift (11 launches) becomes the constant 5 once the `zext(n) >> 32` half folds to zero.
- `max(min(a, c), min(b, c))` is `min(max(a, b), c)`, and dually `min(max(a, c), max(b, c))` is `max(min(a, b), c)`, signed or unsigned, for any shared `c` in either operand position (the distributive lattice identity). The clamp moves outside, where the extent derivation reads the bound as `c` whether or not `a` and `b` are themselves bounded (15 block dimensions of the form `max(min(D1D, 14), min(Q1D, 14))`).

`canonicalize_parallel_launch_folds.mlir`: the packed grid half, the signed and unsigned clamp forms, a non-constant shared clamp in mixed operand positions, and two different clamps left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
