### PR TITLE
canonicalize-parallel: unroll whiles exiting on (counter | x) == 0 or on an scf.if of a flag yielded a constant

### DIFF
--- a/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
+++ b/src/enzyme_ad/jax/Passes/CanonicalizeParallel.cpp
@@ -1001,6 +1001,53 @@ struct StoreOfUndef
   }
 };
 
+// Replace a while loop whose exit test is decided by its second evaluation by
+//   before(inits); if (condition) { after; before(yields) }
+static void unrollWhileTwice(scf::WhileOp whileOp, PatternRewriter &rewriter) {
+  Block &before = whileOp.getBefore().front();
+  Block &after = whileOp.getAfter().front();
+  scf::ConditionOp conditionOp = whileOp.getConditionOp();
+  scf::YieldOp yieldOp = whileOp.getYieldOp();
+  Location loc = whileOp.getLoc();
+  IRMapping firstEvaluation;
+  for (auto [blockArg, init] :
+       llvm::zip(before.getArguments(), whileOp.getInits()))
+    firstEvaluation.map(blockArg, init);
+  for (Operation &op : before.without_terminator())
+    rewriter.clone(op, firstEvaluation);
+  Value firstCondition =
+      firstEvaluation.lookupOrDefault(conditionOp.getCondition());
+  SmallVector<Value> firstForwarded;
+  for (Value value : conditionOp.getArgs())
+    firstForwarded.push_back(firstEvaluation.lookupOrDefault(value));
+
+  auto ifOp = scf::IfOp::create(
+      rewriter, loc, firstCondition,
+      [&](OpBuilder &builder, Location loc) {
+        IRMapping secondEvaluation;
+        for (auto [afterArg, forwarded] :
+             llvm::zip(after.getArguments(), firstForwarded))
+          secondEvaluation.map(afterArg, forwarded);
+        for (Operation &op : after.without_terminator())
+          builder.clone(op, secondEvaluation);
+        for (auto [blockArg, yielded] :
+             llvm::zip(before.getArguments(), yieldOp.getOperands()))
+          secondEvaluation.map(blockArg,
+                               secondEvaluation.lookupOrDefault(
+                                   firstEvaluation.lookupOrDefault(yielded)));
+        for (Operation &op : before.without_terminator())
+          builder.clone(op, secondEvaluation);
+        SmallVector<Value> secondForwarded;
+        for (Value value : conditionOp.getArgs())
+          secondForwarded.push_back(secondEvaluation.lookupOrDefault(value));
+        scf::YieldOp::create(builder, loc, secondForwarded);
+      },
+      [&](OpBuilder &builder, Location loc) {
+        scf::YieldOp::create(builder, loc, firstForwarded);
+      });
+  rewriter.replaceOp(whileOp, ifOp.getResults());
+}
+
 // A while loop whose exit test reads only values from outside the loop and
 // carried arguments yielded values from outside the loop decides the same
 // way on every evaluation after the first: the second evaluation sees the
@@ -1049,44 +1096,101 @@ struct UnrollWhileWithInvariantExit : public OpRewritePattern<scf::WhileOp> {
       worklist.append(definingOp->operand_begin(), definingOp->operand_end());
     }
 
-    Location loc = whileOp.getLoc();
-    IRMapping firstEvaluation;
-    for (auto [blockArg, init] :
-         llvm::zip(before.getArguments(), whileOp.getInits()))
-      firstEvaluation.map(blockArg, init);
-    for (Operation &op : before.without_terminator())
-      rewriter.clone(op, firstEvaluation);
-    Value firstCondition =
-        firstEvaluation.lookupOrDefault(conditionOp.getCondition());
-    SmallVector<Value> firstForwarded;
-    for (Value value : conditionOp.getArgs())
-      firstForwarded.push_back(firstEvaluation.lookupOrDefault(value));
+    unrollWhileTwice(whileOp, rewriter);
+    return success();
+  }
+};
 
-    auto ifOp = scf::IfOp::create(
-        rewriter, loc, firstCondition,
-        [&](OpBuilder &builder, Location loc) {
-          IRMapping secondEvaluation;
-          for (auto [afterArg, forwarded] :
-               llvm::zip(after.getArguments(), firstForwarded))
-            secondEvaluation.map(afterArg, forwarded);
-          for (Operation &op : after.without_terminator())
-            builder.clone(op, secondEvaluation);
-          for (auto [blockArg, yielded] :
-               llvm::zip(before.getArguments(), yieldOp.getOperands()))
-            secondEvaluation.map(blockArg,
-                                 secondEvaluation.lookupOrDefault(
-                                     firstEvaluation.lookupOrDefault(yielded)));
-          for (Operation &op : before.without_terminator())
-            builder.clone(op, secondEvaluation);
-          SmallVector<Value> secondForwarded;
-          for (Value value : conditionOp.getArgs())
-            secondForwarded.push_back(secondEvaluation.lookupOrDefault(value));
-          scf::YieldOp::create(builder, loc, secondForwarded);
-        },
-        [&](OpBuilder &builder, Location loc) {
-          scf::YieldOp::create(builder, loc, firstForwarded);
-        });
-    rewriter.replaceOp(whileOp, ifOp.getResults());
+// A counter that starts at zero and steps by one is one on the second
+// evaluation of the exit test, so `(counter | x) == 0` is false there whatever
+// `x` is: the loop runs at most twice, on the host as well. Clang writes
+// `dx + 1 < 2 - odd` this way for `dx` and `odd` in {0, 1} (MFEM's H(div)
+// mass reductions over a dimension of one or two dofs).
+struct UnrollWhileOfOredCounter : public OpRewritePattern<scf::WhileOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::WhileOp whileOp,
+                                PatternRewriter &rewriter) const override {
+    Block &before = whileOp.getBefore().front();
+    Block &after = whileOp.getAfter().front();
+    scf::ConditionOp conditionOp = whileOp.getConditionOp();
+    scf::YieldOp yieldOp = whileOp.getYieldOp();
+
+    auto cmp = conditionOp.getCondition().getDefiningOp<arith::CmpIOp>();
+    if (!cmp || cmp.getPredicate() != arith::CmpIPredicate::eq)
+      return failure();
+    Value ored;
+    if (matchPattern(cmp.getRhs(), m_Zero()))
+      ored = cmp.getLhs();
+    else if (matchPattern(cmp.getLhs(), m_Zero()))
+      ored = cmp.getRhs();
+    else
+      return failure();
+    auto orOp = ored.getDefiningOp<arith::OrIOp>();
+    if (!orOp)
+      return failure();
+
+    // A before-region argument initialized to zero and yielded itself plus
+    // one, possibly through the condition operand forwarded to the after
+    // region.
+    auto isCounter = [&](Value value) {
+      auto counter = dyn_cast<BlockArgument>(value);
+      if (!counter || counter.getOwner() != &before ||
+          !matchPattern(whileOp.getInits()[counter.getArgNumber()], m_Zero()))
+        return false;
+      Value next = yieldOp.getOperand(counter.getArgNumber());
+      if (auto afterArg = dyn_cast<BlockArgument>(next);
+          afterArg && afterArg.getOwner() == &after)
+        next = conditionOp.getArgs()[afterArg.getArgNumber()];
+      auto add = next.getDefiningOp<arith::AddIOp>();
+      return add &&
+             ((add.getLhs() == counter &&
+               matchPattern(add.getRhs(), m_One())) ||
+              (add.getRhs() == counter && matchPattern(add.getLhs(), m_One())));
+    };
+    if (!isCounter(orOp.getLhs()) && !isCounter(orOp.getRhs()))
+      return failure();
+
+    unrollWhileTwice(whileOp, rewriter);
+    return success();
+  }
+};
+
+// A loop rotated around a flag: the exit test is the result of an scf.if on
+// a carried flag that the after region yields a constant, and the branch that
+// constant selects yields false. The second evaluation takes that branch, so
+// the loop runs at most twice (clang's rotation of a single-trip loop with
+// early exits, the edge scan in batchitrans.cpp).
+struct UnrollWhileOfFlagIf : public OpRewritePattern<scf::WhileOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::WhileOp whileOp,
+                                PatternRewriter &rewriter) const override {
+    Block &before = whileOp.getBefore().front();
+    Block &after = whileOp.getAfter().front();
+    scf::ConditionOp conditionOp = whileOp.getConditionOp();
+    scf::YieldOp yieldOp = whileOp.getYieldOp();
+
+    auto result = dyn_cast<OpResult>(conditionOp.getCondition());
+    auto ifOp = result ? dyn_cast<scf::IfOp>(result.getOwner()) : nullptr;
+    if (!ifOp)
+      return failure();
+    auto flag = dyn_cast<BlockArgument>(ifOp.getCondition());
+    if (!flag || flag.getOwner() != &before)
+      return failure();
+    Value next = yieldOp.getOperand(flag.getArgNumber());
+    if (auto afterArg = dyn_cast<BlockArgument>(next);
+        afterArg && afterArg.getOwner() == &after)
+      next = conditionOp.getArgs()[afterArg.getArgNumber()];
+    APInt constant;
+    if (!matchPattern(next, m_ConstantInt(&constant)))
+      return failure();
+    scf::YieldOp branch =
+        constant.isZero() ? ifOp.elseYield() : ifOp.thenYield();
+    if (!matchPattern(branch.getOperand(result.getResultNumber()), m_Zero()))
+      return failure();
+
+    unrollWhileTwice(whileOp, rewriter);
     return success();
   }
 };
@@ -1129,9 +1233,10 @@ struct CanonicalizeParallelPass
         SinkThroughSelectOfConstants<arith::MulIOp>, SelectOfNullPointer,
         IfOfNullPointer<scf::IfOp>, IfOfNullPointer<affine::AffineIfOp>,
         FlattenAggregateAlloca, StoreOfUndef, UnrollWhileWithInvariantExit,
-        TruncOfMulByOneModWidth, ShiftOfMulByShiftPlusOne,
-        TruncOfOrWithShiftedOut, ShiftOfOrWithShiftedIn,
-        ShiftOfNarrowZeroExtended, ShiftOfOrWithConstant,
+        UnrollWhileOfOredCounter, UnrollWhileOfFlagIf, TruncOfMulByOneModWidth,
+        ShiftOfMulByShiftPlusOne, TruncOfOrWithShiftedOut,
+        ShiftOfOrWithShiftedIn, ShiftOfNarrowZeroExtended,
+        ShiftOfOrWithConstant,
         OuterOfInnersBySharedOperand<arith::MaxSIOp, arith::MinSIOp>,
         OuterOfInnersBySharedOperand<arith::MinSIOp, arith::MaxSIOp>,
         OuterOfInnersBySharedOperand<arith::MaxUIOp, arith::MinUIOp>,

--- a/test/lit_tests/canonicalize_parallel_while_flag_if.mlir
+++ b/test/lit_tests/canonicalize_parallel_while_flag_if.mlir
@@ -1,0 +1,151 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel --allow-unregistered-dialect | FileCheck %s
+
+// Clang's rotation of a single-trip loop with early exits: the exit test is
+// the scf.if on the carried flag, the flag is yielded false, and the else
+// branch yields false, so the second evaluation exits.
+func.func @flag_if(%buf: memref<8xf64>, %out: memref<i32>, %go: i1) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c5_i32 = arith.constant 5 : i32
+  %v = arith.constant 2.0 : f64
+  %r:2 = scf.while (%flag = %true, %res = %c0_i32) : (i1, i32) -> (i32, i1) {
+    %pair:2 = scf.if %flag -> (i32, i1) {
+      affine.store %v, %buf[0] : memref<8xf64>
+      %again = arith.andi %go, %true : i1
+      scf.yield %c5_i32, %again : i32, i1
+    } else {
+      scf.yield %res, %false : i32, i1
+    }
+    scf.condition(%pair#1) %pair#0, %pair#1 : i32, i1
+  } do {
+  ^bb0(%res: i32, %again: i1):
+    scf.yield %false, %res : i1, i32
+  }
+  memref.store %r#0, %out[] : memref<i32>
+  return
+}
+
+// The flag is yielded true, and the then branch's continue value is not
+// constant: the loop may go on.
+func.func @flag_true(%buf: memref<8xf64>, %out: memref<i32>, %go: i1) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c5_i32 = arith.constant 5 : i32
+  %v = arith.constant 2.0 : f64
+  %r:2 = scf.while (%flag = %true, %res = %c0_i32) : (i1, i32) -> (i32, i1) {
+    %pair:2 = scf.if %flag -> (i32, i1) {
+      affine.store %v, %buf[0] : memref<8xf64>
+      %again = arith.andi %go, %true : i1
+      scf.yield %c5_i32, %again : i32, i1
+    } else {
+      scf.yield %res, %false : i32, i1
+    }
+    scf.condition(%pair#1) %pair#0, %pair#1 : i32, i1
+  } do {
+  ^bb0(%res: i32, %again: i1):
+    scf.yield %true, %res : i1, i32
+  }
+  memref.store %r#0, %out[] : memref<i32>
+  return
+}
+
+// The flag is yielded a carried value, not a constant.
+func.func @flag_varies(%buf: memref<8xf64>, %out: memref<i32>, %go: i1) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c5_i32 = arith.constant 5 : i32
+  %v = arith.constant 2.0 : f64
+  %r:2 = scf.while (%flag = %true, %res = %c0_i32) : (i1, i32) -> (i32, i1) {
+    %pair:2 = scf.if %flag -> (i32, i1) {
+      affine.store %v, %buf[0] : memref<8xf64>
+      %again = arith.andi %go, %true : i1
+      scf.yield %c5_i32, %again : i32, i1
+    } else {
+      scf.yield %res, %false : i32, i1
+    }
+    scf.condition(%pair#1) %pair#0, %pair#1 : i32, i1
+  } do {
+  ^bb0(%res: i32, %again: i1):
+    scf.yield %again, %res : i1, i32
+  }
+  memref.store %r#0, %out[] : memref<i32>
+  return
+}
+
+// The selected branch yields a value that is not false.
+func.func @branch_not_false(%buf: memref<8xf64>, %out: memref<i32>, %go: i1) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0_i32 = arith.constant 0 : i32
+  %c5_i32 = arith.constant 5 : i32
+  %v = arith.constant 2.0 : f64
+  %r:2 = scf.while (%flag = %true, %res = %c0_i32) : (i1, i32) -> (i32, i1) {
+    %pair:2 = scf.if %flag -> (i32, i1) {
+      affine.store %v, %buf[0] : memref<8xf64>
+      %again = arith.andi %go, %true : i1
+      scf.yield %c5_i32, %again : i32, i1
+    } else {
+      scf.yield %res, %go : i32, i1
+    }
+    scf.condition(%pair#1) %pair#0, %pair#1 : i32, i1
+  } do {
+  ^bb0(%res: i32, %again: i1):
+    scf.yield %false, %res : i1, i32
+  }
+  memref.store %r#0, %out[] : memref<i32>
+  return
+}
+
+// CHECK:    func.func @flag_if(%arg0: memref<8xf64>, %arg1: memref<i32>, %arg2: i1) {
+// CHECK-NEXT:    %c5_i32 = arith.constant 5 : i32
+// CHECK-NEXT:    %cst = arith.constant 2.000000e+00 : f64
+// CHECK-NEXT:    affine.store %cst, %arg0[0] : memref<8xf64>
+// CHECK-NEXT:    memref.store %c5_i32, %arg1[] : memref<i32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @flag_true(%arg0: memref<8xf64>, %arg1: memref<i32>, %arg2: i1) {
+// CHECK-NEXT:    %c5_i32 = arith.constant 5 : i32
+// CHECK-NEXT:    %cst = arith.constant 2.000000e+00 : f64
+// CHECK-NEXT:    scf.while : () -> () {
+// CHECK-NEXT:      affine.store %cst, %arg0[0] : memref<8xf64>
+// CHECK-NEXT:      scf.condition(%arg2)
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      scf.yield
+// CHECK-NEXT:    }
+// CHECK-NEXT:    memref.store %c5_i32, %arg1[] : memref<i32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @flag_varies(%arg0: memref<8xf64>, %arg1: memref<i32>, %arg2: i1) {
+// CHECK-NEXT:    %c5_i32 = arith.constant 5 : i32
+// CHECK-NEXT:    %cst = arith.constant 2.000000e+00 : f64
+// CHECK-NEXT:    scf.while : () -> () {
+// CHECK-NEXT:      affine.store %cst, %arg0[0] : memref<8xf64>
+// CHECK-NEXT:      scf.condition(%arg2)
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:      scf.yield
+// CHECK-NEXT:    }
+// CHECK-NEXT:    memref.store %c5_i32, %arg1[] : memref<i32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @branch_not_false(%arg0: memref<8xf64>, %arg1: memref<i32>, %arg2: i1) {
+// CHECK-NEXT:    %true = arith.constant true
+// CHECK-NEXT:    %false = arith.constant false
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    %c5_i32 = arith.constant 5 : i32
+// CHECK-NEXT:    %cst = arith.constant 2.000000e+00 : f64
+// CHECK-NEXT:    %0 = scf.while (%arg3 = %true, %arg4 = %c0_i32) : (i1, i32) -> i32 {
+// CHECK-NEXT:      %1 = arith.select %arg3, %c5_i32, %arg4 : i32
+// CHECK-NEXT:      scf.if %arg3 {
+// CHECK-NEXT:        affine.store %cst, %arg0[0] : memref<8xf64>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      scf.condition(%arg2) %1 : i32
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:    ^bb0(%arg3: i32):
+// CHECK-NEXT:      scf.yield %false, %arg3 : i1, i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    memref.store %0, %arg1[] : memref<i32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }

--- a/test/lit_tests/canonicalize_parallel_while_or_counter.mlir
+++ b/test/lit_tests/canonicalize_parallel_while_or_counter.mlir
@@ -1,0 +1,238 @@
+// RUN: enzymexlamlir-opt %s --canonicalize-parallel --allow-unregistered-dialect | FileCheck %s
+
+// The reduction over one or two dofs: clang writes `dx + 1 < 2 - odd` as
+// `(dx | odd) == 0`, and the counter is one on the second evaluation.
+func.func @ored_counter(%x: memref<8xf64>, %b: memref<4xf64>, %out: memref<f64>, %odd: i32) {
+  %c1 = arith.constant 1 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %zero = arith.constant 0.0 : f64
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+    %r:2 = scf.while (%acc = %zero, %dx = %c0_i32) : (f64, i32) -> (f64, i32) {
+      %i = arith.index_cast %dx : i32 to index
+      %xv = memref.load %x[%i] : memref<8xf64>
+      %bv = memref.load %b[%i] : memref<4xf64>
+      %p = arith.mulf %xv, %bv : f64
+      %sum = arith.addf %acc, %p : f64
+      %next = arith.addi %dx, %c1_i32 : i32
+      %or = arith.ori %dx, %odd : i32
+      %again = arith.cmpi eq, %or, %c0_i32 : i32
+      scf.condition(%again) %sum, %next : f64, i32
+    } do {
+    ^bb0(%sum: f64, %next: i32):
+      scf.yield %sum, %next : f64, i32
+    }
+    memref.store %r#0, %out[] : memref<f64>
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// The counter starts at one: the pattern only knows counters from zero.
+func.func @starts_at_one(%x: memref<8xf64>, %b: memref<4xf64>, %out: memref<f64>, %odd: i32) {
+  %c1 = arith.constant 1 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %zero = arith.constant 0.0 : f64
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+    %r:2 = scf.while (%acc = %zero, %dx = %c1_i32) : (f64, i32) -> (f64, i32) {
+      %i = arith.index_cast %dx : i32 to index
+      %xv = memref.load %x[%i] : memref<8xf64>
+      %sum = arith.addf %acc, %xv : f64
+      %next = arith.addi %dx, %c1_i32 : i32
+      %or = arith.ori %dx, %odd : i32
+      %again = arith.cmpi eq, %or, %c0_i32 : i32
+      scf.condition(%again) %sum, %next : f64, i32
+    } do {
+    ^bb0(%sum: f64, %next: i32):
+      scf.yield %sum, %next : f64, i32
+    }
+    memref.store %r#0, %out[] : memref<f64>
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// Stepping by two keeps the low bit clear: the loop may run on.
+func.func @steps_by_two(%x: memref<8xf64>, %out: memref<f64>, %odd: i32) {
+  %c1 = arith.constant 1 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %zero = arith.constant 0.0 : f64
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+    %r:2 = scf.while (%acc = %zero, %dx = %c0_i32) : (f64, i32) -> (f64, i32) {
+      %i = arith.index_cast %dx : i32 to index
+      %xv = memref.load %x[%i] : memref<8xf64>
+      %sum = arith.addf %acc, %xv : f64
+      %next = arith.addi %dx, %c2_i32 : i32
+      %or = arith.ori %dx, %odd : i32
+      %again = arith.cmpi eq, %or, %c0_i32 : i32
+      scf.condition(%again) %sum, %next : f64, i32
+    } do {
+    ^bb0(%sum: f64, %next: i32):
+      scf.yield %sum, %next : f64, i32
+    }
+    memref.store %r#0, %out[] : memref<f64>
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// Masking instead of oring may leave the test true.
+func.func @masked(%x: memref<8xf64>, %out: memref<f64>, %mask: i32) {
+  %c1 = arith.constant 1 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %zero = arith.constant 0.0 : f64
+  %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+    %r:2 = scf.while (%acc = %zero, %dx = %c0_i32) : (f64, i32) -> (f64, i32) {
+      %i = arith.index_cast %dx : i32 to index
+      %xv = memref.load %x[%i] : memref<8xf64>
+      %sum = arith.addf %acc, %xv : f64
+      %next = arith.addi %dx, %c1_i32 : i32
+      %and = arith.andi %dx, %mask : i32
+      %again = arith.cmpi eq, %and, %c0_i32 : i32
+      scf.condition(%again) %sum, %next : f64, i32
+    } do {
+    ^bb0(%sum: f64, %next: i32):
+      scf.yield %sum, %next : f64, i32
+    }
+    memref.store %r#0, %out[] : memref<f64>
+    "enzymexla.polygeist_yield"() : () -> ()
+  }) : (index, index, index, index, index, index) -> index
+  return
+}
+
+// The bound does not rest on forward progress, so a host loop unrolls too.
+func.func @host(%x: memref<8xf64>, %out: memref<f64>, %odd: i32) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %zero = arith.constant 0.0 : f64
+  %r:2 = scf.while (%acc = %zero, %dx = %c0_i32) : (f64, i32) -> (f64, i32) {
+    %i = arith.index_cast %dx : i32 to index
+    %xv = memref.load %x[%i] : memref<8xf64>
+    %sum = arith.addf %acc, %xv : f64
+    %next = arith.addi %dx, %c1_i32 : i32
+    %or = arith.ori %dx, %odd : i32
+    %again = arith.cmpi eq, %or, %c0_i32 : i32
+    scf.condition(%again) %sum, %next : f64, i32
+  } do {
+  ^bb0(%sum: f64, %next: i32):
+    scf.yield %sum, %next : f64, i32
+  }
+  memref.store %r#0, %out[] : memref<f64>
+  return
+}
+
+// CHECK:    func.func @ored_counter(%arg0: memref<8xf64>, %arg1: memref<4xf64>, %arg2: memref<f64>, %arg3: i32) {
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+// CHECK-NEXT:      %1 = memref.load %arg0[%c0] : memref<8xf64>
+// CHECK-NEXT:      %2 = memref.load %arg1[%c0] : memref<4xf64>
+// CHECK-NEXT:      %3 = arith.mulf %1, %2 : f64
+// CHECK-NEXT:      %4 = arith.addf %3, %cst : f64
+// CHECK-NEXT:      %5 = arith.cmpi eq, %arg3, %c0_i32 : i32
+// CHECK-NEXT:      %6 = scf.if %5 -> (f64) {
+// CHECK-NEXT:        %7 = memref.load %arg0[%c1] : memref<8xf64>
+// CHECK-NEXT:        %8 = memref.load %arg1[%c1] : memref<4xf64>
+// CHECK-NEXT:        %9 = arith.mulf %7, %8 : f64
+// CHECK-NEXT:        %10 = arith.addf %4, %9 : f64
+// CHECK-NEXT:        scf.yield %10 : f64
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        scf.yield %4 : f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      memref.store %6, %arg2[] : memref<f64>
+// CHECK-NEXT:      "enzymexla.polygeist_yield"() : () -> ()
+// CHECK-NEXT:    }) : (index, index, index, index, index, index) -> index
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @starts_at_one(%arg0: memref<8xf64>, %arg1: memref<4xf64>, %arg2: memref<f64>, %arg3: i32) {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+// CHECK-NEXT:      %1:2 = scf.while (%arg4 = %cst, %arg5 = %c1_i32) : (f64, i32) -> (f64, i32) {
+// CHECK-NEXT:        %2 = arith.index_cast %arg5 : i32 to index
+// CHECK-NEXT:        %3 = memref.load %arg0[%2] : memref<8xf64>
+// CHECK-NEXT:        %4 = arith.addf %arg4, %3 : f64
+// CHECK-NEXT:        %5 = arith.addi %arg5, %c1_i32 : i32
+// CHECK-NEXT:        %6 = arith.ori %arg5, %arg3 : i32
+// CHECK-NEXT:        %7 = arith.cmpi eq, %6, %c0_i32 : i32
+// CHECK-NEXT:        scf.condition(%7) %4, %5 : f64, i32
+// CHECK-NEXT:      } do {
+// CHECK-NEXT:      ^bb0(%arg4: f64, %arg5: i32):
+// CHECK-NEXT:        scf.yield %arg4, %arg5 : f64, i32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      memref.store %1#0, %arg2[] : memref<f64>
+// CHECK-NEXT:      "enzymexla.polygeist_yield"() : () -> ()
+// CHECK-NEXT:    }) : (index, index, index, index, index, index) -> index
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @steps_by_two(%arg0: memref<8xf64>, %arg1: memref<f64>, %arg2: i32) {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    %c2_i32 = arith.constant 2 : i32
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+// CHECK-NEXT:      %1:2 = scf.while (%arg3 = %cst, %arg4 = %c0_i32) : (f64, i32) -> (f64, i32) {
+// CHECK-NEXT:        %2 = arith.index_cast %arg4 : i32 to index
+// CHECK-NEXT:        %3 = memref.load %arg0[%2] : memref<8xf64>
+// CHECK-NEXT:        %4 = arith.addf %arg3, %3 : f64
+// CHECK-NEXT:        %5 = arith.addi %arg4, %c2_i32 : i32
+// CHECK-NEXT:        %6 = arith.ori %arg4, %arg2 : i32
+// CHECK-NEXT:        %7 = arith.cmpi eq, %6, %c0_i32 : i32
+// CHECK-NEXT:        scf.condition(%7) %4, %5 : f64, i32
+// CHECK-NEXT:      } do {
+// CHECK-NEXT:      ^bb0(%arg3: f64, %arg4: i32):
+// CHECK-NEXT:        scf.yield %arg3, %arg4 : f64, i32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      memref.store %1#0, %arg1[] : memref<f64>
+// CHECK-NEXT:      "enzymexla.polygeist_yield"() : () -> ()
+// CHECK-NEXT:    }) : (index, index, index, index, index, index) -> index
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @masked(%arg0: memref<8xf64>, %arg1: memref<f64>, %arg2: i32) {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    %0 = "enzymexla.gpu_wrapper"(%c1, %c1, %c1, %c1, %c1, %c1) ({
+// CHECK-NEXT:      %1:2 = scf.while (%arg3 = %cst, %arg4 = %c0_i32) : (f64, i32) -> (f64, i32) {
+// CHECK-NEXT:        %2 = arith.index_cast %arg4 : i32 to index
+// CHECK-NEXT:        %3 = memref.load %arg0[%2] : memref<8xf64>
+// CHECK-NEXT:        %4 = arith.addf %arg3, %3 : f64
+// CHECK-NEXT:        %5 = arith.addi %arg4, %c1_i32 : i32
+// CHECK-NEXT:        %6 = arith.andi %arg4, %arg2 : i32
+// CHECK-NEXT:        %7 = arith.cmpi eq, %6, %c0_i32 : i32
+// CHECK-NEXT:        scf.condition(%7) %4, %5 : f64, i32
+// CHECK-NEXT:      } do {
+// CHECK-NEXT:      ^bb0(%arg3: f64, %arg4: i32):
+// CHECK-NEXT:        scf.yield %arg3, %arg4 : f64, i32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      memref.store %1#0, %arg1[] : memref<f64>
+// CHECK-NEXT:      "enzymexla.polygeist_yield"() : () -> ()
+// CHECK-NEXT:    }) : (index, index, index, index, index, index) -> index
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @host(%arg0: memref<8xf64>, %arg1: memref<f64>, %arg2: i32) {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:    %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %0 = memref.load %arg0[%c0] : memref<8xf64>
+// CHECK-NEXT:    %1 = arith.addf %0, %cst : f64
+// CHECK-NEXT:    %2 = arith.cmpi eq, %arg2, %c0_i32 : i32
+// CHECK-NEXT:    %3 = scf.if %2 -> (f64) {
+// CHECK-NEXT:      %4 = memref.load %arg0[%c1] : memref<8xf64>
+// CHECK-NEXT:      %5 = arith.addf %1, %4 : f64
+// CHECK-NEXT:      scf.yield %5 : f64
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      scf.yield %1 : f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    memref.store %3, %arg1[] : memref<f64>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }


### PR DESCRIPTION
Follow-up to #3187: two more exit tests whose second evaluation is decided, sharing #3187's two-evaluation unroll (factored into `unrollWhileTwice`). Neither rests on forward progress, so neither needs the GPU wrapper.

MFEM's H(div) mass reductions run over one or two dofs, `for (dx = 0; dx < nx; ++dx)` with `nx = (vd == 0) ? D1D : D1D - 1` and `D1D = 2`. Clang knows `dx` and `odd` are in {0, 1} and writes the rotated exit test `dx + 1 < 2 - odd` as `(dx | odd) == 0`, which hides the induction variable from the while-to-for uplift and is not an invariant yield either:

```
%67:2 = scf.while (%arg17 = %cst, %arg18 = %c0_i32) : (f64, i32) -> (f64, i32) {
  ...
  %78 = arith.addi %arg18, %c1_i32 overflow<nsw, nuw> : i32
  %79 = arith.ori %arg18, %47 : i32
  %80 = arith.cmpi eq, %79, %c0_i32 : i32
  scf.condition(%80) %77, %78 : f64, i32
} do {
^bb0(%arg17: f64, %arg18: i32):
  scf.yield %arg17, %arg18 : f64, i32
}
```

A counter that starts at zero and steps by one is one on the second evaluation of the exit test, so `(counter | x) == 0` is false there whatever `x` is, and the loop runs at most twice. Unlike #3187's rule this does not rest on forward progress, so it applies on the host as well. The pattern matches exactly that: `cmpi eq (ori counter, x), 0` with the counter a carried argument initialized to zero and yielded itself plus one (possibly through the condition operand forwarded to the after region), and unrolls it as #3187 does.

The second is clang's rotation of a single-trip loop with early exits (the edge scan in `batchitrans.cpp`, `for (d = 0; d < 1; ++d) { ...; switch (solver(idx)) { case Inside: return; ... } if (qptr[i] == 0) break; }`): the exit test is the result of an `scf.if` on a carried flag, the after region yields the flag `false`, and the else branch yields `false` for that result:

```
%208:3 = scf.while (%arg24 = %true, %arg25 = %arg18) : (i1, i32) -> (i32, i32, i32) {
  %210:4 = scf.if %arg24 -> (i32, i32, i32, i1) {
    ... the body and its early-exit tests ...
    scf.yield %220, %221#1, %220, %221#0 : i32, i32, i32, i1
  } else {
    scf.yield %3, %c5_i32, %arg25, %false : i32, i32, i32, i1
  }
  scf.condition(%210#3) %210#0, %210#1, %210#2 : i32, i32, i32
} do {
^bb0(%arg24: i32, %arg25: i32, %arg26: i32):
  scf.yield %false, %arg24 : i1, i32
}
```

The second evaluation takes the branch the constant selects, whose yield is `false`, so the loop exits there. The pattern matches an exit test that is an `scf.if` result whose condition is a carried argument yielded a constant, and requires the yield of that result on the selected branch to be `false`.

With #3187 on main, these two are what the seven TUs that needed #3071 still lacked: the union with #3187 and this PR in place of #3071 compiles all of them.

Tests: `test/lit_tests/canonicalize_parallel_while_or_counter.mlir` (the reduction unrolls, on the host too; a counter from one, a step of two and an `and` instead of the `or` stay) and `test/lit_tests/canonicalize_parallel_while_flag_if.mlir` (the rotated loop unrolls; a flag yielded true, a flag yielded a carried value, and a branch yielding a non-constant stay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
