### PR TITLE
Register ScatterMaskedIndexSimplify with the transform dialect

### DIFF
--- a/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
+++ b/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.cpp
@@ -684,6 +684,7 @@ static void addScatterGatherPasses(std::vector<std::string> &list,
   list.push_back("scatter_div_simplify");
   list.push_back("unary_elementwise_scatter_simplify");
   list.push_back("scatter_indices_are_unique");
+  list.push_back("scatter_masked_index_simplify");
   list.push_back("split_complex_scatter");
   list.push_back("split_complex_gather");
   // const prop patterns

--- a/src/enzyme_ad/jax/TransformOps/TransformOps.td
+++ b/src/enzyme_ad/jax/TransformOps/TransformOps.td
@@ -1806,6 +1806,11 @@ def ApplyScatterUpdateComputationConstPropPatterns : EnzymeHLOPatternOp<
   let patterns = ["ScatterUpdateComputationConstProp"];
 }
 
+def ApplyScatterMaskedIndexSimplifyPatterns : EnzymeHLOPatternOp<
+    "scatter_masked_index_simplify"> {
+  let patterns = ["ScatterMaskedIndexSimplify"];
+}
+
 def ApplyScatterIndicesAreUniquePatterns : EnzymeHLOPatternOp<
     "scatter_indices_are_unique"> {
   let patterns = ["ScatterIndicesAreUnique"];


### PR DESCRIPTION
Follow-up to #3190: register `ScatterMaskedIndexSimplify` with the transform dialect (`scatter_masked_index_simplify`) and the C pattern list, which the PR left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
