### PR TITLE
Add derivative rules for stablehlo CaseOp

### DIFF
--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -450,6 +450,39 @@ public:
   }
 };
 
+class AutoDiffCaseFwd
+    : public AutoDiffOpInterface::ExternalModel<AutoDiffCaseFwd,
+                                                stablehlo::CaseOp> {
+public:
+  LogicalResult createForwardModeTangent(Operation *orig, OpBuilder &builder,
+                                         MGradientUtils *gutils) const {
+    llvm::SmallDenseSet<unsigned> operandPositionsToShadow;
+    llvm::SmallDenseSet<unsigned> resultPositionsToShadow;
+
+    for (auto res : orig->getOpResults()) {
+      if (!gutils->isConstantValue(res))
+        resultPositionsToShadow.insert(res.getResultNumber());
+    }
+    return mlir::enzyme::detail::controlFlowForwardHandler(
+        orig, builder, gutils, operandPositionsToShadow,
+        resultPositionsToShadow);
+  }
+};
+
+class AutoDiffCaseCF
+    : public ControlFlowAutoDiffOpInterface::ExternalModel<AutoDiffCaseCF,
+                                                           stablehlo::CaseOp> {
+public:
+  Operation *createWithShadows(Operation *op, OpBuilder &builder,
+                               MGradientUtils *gutils, Operation *original,
+                               ValueRange remappedOperands,
+                               TypeRange rettys) const {
+    return stablehlo::CaseOp::create(
+        builder, original->getLoc(), rettys, remappedOperands,
+        original->getAttrs(), cast<stablehlo::CaseOp>(op).getBranches().size());
+  }
+};
+
 class AutoDiffWhileFwd
     : public AutoDiffOpInterface::ExternalModel<AutoDiffWhileFwd, WhileOp> {
 public:
@@ -4965,6 +4998,9 @@ void mlir::enzyme::registerStableHLODialectAutoDiffInterface(
     stablehlo::IfOp::attachInterface<AutoDiffIfRev>(*context);
     stablehlo::IfOp::attachInterface<AutoDiffIfFwd>(*context);
     stablehlo::IfOp::attachInterface<AutoDiffIfCF>(*context);
+
+    stablehlo::CaseOp::attachInterface<AutoDiffCaseFwd>(*context);
+    stablehlo::CaseOp::attachInterface<AutoDiffCaseCF>(*context);
 
     SortOp::attachInterface<AutoDiffSortFwd>(*context);
     SortOp::attachInterface<AutoDiffSortRev>(*context);

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -3985,8 +3985,6 @@ struct CaseOpEnzymeOpsRemover
       terminators.push_back(bb->getTerminator());
     }
 
-    // Each gradient set inside a branch becomes an extra return value of
-    // every branch. Branches that did not set it return its current value.
     for (auto grad : gradients) {
       for (auto &&[mapping, term] : llvm::zip(mappings, terminators)) {
         auto mappingValue = mapping.lookupOrNull(grad);
@@ -3999,9 +3997,6 @@ struct CaseOpEnzymeOpsRemover
       }
     }
 
-    // Each value pushed inside a branch becomes an extra return value of
-    // every branch. Only the pushing branch has the value; the others return
-    // a zero of the same type so the pushed value is well defined.
     for (auto &[pushedValue, info] : pushedCaches) {
       Value dummy =
           makeZero(rewriter, pushedValue.getLoc(), pushedValue.getType());
@@ -4012,8 +4007,6 @@ struct CaseOpEnzymeOpsRemover
       }
     }
 
-    // All terminators now agree on their operand types, so any one of them
-    // gives the result types of the rebuilt op.
     auto newCase = stablehlo::CaseOp::create(rewriter, caseOp->getLoc(),
                                              terminators[0]->getOperandTypes(),
                                              caseOp.getIndex(), blocks.size());

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -3957,6 +3957,103 @@ struct IfOpEnzymeOpsRemover
   }
 };
 
+struct CaseOpEnzymeOpsRemover
+    : public EnzymeOpsRemoverOpInterface::ExternalModel<CaseOpEnzymeOpsRemover,
+                                                        stablehlo::CaseOp> {
+  LogicalResult removeEnzymeOps(Operation *op,
+                                PatternRewriter &rewriter) const {
+
+    auto caseOp = cast<stablehlo::CaseOp>(op);
+
+    llvm::SetVector<Value> gradients;
+    llvm::MapVector<Value, CacheInfo> pushedCaches;
+
+    SmallVector<Block *> blocks;
+    SmallVector<IRMapping> mappings;
+    for (auto &reg : caseOp->getRegions()) {
+      blocks.push_back(&reg.front());
+      mappings.emplace_back();
+      removalBlockExplore(blocks.back(), mappings.back(), rewriter, gradients,
+                          pushedCaches);
+    }
+
+    if (gradients.empty() && pushedCaches.empty())
+      return success();
+
+    SmallVector<Operation *> terminators;
+    for (Block *bb : blocks) {
+      terminators.push_back(bb->getTerminator());
+    }
+
+    // Each gradient set inside a branch becomes an extra return value of
+    // every branch. Branches that did not set it return its current value.
+    for (auto grad : gradients) {
+      for (auto &&[mapping, term] : llvm::zip(mappings, terminators)) {
+        auto mappingValue = mapping.lookupOrNull(grad);
+        if (!mappingValue) {
+          mappingValue = enzyme::GetOp::create(
+              rewriter, grad.getLoc(),
+              cast<enzyme::GradientType>(grad.getType()).getBasetype(), grad);
+        }
+        term->insertOperands(term->getNumOperands(), ValueRange(mappingValue));
+      }
+    }
+
+    // Each value pushed inside a branch becomes an extra return value of
+    // every branch. Only the pushing branch has the value; the others return
+    // a zero of the same type so the pushed value is well defined.
+    for (auto &[pushedValue, info] : pushedCaches) {
+      Value dummy =
+          makeZero(rewriter, pushedValue.getLoc(), pushedValue.getType());
+      for (auto &&[bb, term] : llvm::zip(blocks, terminators)) {
+        Value branchValue =
+            pushedValue.getParentBlock() == bb ? pushedValue : dummy;
+        term->insertOperands(term->getNumOperands(), ValueRange(branchValue));
+      }
+    }
+
+    // All terminators now agree on their operand types, so any one of them
+    // gives the result types of the rebuilt op.
+    auto newCase = stablehlo::CaseOp::create(rewriter, caseOp->getLoc(),
+                                             terminators[0]->getOperandTypes(),
+                                             caseOp.getIndex(), blocks.size());
+    for (auto &&[oldReg, newReg] :
+         llvm::zip(caseOp->getRegions(), newCase->getRegions()))
+      newReg.takeBody(oldReg);
+
+    size_t idx = caseOp->getNumResults();
+    for (auto grad : gradients) {
+      enzyme::SetOp::create(rewriter, grad.getLoc(), grad,
+                            newCase->getResult(idx));
+      idx++;
+    }
+
+    for (auto &[pushedValue, info] : pushedCaches) {
+      enzyme::PushOp::create(rewriter, info.pushOp->getLoc(),
+                             info.initOp.getResult(), newCase->getResult(idx));
+      rewriter.eraseOp(info.pushOp);
+
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPoint(info.popOp->getParentOp());
+
+      auto newPop = enzyme::PopOp::create(rewriter, info.popOp->getLoc(),
+                                          info.popOp.getResult().getType(),
+                                          info.popOp.getCache());
+      rewriter.replaceAllUsesWith(info.popOp.getResult(), newPop);
+      rewriter.eraseOp(info.popOp);
+
+      idx++;
+    }
+
+    rewriter.replaceAllUsesWith(
+        caseOp->getResults(),
+        newCase->getResults().slice(0, caseOp->getNumResults()));
+    rewriter.eraseOp(caseOp);
+
+    return success();
+  }
+};
+
 struct SHLOReduceOpBatchInterface
     : public BatchOpInterface::ExternalModel<SHLOReduceOpBatchInterface,
                                              ReduceOp> {
@@ -5045,6 +5142,7 @@ void mlir::enzyme::registerStableHLODialectAutoDiffInterface(
 
     WhileOp::attachInterface<WhileOpEnzymeOpsRemover>(*context);
     stablehlo::IfOp::attachInterface<IfOpEnzymeOpsRemover>(*context);
+    stablehlo::CaseOp::attachInterface<CaseOpEnzymeOpsRemover>(*context);
 
     WhileOp::attachInterface<ADDataFlowWhileOp>(*context);
     SortOp::attachInterface<ADDataFlowSortOp>(*context);

--- a/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
+++ b/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp
@@ -483,6 +483,69 @@ public:
   }
 };
 
+class AutoDiffCaseRev
+    : public ReverseAutoDiffOpInterface::ExternalModel<AutoDiffCaseRev,
+                                                       stablehlo::CaseOp> {
+public:
+  SmallVector<Value> cacheValues(Operation *orig,
+                                 MGradientUtilsReverse *gutils) const {
+    auto op = cast<stablehlo::CaseOp>(orig);
+    OpBuilder cacheBuilder(gutils->getNewFromOriginal(orig));
+    return {gutils->initAndPushCache(gutils->getNewFromOriginal(op.getIndex()),
+                                     cacheBuilder)};
+  }
+
+  LogicalResult createShadowValues(Operation *op, OpBuilder &builder,
+                                   MGradientUtilsReverse *gutils) const {
+    return success();
+  }
+
+  LogicalResult createReverseModeAdjoint(Operation *orig, OpBuilder &builder,
+                                         MGradientUtilsReverse *gutils,
+                                         SmallVector<Value> caches) const {
+    auto caseOp = cast<stablehlo::CaseOp>(orig);
+    auto revOp = stablehlo::CaseOp::create(
+        builder, orig->getLoc(), ArrayRef<mlir::Type>{},
+        gutils->popCache(caches[0], builder), orig->getAttrs(),
+        caseOp.getBranches().size());
+    bool valid = true;
+    for (auto &&[origReg, newReg] :
+         llvm::zip_equal(orig->getRegions(), revOp->getRegions())) {
+      Block *oBB = &origReg.front();
+
+      newReg.push_back(new Block());
+      Block *reverseBB = &newReg.front();
+
+      OpBuilder revBuilder(reverseBB, reverseBB->end());
+      auto term = oBB->getTerminator();
+
+      for (auto &&[ret, op] :
+           llvm::zip_equal(orig->getResults(), term->getOperands())) {
+        if (gutils->isConstantValue(ret))
+          continue;
+        if (gutils->isConstantValue(op))
+          continue;
+
+        gutils->addToDiffe(op, gutils->diffe(ret, revBuilder), revBuilder);
+      }
+
+      auto first = oBB->rbegin(); // terminator
+      first++;
+
+      auto last = oBB->rend();
+
+      for (auto it = first; it != last; ++it) {
+        Operation *op = &*it;
+        valid &= gutils->Logic.visitChild(op, revBuilder, gutils).succeeded();
+      }
+
+      stablehlo::ReturnOp::create(revBuilder, orig->getLoc(),
+                                  ArrayRef<Value>{});
+    }
+    return success(valid);
+  }
+};
+
 class AutoDiffWhileFwd
     : public AutoDiffOpInterface::ExternalModel<AutoDiffWhileFwd, WhileOp> {
 public:
@@ -5001,6 +5064,7 @@ void mlir::enzyme::registerStableHLODialectAutoDiffInterface(
 
     stablehlo::CaseOp::attachInterface<AutoDiffCaseFwd>(*context);
     stablehlo::CaseOp::attachInterface<AutoDiffCaseCF>(*context);
+    stablehlo::CaseOp::attachInterface<AutoDiffCaseRev>(*context);
 
     SortOp::attachInterface<AutoDiffSortFwd>(*context);
     SortOp::attachInterface<AutoDiffSortRev>(*context);

--- a/src/enzyme_ad/jax/Implementations/StableHLODerivatives.td
+++ b/src/enzyme_ad/jax/Implementations/StableHLODerivatives.td
@@ -34,13 +34,3 @@ def : HLODerivative<"UnaryEinsumOp", (Op $x),
                     ],
                     (UnaryEinsum (ResultTypes), (Shadow $x), (EinsumConfig))
                   >;
-
-def : ControlFlowOp<"stablehlo", "CaseOp", [{
-  Operation *createWithShadows(Operation *op, OpBuilder &builder,
-                               MGradientUtils *gutils, Operation *original,
-                               ValueRange remappedOperands,
-                               TypeRange rettys) const {
-    return stablehlo::CaseOp::create(builder, original->getLoc(), rettys,
-                                        remappedOperands, original->getAttrs(), cast<stablehlo::CaseOp>(op).getBranches().size());
-  }
-}]>;

--- a/test/lit_tests/diffrules/stablehlo/case.mlir
+++ b/test/lit_tests/diffrules/stablehlo/case.mlir
@@ -1,4 +1,5 @@
 // RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup,enzyme_const mode=ForwardMode" --canonicalize | FileCheck %s --check-prefix=FORWARD
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_active argTys=enzyme_active,enzyme_const mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops | FileCheck %s --check-prefix=REVERSE
 
 module {
 	func.func @main(%arg0: tensor<10xf32>, %index: tensor<i32>) -> tensor<10xf32> {
@@ -37,3 +38,23 @@ module {
 // FORWARD-NEXT:      return %0#0, %0#1 : tensor<10xf32>, tensor<10xf32>
 // FORWARD-NEXT:    }
 // FORWARD-NEXT:  }
+
+// REVERSE: func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<i32>, %arg2: tensor<10xf32>) -> tensor<10xf32> {
+// REVERSE-NEXT:    %cst = arith.constant dense<0.000000e+00> : tensor<10xf32>
+// REVERSE-NEXT:    %0 = arith.addf %arg2, %cst fastmath<fast> : tensor<10xf32>
+// REVERSE-NEXT:    %1:3 = "stablehlo.case"(%arg1) ({
+// REVERSE-NEXT:      %2 = arith.addf %0, %cst fastmath<fast> : tensor<10xf32>
+// REVERSE-NEXT:      %3 = arith.addf %2, %cst fastmath<fast> : tensor<10xf32>
+// REVERSE-NEXT:      stablehlo.return %cst, %3, %cst : tensor<10xf32>, tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      %2 = arith.addf %0, %cst fastmath<fast> : tensor<10xf32>
+// REVERSE-NEXT:      %3 = stablehlo.multiply %2, %arg0 : tensor<10xf32>
+// REVERSE-NEXT:      %4 = arith.addf %3, %cst fastmath<fast> : tensor<10xf32>
+// REVERSE-NEXT:      %5 = stablehlo.multiply %2, %arg0 : tensor<10xf32>
+// REVERSE-NEXT:      %6 = arith.addf %4, %5 fastmath<fast> : tensor<10xf32>
+// REVERSE-NEXT:      stablehlo.return %cst, %6, %cst : tensor<10xf32>, tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      stablehlo.return %cst, %cst, %cst : tensor<10xf32>, tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }) : (tensor<i32>) -> (tensor<10xf32>, tensor<10xf32>, tensor<10xf32>)
+// REVERSE-NEXT:    return %1#1 : tensor<10xf32>
+// REVERSE-NEXT:  }

--- a/test/lit_tests/diffrules/stablehlo/case.mlir
+++ b/test/lit_tests/diffrules/stablehlo/case.mlir
@@ -1,0 +1,39 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= retTys=enzyme_dup argTys=enzyme_dup,enzyme_const mode=ForwardMode" --canonicalize | FileCheck %s --check-prefix=FORWARD
+
+module {
+	func.func @main(%arg0: tensor<10xf32>, %index: tensor<i32>) -> tensor<10xf32> {
+		%cst = stablehlo.constant dense<1.0> : tensor<10xf32>
+
+		%0 = "stablehlo.case"(%index) ({
+			%1 = "stablehlo.add" (%arg0, %cst) : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
+			"stablehlo.return"(%1) : (tensor<10xf32>) -> ()
+		}, {
+			%2 = "stablehlo.multiply" (%arg0, %arg0): (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
+			"stablehlo.return"(%2): (tensor<10xf32>) -> ()
+		}, {
+			"stablehlo.return"(%cst): (tensor<10xf32>) -> ()
+		}): (tensor<i32>) -> tensor<10xf32>
+
+		func.return %0 : tensor<10xf32>
+	}
+}
+
+// FORWARD:    func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<10xf32>, %arg2: tensor<i32>) -> (tensor<10xf32>, tensor<10xf32>) {
+// FORWARD-NEXT:      %cst = arith.constant dense<0.000000e+00> : tensor<10xf32>
+// FORWARD-NEXT:      %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<10xf32>
+// FORWARD-NEXT:      %0:2 = "stablehlo.case"(%arg2) ({
+// FORWARD-NEXT:        %1 = stablehlo.add %arg1, %cst : tensor<10xf32>
+// FORWARD-NEXT:        %2 = stablehlo.add %arg0, %cst_0 : tensor<10xf32>
+// FORWARD-NEXT:        stablehlo.return %2, %1 : tensor<10xf32>, tensor<10xf32>
+// FORWARD-NEXT:      }, {
+// FORWARD-NEXT:        %1 = stablehlo.multiply %arg1, %arg0 : tensor<10xf32>
+// FORWARD-NEXT:        %2 = stablehlo.multiply %arg1, %arg0 : tensor<10xf32>
+// FORWARD-NEXT:        %3 = arith.addf %1, %2 fastmath<fast> : tensor<10xf32>
+// FORWARD-NEXT:        %4 = stablehlo.multiply %arg0, %arg0 : tensor<10xf32>
+// FORWARD-NEXT:        stablehlo.return %4, %3 : tensor<10xf32>, tensor<10xf32>
+// FORWARD-NEXT:      }, {
+// FORWARD-NEXT:        stablehlo.return %cst_0, %cst : tensor<10xf32>, tensor<10xf32>
+// FORWARD-NEXT:      }) : (tensor<i32>) -> (tensor<10xf32>, tensor<10xf32>)
+// FORWARD-NEXT:      return %0#0, %0#1 : tensor<10xf32>, tensor<10xf32>
+// FORWARD-NEXT:    }
+// FORWARD-NEXT:  }

--- a/test/lit_tests/diffrules/stablehlo/case_remove.mlir
+++ b/test/lit_tests/diffrules/stablehlo/case_remove.mlir
@@ -18,9 +18,6 @@ module {
     return %0 : tensor<10xf32>
   }
 
-  // Hand-written post-differentiation IR: two branches set the gradient slot,
-  // the third does not. The ops remover must turn the sets into case results,
-  // reading the slot's current value for the branch that leaves it alone.
   func.func @zmain2(%arg0: tensor<10xf32>, %index: tensor<i32>, %arg2: tensor<10xf32>) -> (tensor<10xf32>, tensor<10xf32>) {
     %cst = stablehlo.constant dense<1.000000e+00> : tensor<10xf32>
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<10xf32>

--- a/test/lit_tests/diffrules/stablehlo/case_remove.mlir
+++ b/test/lit_tests/diffrules/stablehlo/case_remove.mlir
@@ -1,0 +1,82 @@
+// RUN: enzymexlamlir-opt %s --enzyme-wrap="infn=main outfn= argTys=enzyme_active,enzyme_const retTys=enzyme_active mode=ReverseModeCombined" --canonicalize --remove-unnecessary-enzyme-ops --arith-raise --enzyme-hlo-opt --allow-unregistered-dialect | FileCheck %s --check-prefix=REVERSE
+
+module {
+  func.func @main(%arg0: tensor<10xf32>, %index: tensor<i32>) -> tensor<10xf32> {
+    %cst = stablehlo.constant dense<1.0> : tensor<10xf32>
+
+    %0 = "stablehlo.case"(%index) ({
+      %1 = stablehlo.add %arg0, %cst : tensor<10xf32>
+      "stablehlo.return"(%1) : (tensor<10xf32>) -> ()
+    }, {
+      %2 = stablehlo.multiply %arg0, %cst : tensor<10xf32>
+      %3 = stablehlo.multiply %2, %2 : tensor<10xf32>
+      "stablehlo.return"(%3) : (tensor<10xf32>) -> ()
+    }, {
+      "stablehlo.return"(%cst) : (tensor<10xf32>) -> ()
+    }) : (tensor<i32>) -> tensor<10xf32>
+
+    return %0 : tensor<10xf32>
+  }
+
+  // Hand-written post-differentiation IR: two branches set the gradient slot,
+  // the third does not. The ops remover must turn the sets into case results,
+  // reading the slot's current value for the branch that leaves it alone.
+  func.func @zmain2(%arg0: tensor<10xf32>, %index: tensor<i32>, %arg2: tensor<10xf32>) -> (tensor<10xf32>, tensor<10xf32>) {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<10xf32>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<10xf32>
+    %0 = "enzyme.init"() : () -> !enzyme.Gradient<tensor<10xf32>>
+    "enzyme.set"(%0, %arg0) : (!enzyme.Gradient<tensor<10xf32>>, tensor<10xf32>) -> ()
+    %1 = "stablehlo.case"(%index) ({
+      "enzyme.set"(%0, %cst_0) : (!enzyme.Gradient<tensor<10xf32>>, tensor<10xf32>) -> ()
+      %2 = "test.foo"(%arg0) : (tensor<10xf32>) -> tensor<10xf32>
+      stablehlo.return %2 : tensor<10xf32>
+    }, {
+      "enzyme.set"(%0, %arg2) : (!enzyme.Gradient<tensor<10xf32>>, tensor<10xf32>) -> ()
+      stablehlo.return %cst : tensor<10xf32>
+    }, {
+      %3 = "test.bar"(%arg2) : (tensor<10xf32>) -> tensor<10xf32>
+      stablehlo.return %3 : tensor<10xf32>
+    }) : (tensor<i32>) -> tensor<10xf32>
+    %4 = "enzyme.get"(%0) : (!enzyme.Gradient<tensor<10xf32>>) -> tensor<10xf32>
+    return %1, %4 : tensor<10xf32>, tensor<10xf32>
+  }
+}
+
+// REVERSE:  func.func @zmain2(%arg0: tensor<10xf32>, %arg1: tensor<i32>, %arg2: tensor<10xf32>) -> (tensor<10xf32>, tensor<10xf32>) {
+// REVERSE-NEXT:    %cst = stablehlo.constant dense<1.000000e+00> : tensor<10xf32>
+// REVERSE-NEXT:    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<10xf32>
+// REVERSE-NEXT:    %0:2 = "stablehlo.case"(%arg1) ({
+// REVERSE-NEXT:      %1 = "test.foo"(%arg0) : (tensor<10xf32>) -> tensor<10xf32>
+// REVERSE-NEXT:      stablehlo.return %1, %cst_0 : tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      stablehlo.return %cst, %arg2 : tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      %1 = "test.bar"(%arg2) : (tensor<10xf32>) -> tensor<10xf32>
+// REVERSE-NEXT:      stablehlo.return %1, %arg0 : tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }) : (tensor<i32>) -> (tensor<10xf32>, tensor<10xf32>)
+// REVERSE-NEXT:    return %0#0, %0#1 : tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:  }
+
+// REVERSE:  func.func @main(%arg0: tensor<10xf32>, %arg1: tensor<i32>, %arg2: tensor<10xf32>) -> tensor<10xf32> {
+// REVERSE-NEXT:    %cst = stablehlo.constant dense<0.000000e+00> : tensor<10xf32>
+// REVERSE-NEXT:    %cst_0 = stablehlo.constant dense<1.000000e+00> : tensor<10xf32>
+// REVERSE-NEXT:    %0:2 = "stablehlo.case"(%arg1) ({
+// REVERSE-NEXT:      %2 = stablehlo.add %arg0, %cst_0 : tensor<10xf32>
+// REVERSE-NEXT:      stablehlo.return %2, %cst : tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      %2 = stablehlo.multiply %arg0, %arg0 : tensor<10xf32>
+// REVERSE-NEXT:      stablehlo.return %2, %arg0 : tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      stablehlo.return %cst_0, %cst : tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }) : (tensor<i32>) -> (tensor<10xf32>, tensor<10xf32>)
+// REVERSE-NEXT:    %1:4 = "stablehlo.case"(%arg1) ({
+// REVERSE-NEXT:      stablehlo.return %cst, %arg2, %cst, %cst : tensor<10xf32>, tensor<10xf32>, tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      %2 = stablehlo.multiply %arg2, %0#1 : tensor<10xf32>
+// REVERSE-NEXT:      %3 = stablehlo.add %2, %2 : tensor<10xf32>
+// REVERSE-NEXT:      stablehlo.return %cst, %3, %cst, %cst : tensor<10xf32>, tensor<10xf32>, tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }, {
+// REVERSE-NEXT:      stablehlo.return %cst, %cst, %cst, %cst : tensor<10xf32>, tensor<10xf32>, tensor<10xf32>, tensor<10xf32>
+// REVERSE-NEXT:    }) : (tensor<i32>) -> (tensor<10xf32>, tensor<10xf32>, tensor<10xf32>, tensor<10xf32>)
+// REVERSE-NEXT:    return %1#1 : tensor<10xf32>
+// REVERSE-NEXT:  }


### PR DESCRIPTION
Closes #2939 
- `AutoDiffCaseFwd`, `AutoDiffCaseCF`, `AutoDiffCaseRev`, and the associated `CaseOpEnzymeOpsRemover`. Basically just generalizing the existing IfOp case to multi-region
- Remove the `CaseOp` stub from `StableHLODerivatives.td`. It auto-registered the generic forward handler, which requires `RegionBranchOpInterface`; StableHLO's `CaseOp` does not implement it
-  Tests for forward, reverse, and the ops remover (`case.mlir`, `case_remove.mlir`)