### PR TITLE
EnzymeHLOOpt: resolve a masked scatter index before the single-point DUS rewrite

### DIFF
--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -3118,6 +3118,15 @@ struct SliceBroadcast final
     if (innerSlice && !llvm::hasSingleElement(bcast->getUsers()))
       return failure();
 
+    // The new broadcast must be dimensionally consistent: every mapped
+    // operand dim must equal its result dim or be 1.
+    for (auto [i, outdim] : llvm::enumerate(bcast.getBroadcastDimensions())) {
+      int64_t od = (in_end[i] - in_start[i] + in_stride[i] - 1) / in_stride[i];
+      int64_t rd = op.getType().getShape()[outdim];
+      if (od != rd && od != 1)
+        return failure();
+    }
+
     Value tobcast = bcast.getOperand();
     if (innerSlice)
       tobcast = stablehlo::SliceOp::create(rewriter, op.getLoc(), tobcast,
@@ -35539,6 +35548,134 @@ struct RecognizeMultiPad final
   }
 };
 
+// Whether an index tensor maps every grid position to a distinct value: a
+// sum of iota-like terms, each along its own grid dimension, whose strides
+// make the sum injective (the raising's row-major linearization of a store's
+// lane grid, `i * N1 + j`), plus a constant. Dimensions of extent one need
+// no term.
+static bool isInjectiveGridIndex(Value index) {
+  auto ty = cast<RankedTensorType>(index.getType());
+  SmallVector<Value> terms{index};
+  SmallVector<std::pair<int64_t, int64_t>> strides; // (|scale|, dimension)
+  DenseSet<int64_t> covered;
+  while (!terms.empty()) {
+    Value term = terms.pop_back_val();
+    if (auto add = term.getDefiningOp<stablehlo::AddOp>()) {
+      terms.push_back(add.getLhs());
+      terms.push_back(add.getRhs());
+      continue;
+    }
+    if (matchPattern(term, m_Constant()))
+      continue;
+    auto iota = detectIotaLikeTensor(term);
+    if (!iota || !iota->scale || iota->dimension >= ty.getRank() ||
+        !covered.insert(iota->dimension).second)
+      return false;
+    int64_t scale = cast<IntegerAttr>(iota->scale).getValue().getSExtValue();
+    if (scale == 0)
+      return false;
+    strides.push_back({std::abs(scale), iota->dimension});
+  }
+  for (int64_t d = 0; d < ty.getRank(); ++d)
+    if (ty.getDimSize(d) > 1 && !covered.contains(d))
+      return false;
+  // Sorted by stride, each term must step past everything the smaller terms
+  // can add up to.
+  llvm::sort(strides);
+  int64_t reach = 0;
+  for (auto [stride, dim] : strides) {
+    if (stride <= reach)
+      return false;
+    reach += stride * (ty.getDimSize(dim) - 1);
+  }
+  return true;
+}
+
+// The raising masks a store by sending dead lanes' scatter indices out of
+// bounds, which scatter semantics drop. Single-point and iota-indexed
+// scatter rewrites turn the op into a dynamic_update_slice, whose index
+// clamping would bring the dead write back in range; resolve the mask first:
+// scatter at the live index and write the original value back when masked
+// off (a no-op store). That is only a no-op when no live lane writes the
+// same slot, so the live indices must be unique: a single index, an
+// injective grid linearization, or unique_indices.
+struct ScatterMaskedIndexSimplify final
+    : CheckedOpRewritePattern<stablehlo::ScatterOp,
+                              ScatterMaskedIndexSimplify> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ScatterOp op,
+                                    PatternRewriter &rewriter) const {
+    if (op.getInputs().size() != 1)
+      return failure();
+    auto &block = op.getUpdateComputation().front();
+    if (!isSetindexBlock(&block))
+      return failure();
+    auto inputTy = cast<RankedTensorType>(op.getInputs()[0].getType());
+    if (inputTy.getRank() != 1)
+      return failure();
+    auto dims = op.getScatterDimensionNumbers();
+    if (dims.getInsertedWindowDims() != ArrayRef<int64_t>{0} ||
+        dims.getScatterDimsToOperandDims() != ArrayRef<int64_t>{0} ||
+        !dims.getUpdateWindowDims().empty())
+      return failure();
+    auto indices = op.getScatterIndices();
+    auto idxTy = cast<RankedTensorType>(indices.getType());
+    // The select may sit behind reshapes of the index.
+    Value idxSrc = indices;
+    while (auto rs = idxSrc.getDefiningOp<stablehlo::ReshapeOp>())
+      idxSrc = rs.getOperand();
+    auto sel = idxSrc.getDefiningOp<stablehlo::SelectOp>();
+    if (!sel)
+      return failure();
+    SplatElementsAttr offSplat;
+    if (!matchPattern(sel.getOnFalse(), m_Constant(&offSplat)) ||
+        !offSplat.getSplatValue<APInt>().isNegative())
+      return failure();
+    auto predTy = cast<RankedTensorType>(sel.getPred().getType());
+    int64_t count = idxTy.getNumElements();
+    if (predTy.getNumElements() != 1 && predTy.getNumElements() != count)
+      return failure();
+    if (count != 1 && !op.getUniqueIndices() &&
+        !isInjectiveGridIndex(sel.getOnTrue()))
+      return failure();
+
+    auto loc = op.getLoc();
+    Value update = op.getUpdates()[0];
+    auto updTy = cast<RankedTensorType>(update.getType());
+    Value live = stablehlo::ReshapeOpCreate(rewriter, loc, sel.getOnTrue(),
+                                            idxTy.getShape());
+    // The original values at the live indices, gathered as the scatter
+    // addresses them.
+    Value orig = stablehlo::GatherOp::create(
+        rewriter, loc, op.getInputs()[0], live,
+        stablehlo::GatherDimensionNumbersAttr::get(
+            rewriter.getContext(), /*offsetDims*/ {},
+            /*collapsedSliceDims*/ {0}, /*operandBatchingDims*/ {},
+            /*startIndicesBatchingDims*/ {}, /*startIndexMap*/ {0},
+            dims.getIndexVectorDim()),
+        rewriter.getDenseI64ArrayAttr({1}));
+    orig = stablehlo::ReshapeOpCreate(rewriter, loc, orig, updTy.getShape());
+    Value pred = sel.getPred();
+    if (predTy.getNumElements() == 1 && updTy.getNumElements() != 1) {
+      pred = stablehlo::ReshapeOpCreate(rewriter, loc, pred, {});
+      pred = stablehlo::BroadcastInDimOp::create(
+          rewriter, loc,
+          RankedTensorType::get(updTy.getShape(), rewriter.getI1Type()), pred,
+          rewriter.getDenseI64ArrayAttr({}));
+    } else {
+      pred = stablehlo::ReshapeOpCreate(rewriter, loc, pred, updTy.getShape());
+    }
+    Value newUpd =
+        stablehlo::SelectOp::create(rewriter, loc, pred, update, orig);
+    rewriter.modifyOpInPlace(op, [&] {
+      op.getScatterIndicesMutable().assign(live);
+      op.getUpdatesMutable()[0].assign(newUpd);
+    });
+    return success();
+  }
+};
+
 struct ScatterOpCanon final
     : CheckedOpRewritePattern<stablehlo::ScatterOp, ScatterOpCanon> {
   using CheckedOpRewritePattern::CheckedOpRewritePattern;
@@ -37328,6 +37465,7 @@ struct EnzymeHLOOptPass
         DynamicReshapeOpCanon,
         EmptyReduceOpCanon,
         GatherOpCanon,
+        ScatterMaskedIndexSimplify,
         ScatterOpCanon,
         GetDimensionSizeOpCanon,
         GetTupleElementOpCanon,

--- a/test/lit_tests/scatter_masked_index.mlir
+++ b/test/lit_tests/scatter_masked_index.mlir
@@ -1,0 +1,53 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// A masked store scatters with its index sent out of bounds on the dead
+// path (scatter drops it). The single-point scatter must not become a
+// plain dynamic_update_slice — DUS clamps the index back in bounds — so
+// the mask is resolved first: slice the original value and write it back
+// when masked off.
+func.func @main(%buf: tensor<50xf64>, %i: tensor<i64>, %p: tensor<i1>, %v: tensor<f64>) -> tensor<50xf64> {
+  %cm1 = stablehlo.constant dense<-1> : tensor<1xi64>
+  %ir = stablehlo.reshape %i : (tensor<i64>) -> tensor<1xi64>
+  %pb = stablehlo.reshape %p : (tensor<i1>) -> tensor<1xi1>
+  %sel = stablehlo.select %pb, %ir, %cm1 : tensor<1xi1>, tensor<1xi64>
+  %r = "stablehlo.scatter"(%buf, %sel, %v) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0]>, unique_indices = false}> ({
+  ^bb0(%a: tensor<f64>, %b: tensor<f64>):
+    stablehlo.return %b : tensor<f64>
+  }) : (tensor<50xf64>, tensor<1xi64>, tensor<f64>) -> tensor<50xf64>
+  return %r : tensor<50xf64>
+}
+
+// A full-grid masked store: the live indices are a linearized iota, so the
+// masked-off lanes write their original values back and the scatter folds to
+// a select over the whole tensor.
+func.func @dense_masked(%input: tensor<100xf32>, %update: tensor<10x10xf32>, %pred: tensor<10x10x1xi1>) -> tensor<100xf32> {
+  %c10 = stablehlo.constant dense<10> : tensor<10xi64>
+  %off = stablehlo.constant dense<-1> : tensor<10x10x1xi64>
+  %i = stablehlo.iota dim = 0 : tensor<10xi64>
+  %row = stablehlo.multiply %i, %c10 : tensor<10xi64>
+  %col = stablehlo.iota dim = 1 : tensor<10x10x1xi64>
+  %rowb = stablehlo.broadcast_in_dim %row, dims = [0] : (tensor<10xi64>) -> tensor<10x10x1xi64>
+  %lin = stablehlo.add %rowb, %col : tensor<10x10x1xi64>
+  %idx = stablehlo.select %pred, %lin, %off : tensor<10x10x1xi1>, tensor<10x10x1xi64>
+  %0 = "stablehlo.scatter"(%input, %idx, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = false}> ({
+  ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+    stablehlo.return %b : tensor<f32>
+  }) : (tensor<100xf32>, tensor<10x10x1xi64>, tensor<10x10xf32>) -> tensor<100xf32>
+  return %0 : tensor<100xf32>
+}
+
+// CHECK:    func.func @main(%arg0: tensor<50xf64>, %arg1: tensor<i64>, %arg2: tensor<i1>, %arg3: tensor<f64>) -> tensor<50xf64> {
+// CHECK-NEXT:    %0 = stablehlo.dynamic_slice %arg0, %arg1, sizes = [1] : (tensor<50xf64>, tensor<i64>) -> tensor<1xf64>
+// CHECK-NEXT:    %1 = stablehlo.reshape %0 : (tensor<1xf64>) -> tensor<f64>
+// CHECK-NEXT:    %2 = stablehlo.select %arg2, %arg3, %1 : tensor<i1>, tensor<f64>
+// CHECK-NEXT:    %3 = stablehlo.reshape %2 : (tensor<f64>) -> tensor<1xf64>
+// CHECK-NEXT:    %4 = stablehlo.dynamic_update_slice %arg0, %3, %arg1 : (tensor<50xf64>, tensor<1xf64>, tensor<i64>) -> tensor<50xf64>
+// CHECK-NEXT:    return %4 : tensor<50xf64>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @dense_masked(%arg0: tensor<100xf32>, %arg1: tensor<10x10xf32>, %arg2: tensor<10x10x1xi1>) -> tensor<100xf32> {
+// CHECK-NEXT:    %0 = stablehlo.reshape %arg0 : (tensor<100xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:    %1 = stablehlo.reshape %arg2 : (tensor<10x10x1xi1>) -> tensor<10x10xi1>
+// CHECK-NEXT:    %2 = stablehlo.select %1, %arg1, %0 : tensor<10x10xi1>, tensor<10x10xf32>
+// CHECK-NEXT:    %3 = stablehlo.reshape %2 : (tensor<10x10xf32>) -> tensor<100xf32>
+// CHECK-NEXT:    return %3 : tensor<100xf32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
The EnzymeHLOOpt half of #2993, split out so that PR carries only the raising change.

The raising masks a store by sending dead lanes' scatter indices out of bounds (index -1), which scatter semantics drop. The single-point scatter-to-DUS rewrite would then clamp that index to 0 and resurrect the dead write. `ScatterMaskedIndexSimplify` resolves the mask before that rewrite: for a setindex scatter whose indices are `select(pred, live, negative)`, it scatters at the live indices and, where a lane is masked off, writes the original value back (a gather of the input at the live index), so the store is a no-op there and the indices are in bounds for the DUS conversion. Writing the original back is only a no-op when no live lane writes the same slot, so the live indices must be unique: a single index, an iota-like tensor, or `unique_indices`. The select may sit behind reshapes of the indices.

With the iota-like case, the full-grid masked store that #2993 now raises as `scatter(input, select(mask, linearized iota, -1), update)` folds back to the `reshape(select(mask, update, reshape(input)))` it produced before that change: the existing iota path turns the scatter into a dynamic_update_slice over the whole operand, and the gather at a full iota becomes a reshape.

Also carried over from the union: `SliceBroadcast` now checks that the broadcast it builds is dimensionally consistent (every mapped operand dim equals its result dim or is 1) before rewriting; without it the pattern could emit a broadcast the verifier rejects.

Test: `test/lit_tests/scatter_masked_index.mlir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
