### PR TITLE
Raising: drop the disjoint-or extent derivation

### DIFF
--- a/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
+++ b/src/enzyme_ad/jax/Passes/AffineToStableHLORaising.cpp
@@ -5512,18 +5512,6 @@ struct AffineToStableHLORaisingPass
     if (isa_and_nonnull<arith::ExtUIOp, arith::ExtSIOp>(def))
       return operandBound(0);
     APInt k;
-    // dim3 packing with a constant second half arrives as a disjoint or:
-    // either half of (a | c) recovers its own dim. a <= b does not order
-    // a|c against b|c bitwise; a|c <= a+c <= b+c.
-    if (auto orOp = dyn_cast_or_null<arith::OrIOp>(def)) {
-      if (matchPattern(orOp.getRhs(), m_ConstantInt(&k)) &&
-          k.getSExtValue() >= 0) {
-        auto b = operandBound(0);
-        if (b && *b >= 0)
-          return *b + k.getSExtValue();
-      }
-      return std::nullopt;
-    }
     // Launch dims are non-negative by construction, so a product of two
     // bounded dims (a dof count like 2*(D1D-1)*D1D) stays under the product
     // of the bounds.


### PR DESCRIPTION
Follow-up to #3180, in the spirit of #3179. The disjoint-or dim3 packing is unpacked by canonicalize-parallel before the raiser runs, so the extent derivation no longer meets an or with a constant side; the arm goes.

Probe on the union: with the arm switched off, all 25 runtime-dispatch TUs compile and their raised IR (loop count and batched-axis widths per TU) is identical to the run with the arm on. The same probe kept the product arm: without it hdiv_ea fails to raise (`NDOF = 2*(D1D-1)*D1D` is a product of bounded values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
