### PR TITLE
EnzymeHLOOpt: scatter only the live box of a statically masked store

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -684,6 +684,7 @@ static void addScatterGatherPasses(std::vector<std::string> &list,
   list.push_back("scatter_div_simplify");
   list.push_back("unary_elementwise_scatter_simplify");
   list.push_back("scatter_indices_are_unique");
+  list.push_back("scatter_masked_index_slice");
   list.push_back("scatter_masked_index_simplify");
   list.push_back("split_complex_scatter");
   list.push_back("split_complex_gather");

--- a/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
+++ b/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp
@@ -35548,6 +35548,193 @@ struct RecognizeMultiPad final
   }
 };
 
+// A masked scatter whose mask is decided by comparisons of iotas against
+// constants is live on a box of its lane grid: the lanes outside the box are
+// exactly the ones the negative index drops. Slice the live indices and the
+// updates to the box and scatter those, with no mask left for the index
+// rewrites to see through.
+struct ScatterMaskedIndexSlice final
+    : CheckedOpRewritePattern<stablehlo::ScatterOp, ScatterMaskedIndexSlice> {
+  using CheckedOpRewritePattern::CheckedOpRewritePattern;
+
+  // The positions along one grid dimension where `iota * scale + start <pred>
+  // constant` holds, when they form one interval.
+  static std::optional<std::pair<int64_t, int64_t>>
+  compareInterval(stablehlo::ComparisonDirection direction, int64_t start,
+                  int64_t scale, int64_t constant, int64_t extent,
+                  bool iotaOnLeft) {
+    std::optional<int64_t> lo, hi;
+    for (int64_t k = 0; k < extent; ++k) {
+      int64_t value = start + scale * k;
+      int64_t l = iotaOnLeft ? value : constant;
+      int64_t r = iotaOnLeft ? constant : value;
+      bool holds;
+      switch (direction) {
+      case stablehlo::ComparisonDirection::LT:
+        holds = l < r;
+        break;
+      case stablehlo::ComparisonDirection::LE:
+        holds = l <= r;
+        break;
+      case stablehlo::ComparisonDirection::GT:
+        holds = l > r;
+        break;
+      case stablehlo::ComparisonDirection::GE:
+        holds = l >= r;
+        break;
+      case stablehlo::ComparisonDirection::EQ:
+        holds = l == r;
+        break;
+      case stablehlo::ComparisonDirection::NE:
+        holds = l != r;
+        break;
+      }
+      if (!holds)
+        continue;
+      if (hi && *hi != k)
+        return std::nullopt; // a second interval
+      if (!lo)
+        lo = k;
+      hi = k + 1;
+    }
+    if (!lo)
+      return std::make_pair(int64_t(0), int64_t(0));
+    return std::make_pair(*lo, *hi);
+  }
+
+  LogicalResult matchAndRewriteImpl(stablehlo::ScatterOp op,
+                                    PatternRewriter &rewriter) const {
+    if (op.getInputs().size() != 1)
+      return failure();
+    auto &block = op.getUpdateComputation().front();
+    if (!isSetindexBlock(&block))
+      return failure();
+    auto inputTy = cast<RankedTensorType>(op.getInputs()[0].getType());
+    if (inputTy.getRank() != 1)
+      return failure();
+    auto dims = op.getScatterDimensionNumbers();
+    if (dims.getInsertedWindowDims() != ArrayRef<int64_t>{0} ||
+        dims.getScatterDimsToOperandDims() != ArrayRef<int64_t>{0} ||
+        !dims.getUpdateWindowDims().empty())
+      return failure();
+    Value indices = op.getScatterIndices();
+    auto idxTy = cast<RankedTensorType>(indices.getType());
+    int64_t vectorDim = dims.getIndexVectorDim();
+    // The grid is every index dimension but the index vector one.
+    SmallVector<int64_t> grid;
+    for (int64_t d = 0; d < idxTy.getRank(); ++d)
+      if (d != vectorDim)
+        grid.push_back(idxTy.getDimSize(d));
+    Value update = op.getUpdates()[0];
+    auto updTy = cast<RankedTensorType>(update.getType());
+    if (updTy.getShape() != ArrayRef<int64_t>(grid))
+      return failure();
+
+    Value idxSrc = indices;
+    while (auto rs = idxSrc.getDefiningOp<stablehlo::ReshapeOp>())
+      idxSrc = rs.getOperand();
+    auto sel = idxSrc.getDefiningOp<stablehlo::SelectOp>();
+    if (!sel)
+      return failure();
+    SplatElementsAttr offSplat;
+    if (!matchPattern(sel.getOnFalse(), m_Constant(&offSplat)) ||
+        !offSplat.getSplatValue<APInt>().isNegative())
+      return failure();
+    auto predTy = cast<RankedTensorType>(sel.getPred().getType());
+    // The mask's dimensions are the grid's, with the index vector dimension
+    // possibly kept as a unit dimension.
+    SmallVector<int64_t> predGrid;
+    for (int64_t d = 0; d < predTy.getRank(); ++d)
+      if (!(predTy.getRank() == idxTy.getRank() && d == vectorDim))
+        predGrid.push_back(predTy.getDimSize(d));
+    if (predGrid != grid)
+      return failure();
+    auto gridDimOf = [&](int64_t predDim) -> std::optional<int64_t> {
+      if (predTy.getRank() == idxTy.getRank()) {
+        if (predDim == vectorDim)
+          return std::nullopt;
+        return predDim < vectorDim ? predDim : predDim - 1;
+      }
+      return predDim;
+    };
+
+    // Intersect the box over every compare the mask ands together.
+    SmallVector<int64_t> lo(grid.size(), 0), hi(grid.begin(), grid.end());
+    SmallVector<Value> terms{sel.getPred()};
+    while (!terms.empty()) {
+      Value term = terms.pop_back_val();
+      if (auto andOp = term.getDefiningOp<stablehlo::AndOp>()) {
+        terms.push_back(andOp.getLhs());
+        terms.push_back(andOp.getRhs());
+        continue;
+      }
+      auto cmp = term.getDefiningOp<stablehlo::CompareOp>();
+      if (!cmp)
+        return failure();
+      bool iotaOnLeft = true;
+      auto iota = detectIotaLikeTensor(cmp.getLhs());
+      SplatElementsAttr cst;
+      if (!iota || !matchPattern(cmp.getRhs(), m_Constant(&cst))) {
+        iotaOnLeft = false;
+        iota = detectIotaLikeTensor(cmp.getRhs());
+        if (!iota || !matchPattern(cmp.getLhs(), m_Constant(&cst)))
+          return failure();
+      }
+      auto gridDim = gridDimOf(iota->dimension);
+      if (!gridDim)
+        return failure();
+      int64_t start = cast<IntegerAttr>(iota->start).getValue().getSExtValue();
+      int64_t scale =
+          iota->scale ? cast<IntegerAttr>(iota->scale).getValue().getSExtValue()
+                      : 1;
+      auto interval =
+          compareInterval(cmp.getComparisonDirection(), start, scale,
+                          cst.getSplatValue<APInt>().getSExtValue(),
+                          grid[*gridDim], iotaOnLeft);
+      if (!interval)
+        return failure();
+      lo[*gridDim] = std::max(lo[*gridDim], interval->first);
+      hi[*gridDim] = std::min(hi[*gridDim], interval->second);
+    }
+
+    auto loc = op.getLoc();
+    Value live = stablehlo::ReshapeOpCreate(rewriter, loc, sel.getOnTrue(),
+                                            idxTy.getShape());
+    bool full = true, empty = false;
+    for (size_t d = 0; d < grid.size(); ++d) {
+      full &= lo[d] == 0 && hi[d] == grid[d];
+      empty |= hi[d] <= lo[d];
+    }
+    if (empty) {
+      rewriter.replaceOp(op, op.getInputs()[0]);
+      return success();
+    }
+    if (!full) {
+      SmallVector<int64_t> idxLo, idxHi, idxStride(idxTy.getRank(), 1);
+      for (int64_t d = 0, g = 0; d < idxTy.getRank(); ++d) {
+        if (d == vectorDim) {
+          idxLo.push_back(0);
+          idxHi.push_back(idxTy.getDimSize(d));
+        } else {
+          idxLo.push_back(lo[g]);
+          idxHi.push_back(hi[g]);
+          ++g;
+        }
+      }
+      live = stablehlo::SliceOpCreate(rewriter, loc, live, idxLo, idxHi,
+                                      idxStride);
+      SmallVector<int64_t> updStride(grid.size(), 1);
+      update =
+          stablehlo::SliceOpCreate(rewriter, loc, update, lo, hi, updStride);
+    }
+    rewriter.modifyOpInPlace(op, [&] {
+      op.getScatterIndicesMutable().assign(live);
+      op.getUpdatesMutable()[0].assign(update);
+    });
+    return success();
+  }
+};
+
 // Whether an index tensor maps every grid position to a distinct value: a
 // sum of iota-like terms, each along its own grid dimension, whose strides
 // make the sum injective (the raising's row-major linearization of a store's
@@ -37465,6 +37652,7 @@ struct EnzymeHLOOptPass
         DynamicReshapeOpCanon,
         EmptyReduceOpCanon,
         GatherOpCanon,
+        ScatterMaskedIndexSlice,
         ScatterMaskedIndexSimplify,
         ScatterOpCanon,
         GetDimensionSizeOpCanon,

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1806,6 +1806,11 @@ def ApplyScatterUpdateComputationConstPropPatterns : EnzymeHLOPatternOp<
   let patterns = ["ScatterUpdateComputationConstProp"];
 }
 
+def ApplyScatterMaskedIndexSlicePatterns : EnzymeHLOPatternOp<
+    "scatter_masked_index_slice"> {
+  let patterns = ["ScatterMaskedIndexSlice"];
+}
+
 def ApplyScatterMaskedIndexSimplifyPatterns : EnzymeHLOPatternOp<
     "scatter_masked_index_simplify"> {
   let patterns = ["ScatterMaskedIndexSimplify"];

--- a/test/lit_tests/scatter_masked_slice.mlir
+++ b/test/lit_tests/scatter_masked_slice.mlir
@@ -1,0 +1,101 @@
+// RUN: enzymexlamlir-opt %s --enzyme-hlo-opt | FileCheck %s
+
+// A store masked by `lane < 6` over a 1-D lane grid: the live box is lanes
+// 0..5, so the scatter is sliced to them and becomes an update of that range.
+func.func @prefix(%input: tensor<16xf32>, %update: tensor<10xf32>) -> tensor<16xf32> {
+  %c6 = stablehlo.constant dense<6> : tensor<10x1xi64>
+  %off = stablehlo.constant dense<-1> : tensor<10x1xi64>
+  %iota = stablehlo.iota dim = 0 : tensor<10x1xi64>
+  %pred = stablehlo.compare LT, %iota, %c6 : (tensor<10x1xi64>, tensor<10x1xi64>) -> tensor<10x1xi1>
+  %idx = stablehlo.select %pred, %iota, %off : tensor<10x1xi1>, tensor<10x1xi64>
+  %0 = "stablehlo.scatter"(%input, %idx, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+  ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+    stablehlo.return %b : tensor<f32>
+  }) : (tensor<16xf32>, tensor<10x1xi64>, tensor<10xf32>) -> tensor<16xf32>
+  return %0 : tensor<16xf32>
+}
+
+// A box in a 2-D lane grid: rows below 5 and columns from 2 on.
+func.func @box(%input: tensor<100xf32>, %update: tensor<10x10xf32>) -> tensor<100xf32> {
+  %c5 = stablehlo.constant dense<5> : tensor<10x10x1xi64>
+  %c2 = stablehlo.constant dense<2> : tensor<10x10x1xi64>
+  %c10 = stablehlo.constant dense<10> : tensor<10xi64>
+  %off = stablehlo.constant dense<-1> : tensor<10x10x1xi64>
+  %i = stablehlo.iota dim = 0 : tensor<10xi64>
+  %row = stablehlo.multiply %i, %c10 : tensor<10xi64>
+  %rowb = stablehlo.broadcast_in_dim %row, dims = [0] : (tensor<10xi64>) -> tensor<10x10x1xi64>
+  %rows = stablehlo.iota dim = 0 : tensor<10x10x1xi64>
+  %cols = stablehlo.iota dim = 1 : tensor<10x10x1xi64>
+  %lin = stablehlo.add %rowb, %cols : tensor<10x10x1xi64>
+  %p0 = stablehlo.compare LT, %rows, %c5 : (tensor<10x10x1xi64>, tensor<10x10x1xi64>) -> tensor<10x10x1xi1>
+  %p1 = stablehlo.compare GE, %cols, %c2 : (tensor<10x10x1xi64>, tensor<10x10x1xi64>) -> tensor<10x10x1xi1>
+  %pred = stablehlo.and %p0, %p1 : tensor<10x10x1xi1>
+  %idx = stablehlo.select %pred, %lin, %off : tensor<10x10x1xi1>, tensor<10x10x1xi64>
+  %0 = "stablehlo.scatter"(%input, %idx, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 2>, unique_indices = false}> ({
+  ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+    stablehlo.return %b : tensor<f32>
+  }) : (tensor<100xf32>, tensor<10x10x1xi64>, tensor<10x10xf32>) -> tensor<100xf32>
+  return %0 : tensor<100xf32>
+}
+
+// The bound is a runtime value: no static box, the scatter stays.
+func.func @dynamic_bound(%input: tensor<16xf32>, %update: tensor<10xf32>, %n: tensor<i64>) -> tensor<16xf32> {
+  %off = stablehlo.constant dense<-1> : tensor<10x1xi64>
+  %iota = stablehlo.iota dim = 0 : tensor<10x1xi64>
+  %nb = stablehlo.broadcast_in_dim %n, dims = [] : (tensor<i64>) -> tensor<10x1xi64>
+  %pred = stablehlo.compare LT, %iota, %nb : (tensor<10x1xi64>, tensor<10x1xi64>) -> tensor<10x1xi1>
+  %idx = stablehlo.select %pred, %iota, %off : tensor<10x1xi1>, tensor<10x1xi64>
+  %0 = "stablehlo.scatter"(%input, %idx, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+  ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+    stablehlo.return %b : tensor<f32>
+  }) : (tensor<16xf32>, tensor<10x1xi64>, tensor<10xf32>) -> tensor<16xf32>
+  return %0 : tensor<16xf32>
+}
+
+// A mask that is not one interval along the lane: the scatter stays.
+func.func @two_intervals(%input: tensor<16xf32>, %update: tensor<10xf32>) -> tensor<16xf32> {
+  %c6 = stablehlo.constant dense<6> : tensor<10x1xi64>
+  %off = stablehlo.constant dense<-1> : tensor<10x1xi64>
+  %iota = stablehlo.iota dim = 0 : tensor<10x1xi64>
+  %pred = stablehlo.compare NE, %iota, %c6 : (tensor<10x1xi64>, tensor<10x1xi64>) -> tensor<10x1xi1>
+  %idx = stablehlo.select %pred, %iota, %off : tensor<10x1xi1>, tensor<10x1xi64>
+  %0 = "stablehlo.scatter"(%input, %idx, %update) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false}> ({
+  ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+    stablehlo.return %b : tensor<f32>
+  }) : (tensor<16xf32>, tensor<10x1xi64>, tensor<10xf32>) -> tensor<16xf32>
+  return %0 : tensor<16xf32>
+}
+
+// CHECK:      func.func @prefix(%arg0: tensor<16xf32>, %arg1: tensor<10xf32>) -> tensor<16xf32> {
+// CHECK-NEXT:    %0 = stablehlo.slice %arg1 [0:6] : (tensor<10xf32>) -> tensor<6xf32>
+// CHECK-NEXT:    %1 = stablehlo.slice %arg0 [6:16] : (tensor<16xf32>) -> tensor<10xf32>
+// CHECK-NEXT:    %2 = stablehlo.concatenate %0, %1, dim = 0 : (tensor<6xf32>, tensor<10xf32>) -> tensor<16xf32>
+// CHECK-NEXT:    return %2 : tensor<16xf32>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @box(%arg0: tensor<100xf32>, %arg1: tensor<10x10xf32>) -> tensor<100xf32> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<2> : tensor<i32>
+// CHECK-NEXT:    %c_0 = stablehlo.constant dense<0> : tensor<i32>
+// CHECK-NEXT:    %0 = stablehlo.slice %arg1 [0:5, 2:10] : (tensor<10x10xf32>) -> tensor<5x8xf32>
+// CHECK-NEXT:    %1 = stablehlo.reshape %arg0 : (tensor<100xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:    %2 = stablehlo.dynamic_update_slice %1, %0, %c_0, %c : (tensor<10x10xf32>, tensor<5x8xf32>, tensor<i32>, tensor<i32>) -> tensor<10x10xf32>
+// CHECK-NEXT:    %3 = stablehlo.reshape %2 : (tensor<10x10xf32>) -> tensor<100xf32>
+// CHECK-NEXT:    return %3 : tensor<100xf32>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @dynamic_bound(%arg0: tensor<16xf32>, %arg1: tensor<10xf32>, %arg2: tensor<i64>) -> tensor<16xf32> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]> : tensor<10xi64>
+// CHECK-NEXT:    %0 = stablehlo.broadcast_in_dim %arg2, dims = [] {enzymexla.non_negative = [#enzymexla<guaranteed NOTGUARANTEED>]} : (tensor<i64>) -> tensor<10xi64>
+// CHECK-NEXT:    %1 = stablehlo.compare LT, %c, %0 : (tensor<10xi64>, tensor<10xi64>) -> tensor<10xi1>
+// CHECK-NEXT:    %2 = stablehlo.slice %arg0 [0:10] : (tensor<16xf32>) -> tensor<10xf32>
+// CHECK-NEXT:    %3 = stablehlo.select %1, %arg1, %2 : tensor<10xi1>, tensor<10xf32>
+// CHECK-NEXT:    %4 = stablehlo.slice %arg0 [10:16] : (tensor<16xf32>) -> tensor<6xf32>
+// CHECK-NEXT:    %5 = stablehlo.concatenate %3, %4, dim = 0 : (tensor<10xf32>, tensor<6xf32>) -> tensor<16xf32>
+// CHECK-NEXT:    return %5 : tensor<16xf32>
+// CHECK-NEXT:  }
+// CHECK-NEXT:  func.func @two_intervals(%arg0: tensor<16xf32>, %arg1: tensor<10xf32>) -> tensor<16xf32> {
+// CHECK-NEXT:    %c = stablehlo.constant dense<[true, true, true, true, true, true, false, true, true, true]> : tensor<10xi1>
+// CHECK-NEXT:    %0 = stablehlo.slice %arg0 [0:10] : (tensor<16xf32>) -> tensor<10xf32>
+// CHECK-NEXT:    %1 = stablehlo.select %c, %arg1, %0 : tensor<10xi1>, tensor<10xf32>
+// CHECK-NEXT:    %2 = stablehlo.slice %arg0 [10:16] : (tensor<16xf32>) -> tensor<6xf32>
+// CHECK-NEXT:    %3 = stablehlo.concatenate %1, %2, dim = 0 : (tensor<10xf32>, tensor<6xf32>) -> tensor<16xf32>
+// CHECK-NEXT:    return %3 : tensor<16xf32>
+// CHECK-NEXT:  }


### PR DESCRIPTION
Complement to #3190 for the static case. The raising masks a store by sending dead lanes' scatter indices to -1 (#2993). When the mask is decided by comparisons of iotas against constants, an `and` of them, the live lanes form a box of the lane grid, and the lanes outside it are exactly the ones the negative index drops. `ScatterMaskedIndexSlice` slices the live indices and the updates to that box and scatters those, so no mask is left in the index chain and the existing single-point and iota rewrites see a plain in-bounds index. It needs no uniqueness of the indices, since it only removes lanes that never wrote. A mask against a runtime bound, or one that is not a single interval along a dimension, is left to #3190's write-back form.

Test: `test/lit_tests/scatter_masked_slice.mlir` (a prefix along a lane, a 2-D box; a runtime bound and a two-interval mask stay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
